### PR TITLE
Extract ActionContext, dispatcher, and node click handler from main.js

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,11 +106,12 @@ this one) that don't touch game logic.
 
 ## Dev Sessions
 
+> **Session directory override:** `docs/dev-sessions/` (not `.claude/dev-sessions/`)
+> Session artifacts are tracked in git alongside source code.
+
 Session docs live in `docs/dev-sessions/{timestamp}-{slug}/` with `spec.md`, `plan.md`, `notes.md`.
 
-Note: this project uses `docs/dev-sessions/` (not `.claude/dev-sessions/`) so session artifacts are tracked in git alongside the source.
-
-Most recent session: `docs/dev-sessions/2026-02-26-0956-node-visual-indicators/`
+Most recent session: `docs/dev-sessions/2026-02-27-0950-node-action-registry/`
 
 ## Headless Playtest Harness
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ lint:
 		js/types.js js/events.js js/state.js js/exploits.js js/combat.js js/loot.js \
 		js/alert.js js/timers.js js/ice.js js/log.js js/log-renderer.js js/visual-renderer.js js/console.js js/cheats.js \
 		js/node-types.js js/node-lifecycle.js \
-		js/node-actions.js js/global-actions.js
+		js/node-actions.js js/global-actions.js js/action-context.js
 
 # Run unit + integration tests
 test:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ lint:
 	npx tsc --noEmit --allowJs --checkJs --target ES2020 --moduleResolution bundler --module ES2020 \
 		js/types.js js/events.js js/state.js js/exploits.js js/combat.js js/loot.js \
 		js/alert.js js/timers.js js/ice.js js/log.js js/log-renderer.js js/visual-renderer.js js/console.js js/cheats.js \
-		js/node-types.js js/node-lifecycle.js
+		js/node-types.js js/node-lifecycle.js \
+		js/node-actions.js js/global-actions.js
 
 # Run unit + integration tests
 test:

--- a/docs/dev-sessions/2026-02-27-0950-node-action-registry/notes.md
+++ b/docs/dev-sessions/2026-02-27-0950-node-action-registry/notes.md
@@ -1,0 +1,2 @@
+# Notes: Node Action Registry
+

--- a/docs/dev-sessions/2026-02-27-0950-node-action-registry/notes.md
+++ b/docs/dev-sessions/2026-02-27-0950-node-action-registry/notes.md
@@ -1,2 +1,136 @@
 # Notes: Node Action Registry
 
+## Recap
+
+Centralized all action availability logic into a composable registry.
+Before this session, both `visual-renderer.js` and `console.js` duplicated
+nearly identical if/else chains to decide which action buttons to render or
+list. Now that logic lives in two registry files:
+
+- `js/node-actions.js` — 8 node-contextual `ActionDef` objects (probe,
+  cancel-probe, exploit, cancel-exploit, read, loot, eject, reboot) plus
+  `getNodeActions()` and `getAvailableActions()`
+- `js/global-actions.js` — 3 global `ActionDef` objects (jackout, select,
+  deselect) plus `getGlobalActions()`
+
+Each `ActionDef` carries `available()`, `desc()`, and `execute()`. The
+`execute()` takes a dependency-injected `ActionContext`, making the actions
+fully testable without any game state initialization.
+
+`main.js` now builds one `ActionContext` instance and routes all UI/console
+actions through a single `on("starnet:action", ...)` dispatcher, replacing
+12 individual per-action handlers. Type-specific actions (`reconfigure`,
+`cancel-trace`) also received `execute()` methods and were folded into the
+unified dispatch.
+
+143 tests passing across 37 suites.
+
+---
+
+## Divergences from Plan
+
+**Phase 6 (visual-renderer.js):** The plan said to use `getAvailableActions()`
+directly, but global actions (jackout, select, deselect) are already rendered
+as hardcoded UI fixtures — a dedicated deselect button in the node header,
+jackout in the HTML. Using `getAvailableActions()` would have duplicated those.
+Used `getNodeActions()` + `getTypeActions()` instead, which is the correct
+semantic split.
+
+**Phase 7 (console.js):** The plan suggested a simple `forEach` over
+`getAvailableActions()` for the `actions` output, but the exploit action
+needs a rich card listing (sorted, with match indicators, worn/disclosed
+status). Kept the card listing logic intact and used a `has` Set for
+availability gating instead.
+
+**Phase 9 (main.js dispatch):** The plan showed a unified `starnet:action`
+event schema as a possible approach. We committed to it, which required also
+changing event emitters in visual-renderer.js and console.js. Added execute()
+to `reconfigure` and `cancel-trace` in node-types.js (not originally scoped)
+to make the unified dispatcher work cleanly without carve-outs.
+
+**Probe predicate bug:** The Phase 5 parity tests caught a missing check in
+the probe `available()` predicate — it didn't block when an exploit was
+already executing on the same node. The original visual-renderer.js had an
+early-return that blocked all non-cancel-exploit actions when a exploit was
+running; this wasn't mirrored in the new predicate. Fixed before proceeding.
+
+---
+
+## Insights
+
+**Test-before-migrate paid off.** Writing parity tests (Phase 5) before
+touching any consumer (Phases 6–7) caught the probe predicate bug immediately.
+Without that gate, the bug would have silently survived the migration and
+showed up as a subtle gameplay regression.
+
+**`ActionDef` with execute() is a clean contract.** The DI context pattern
+(`ActionContext`) makes every action independently testable with a 10-line
+mock. The dispatch routing tests (Phase 8) run fast, require no game
+initialization, and give exact call-site verification.
+
+**The `exploit` action needs special treatment in two places.** Visual display
+(card listing in the console `actions` command) and log format (card index vs
+node ID) both required small carve-outs. These are display concerns, not
+availability concerns — the registry correctly only owns the latter.
+
+**Unified event schema is worth the churn.** Changing from `starnet:action:*`
+to `starnet:action` + `{ actionId }` required touching emitters in three
+files, but the result is one dispatcher instead of 12 handlers. The
+`fromConsole` flag for suppressing log echoes carries over cleanly.
+
+**node-types.js type-specific actions were half-finished.** They had
+`available()` and `desc()` but no `execute()`. This wasn't noticed until
+Phase 9 forced the issue. A more thorough initial audit of action-adjacent
+code would have caught this earlier.
+
+---
+
+## Efficiency
+
+- **Smooth:** All 10 phases executed without backtracking. The incremental
+  commit-per-phase structure kept the work reviewable and made it easy to
+  reason about what each change added.
+- **Friction:** The context window ran out mid-session (before Phase 5 tests
+  were run), requiring a resume. No work was lost but some re-orientation was
+  needed.
+- **Fast:** Phase 6 and 7 migrations were trivially small once the registry
+  was in place — the preparation phases paid for themselves quickly.
+
+---
+
+## Process Improvements
+
+- **Audit ALL action-adjacent code before writing the spec.** node-types.js
+  had action definitions without `execute()` — surfacing this during brainstorm
+  would have scoped them in from the start.
+- **Name event schema changes explicitly in the plan.** The plan described
+  the unified `starnet:action` event format but didn't call out that it
+  requires touching emitters in multiple files. Flagging that as a distinct
+  step (not buried in Phase 9) would have made the scope clearer.
+- **Keep retros short.** Future retros can be lighter — key divergences and
+  one or two insights are sufficient. The value is in the pattern over time,
+  not the length per entry.
+
+---
+
+## Conversation Turns
+
+Approximately 30–35 back-and-forth exchanges (this session spanned two
+context windows due to a mid-session compaction).
+
+---
+
+## Other Highlights
+
+- The `select` global action is purely a console/API concept — there's no
+  corresponding sidebar button (you select by clicking graph nodes). The
+  registry correctly models it as an available action, and the console
+  `actions` command lists it. The sidebar has no equivalent UI element, which
+  is correct.
+- `starnet:action:run-again` intentionally stays outside the registry — it's
+  a meta-action for resetting the game, not a gameplay action with an
+  `available()` predicate.
+- The playtest harness (`scripts/playtest.js`) was not updated this session
+  to use the new unified event format — it dispatches actions differently
+  (directly calling state functions). It remains functional but would benefit
+  from being wired through ActionContext in a future session.

--- a/docs/dev-sessions/2026-02-27-0950-node-action-registry/plan.md
+++ b/docs/dev-sessions/2026-02-27-0950-node-action-registry/plan.md
@@ -1,0 +1,376 @@
+# Plan: Node Action Registry
+
+## Overview
+
+Ten phases, each building cleanly on the last. Tests come *before* the risky migrations — the registry is verified against known expected behavior before any consumer is changed.
+
+1. Extend `ActionDef` typedef + add `ActionContext` to `types.js`
+2. Create `js/node-actions.js` with all core node-contextual actions
+3. Create `js/global-actions.js` with jackout / select / deselect
+4. Export unified `getAvailableActions(node, state)` from `node-actions.js`
+5. **Tests: availability parity** — verify registry output matches current hard-coded behavior for all known game states
+6. Migrate `visual-renderer.js` to use `getAvailableActions()`
+7. Migrate `console.js` to use `getAvailableActions()`
+8. **Tests: dispatch routing** — verify ActionContext methods are called correctly before touching main.js
+9. Build `ActionContext` and simplify `main.js` dispatch loop
+10. Final test pass
+
+Each phase ends in a working, test-passing state. The test phases (5 and 8) act as safety nets that must be green before the riskiest changes proceed.
+
+---
+
+## Phase 1 — Extend types.js
+
+**Context:** `ActionDef` already exists but lacks `execute`. `BehaviorAtom` already uses a `ctx: Object` injection pattern — model `ActionContext` the same way.
+
+**Prompt:**
+
+In `js/types.js`, make two changes:
+
+1. Add an `execute` field to the `ActionDef` typedef:
+```js
+/**
+ * @typedef {{
+ *   id:        string,
+ *   label:     string,
+ *   available: (node: NodeState, state: GameState) => boolean,
+ *   desc:      (node: NodeState, state: GameState) => string,
+ *   execute:   (node: NodeState, state: GameState, ctx: ActionContext, payload?: Object) => void,
+ * }} ActionDef
+ */
+```
+The optional `payload` carries event-specific data (e.g. `exploitId` / `cardIndex` for the exploit action, `nodeId` for select).
+
+2. Add the `ActionContext` typedef immediately after `ActionDef`:
+```js
+/**
+ * Dependency-injection context passed to action execute() functions.
+ * main.js constructs one instance at init, wiring each field to the
+ * corresponding state mutator. Tests can pass mock contexts.
+ * @typedef {{
+ *   getState:      () => GameState,
+ *   selectNode:    (nodeId: string) => void,
+ *   deselectNode:  () => void,
+ *   startProbe:    (nodeId: string) => void,
+ *   cancelProbe:   () => void,
+ *   startExploit:  (nodeId: string, exploitId: string) => void,
+ *   cancelExploit: () => void,
+ *   readNode:      (nodeId: string) => void,
+ *   lootNode:      (nodeId: string) => void,
+ *   ejectIce:      () => void,
+ *   rebootNode:    (nodeId: string) => void,
+ *   jackOut:       () => void,
+ *   logCommand:    (cmd: string) => void,
+ * }} ActionContext
+ */
+```
+
+Note that `logCommand` is on the context — this lets actions (and tests) assert that the correct command string was echoed to the log without importing `log-renderer.js` directly.
+
+Run `make lint` to confirm no type errors introduced.
+
+---
+
+## Phase 2 — Create js/node-actions.js
+
+**Context:** `types.js` now has the full `ActionDef` shape. This phase creates the registry for node-contextual actions. No other files change yet — this is purely additive.
+
+**Prompt:**
+
+Create `js/node-actions.js`. It should:
+
+- Import `ActionDef`, `NodeState`, `GameState`, `ActionContext` types from `./types.js`
+- Define and export `NODE_ACTIONS` as a frozen array of `ActionDef` objects, one per action:
+  - `probe` — available when `node.accessLevel === "locked"` and `!node.probed` and `!node.rebooting` and no active probe on this node
+  - `cancel-probe` — available when `state.activeProbe?.nodeId === node.id`
+  - `exploit` — available when `node.visibility === "accessible"` and `!node.rebooting` and `node.accessLevel !== "owned"` and no exploit currently executing on this node; execute calls `ctx.startExploit(node.id, payload.exploitId)`
+  - `cancel-exploit` — available when `state.executingExploit?.nodeId === node.id`; desc includes the executing card name if available
+  - `read` — available when `(node.accessLevel === "compromised" || node.accessLevel === "owned")` and `!node.read`
+  - `loot` — available when `node.accessLevel === "owned"` and `node.read` and `node.macguffins.some(m => !m.collected)`
+  - `eject` — available when `state.ice?.active && state.ice.attentionNodeId === node.id`
+  - `reboot` — available when `node.accessLevel === "owned"` and `!node.rebooting`
+
+Each action's `execute` calls the appropriate `ctx` method. Actions that require a `nodeId` use `node.id` from the first argument — they do not read it from `payload`.
+
+- Export `getNodeActions(node, state)` that returns `NODE_ACTIONS.filter(a => a.available(node, state))`.
+
+Do not import from `state.js`, `events.js`, or any game-logic module. All mutations go through `ctx`.
+
+Run `make lint`.
+
+---
+
+## Phase 3 — Create js/global-actions.js
+
+**Context:** Node-contextual actions exist. This phase adds the global tier — actions that are available regardless of which node is selected (though they still flow through `available` predicates so future mechanics can gate them).
+
+**Prompt:**
+
+Create `js/global-actions.js`. It should:
+
+- Import relevant types from `./types.js`
+- Define and export `GLOBAL_ACTIONS` as a frozen array of `ActionDef` objects:
+  - `jackout` — always available (`available: () => state.phase === "playing"`); execute calls `ctx.jackOut()`
+  - `select` — available when there exists at least one accessible or revealed node other than the current selection; `payload.nodeId` is the target; execute calls `ctx.selectNode(payload.nodeId)`
+  - `deselect` — available when `state.selectedNodeId !== null`; execute calls `ctx.deselectNode()`
+
+- Export `getGlobalActions(node, state)` that returns `GLOBAL_ACTIONS.filter(a => a.available(node, state))`.
+
+Note: `node` may be `null` for global actions (no node selected). The `available` and `execute` signatures accept `node: NodeState | null`.
+
+Run `make lint`.
+
+---
+
+## Phase 4 — Add getAvailableActions() to node-actions.js
+
+**Context:** Both registries exist. This phase adds the single unified query function that consumers will call. Still no existing files modified.
+
+**Prompt:**
+
+In `js/node-actions.js`, add:
+
+```js
+import { getGlobalActions } from "./global-actions.js";
+import { getActions as getTypeActions } from "./node-types.js";
+
+/**
+ * Returns all available actions for the given node and game state,
+ * merging global actions, node-contextual actions, and type-specific actions.
+ * @param {NodeState | null} node
+ * @param {GameState} state
+ * @returns {ActionDef[]}
+ */
+export function getAvailableActions(node, state) {
+  const global = getGlobalActions(node, state);
+  if (!node) return global;
+  return [
+    ...global,
+    ...getNodeActions(node, state),
+    ...getTypeActions(node, state),
+  ];
+}
+```
+
+Write a quick smoke test: call `getAvailableActions(null, someMinimalState)` and assert `jackout` is present; call it with a locked unprobed node and assert `probe` is present.
+
+Run `make lint` and `make test`.
+
+---
+
+## Phase 5 — Tests: availability parity
+
+**Context:** The registry exists and is callable, but no consumers have been changed yet. This phase writes the full test suite *now*, before migration, to lock in the expected behavior. If a predicate is wrong, we catch it here — not after we've deleted the old code.
+
+**Prompt:**
+
+Create `tests/node-actions.test.js`. The goal is to verify that `getAvailableActions()` returns the same action IDs as the current hard-coded logic in `visual-renderer.js` and `console.js` for a representative set of game states.
+
+For each action, test the `available` predicate with minimal state stubs (only populate fields the predicate actually reads):
+
+```js
+// Example stub shapes
+const lockedNode    = { id: "t", accessLevel: "locked",      probed: false, rebooting: false, visibility: "accessible", macguffins: [], type: "workstation", grade: "D" };
+const compromisedNode = { ...lockedNode, accessLevel: "compromised", probed: true };
+const ownedNode     = { ...lockedNode, accessLevel: "owned",       probed: true, read: true, macguffins: [{ collected: false }] };
+const baseState     = { activeProbe: null, executingExploit: null, ice: null, selectedNodeId: null, phase: "playing", traceSecondsRemaining: null, nodes: {}, player: { hand: [] } };
+```
+
+**Required parity tests** — each verifies the registry matches current behavior:
+
+- `probe`: present for locked+unprobed, absent for locked+probed, absent for compromised
+- `cancel-probe`: present when `state.activeProbe.nodeId === node.id`, absent otherwise
+- `exploit`: present for locked accessible non-rebooting, absent for owned, absent when exploit already executing
+- `cancel-exploit`: present when `state.executingExploit.nodeId === node.id`, absent otherwise
+- `read`: present for compromised+unread, present for owned+unread, absent when already read
+- `loot`: present for owned+read with uncollected macguffins, absent when all collected, absent when unread
+- `eject`: present when ICE active at this node, absent when ICE not at this node
+- `reboot`: present for owned+not-rebooting, absent when rebooting
+- `jackout`: present when `phase === "playing"`, absent when `phase !== "playing"`
+- `deselect`: present when `selectedNodeId` is set, absent when null
+
+**Integration parity tests** — verify exact action sets for composite states:
+
+- Locked unprobed node: actions should be `["jackout", "deselect", "probe"]` (no others)
+- Owned read node with loot: actions should include `jackout`, `deselect`, `reboot`, `loot` but not `probe` or `read`
+- Node with active exploit running: actions should be `["jackout", "deselect", "cancel-exploit"]` only
+
+Run `make test`. All tests must pass before proceeding to Phase 6.
+
+---
+
+## Phase 6 — Migrate visual-renderer.js
+
+**Context:** `getAvailableActions()` is ready and parity-tested. This phase replaces `renderActions()` in `visual-renderer.js`. The parity tests from Phase 5 are the regression net — run them after the change to confirm nothing broke.
+
+**Prompt:**
+
+In `js/visual-renderer.js`:
+
+1. Add import: `import { getAvailableActions } from "./node-actions.js";`
+2. Remove the import of `getActions` from `./node-types.js` (it's now subsumed by `getAvailableActions`)
+3. Replace the entire body of `renderActions(node, state)` with:
+
+```js
+function renderActions(node, state) {
+  const actions = getAvailableActions(node, state);
+  if (actions.length === 0) return `<span class="nd-dim">No actions available.</span>`;
+  return actions.map(a => actionBtn(a.id, a.label, a.desc(node, state))).join("");
+}
+```
+
+The `actionBtn` and `wireActionButtons` helpers are unchanged.
+
+Note: the current `renderActions` has special early-return logic when an exploit is executing (only shows cancel-exploit). This is now handled by the `available` predicates: when `cancel-exploit` is available (exploit executing on this node), `exploit` is not (its predicate excludes nodes with an active exploit). Verify this is correct before removing the early return.
+
+Run `make lint` and `make test`. Then do a manual browser pass: select a node, verify probe/exploit/read/loot/eject/reboot/cancel-* all appear and disappear correctly as game state changes.
+
+---
+
+## Phase 7 — Migrate console.js
+
+**Context:** Visual rendering is migrated and verified. Console is next — it has the same duplication but with richer exploit card listing. That listing stays as a supplement on top of the registry output.
+
+**Prompt:**
+
+In `js/console.js`:
+
+1. Add import: `import { getAvailableActions } from "./node-actions.js";`
+2. Remove the import of `getActions` from `./node-types.js`
+3. In `cmdActions()`, replace all the hard-coded per-action `if` chains for probe / cancel-probe / exploit / cancel-exploit / read / loot / eject / reboot / reconfigure / cancel-trace with a loop over `getAvailableActions(sel, s)`:
+
+```js
+getAvailableActions(sel, s).forEach(a => {
+  lines.push(`  ${a.id.padEnd(24)} — ${a.desc(sel, s)}`);
+});
+```
+
+4. The rich exploit card listing (sorted cards, match indicators, worn/disclosed status) is **not** part of the action registry — it is supplementary detail shown only in the console. Keep it as a separate block immediately after the `exploit` action appears in the output. You can detect that exploit is available by checking `getAvailableActions(sel, s).some(a => a.id === "exploit")`.
+
+5. `jackout`, `select`, and `deselect` will now appear via `getAvailableActions` — remove their hard-coded equivalents from the top of the function.
+
+The cheat command lines at the bottom of `cmdActions()` are out of scope — leave them as-is.
+
+Run `make lint` and `make test`. Verify `actions` command output in browser or playtest harness.
+
+---
+
+## Phase 8 — Tests: dispatch routing
+
+**Context:** Both rendering consumers are migrated. Before touching `main.js` dispatch, write tests that verify `execute()` on each action calls the right `ActionContext` method with the right arguments. These tests use a mock context — no game state initialization required.
+
+**Prompt:**
+
+In `tests/node-actions.test.js`, add a second describe block: `"action execute() routing"`.
+
+For each action, construct a mock `ActionContext` where all methods are no-op stubs (e.g. using simple functions that record calls), then call `action.execute(node, state, ctx, payload)` and assert the correct method was called with the correct arguments:
+
+```js
+function mockCtx(overrides = {}) {
+  return {
+    getState:      () => baseState,
+    selectNode:    () => {},
+    deselectNode:  () => {},
+    startProbe:    () => {},
+    cancelProbe:   () => {},
+    startExploit:  () => {},
+    cancelExploit: () => {},
+    readNode:      () => {},
+    lootNode:      () => {},
+    ejectIce:      () => {},
+    rebootNode:    () => {},
+    jackOut:       () => {},
+    logCommand:    () => {},
+    ...overrides,
+  };
+}
+```
+
+Required routing assertions:
+- `probe`: calls `ctx.startProbe(node.id)`
+- `cancel-probe`: calls `ctx.cancelProbe()`
+- `exploit`: calls `ctx.startExploit(node.id, payload.exploitId)`
+- `cancel-exploit`: calls `ctx.cancelExploit()`
+- `read`: calls `ctx.readNode(node.id)`
+- `loot`: calls `ctx.lootNode(node.id)`
+- `eject`: calls `ctx.ejectIce()`
+- `reboot`: calls `ctx.rebootNode(node.id)`
+- `jackout`: calls `ctx.jackOut()`
+- `select`: calls `ctx.selectNode(payload.nodeId)`
+- `deselect`: calls `ctx.deselectNode()`
+
+Run `make test`. All tests must pass before proceeding to Phase 9.
+
+---
+
+## Phase 9 — Build ActionContext and simplify main.js
+
+**Context:** Both consumers use the registry. Execute routing is verified by tests. This phase wires `execute()` by building `ActionContext` in `main.js` and replacing individual `on("starnet:action:*")` handlers with a unified dispatch loop.
+
+**Prompt:**
+
+In `js/main.js`:
+
+1. Add import: `import { getAvailableActions } from "./node-actions.js";`
+
+2. In the init function, construct an `ActionContext` object:
+```js
+/** @type {import('./types.js').ActionContext} */
+const ctx = {
+  getState,
+  selectNode:    (nodeId) => navigateTo(nodeId),
+  deselectNode:  ()       => navigateAway(),
+  startProbe:    (nodeId) => startProbe(nodeId),
+  cancelProbe:   ()       => cancelProbe(),
+  startExploit:  (nodeId, exploitId) => startExploit(nodeId, exploitId),
+  cancelExploit: ()       => cancelExploit(),
+  readNode:      (nodeId) => readNode(nodeId),
+  lootNode:      (nodeId) => lootNode(nodeId),
+  ejectIce:      ()       => ejectIce(),
+  rebootNode:    (nodeId) => rebootNode(nodeId),
+  jackOut:       ()       => endRun("success"),
+  logCommand:    (cmd)    => logCommand(cmd),
+};
+```
+
+3. Replace all individual `on("starnet:action:*")` handlers with a single unified dispatcher:
+```js
+on("starnet:action", ({ actionId, nodeId, fromConsole, ...payload }) => {
+  const state = getState();
+  const node = nodeId ? state.nodes[nodeId] : (state.selectedNodeId ? state.nodes[state.selectedNodeId] : null);
+  const actions = getAvailableActions(node, state);
+  const action = actions.find(a => a.id === actionId);
+  if (!action) return;
+  if (!fromConsole) ctx.logCommand(actionId + (nodeId ? ` ${nodeId}` : ""));
+  action.execute(node, state, ctx, { nodeId, ...payload });
+});
+```
+
+4. Update `wireActionButtons` in `visual-renderer.js` to emit `starnet:action` with `{ actionId, nodeId }` instead of `starnet:action:${action}`.
+
+5. Update all `emitEvent("starnet:action:*")` calls in `console.js` to use the new unified event shape.
+
+Keep the timer event handlers (`TIMER.ICE_MOVE`, etc.) and `starnet:action:run-again` — those are not part of the action registry.
+
+Run `make lint` and `make test`. Do a full browser playthrough.
+
+---
+
+## Phase 10 — Final test pass
+
+**Context:** Everything is wired. Run the full suite and do a final integration check.
+
+**Prompt:**
+
+Run `make check` (lint + all tests). All must pass.
+
+Then do a full browser playthrough covering:
+- Probe a node → probe button disappears, cancel-probe appears during scan
+- Exploit a node → exploit options appear pre-probe, only matching cards highlighted post-probe
+- Cancel an exploit mid-execution → cancel-exploit disappears, exploit reappears
+- Read, loot, eject, reboot each appear and disappear at the right access levels
+- Type an `actions` command in console → output matches sidebar buttons exactly
+- ICE detection → eject appears; eject → eject disappears
+- Jack out → run ends cleanly
+
+Fix any discrepancies found. The test suite is the source of truth for availability; the browser pass is the source of truth for visual correctness.

--- a/docs/dev-sessions/2026-02-27-0950-node-action-registry/spec.md
+++ b/docs/dev-sessions/2026-02-27-0950-node-action-registry/spec.md
@@ -1,0 +1,99 @@
+# Spec: Node Action Registry
+
+## Problem
+
+"What actions are available on this node?" is currently answered in two separate places:
+
+- **`visual-renderer.js`** (`renderActions()`) — hard-coded `if (node.accessLevel === ...)` chains that produce sidebar buttons
+- **`console.js`** (`cmdActions()`) — a parallel set of hard-coded conditionals that produce the `actions` command output
+
+These two implementations drift. The backlog already documents a real bug from this: `cancel-trace` is present in console output but missing from the sidebar. Any new action, condition change, or new node type requires touching both files.
+
+Type-specific actions (`reconfigure`, `cancel-trace`) are already in a partial registry in `node-types.js` via `getActions()`, but the universal core actions are not.
+
+## Solution
+
+Introduce two new modules that make actions first-class, self-contained objects:
+
+### `js/node-actions.js`
+
+Holds all node-contextual actions — those that operate on a selected node. Each action is a composable `ActionDef` object:
+
+```js
+{
+  id:        string,
+  label:     string,
+  available: (node: NodeState, state: GameState) => boolean,
+  desc:      (node: NodeState, state: GameState) => string,
+  execute:   (node: NodeState, state: GameState, ctx: ActionContext) => void,
+}
+```
+
+Actions to migrate here:
+- `probe` / `cancel-probe`
+- `exploit` / `cancel-exploit`
+- `read`
+- `loot`
+- `eject`
+- `reboot`
+
+### `js/global-actions.js`
+
+Holds actions that are always available regardless of node selection — but still flow through the same `ActionDef` shape and `available` predicate. This means future mechanics (e.g. a node or ICE state that locks jackout) are a single predicate change, not a cross-file surgery.
+
+Actions to migrate here:
+- `jackout`
+- `select`
+- `deselect`
+
+### `ActionContext`
+
+The `execute` function receives a context object rather than importing state mutators directly. This makes actions testable in isolation — a test can pass a mock context with stub functions and assert on what was called.
+
+```js
+/**
+ * @typedef {{
+ *   emit:          (event: string, payload?: any) => void,
+ *   getState:      () => GameState,
+ *   startProbe:    (nodeId: string) => void,
+ *   cancelProbe:   () => void,
+ *   startExploit:  (nodeId: string, cardIndex: number) => void,
+ *   cancelExploit: () => void,
+ *   readNode:      (nodeId: string) => void,
+ *   lootNode:      (nodeId: string) => void,
+ *   ejectIce:      (nodeId: string) => void,
+ *   rebootNode:    (nodeId: string) => void,
+ *   jackOut:       () => void,
+ *   selectNode:    (nodeId: string) => void,
+ *   deselectNode:  () => void,
+ * }} ActionContext
+ ```
+
+`main.js` constructs a single `ActionContext` at init, wiring each field to the appropriate state mutator. The dispatch loop becomes: look up action by id → call `execute(node, state, ctx)`.
+
+### `getAvailableActions(node, state)`
+
+A unified function (likely exported from `node-actions.js` or a thin `actions.js` facade) that merges:
+1. Global actions from `global-actions.js`
+2. Node-contextual actions from `node-actions.js`
+3. Type-specific actions from `node-types.js` (via existing `getActions()`)
+
+Both `visual-renderer.js` and `console.js` call this single function to get the action list. The sidebar renders buttons from it; the console prints the list from it.
+
+## Acceptance Criteria
+
+1. `js/node-actions.js` exists with all core node-contextual actions as `ActionDef` objects
+2. `js/global-actions.js` exists with all global actions as `ActionDef` objects
+3. `ActionContext` typedef added to `js/types.js`
+4. `visual-renderer.js` derives its sidebar action buttons entirely from `getAvailableActions()`
+5. `console.js` derives its `actions` command output entirely from `getAvailableActions()`
+6. `main.js` dispatch loop is reduced to: look up action by id → call `execute(node, state, ctx)`
+7. All existing tests pass
+8. New unit tests cover the `available` predicates for all migrated actions
+
+## Out of Scope
+
+- **Moving type-specific actions out of `node-types.js`** — `reconfigure` and `cancel-trace` stay where they are. A future session could merge all action definitions into a single location, but that's a bigger refactor.
+- **New actions or gameplay mechanics** — this session is purely structural migration.
+- **Broader `js/` directory restructuring** — noted as a future concern; for now the flat file structure is retained.
+- **Applying the context/dispatch pattern elsewhere** — `ActionContext` establishes the pattern for this module; propagating it to other parts of the codebase is future work.

--- a/js/action-context.js
+++ b/js/action-context.js
@@ -1,0 +1,62 @@
+// @ts-check
+// ActionContext factory and unified action dispatcher.
+// Extracted from main.js so both are independently testable.
+
+/** @typedef {import('./types.js').ActionContext} ActionContext */
+
+import { getState, reconfigureNode, readNode, lootNode, endRun, ejectIce, rebootNode } from "./state.js";
+import { startExploit, cancelExploit } from "./exploit-exec.js";
+import { startProbe, cancelProbe } from "./probe-exec.js";
+import { navigateTo, navigateAway } from "./navigation.js";
+import { cancelTraceCountdown } from "./alert.js";
+import { getAvailableActions } from "./node-actions.js";
+import { on, emitEvent, E } from "./events.js";
+
+/**
+ * Build the wired ActionContext — maps abstract ctx methods to concrete state mutators.
+ * @returns {ActionContext}
+ */
+export function buildActionContext() {
+  return {
+    getState,
+    selectNode:       (nodeId) => navigateTo(nodeId),
+    deselectNode:     ()       => navigateAway(),
+    startProbe:       (nodeId) => startProbe(nodeId),
+    cancelProbe:      ()       => cancelProbe(),
+    startExploit:     (nodeId, exploitId) => startExploit(nodeId, exploitId),
+    cancelExploit:    ()       => cancelExploit(),
+    readNode:         (nodeId) => readNode(nodeId),
+    lootNode:         (nodeId) => lootNode(nodeId),
+    ejectIce:         ()       => ejectIce(),
+    rebootNode:       (nodeId) => rebootNode(nodeId),
+    jackOut:          ()       => endRun("success"),
+    reconfigureNode:  (nodeId) => reconfigureNode(nodeId),
+    cancelTrace:      ()       => cancelTraceCountdown(),
+  };
+}
+
+/**
+ * Register the unified starnet:action dispatcher.
+ * All UI and console actions fire "starnet:action" with { actionId, nodeId?, ...payload }.
+ * fromConsole suppresses the COMMAND_ISSUED echo (console already logged it via submitCommand).
+ * @param {ActionContext} ctx
+ */
+export function initActionDispatcher(ctx) {
+  on("starnet:action", ({ actionId, nodeId, fromConsole, ...payload }) => {
+    const state = ctx.getState();
+    const node = nodeId
+      ? state.nodes[nodeId]
+      : (state.selectedNodeId ? state.nodes[state.selectedNodeId] : null);
+    const available = getAvailableActions(node, state);
+    const action = available.find((a) => a.id === actionId);
+    if (!action?.execute) return;
+    if (!fromConsole) {
+      // For exploit, log the card reference rather than the nodeId (matches console output)
+      const logStr = (actionId === "exploit" && (payload.cardIndex ?? payload.exploitId))
+        ? `exploit ${payload.cardIndex ?? payload.exploitId}`
+        : actionId + (nodeId ? ` ${nodeId}` : "");
+      emitEvent(E.COMMAND_ISSUED, { cmd: logStr });
+    }
+    action.execute(node, state, ctx, { nodeId, ...payload });
+  });
+}

--- a/js/action-context.js
+++ b/js/action-context.js
@@ -36,6 +36,23 @@ export function buildActionContext() {
 }
 
 /**
+ * Build the node click handler for graph.js — translates a Cytoscape tap
+ * into a select or deselect action event based on current selection state.
+ * @returns {(nodeId: string) => void}
+ */
+export function buildNodeClickHandler() {
+  return (nodeId) => {
+    const s = getState();
+    const node = s.nodes[nodeId];
+    if (!node || node.visibility === "hidden") return;
+    emitEvent("starnet:action", {
+      actionId: s.selectedNodeId === nodeId ? "deselect" : "select",
+      nodeId,
+    });
+  };
+}
+
+/**
  * Register the unified starnet:action dispatcher.
  * All UI and console actions fire "starnet:action" with { actionId, nodeId?, ...payload }.
  * fromConsole suppresses the COMMAND_ISSUED echo (console already logged it via submitCommand).

--- a/js/action-context.js
+++ b/js/action-context.js
@@ -45,9 +45,10 @@ export function buildNodeClickHandler() {
     const s = getState();
     const node = s.nodes[nodeId];
     if (!node || node.visibility === "hidden") return;
+    const isDeselect = s.selectedNodeId === nodeId;
     emitEvent("starnet:action", {
-      actionId: s.selectedNodeId === nodeId ? "deselect" : "select",
-      nodeId,
+      actionId: isDeselect ? "deselect" : "select",
+      ...(isDeselect ? {} : { nodeId }),
     });
   };
 }

--- a/js/console.js
+++ b/js/console.js
@@ -8,7 +8,7 @@
 
 import { getState, isIceVisible } from "./state.js";
 import { addLogEntry, getRecentLog } from "./log.js";
-import { emitEvent } from "./events.js";
+import { emitEvent, on, E } from "./events.js";
 import { getVisibleTimers } from "./timers.js";
 import { exploitSortKey } from "./exploits.js";
 import { getActions } from "./node-types.js";
@@ -30,14 +30,14 @@ export function initConsole() {
   const input = /** @type {HTMLInputElement|null} */ (document.getElementById("console-input"));
   if (!input) return;
 
+  on(E.COMMAND_ISSUED, ({ cmd }) => pushHistory(cmd));
+
   input.addEventListener("keydown", (evt) => {
     if (evt.key === "Enter") {
       const raw = input.value.trim();
       input.value = "";
       historyIndex = -1;
       if (!raw) return;
-      history.unshift(raw);
-      if (history.length > 50) history.length = 50;
       submitCommand(raw);
 
     } else if (evt.key === "ArrowUp") {
@@ -72,7 +72,7 @@ export function runCommand(raw) {
 // ── Command dispatch ──────────────────────────────────────
 
 function submitCommand(raw) {
-  addLogEntry(`> ${raw}`, "command");
+  emitEvent(E.COMMAND_ISSUED, { cmd: raw });
   const tokens = raw.trim().split(/\s+/);
   const verb = tokens[0].toLowerCase();
   const args = tokens.slice(1);

--- a/js/console.js
+++ b/js/console.js
@@ -174,8 +174,8 @@ function resolveCard(token) {
   return null;
 }
 
-function dispatch(eventName, detail = {}) {
-  emitEvent(eventName, { ...detail, fromConsole: true });
+function dispatch(actionId, detail = {}) {
+  emitEvent("starnet:action", { actionId, ...detail, fromConsole: true });
 }
 
 // ── Command implementations ───────────────────────────────
@@ -184,17 +184,17 @@ function cmdSelect(args) {
   if (args.length < 1) { addLogEntry("Usage: select <node>", "error"); return; }
   const node = resolveNode(args[0]);
   if (!node) return;
-  dispatch("starnet:action:select", { nodeId: node.id });
+  dispatch("select", { nodeId: node.id });
 }
 
 function cmdDeselect() {
-  dispatch("starnet:action:deselect");
+  dispatch("deselect");
 }
 
 function cmdProbe(args) {
   const node = args.length >= 1 ? resolveNode(args[0]) : resolveImplicitNode();
   if (!node) return;
-  dispatch("starnet:action:probe", { nodeId: node.id });
+  dispatch("probe", { nodeId: node.id });
 }
 
 function cmdExploit(args) {
@@ -205,14 +205,14 @@ function cmdExploit(args) {
     if (!node) return;
     const card = resolveCard(args.slice(1).join(" "));
     if (!card) return;
-    dispatch("starnet:action:launch-exploit", { nodeId: node.id, exploitId: card.id });
+    dispatch("exploit", { nodeId: node.id, exploitId: card.id });
   } else if (args.length === 1 && s.selectedNodeId) {
     // Implicit form: exploit <card>  (uses selected node)
     const node = resolveImplicitNode();
     if (!node) return;
     const card = resolveCard(args[0]);
     if (!card) return;
-    dispatch("starnet:action:launch-exploit", { nodeId: node.id, exploitId: card.id });
+    dispatch("exploit", { nodeId: node.id, exploitId: card.id });
   } else {
     addLogEntry("Usage: exploit <node> <card>  (or select a node first: exploit <card>)", "error");
   }
@@ -221,19 +221,19 @@ function cmdExploit(args) {
 function cmdRead(args) {
   const node = args.length >= 1 ? resolveNode(args[0]) : resolveImplicitNode();
   if (!node) return;
-  dispatch("starnet:action:read", { nodeId: node.id });
+  dispatch("read", { nodeId: node.id });
 }
 
 function cmdLoot(args) {
   const node = args.length >= 1 ? resolveNode(args[0]) : resolveImplicitNode();
   if (!node) return;
-  dispatch("starnet:action:loot", { nodeId: node.id });
+  dispatch("loot", { nodeId: node.id });
 }
 
 function cmdReconfigure(args) {
   const node = args.length >= 1 ? resolveNode(args[0]) : resolveImplicitNode();
   if (!node) return;
-  dispatch("starnet:action:reconfigure", { nodeId: node.id });
+  dispatch("reconfigure", { nodeId: node.id });
 }
 
 function cmdEject() {
@@ -242,7 +242,7 @@ function cmdEject() {
     addLogEntry("No ICE present at selected node.", "error");
     return;
   }
-  dispatch("starnet:action:eject", { nodeId: s.selectedNodeId });
+  dispatch("eject", { nodeId: s.selectedNodeId });
 }
 
 function cmdReboot(args) {
@@ -252,7 +252,7 @@ function cmdReboot(args) {
     addLogEntry(`${node.label}: must be owned to reboot.`, "error");
     return;
   }
-  dispatch("starnet:action:reboot", { nodeId: node.id });
+  dispatch("reboot", { nodeId: node.id });
 }
 
 function cmdActions() {
@@ -665,7 +665,7 @@ function cmdCancelProbe() {
     addLogEntry("No probe scan in progress.", "error");
     return;
   }
-  dispatch("starnet:action:cancel-probe");
+  dispatch("cancel-probe");
 }
 
 function cmdCancelExploit() {
@@ -674,7 +674,7 @@ function cmdCancelExploit() {
     addLogEntry("No exploit execution in progress.", "error");
     return;
   }
-  dispatch("starnet:action:cancel-exploit");
+  dispatch("cancel-exploit");
 }
 
 function cmdCancelTrace() {
@@ -683,11 +683,11 @@ function cmdCancelTrace() {
   if (!sel) { addLogEntry("No node selected.", "error"); return; }
   const available = getActions(sel, s).find((a) => a.id === "cancel-trace");
   if (!available) { addLogEntry(`${sel.label}: cancel-trace not available.`, "error"); return; }
-  dispatch("starnet:action:cancel-trace", { nodeId: sel.id });
+  dispatch("cancel-trace", { nodeId: sel.id });
 }
 
 function cmdJackout() {
-  dispatch("starnet:action:jackout");
+  dispatch("jackout");
 }
 
 function cmdCheat(args) {

--- a/js/console.js
+++ b/js/console.js
@@ -12,6 +12,7 @@ import { emitEvent } from "./events.js";
 import { getVisibleTimers } from "./timers.js";
 import { exploitSortKey } from "./exploits.js";
 import { getActions } from "./node-types.js";
+import { getAvailableActions } from "./node-actions.js";
 
 const VERBS = ["select", "deselect", "probe", "exploit", "eject", "reboot", "read", "loot", "reconfigure", "cancel-probe", "cancel-exploit", "cancel-trace", "jackout", "status", "actions", "log", "help", "cheat"];
 const STATUS_NOUNS = ["summary", "ice", "hand", "node", "alert", "mission"];
@@ -257,17 +258,19 @@ function cmdReboot(args) {
 function cmdActions() {
   const s = getState();
   const sel = s.selectedNodeId ? s.nodes[s.selectedNodeId] : null;
+  const actions = getAvailableActions(sel, s);
+  const has = new Set(actions.map((a) => a.id));
   const lines = ["AVAILABLE ACTIONS", "─────────────────"];
 
-  // jackout always available
-  lines.push("  jackout                  — disconnect and end run");
+  if (has.has("jackout")) {
+    lines.push("  jackout                  — disconnect and end run");
+  }
 
-  // select: list accessible non-rebooting nodes + revealed nodes (traverse)
-  const accessible = Object.values(s.nodes)
-    .filter((n) => n.visibility === "accessible" && !n.rebooting && n.id !== s.selectedNodeId);
-  const revealed = Object.values(s.nodes)
-    .filter((n) => n.visibility === "revealed" && n.id !== s.selectedNodeId);
-  if (accessible.length > 0 || revealed.length > 0) {
+  if (has.has("select")) {
+    const accessible = Object.values(s.nodes)
+      .filter((n) => n.visibility === "accessible" && !n.rebooting && n.id !== s.selectedNodeId);
+    const revealed = Object.values(s.nodes)
+      .filter((n) => n.visibility === "revealed" && n.id !== s.selectedNodeId);
     const parts = [];
     if (accessible.length > 0) parts.push(`accessible: ${accessible.map((n) => n.id).join(", ")}`);
     if (revealed.length > 0) parts.push(`traverse: ${revealed.map((n) => n.id).join(", ")}`);
@@ -275,19 +278,18 @@ function cmdActions() {
   }
 
   if (sel) {
-    lines.push("  deselect                 — clear selection");
+    if (has.has("deselect")) lines.push("  deselect                 — clear selection");
 
-    if (s.activeProbe?.nodeId === sel.id) {
+    if (has.has("cancel-probe")) {
       lines.push(`  cancel-probe             — abort vulnerability scan`);
-    } else if (!sel.probed && !sel.rebooting) {
+    } else if (has.has("probe")) {
       lines.push(`  probe                    — scan ${sel.id} for vulnerabilities`);
     }
 
-    if (s.executingExploit?.nodeId === sel.id) {
-      const execCard = s.player.hand.find((c) => c.id === s.executingExploit.exploitId);
+    if (has.has("cancel-exploit")) {
+      const execCard = s.player.hand.find((c) => c.id === s.executingExploit?.exploitId);
       lines.push(`  cancel-exploit           — abort ${execCard?.name ?? "exploit"} execution`);
-    } else if (sel.visibility === "accessible" && !sel.rebooting && sel.accessLevel !== "owned") {
-      // exploit: list all cards sorted by match
+    } else if (has.has("exploit")) {
       const sorted = [...s.player.hand].sort(
         (a, b) => exploitSortKey(a, sel) - exploitSortKey(b, sel)
       );
@@ -306,22 +308,12 @@ function cmdActions() {
       }
     }
 
-    if ((sel.accessLevel === "compromised" || sel.accessLevel === "owned") && !sel.read) {
-      lines.push(`  read                     — scan ${sel.id} contents`);
-    }
+    if (has.has("read"))   lines.push(`  read                     — scan ${sel.id} contents`);
+    if (has.has("loot"))   lines.push(`  loot                     — collect items from ${sel.id}`);
+    if (has.has("eject"))  lines.push(`  eject                    — push ICE to adjacent node`);
+    if (has.has("reboot")) lines.push(`  reboot                   — send ICE home, take ${sel.id} offline briefly`);
 
-    if (sel.accessLevel === "owned" && sel.read && sel.macguffins.some((m) => !m.collected)) {
-      lines.push(`  loot                     — collect items from ${sel.id}`);
-    }
-
-    if (s.ice?.active && s.ice.attentionNodeId === s.selectedNodeId) {
-      lines.push(`  eject                    — push ICE to adjacent node`);
-    }
-
-    if (sel.accessLevel === "owned" && !sel.rebooting) {
-      lines.push(`  reboot                   — send ICE home, take ${sel.id} offline briefly`);
-    }
-
+    // Type-specific actions (reconfigure, cancel-trace, etc.)
     getActions(sel, s).forEach((a) => {
       lines.push(`  ${a.id.padEnd(24)} — ${a.desc(sel, s)}`);
     });

--- a/js/events.js
+++ b/js/events.js
@@ -70,4 +70,6 @@ export const E = Object.freeze({
 
   MISSION_STARTED:      "mission:started",
   MISSION_COMPLETE:     "mission:complete",
+
+  COMMAND_ISSUED:       "command:issued",
 });

--- a/js/global-actions.js
+++ b/js/global-actions.js
@@ -1,0 +1,57 @@
+// @ts-check
+/**
+ * Global action registry.
+ * Actions here are available regardless of which node is selected.
+ * They still flow through available() predicates so future mechanics
+ * (e.g. a node state that disables jackout) are a single predicate change.
+ *
+ * node may be null when no node is selected.
+ */
+
+/** @typedef {import('./types.js').ActionDef} ActionDef */
+/** @typedef {import('./types.js').NodeState} NodeState */
+/** @typedef {import('./types.js').GameState} GameState */
+
+/** @type {readonly ActionDef[]} */
+export const GLOBAL_ACTIONS = Object.freeze([
+  {
+    id: "jackout",
+    label: "JACK OUT",
+    available: (_node, state) => state.phase === "playing",
+    desc: () => "Disconnect and end run.",
+    execute: (_node, _state, ctx) => ctx.jackOut(),
+  },
+
+  {
+    id: "select",
+    label: "SELECT",
+    available: (_node, state) =>
+      Object.values(state.nodes).some(
+        (n) =>
+          (n.visibility === "accessible" || n.visibility === "revealed") &&
+          !n.rebooting &&
+          n.id !== state.selectedNodeId
+      ),
+    desc: () => "Select a node.",
+    execute: (_node, _state, ctx, payload) =>
+      ctx.selectNode(/** @type {any} */ (payload)?.nodeId),
+  },
+
+  {
+    id: "deselect",
+    label: "DESELECT",
+    available: (_node, state) => state.selectedNodeId !== null,
+    desc: () => "Clear selection.",
+    execute: (_node, _state, ctx) => ctx.deselectNode(),
+  },
+]);
+
+/**
+ * Returns all global actions whose available() predicate is true.
+ * @param {NodeState | null} node
+ * @param {GameState} state
+ * @returns {ActionDef[]}
+ */
+export function getGlobalActions(node, state) {
+  return GLOBAL_ACTIONS.filter((a) => a.available(node, state));
+}

--- a/js/graph.js
+++ b/js/graph.js
@@ -732,6 +732,16 @@ function drawIceTrace(fromId, toId, nodeStates) {
   cy.getElementById(toId).addClass("ice-resident");
 }
 
+export function fitGraph(cy) {
+  const visible = cy.nodes(".accessible, .revealed");
+  if (visible.length <= 1) {
+    cy.zoom(1.5);
+    cy.center(visible);
+  } else {
+    cy.fit(visible, 50);
+  }
+}
+
 // Flash a node with a brief animated pulse.
 // type: 'success' (cyan→white→cyan), 'failure' (red flash), 'reveal' (dim cyan pulse)
 export function flashNode(nodeId, type) {

--- a/js/log-renderer.js
+++ b/js/log-renderer.js
@@ -48,6 +48,8 @@ export function initLogRenderer() {
     renderLogPane();
   });
 
+  on(E.COMMAND_ISSUED, (/** @type {{ cmd: string }} */ { cmd }) => add(`> ${cmd}`, "command"));
+
   // ── Node events ──────────────────────────────────────────
   // Batch multiple simultaneous NODE_REVEALED events (e.g. hub node with several hidden
   // neighbors) into a single log entry via a microtask, rather than N identical lines.

--- a/js/main.js
+++ b/js/main.js
@@ -14,6 +14,7 @@ import { handleTraceTick, cancelTraceCountdown } from "./alert.js";
 import { initVisualRenderer } from "./visual-renderer.js";
 import { initLogRenderer } from "./log-renderer.js";
 import { initNodeLifecycle } from "./node-lifecycle.js";
+import { getAvailableActions } from "./node-actions.js";
 
 // Log a UI-sourced command to both the log pane and the console history.
 function logCommand(cmd) {
@@ -24,7 +25,7 @@ function logCommand(cmd) {
 function init() {
   initLogRenderer();
   const cy = initGraph(NETWORK, onNodeClick, () => {
-    emitEvent("starnet:action:deselect", {});
+    emitEvent("starnet:action", { actionId: "deselect" });
   });
   addIceNode();
   initConsole();
@@ -40,84 +41,56 @@ function init() {
   // LLM playtesting API — accessible via browser console or Playwright evaluate
   window.starnet = { cmd: runCommand, state: getState };
 
+  // ── ActionContext ─────────────────────────────────────────
+  const ctx = {
+    getState,
+    selectNode:       (nodeId) => navigateTo(nodeId),
+    deselectNode:     ()       => navigateAway(),
+    startProbe:       (nodeId) => startProbe(nodeId),
+    cancelProbe:      ()       => cancelProbe(),
+    startExploit:     (nodeId, exploitId) => startExploit(nodeId, exploitId),
+    cancelExploit:    ()       => cancelExploit(),
+    readNode:         (nodeId) => readNode(nodeId),
+    lootNode:         (nodeId) => lootNode(nodeId),
+    ejectIce:         ()       => ejectIce(),
+    rebootNode:       (nodeId) => rebootNode(nodeId),
+    jackOut:          ()       => endRun("success"),
+    logCommand,
+    reconfigureNode:  (nodeId) => reconfigureNode(nodeId),
+    cancelTrace:      ()       => cancelTraceCountdown(),
+  };
+
   // Wire HUD jack-out button
   document.getElementById("jack-out-btn").addEventListener("click", () => {
-    emitEvent("starnet:action:jackout", {});
+    emitEvent("starnet:action", { actionId: "jackout" });
   });
 
-  // ── Action event listeners ────────────────────────────────
-  // Click-sourced events (no fromConsole flag) echo their equivalent command to the log.
-
-  on("starnet:action:select", ({ nodeId, fromConsole }) => {
-    if (!fromConsole) logCommand(`select ${nodeId}`);
-    navigateTo(nodeId);
+  // ── Unified action dispatcher ─────────────────────────────
+  // All UI and console actions fire "starnet:action" with { actionId, nodeId?, ...payload }.
+  // fromConsole suppresses the command echo (console already logged it).
+  on("starnet:action", ({ actionId, nodeId, fromConsole, ...payload }) => {
+    const state = getState();
+    const node = nodeId
+      ? state.nodes[nodeId]
+      : (state.selectedNodeId ? state.nodes[state.selectedNodeId] : null);
+    const available = getAvailableActions(node, state);
+    const action = available.find((a) => a.id === actionId);
+    if (!action?.execute) return;
+    if (!fromConsole) {
+      // For exploit, log the card reference rather than the nodeId (matches console output)
+      const logStr = (actionId === "exploit" && (payload.cardIndex ?? payload.exploitId))
+        ? `exploit ${payload.cardIndex ?? payload.exploitId}`
+        : actionId + (nodeId ? ` ${nodeId}` : "");
+      ctx.logCommand(logStr);
+    }
+    action.execute(node, state, ctx, { nodeId, ...payload });
   });
 
-  on("starnet:action:deselect", ({ fromConsole } = {}) => {
-    if (!fromConsole) logCommand("deselect");
-    navigateAway();
-  });
-
-  on(TIMER.ICE_MOVE,    () => handleIceTick());
-  on(TIMER.ICE_DETECT,  (payload) => handleIceDetect(payload));
-  on(TIMER.TRACE_TICK,  () => handleTraceTick());
+  on(TIMER.ICE_MOVE,     () => handleIceTick());
+  on(TIMER.ICE_DETECT,   (payload) => handleIceDetect(payload));
+  on(TIMER.TRACE_TICK,   () => handleTraceTick());
   on(TIMER.EXPLOIT_EXEC, (payload) => handleExploitExecTimer(payload));
   on(TIMER.PROBE_SCAN,   (payload) => handleProbeScanTimer(payload));
-
-  on("starnet:action:probe", ({ nodeId, fromConsole }) => {
-    if (!fromConsole) logCommand(`probe ${nodeId}`);
-    startProbe(nodeId);
-  });
-
-  on("starnet:action:cancel-probe", ({ fromConsole } = {}) => {
-    if (!fromConsole) logCommand("cancel-probe");
-    cancelProbe();
-  });
-
-  on("starnet:action:launch-exploit", ({ nodeId, exploitId, cardIndex, fromConsole }) => {
-    if (!fromConsole) logCommand(`exploit ${cardIndex ?? exploitId}`);
-    startExploit(nodeId, exploitId);
-  });
-
-  on("starnet:action:cancel-exploit", ({ fromConsole } = {}) => {
-    if (!fromConsole) logCommand("cancel-exploit");
-    cancelExploit();
-  });
-
-  on("starnet:action:reconfigure", ({ nodeId, fromConsole }) => {
-    if (!fromConsole) logCommand(`reconfigure ${nodeId}`);
-    reconfigureNode(nodeId);
-  });
-
-  on("starnet:action:read", ({ nodeId, fromConsole }) => {
-    if (!fromConsole) logCommand(`read ${nodeId}`);
-    readNode(nodeId);
-  });
-
-  on("starnet:action:loot", ({ nodeId, fromConsole }) => {
-    if (!fromConsole) logCommand(`loot ${nodeId}`);
-    lootNode(nodeId);
-  });
-
-  on("starnet:action:cancel-trace", ({ fromConsole }) => {
-    if (!fromConsole) logCommand(`cancel-trace`);
-    cancelTraceCountdown();
-  });
-
-  on("starnet:action:jackout", ({ fromConsole } = {}) => {
-    if (!fromConsole) logCommand(`jackout`);
-    endRun("success");
-  });
-
-  on("starnet:action:eject", ({ fromConsole } = {}) => {
-    if (!fromConsole) logCommand(`eject`);
-    ejectIce();
-  });
-
-  on("starnet:action:reboot", ({ nodeId, fromConsole }) => {
-    if (!fromConsole) logCommand(`reboot ${nodeId}`);
-    rebootNode(nodeId);
-  });
 
   on(TIMER.REBOOT_COMPLETE, (payload) => {
     completeReboot(payload.nodeId);
@@ -148,9 +121,9 @@ function onNodeClick(nodeId) {
   const node = s.nodes[nodeId];
   if (!node || node.visibility === "hidden") return;
   if (s.selectedNodeId === nodeId) {
-    emitEvent("starnet:action:deselect", {});
+    emitEvent("starnet:action", { actionId: "deselect" });
   } else {
-    emitEvent("starnet:action:select", { nodeId });
+    emitEvent("starnet:action", { actionId: "select", nodeId });
   }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -12,11 +12,11 @@ import { handleTraceTick } from "./alert.js";
 import { initVisualRenderer } from "./visual-renderer.js";
 import { initLogRenderer } from "./log-renderer.js";
 import { initNodeLifecycle } from "./node-lifecycle.js";
-import { buildActionContext, initActionDispatcher } from "./action-context.js";
+import { buildActionContext, initActionDispatcher, buildNodeClickHandler } from "./action-context.js";
 
 function init() {
   initLogRenderer();
-  const cy = initGraph(NETWORK, onNodeClick, () => {
+  const cy = initGraph(NETWORK, buildNodeClickHandler(), () => {
     emitEvent("starnet:action", { actionId: "deselect" });
   });
   addIceNode();
@@ -58,17 +58,6 @@ function init() {
     addIceNode();
     startIce();
   });
-}
-
-function onNodeClick(nodeId) {
-  const s = getState();
-  const node = s.nodes[nodeId];
-  if (!node || node.visibility === "hidden") return;
-  if (s.selectedNodeId === nodeId) {
-    emitEvent("starnet:action", { actionId: "deselect" });
-  } else {
-    emitEvent("starnet:action", { actionId: "select", nodeId });
-  }
 }
 
 document.addEventListener("DOMContentLoaded", init);

--- a/js/main.js
+++ b/js/main.js
@@ -1,26 +1,18 @@
 // @ts-nocheck — main.js is DOM event wiring; CustomEvent.detail typing noise outweighs benefit here.
 import { NETWORK } from "../data/network.js";
-import { initGraph, getCy, addIceNode } from "./graph.js";
-import { initState, getState, reconfigureNode, readNode, lootNode, endRun, ejectIce, rebootNode, completeReboot, emit } from "./state.js";
-import { startExploit, cancelExploit, handleExploitExecTimer } from "./exploit-exec.js";
-import { startProbe, cancelProbe, handleProbeScanTimer } from "./probe-exec.js";
-import { navigateTo, navigateAway } from "./navigation.js";
-import { addLogEntry } from "./log.js";
+import { initGraph, getCy, addIceNode, fitGraph } from "./graph.js";
+import { initState, getState, completeReboot } from "./state.js";
+import { handleExploitExecTimer } from "./exploit-exec.js";
+import { handleProbeScanTimer } from "./probe-exec.js";
 import { startIce, handleIceTick, handleIceDetect } from "./ice.js";
-import { initConsole, runCommand, pushHistory } from "./console.js";
+import { initConsole, runCommand } from "./console.js";
 import { on, emitEvent, E } from "./events.js";
 import { tick, TICK_MS, TIMER, getVisibleTimers } from "./timers.js";
-import { handleTraceTick, cancelTraceCountdown } from "./alert.js";
+import { handleTraceTick } from "./alert.js";
 import { initVisualRenderer } from "./visual-renderer.js";
 import { initLogRenderer } from "./log-renderer.js";
 import { initNodeLifecycle } from "./node-lifecycle.js";
-import { getAvailableActions } from "./node-actions.js";
-
-// Log a UI-sourced command to both the log pane and the console history.
-function logCommand(cmd) {
-  addLogEntry(`> ${cmd}`, "command");
-  pushHistory(cmd);
-}
+import { buildActionContext, initActionDispatcher } from "./action-context.js";
 
 function init() {
   initLogRenderer();
@@ -41,50 +33,13 @@ function init() {
   // LLM playtesting API — accessible via browser console or Playwright evaluate
   window.starnet = { cmd: runCommand, state: getState };
 
-  // ── ActionContext ─────────────────────────────────────────
-  const ctx = {
-    getState,
-    selectNode:       (nodeId) => navigateTo(nodeId),
-    deselectNode:     ()       => navigateAway(),
-    startProbe:       (nodeId) => startProbe(nodeId),
-    cancelProbe:      ()       => cancelProbe(),
-    startExploit:     (nodeId, exploitId) => startExploit(nodeId, exploitId),
-    cancelExploit:    ()       => cancelExploit(),
-    readNode:         (nodeId) => readNode(nodeId),
-    lootNode:         (nodeId) => lootNode(nodeId),
-    ejectIce:         ()       => ejectIce(),
-    rebootNode:       (nodeId) => rebootNode(nodeId),
-    jackOut:          ()       => endRun("success"),
-    logCommand,
-    reconfigureNode:  (nodeId) => reconfigureNode(nodeId),
-    cancelTrace:      ()       => cancelTraceCountdown(),
-  };
-
   // Wire HUD jack-out button
   document.getElementById("jack-out-btn").addEventListener("click", () => {
     emitEvent("starnet:action", { actionId: "jackout" });
   });
 
-  // ── Unified action dispatcher ─────────────────────────────
-  // All UI and console actions fire "starnet:action" with { actionId, nodeId?, ...payload }.
-  // fromConsole suppresses the command echo (console already logged it).
-  on("starnet:action", ({ actionId, nodeId, fromConsole, ...payload }) => {
-    const state = getState();
-    const node = nodeId
-      ? state.nodes[nodeId]
-      : (state.selectedNodeId ? state.nodes[state.selectedNodeId] : null);
-    const available = getAvailableActions(node, state);
-    const action = available.find((a) => a.id === actionId);
-    if (!action?.execute) return;
-    if (!fromConsole) {
-      // For exploit, log the card reference rather than the nodeId (matches console output)
-      const logStr = (actionId === "exploit" && (payload.cardIndex ?? payload.exploitId))
-        ? `exploit ${payload.cardIndex ?? payload.exploitId}`
-        : actionId + (nodeId ? ` ${nodeId}` : "");
-      ctx.logCommand(logStr);
-    }
-    action.execute(node, state, ctx, { nodeId, ...payload });
-  });
+  const ctx = buildActionContext();
+  initActionDispatcher(ctx);
 
   on(TIMER.ICE_MOVE,     () => handleIceTick());
   on(TIMER.ICE_DETECT,   (payload) => handleIceDetect(payload));
@@ -103,17 +58,6 @@ function init() {
     addIceNode();
     startIce();
   });
-}
-
-function fitGraph(cy) {
-  const visible = cy.nodes(".accessible, .revealed");
-  if (visible.length <= 1) {
-    // Single node — fit would zoom in absurdly; just center at a sane zoom level
-    cy.zoom(1.5);
-    cy.center(visible);
-  } else {
-    cy.fit(visible, 50);
-  }
 }
 
 function onNodeClick(nodeId) {

--- a/js/node-actions.js
+++ b/js/node-actions.js
@@ -1,0 +1,136 @@
+// @ts-check
+/**
+ * Node-contextual action registry.
+ * Actions here operate on a selected node. Each is a self-contained ActionDef:
+ * available predicate, display desc, and execute handler (via injected ctx).
+ *
+ * No imports from state.js, events.js, or game-logic modules — all mutations
+ * go through ActionContext (dependency injection for testability).
+ */
+
+/** @typedef {import('./types.js').ActionDef} ActionDef */
+/** @typedef {import('./types.js').NodeState} NodeState */
+/** @typedef {import('./types.js').GameState} GameState */
+/** @typedef {import('./types.js').ActionContext} ActionContext */
+
+/** @type {readonly ActionDef[]} */
+export const NODE_ACTIONS = Object.freeze([
+  {
+    id: "probe",
+    label: "PROBE",
+    available: (node, state) =>
+      node.accessLevel === "locked" &&
+      !node.probed &&
+      !node.rebooting &&
+      state.activeProbe?.nodeId !== node.id,
+    desc: () => "Reveal vulnerabilities. Raises local alert.",
+    execute: (node, _state, ctx) => ctx.startProbe(node.id),
+  },
+
+  {
+    id: "cancel-probe",
+    label: "CANCEL PROBE",
+    available: (node, state) => state.activeProbe?.nodeId === node.id,
+    desc: () => "Abort vulnerability scan.",
+    execute: (_node, _state, ctx) => ctx.cancelProbe(),
+  },
+
+  {
+    id: "exploit",
+    label: "EXPLOIT",
+    available: (node, state) =>
+      node.visibility === "accessible" &&
+      !node.rebooting &&
+      node.accessLevel !== "owned" &&
+      state.executingExploit?.nodeId !== node.id,
+    desc: (node) => `Attack ${node.id} with an exploit card.`,
+    execute: (node, _state, ctx, payload) =>
+      ctx.startExploit(node.id, /** @type {any} */ (payload)?.exploitId),
+  },
+
+  {
+    id: "cancel-exploit",
+    label: "CANCEL EXPLOIT",
+    available: (node, state) => state.executingExploit?.nodeId === node.id,
+    desc: (node, state) => {
+      const card = state.player.hand.find(
+        (c) => c.id === state.executingExploit?.exploitId
+      );
+      return `Abort ${card?.name ?? "exploit"} execution.`;
+    },
+    execute: (_node, _state, ctx) => ctx.cancelExploit(),
+  },
+
+  {
+    id: "read",
+    label: "READ",
+    available: (node) =>
+      (node.accessLevel === "compromised" || node.accessLevel === "owned") &&
+      !node.read,
+    desc: (node) =>
+      node.accessLevel === "compromised"
+        ? "Scan node contents for loot or connections."
+        : "Scan node contents.",
+    execute: (node, _state, ctx) => ctx.readNode(node.id),
+  },
+
+  {
+    id: "loot",
+    label: "LOOT",
+    available: (node) =>
+      node.accessLevel === "owned" &&
+      node.read &&
+      node.macguffins.some((m) => !m.collected),
+    desc: () => "Collect macguffins for cash.",
+    execute: (node, _state, ctx) => ctx.lootNode(node.id),
+  },
+
+  {
+    id: "eject",
+    label: "EJECT",
+    available: (node, state) =>
+      !!(state.ice?.active && state.ice.attentionNodeId === node.id),
+    desc: () => "Boot ICE attention to a random adjacent node.",
+    execute: (_node, _state, ctx) => ctx.ejectIce(),
+  },
+
+  {
+    id: "reboot",
+    label: "REBOOT",
+    available: (node) => node.accessLevel === "owned" && !node.rebooting,
+    desc: () => "Force ICE home and take node offline 1–3s.",
+    execute: (node, _state, ctx) => ctx.rebootNode(node.id),
+  },
+]);
+
+/**
+ * Returns all node-contextual actions whose available() predicate is true.
+ * @param {NodeState} node
+ * @param {GameState} state
+ * @returns {ActionDef[]}
+ */
+export function getNodeActions(node, state) {
+  return NODE_ACTIONS.filter((a) => a.available(node, state));
+}
+
+// ── Unified query ──────────────────────────────────────────
+
+import { getGlobalActions } from "./global-actions.js";
+import { getActions as getTypeActions } from "./node-types.js";
+
+/**
+ * Returns all available actions for the given node and game state,
+ * merging global actions, node-contextual actions, and type-specific actions.
+ * @param {NodeState | null} node
+ * @param {GameState} state
+ * @returns {ActionDef[]}
+ */
+export function getAvailableActions(node, state) {
+  const global = getGlobalActions(node, state);
+  if (!node) return global;
+  return [
+    ...global,
+    ...getNodeActions(node, state),
+    ...getTypeActions(node, state),
+  ];
+}

--- a/js/node-actions.js
+++ b/js/node-actions.js
@@ -22,7 +22,8 @@ export const NODE_ACTIONS = Object.freeze([
       node.accessLevel === "locked" &&
       !node.probed &&
       !node.rebooting &&
-      state.activeProbe?.nodeId !== node.id,
+      state.activeProbe?.nodeId !== node.id &&
+      state.executingExploit?.nodeId !== node.id,
     desc: () => "Reveal vulnerabilities. Raises local alert.",
     execute: (node, _state, ctx) => ctx.startProbe(node.id),
   },

--- a/js/node-types.js
+++ b/js/node-types.js
@@ -87,6 +87,7 @@ export const NODE_TYPES = {
           !node.eventForwardingDisabled &&
           (node.accessLevel === "compromised" || node.accessLevel === "owned"),
         desc: () => "Disable event forwarding to security monitor.",
+        execute: (node, _state, ctx) => ctx.reconfigureNode(node.id),
       },
     ],
     // Grade S/A: skip propagation, start trace directly on detection
@@ -106,6 +107,7 @@ export const NODE_TYPES = {
           node.accessLevel === "owned" && state.traceSecondsRemaining !== null,
         desc: (node, state) =>
           `Abort trace countdown (${state.traceSecondsRemaining}s remaining).`,
+        execute: (_node, _state, ctx) => ctx.cancelTrace(),
       },
     ],
   },

--- a/js/types.js
+++ b/js/types.js
@@ -183,7 +183,6 @@
  *   ejectIce:         () => void,
  *   rebootNode:       (nodeId: string) => void,
  *   jackOut:          () => void,
- *   logCommand:       (cmd: string) => void,
  *   reconfigureNode:  (nodeId: string) => void,
  *   cancelTrace:      () => void,
  * }} ActionContext

--- a/js/types.js
+++ b/js/types.js
@@ -167,12 +167,34 @@
  */
 
 /**
+ * Dependency-injection context passed to action execute() functions.
+ * main.js constructs one instance at init, wiring each field to the
+ * corresponding state mutator. Tests can pass mock contexts.
+ * @typedef {{
+ *   getState:      () => GameState,
+ *   selectNode:    (nodeId: string) => void,
+ *   deselectNode:  () => void,
+ *   startProbe:    (nodeId: string) => void,
+ *   cancelProbe:   () => void,
+ *   startExploit:  (nodeId: string, exploitId: string) => void,
+ *   cancelExploit: () => void,
+ *   readNode:      (nodeId: string) => void,
+ *   lootNode:      (nodeId: string) => void,
+ *   ejectIce:      () => void,
+ *   rebootNode:    (nodeId: string) => void,
+ *   jackOut:       () => void,
+ *   logCommand:    (cmd: string) => void,
+ * }} ActionContext
+ */
+
+/**
  * An action available on a node — rendered as a sidebar button and console action.
  * @typedef {{
  *   id:        string,
  *   label:     string,
  *   available: (node: NodeState, state: GameState) => boolean,
  *   desc:      (node: NodeState, state: GameState) => string,
+ *   execute?:  (node: NodeState, state: GameState, ctx: ActionContext, payload?: Object) => void,
  * }} ActionDef
  */
 

--- a/js/types.js
+++ b/js/types.js
@@ -180,10 +180,12 @@
  *   cancelExploit: () => void,
  *   readNode:      (nodeId: string) => void,
  *   lootNode:      (nodeId: string) => void,
- *   ejectIce:      () => void,
- *   rebootNode:    (nodeId: string) => void,
- *   jackOut:       () => void,
- *   logCommand:    (cmd: string) => void,
+ *   ejectIce:         () => void,
+ *   rebootNode:       (nodeId: string) => void,
+ *   jackOut:          () => void,
+ *   logCommand:       (cmd: string) => void,
+ *   reconfigureNode:  (nodeId: string) => void,
+ *   cancelTrace:      () => void,
  * }} ActionContext
  */
 

--- a/js/visual-renderer.js
+++ b/js/visual-renderer.js
@@ -12,6 +12,7 @@
 
 import { on, emitEvent, E } from "./events.js";
 import { getActions } from "./node-types.js";
+import { getNodeActions } from "./node-actions.js";
 import { updateNodeStyle, getCy, flashNode, addIceNode, syncIceGraph, syncSelection } from "./graph.js";
 import { getVisibleTimers } from "./timers.js";
 import { exploitSortKey } from "./exploits.js";
@@ -290,49 +291,11 @@ function renderSidebarNode(sidebarNode, node, state) {
 // ── Actions ───────────────────────────────────────────────
 
 function renderActions(node, state) {
-  const btns = [];
-
-  // While an exploit is executing at this node, only allow cancellation.
-  if (state.executingExploit?.nodeId === node.id) {
-    const execCard = state.player.hand.find((c) => c.id === state.executingExploit.exploitId);
-    btns.push(actionBtn("cancel-exploit", "CANCEL EXPLOIT", `Abort ${execCard?.name ?? "exploit"} execution.`));
-    return btns.join("");
-  }
-
-  if (node.accessLevel === "locked") {
-    if (state.activeProbe?.nodeId === node.id) {
-      btns.push(actionBtn("cancel-probe", "CANCEL PROBE", "Abort vulnerability scan."));
-    } else if (!node.probed && !node.rebooting) {
-      btns.push(actionBtn("probe", "PROBE", "Reveal vulnerabilities. Raises local alert."));
-    }
-  }
-
-  if (node.accessLevel === "compromised") {
-    if (!node.read) {
-      btns.push(actionBtn("read", "READ", "Scan node contents for loot or connections."));
-    }
-  }
-
-  if (node.accessLevel === "owned") {
-    const icePresent = state?.ice?.active && state.ice.attentionNodeId === node.id;
-    if (icePresent) {
-      btns.push(actionBtn("eject", "EJECT", "Boot ICE attention to a random adjacent node."));
-    }
-    if (!node.rebooting) {
-      btns.push(actionBtn("reboot", "REBOOT", "Force ICE home and take node offline 1–3s."));
-    }
-    if (!node.read) {
-      btns.push(actionBtn("read", "READ", "Scan node contents."));
-    }
-    const hasLoot = node.macguffins.some((m) => !m.collected);
-    if (hasLoot) {
-      btns.push(actionBtn("loot", "LOOT", "Collect macguffins for cash."));
-    }
-  }
-
-  // Type-specific actions from the registry
-  getActions(node, state).forEach((a) => btns.push(actionBtn(a.id, a.label, a.desc(node, state))));
-
+  const actions = [
+    ...getNodeActions(node, state),
+    ...getActions(node, state),
+  ];
+  const btns = actions.map((a) => actionBtn(a.id, a.label, a.desc(node, state)));
   return btns.join("") || `<span class="nd-dim">No actions available.</span>`;
 }
 

--- a/js/visual-renderer.js
+++ b/js/visual-renderer.js
@@ -284,7 +284,7 @@ function renderSidebarNode(sidebarNode, node, state) {
   wireActionButtons(node);
 
   sidebarNode.querySelector(".deselect-btn")?.addEventListener("click", () => {
-    emitEvent("starnet:action:deselect", {});
+    emitEvent("starnet:action", { actionId: "deselect" });
   });
 }
 
@@ -308,8 +308,8 @@ function actionBtn(action, label, desc, stub = false) {
 function wireActionButtons(node) {
   document.querySelectorAll(".action-btn:not(.stub)").forEach((btn) => {
     btn.addEventListener("click", () => {
-      const action = /** @type {HTMLElement} */ (btn).dataset.action;
-      emitEvent(`starnet:action:${action}`, { nodeId: node.id });
+      const actionId = /** @type {HTMLElement} */ (btn).dataset.action;
+      emitEvent("starnet:action", { actionId, nodeId: node.id });
     });
   });
 }
@@ -348,7 +348,7 @@ function syncHandPane(state) {
       cardEl.addEventListener("click", () => {
         const exploitId = /** @type {HTMLElement} */ (cardEl).dataset.exploitId;
         const cardIndex = /** @type {HTMLElement} */ (cardEl).dataset.cardIndex;
-        emitEvent("starnet:action:launch-exploit", { nodeId: state.selectedNodeId, exploitId, cardIndex });
+        emitEvent("starnet:action", { actionId: "exploit", nodeId: state.selectedNodeId, exploitId, cardIndex });
       });
     });
   }

--- a/tests/node-actions.test.js
+++ b/tests/node-actions.test.js
@@ -296,6 +296,123 @@ describe("select available", () => {
   });
 });
 
+// ── action execute() routing ──────────────────────────────
+
+/** Build a mock ActionContext that records the last call per method */
+function mockCtx(overrides = {}) {
+  return /** @type {any} */ ({
+    getState:      () => baseState(),
+    selectNode:    () => {},
+    deselectNode:  () => {},
+    startProbe:    () => {},
+    cancelProbe:   () => {},
+    startExploit:  () => {},
+    cancelExploit: () => {},
+    readNode:      () => {},
+    lootNode:      () => {},
+    ejectIce:      () => {},
+    rebootNode:    () => {},
+    jackOut:       () => {},
+    logCommand:    () => {},
+    ...overrides,
+  });
+}
+
+describe("action execute() routing", () => {
+  it("probe calls ctx.startProbe(node.id)", () => {
+    const a = action("probe");
+    const node = lockedNode();
+    let called = null;
+    const ctx = mockCtx({ startProbe: (id) => { called = id; } });
+    a.execute(node, baseState(), ctx);
+    assert.equal(called, node.id);
+  });
+
+  it("cancel-probe calls ctx.cancelProbe()", () => {
+    const a = action("cancel-probe");
+    let called = false;
+    const ctx = mockCtx({ cancelProbe: () => { called = true; } });
+    a.execute(lockedNode(), baseState(), ctx);
+    assert.ok(called);
+  });
+
+  it("exploit calls ctx.startExploit(node.id, payload.exploitId)", () => {
+    const a = action("exploit");
+    const node = lockedNode();
+    let args = null;
+    const ctx = mockCtx({ startExploit: (nid, eid) => { args = [nid, eid]; } });
+    a.execute(node, baseState(), ctx, { exploitId: "card-1" });
+    assert.deepEqual(args, [node.id, "card-1"]);
+  });
+
+  it("cancel-exploit calls ctx.cancelExploit()", () => {
+    const a = action("cancel-exploit");
+    let called = false;
+    const ctx = mockCtx({ cancelExploit: () => { called = true; } });
+    a.execute(lockedNode(), baseState(), ctx);
+    assert.ok(called);
+  });
+
+  it("read calls ctx.readNode(node.id)", () => {
+    const a = action("read");
+    const node = lockedNode({ accessLevel: "compromised" });
+    let called = null;
+    const ctx = mockCtx({ readNode: (id) => { called = id; } });
+    a.execute(node, baseState(), ctx);
+    assert.equal(called, node.id);
+  });
+
+  it("loot calls ctx.lootNode(node.id)", () => {
+    const a = action("loot");
+    const node = lockedNode({ accessLevel: "owned", read: true, macguffins: [{ collected: false }] });
+    let called = null;
+    const ctx = mockCtx({ lootNode: (id) => { called = id; } });
+    a.execute(node, baseState(), ctx);
+    assert.equal(called, node.id);
+  });
+
+  it("eject calls ctx.ejectIce()", () => {
+    const a = action("eject");
+    let called = false;
+    const ctx = mockCtx({ ejectIce: () => { called = true; } });
+    a.execute(lockedNode(), baseState(), ctx);
+    assert.ok(called);
+  });
+
+  it("reboot calls ctx.rebootNode(node.id)", () => {
+    const a = action("reboot");
+    const node = lockedNode({ accessLevel: "owned" });
+    let called = null;
+    const ctx = mockCtx({ rebootNode: (id) => { called = id; } });
+    a.execute(node, baseState(), ctx);
+    assert.equal(called, node.id);
+  });
+
+  it("jackout calls ctx.jackOut()", () => {
+    const a = action("jackout");
+    let called = false;
+    const ctx = mockCtx({ jackOut: () => { called = true; } });
+    a.execute(null, baseState(), ctx);
+    assert.ok(called);
+  });
+
+  it("select calls ctx.selectNode(payload.nodeId)", () => {
+    const a = action("select");
+    let called = null;
+    const ctx = mockCtx({ selectNode: (id) => { called = id; } });
+    a.execute(null, baseState(), ctx, { nodeId: "router-a" });
+    assert.equal(called, "router-a");
+  });
+
+  it("deselect calls ctx.deselectNode()", () => {
+    const a = action("deselect");
+    let called = false;
+    const ctx = mockCtx({ deselectNode: () => { called = true; } });
+    a.execute(null, baseState(), ctx);
+    assert.ok(called);
+  });
+});
+
 // ── getAvailableActions integration parity ────────────────
 
 describe("getAvailableActions integration parity", () => {

--- a/tests/node-actions.test.js
+++ b/tests/node-actions.test.js
@@ -1,0 +1,351 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { NODE_ACTIONS, getNodeActions, getAvailableActions } from "../js/node-actions.js";
+import { GLOBAL_ACTIONS, getGlobalActions } from "../js/global-actions.js";
+
+// ── stub helpers ──────────────────────────────────────────
+
+/** Base locked node — override fields as needed */
+function lockedNode(extra = {}) {
+  return /** @type {any} */ ({
+    id: "test-node",
+    type: "workstation",
+    grade: "D",
+    accessLevel: "locked",
+    visibility: "accessible",
+    probed: false,
+    rebooting: false,
+    read: false,
+    macguffins: [],
+    eventForwardingDisabled: false,
+    ...extra,
+  });
+}
+
+/** Base game state — override fields as needed */
+function baseState(extra = {}) {
+  return /** @type {any} */ ({
+    phase: "playing",
+    selectedNodeId: null,
+    activeProbe: null,
+    executingExploit: null,
+    ice: null,
+    traceSecondsRemaining: null,
+    nodes: {},
+    player: { hand: [] },
+    ...extra,
+  });
+}
+
+/** Find an action by id from a registry array */
+function action(id) {
+  return (
+    NODE_ACTIONS.find((a) => a.id === id) ??
+    GLOBAL_ACTIONS.find((a) => a.id === id)
+  );
+}
+
+// ── probe ─────────────────────────────────────────────────
+
+describe("probe available", () => {
+  it("available for locked unprobed node", () => {
+    const a = action("probe");
+    assert.ok(a.available(lockedNode(), baseState()));
+  });
+  it("unavailable when already probed", () => {
+    const a = action("probe");
+    assert.ok(!a.available(lockedNode({ probed: true }), baseState()));
+  });
+  it("unavailable when rebooting", () => {
+    const a = action("probe");
+    assert.ok(!a.available(lockedNode({ rebooting: true }), baseState()));
+  });
+  it("unavailable when probe already active on this node", () => {
+    const a = action("probe");
+    const node = lockedNode();
+    assert.ok(!a.available(node, baseState({ activeProbe: { nodeId: node.id } })));
+  });
+  it("unavailable for compromised node", () => {
+    const a = action("probe");
+    assert.ok(!a.available(lockedNode({ accessLevel: "compromised" }), baseState()));
+  });
+  it("unavailable for owned node", () => {
+    const a = action("probe");
+    assert.ok(!a.available(lockedNode({ accessLevel: "owned" }), baseState()));
+  });
+});
+
+// ── cancel-probe ──────────────────────────────────────────
+
+describe("cancel-probe available", () => {
+  it("available when active probe is on this node", () => {
+    const a = action("cancel-probe");
+    const node = lockedNode();
+    assert.ok(a.available(node, baseState({ activeProbe: { nodeId: node.id } })));
+  });
+  it("unavailable when no active probe", () => {
+    const a = action("cancel-probe");
+    assert.ok(!a.available(lockedNode(), baseState()));
+  });
+  it("unavailable when active probe is on a different node", () => {
+    const a = action("cancel-probe");
+    assert.ok(!a.available(lockedNode(), baseState({ activeProbe: { nodeId: "other-node" } })));
+  });
+});
+
+// ── exploit ───────────────────────────────────────────────
+
+describe("exploit available", () => {
+  it("available for locked accessible non-rebooting node", () => {
+    const a = action("exploit");
+    assert.ok(a.available(lockedNode(), baseState()));
+  });
+  it("available for compromised node", () => {
+    const a = action("exploit");
+    assert.ok(a.available(lockedNode({ accessLevel: "compromised" }), baseState()));
+  });
+  it("unavailable for owned node", () => {
+    const a = action("exploit");
+    assert.ok(!a.available(lockedNode({ accessLevel: "owned" }), baseState()));
+  });
+  it("unavailable when rebooting", () => {
+    const a = action("exploit");
+    assert.ok(!a.available(lockedNode({ rebooting: true }), baseState()));
+  });
+  it("unavailable when exploit already executing on this node", () => {
+    const a = action("exploit");
+    const node = lockedNode();
+    assert.ok(!a.available(node, baseState({ executingExploit: { nodeId: node.id } })));
+  });
+  it("unavailable for hidden node", () => {
+    const a = action("exploit");
+    assert.ok(!a.available(lockedNode({ visibility: "hidden" }), baseState()));
+  });
+});
+
+// ── cancel-exploit ────────────────────────────────────────
+
+describe("cancel-exploit available", () => {
+  it("available when exploit executing on this node", () => {
+    const a = action("cancel-exploit");
+    const node = lockedNode();
+    assert.ok(a.available(node, baseState({ executingExploit: { nodeId: node.id, exploitId: "e1" } })));
+  });
+  it("unavailable when no exploit executing", () => {
+    const a = action("cancel-exploit");
+    assert.ok(!a.available(lockedNode(), baseState()));
+  });
+  it("unavailable when exploit executing on different node", () => {
+    const a = action("cancel-exploit");
+    assert.ok(!a.available(lockedNode(), baseState({ executingExploit: { nodeId: "other" } })));
+  });
+});
+
+// ── read ──────────────────────────────────────────────────
+
+describe("read available", () => {
+  it("available for compromised unread node", () => {
+    const a = action("read");
+    assert.ok(a.available(lockedNode({ accessLevel: "compromised" }), baseState()));
+  });
+  it("available for owned unread node", () => {
+    const a = action("read");
+    assert.ok(a.available(lockedNode({ accessLevel: "owned" }), baseState()));
+  });
+  it("unavailable when already read", () => {
+    const a = action("read");
+    assert.ok(!a.available(lockedNode({ accessLevel: "owned", read: true }), baseState()));
+  });
+  it("unavailable for locked node", () => {
+    const a = action("read");
+    assert.ok(!a.available(lockedNode(), baseState()));
+  });
+});
+
+// ── loot ──────────────────────────────────────────────────
+
+describe("loot available", () => {
+  it("available for owned read node with uncollected macguffins", () => {
+    const a = action("loot");
+    assert.ok(a.available(
+      lockedNode({ accessLevel: "owned", read: true, macguffins: [{ collected: false }] }),
+      baseState()
+    ));
+  });
+  it("unavailable when all macguffins collected", () => {
+    const a = action("loot");
+    assert.ok(!a.available(
+      lockedNode({ accessLevel: "owned", read: true, macguffins: [{ collected: true }] }),
+      baseState()
+    ));
+  });
+  it("unavailable when node not read", () => {
+    const a = action("loot");
+    assert.ok(!a.available(
+      lockedNode({ accessLevel: "owned", read: false, macguffins: [{ collected: false }] }),
+      baseState()
+    ));
+  });
+  it("unavailable when not owned", () => {
+    const a = action("loot");
+    assert.ok(!a.available(
+      lockedNode({ accessLevel: "compromised", read: true, macguffins: [{ collected: false }] }),
+      baseState()
+    ));
+  });
+  it("unavailable when no macguffins", () => {
+    const a = action("loot");
+    assert.ok(!a.available(
+      lockedNode({ accessLevel: "owned", read: true, macguffins: [] }),
+      baseState()
+    ));
+  });
+});
+
+// ── eject ─────────────────────────────────────────────────
+
+describe("eject available", () => {
+  it("available when ICE active at this node", () => {
+    const a = action("eject");
+    const node = lockedNode({ accessLevel: "owned" });
+    assert.ok(a.available(node, baseState({ ice: { active: true, attentionNodeId: node.id } })));
+  });
+  it("unavailable when ICE not active", () => {
+    const a = action("eject");
+    const node = lockedNode({ accessLevel: "owned" });
+    assert.ok(!a.available(node, baseState({ ice: { active: false, attentionNodeId: node.id } })));
+  });
+  it("unavailable when ICE at a different node", () => {
+    const a = action("eject");
+    assert.ok(!a.available(lockedNode({ accessLevel: "owned" }), baseState({ ice: { active: true, attentionNodeId: "other" } })));
+  });
+  it("unavailable when no ICE", () => {
+    const a = action("eject");
+    assert.ok(!a.available(lockedNode({ accessLevel: "owned" }), baseState()));
+  });
+});
+
+// ── reboot ────────────────────────────────────────────────
+
+describe("reboot available", () => {
+  it("available for owned non-rebooting node", () => {
+    const a = action("reboot");
+    assert.ok(a.available(lockedNode({ accessLevel: "owned" }), baseState()));
+  });
+  it("unavailable when rebooting", () => {
+    const a = action("reboot");
+    assert.ok(!a.available(lockedNode({ accessLevel: "owned", rebooting: true }), baseState()));
+  });
+  it("unavailable when not owned", () => {
+    const a = action("reboot");
+    assert.ok(!a.available(lockedNode({ accessLevel: "compromised" }), baseState()));
+  });
+});
+
+// ── jackout ───────────────────────────────────────────────
+
+describe("jackout available", () => {
+  it("available when phase is playing", () => {
+    const a = action("jackout");
+    assert.ok(a.available(null, baseState({ phase: "playing" })));
+  });
+  it("unavailable when phase is not playing", () => {
+    const a = action("jackout");
+    assert.ok(!a.available(null, baseState({ phase: "ended" })));
+  });
+});
+
+// ── deselect ──────────────────────────────────────────────
+
+describe("deselect available", () => {
+  it("available when a node is selected", () => {
+    const a = action("deselect");
+    assert.ok(a.available(null, baseState({ selectedNodeId: "gateway" })));
+  });
+  it("unavailable when nothing is selected", () => {
+    const a = action("deselect");
+    assert.ok(!a.available(null, baseState({ selectedNodeId: null })));
+  });
+});
+
+// ── select ────────────────────────────────────────────────
+
+describe("select available", () => {
+  it("available when an accessible node exists", () => {
+    const a = action("select");
+    const state = baseState({
+      selectedNodeId: "gateway",
+      nodes: {
+        "router-a": { id: "router-a", visibility: "accessible", rebooting: false },
+      },
+    });
+    assert.ok(a.available(null, state));
+  });
+  it("available when a revealed node exists", () => {
+    const a = action("select");
+    const state = baseState({
+      nodes: {
+        "router-a": { id: "router-a", visibility: "revealed", rebooting: false },
+      },
+    });
+    assert.ok(a.available(null, state));
+  });
+  it("unavailable when no selectable nodes", () => {
+    const a = action("select");
+    assert.ok(!a.available(null, baseState({ nodes: {} })));
+  });
+});
+
+// ── getAvailableActions integration parity ────────────────
+
+describe("getAvailableActions integration parity", () => {
+  it("locked unprobed node: probe + jackout, no read/loot/reboot", () => {
+    const node = lockedNode();
+    const state = baseState({ selectedNodeId: node.id });
+    const ids = getAvailableActions(node, state).map((a) => a.id);
+    assert.ok(ids.includes("probe"), "should include probe");
+    assert.ok(ids.includes("jackout"), "should include jackout");
+    assert.ok(ids.includes("deselect"), "should include deselect");
+    assert.ok(!ids.includes("read"), "should not include read");
+    assert.ok(!ids.includes("loot"), "should not include loot");
+    assert.ok(!ids.includes("reboot"), "should not include reboot");
+    assert.ok(!ids.includes("cancel-probe"), "should not include cancel-probe");
+  });
+
+  it("owned read node with loot: reboot + loot, no probe/read/exploit", () => {
+    const node = lockedNode({
+      accessLevel: "owned",
+      read: true,
+      macguffins: [{ collected: false }],
+    });
+    const state = baseState({ selectedNodeId: node.id });
+    const ids = getAvailableActions(node, state).map((a) => a.id);
+    assert.ok(ids.includes("reboot"), "should include reboot");
+    assert.ok(ids.includes("loot"), "should include loot");
+    assert.ok(ids.includes("jackout"), "should include jackout");
+    assert.ok(!ids.includes("probe"), "should not include probe");
+    assert.ok(!ids.includes("read"), "should not include read");
+    assert.ok(!ids.includes("exploit"), "should not include exploit");
+  });
+
+  it("active exploit on node: only cancel-exploit (no probe/exploit/read)", () => {
+    const node = lockedNode();
+    const state = baseState({
+      selectedNodeId: node.id,
+      executingExploit: { nodeId: node.id, exploitId: "e1" },
+    });
+    const ids = getAvailableActions(node, state).map((a) => a.id);
+    assert.ok(ids.includes("cancel-exploit"), "should include cancel-exploit");
+    assert.ok(!ids.includes("probe"), "should not include probe");
+    assert.ok(!ids.includes("exploit"), "should not include exploit");
+    assert.ok(!ids.includes("read"), "should not include read");
+  });
+
+  it("null node: only global actions returned", () => {
+    const state = baseState({ phase: "playing" });
+    const ids = getAvailableActions(null, state).map((a) => a.id);
+    assert.ok(ids.includes("jackout"), "should include jackout");
+    assert.ok(!ids.includes("probe"), "should not include probe");
+    assert.ok(!ids.includes("read"), "should not include read");
+  });
+});

--- a/tests/node-actions.test.js
+++ b/tests/node-actions.test.js
@@ -313,7 +313,6 @@ function mockCtx(overrides = {}) {
     ejectIce:      () => {},
     rebootNode:    () => {},
     jackOut:       () => {},
-    logCommand:    () => {},
     ...overrides,
   });
 }


### PR DESCRIPTION
## Summary

- Extracts `buildActionContext()`, `initActionDispatcher()`, and `buildNodeClickHandler()` from `main.js` into `js/action-context.js` — all three are now independently testable
- Adds `E.COMMAND_ISSUED` event to decouple the log entry and console history concerns previously bundled in `logCommand` in `main.js`
- Exports `fitGraph()` from `graph.js` (it was always a graph viewport operation)
- `main.js` shrinks from 131 to 63 lines — pure wiring, zero decision logic

## Test plan

- [x] 143/143 unit tests passing (`make check`)
- [x] Browser playtest: graph node tap select/deselect, console commands, exploit card click, sidebar DESELECT button, JACK OUT button — all flows verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)