### PR TITLE
Convert read action from instant to timed with pie-sector animation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ lint:
 		js/exploits.js js/combat.js js/loot.js \
 		js/alert.js js/timers.js js/ice.js js/log.js js/log-renderer.js js/visual-renderer.js js/store.js js/console.js js/cheats.js \
 		js/node-types.js js/node-lifecycle.js \
+		js/probe-exec.js js/read-exec.js js/navigation.js \
 		js/node-actions.js js/global-actions.js js/action-context.js js/node-orchestration.js
 
 # Run unit + integration tests

--- a/index.html
+++ b/index.html
@@ -64,6 +64,11 @@
                style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
             <path id="ice-detect-arc" fill="none" stroke="#ff00aa" stroke-width="4" stroke-linecap="round"/>
           </svg>
+          <svg id="read-sectors"
+               style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
+            <path id="read-sectors-fill" fill="rgba(0,255,65,0.15)" />
+            <circle id="read-sectors-ring" fill="none" stroke="#00ff41" stroke-width="1" stroke-opacity="0.45" />
+          </svg>
           <svg id="exploit-brackets"
                style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
             <line id="bracket-tl-h" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>

--- a/js/action-context.js
+++ b/js/action-context.js
@@ -5,7 +5,8 @@
 /** @typedef {import('./types.js').ActionContext} ActionContext */
 
 import { getState, getVersion, endRun, buyExploit } from "./state.js";
-import { readNode, lootNode, reconfigureNode, rebootNode } from "./node-orchestration.js";
+import { lootNode, reconfigureNode, rebootNode } from "./node-orchestration.js";
+import { startRead, cancelRead } from "./read-exec.js";
 import { ejectIce } from "./ice.js";
 import { addLogEntry } from "./log.js";
 import { startExploit, cancelExploit } from "./exploit-exec.js";
@@ -30,7 +31,8 @@ export function buildActionContext() {
     cancelProbe:      ()       => cancelProbe(),
     startExploit:     (nodeId, exploitId) => startExploit(nodeId, exploitId),
     cancelExploit:    ()       => cancelExploit(),
-    readNode:         (nodeId) => readNode(nodeId),
+    startRead:        (nodeId) => startRead(nodeId),
+    cancelRead:       ()       => cancelRead(),
     lootNode:         (nodeId) => lootNode(nodeId),
     ejectIce:         ()       => ejectIce(),
     rebootNode:       (nodeId) => rebootNode(nodeId),

--- a/js/console.js
+++ b/js/console.js
@@ -14,7 +14,7 @@ import { exploitSortKey, getStoreCatalog, generateExploitForVuln } from "./explo
 import { getActions } from "./node-types.js";
 import { getAvailableActions } from "./node-actions.js";
 
-const VERBS = ["select", "deselect", "probe", "exploit", "eject", "reboot", "read", "loot", "reconfigure", "cancel-probe", "cancel-exploit", "cancel-trace", "jackout", "status", "actions", "store", "buy", "log", "help", "cheat"];
+const VERBS = ["select", "deselect", "probe", "exploit", "eject", "reboot", "read", "loot", "reconfigure", "cancel-probe", "cancel-exploit", "cancel-read", "cancel-trace", "jackout", "status", "actions", "store", "buy", "log", "help", "cheat"];
 const STATUS_NOUNS = ["summary", "ice", "hand", "node", "alert", "mission"];
 
 let history = [];
@@ -92,6 +92,7 @@ function handleCommand(verb, args) {
     case "reconfigure":  return cmdReconfigure(args);
     case "cancel-probe":   return cmdCancelProbe();
     case "cancel-exploit": return cmdCancelExploit();
+    case "cancel-read":    return cmdCancelRead();
     case "cancel-trace": return cmdCancelTrace();
     case "jackout":      return cmdJackout();
     case "actions":      return cmdActions();
@@ -310,7 +311,11 @@ function cmdActions() {
       }
     }
 
-    if (has.has("read"))   lines.push(`  read                     — scan ${sel.id} contents`);
+    if (has.has("cancel-read")) {
+      lines.push(`  cancel-read              — abort data extraction`);
+    } else if (has.has("read")) {
+      lines.push(`  read                     — scan ${sel.id} contents`);
+    }
     if (has.has("loot"))   lines.push(`  loot                     — collect items from ${sel.id}`);
     if (has.has("eject"))  lines.push(`  eject                    — push ICE to adjacent node`);
     if (has.has("reboot")) lines.push(`  reboot                   — send ICE home, take ${sel.id} offline briefly`);
@@ -388,6 +393,13 @@ function cmdStatusSummary() {
     const scanTimer = timers.find((t) => t.label === "SCANNING");
     const scanStr = scanTimer ? `${scanTimer.remaining}s remaining` : "resolving...";
     lines.push(`  Scanning: ${s.nodes[s.activeProbe.nodeId]?.label ?? s.activeProbe.nodeId}  |  ${scanStr}`);
+  }
+
+  // Active read scan
+  if (s.activeRead) {
+    const readTimer = timers.find((t) => t.label === "READING");
+    const readStr = readTimer ? `${readTimer.remaining}s remaining` : "resolving...";
+    lines.push(`  Reading: ${s.nodes[s.activeRead.nodeId]?.label ?? s.activeRead.nodeId}  |  ${readStr}`);
   }
 
   // Executing exploit
@@ -695,6 +707,7 @@ function cmdHelp() {
     "  loot [node]               Collect macguffins from owned node.",
     "  reconfigure [node]        Disable IDS event forwarding.",
     "  cancel-probe              Abort an in-progress probe scan.",
+    "  cancel-read               Abort an in-progress data extraction.",
     "  cancel-exploit            Abort an in-progress exploit execution (no card decay).",
     "  cancel-trace              Abort trace countdown (requires owned security-monitor selected).",
     "  eject                     Push ICE attention to adjacent node.",
@@ -725,6 +738,15 @@ function cmdCancelProbe() {
     return;
   }
   dispatch("cancel-probe");
+}
+
+function cmdCancelRead() {
+  const s = getState();
+  if (!s.activeRead) {
+    addLogEntry("No read scan in progress.", "error");
+    return;
+  }
+  dispatch("cancel-read");
 }
 
 function cmdCancelExploit() {

--- a/js/events.js
+++ b/js/events.js
@@ -46,6 +46,9 @@ export const E = Object.freeze({
   PROBE_SCAN_STARTED:   "probe:scan-started",
   PROBE_SCAN_CANCELLED: "probe:scan-cancelled",
 
+  READ_SCAN_STARTED:    "read:scan-started",
+  READ_SCAN_CANCELLED:  "read:scan-cancelled",
+
   EXPLOIT_STARTED:      "exploit:started",
   EXPLOIT_NOISE:        "exploit:noise",
   EXPLOIT_INTERRUPTED:  "exploit:interrupted",

--- a/js/graph.js
+++ b/js/graph.js
@@ -35,6 +35,10 @@ let prevIceNodeId = null;        // tracks ICE's last position for movement flas
 let currentSelectedNodeId = null; // tracks selected node for reticle positioning
 let currentProbeSweepNodeId = null;  // tracks node being probed for sweep overlay
 let currentProbeSweepProgress = 0;   // 0..1
+let currentReadSectorsNodeId = null;
+let currentReadSectorsProgress = 0;
+let readSectorCount = 0;
+let readSectorOrder = [];
 let currentExploitBracketsNodeId = null;
 let currentExploitBracketsProgress = 0;
 let currentIceDetectNodeId = null;
@@ -162,6 +166,7 @@ export function initGraph(networkData, onNodeClick, onBackgroundTap) {
   const onPanZoom = () => {
     syncReticle();
     _renderProbeSweep();
+    _renderReadSectors();
     _renderExploitBrackets();
     _renderIceDetectSweep();
     const pan = cy.pan();
@@ -795,6 +800,87 @@ function _renderProbeSweep() {
     fill.setAttribute("d",
       `M ${r},${r} L ${r},${0} A ${r},${r} 0 ${p > 0.5 ? 1 : 0},1 ${endX},${endY} Z`);
   }
+}
+
+export function syncReadSectors(nodeId, progress) {
+  if (nodeId !== currentReadSectorsNodeId) {
+    // New read target — generate random sector count and fill order
+    currentReadSectorsNodeId = nodeId;
+    readSectorCount = 7 + Math.floor(Math.random() * 14); // 7–20
+    readSectorOrder = Array.from({ length: readSectorCount }, (_, i) => i);
+    // Fisher-Yates shuffle
+    for (let i = readSectorOrder.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [readSectorOrder[i], readSectorOrder[j]] = [readSectorOrder[j], readSectorOrder[i]];
+    }
+  }
+  // Scale so all sectors are filled at 90% progress — looks full just before completion
+  currentReadSectorsProgress = Math.max(0, Math.min(1, progress / 0.9));
+  _renderReadSectors();
+}
+
+export function clearReadSectors() {
+  currentReadSectorsNodeId = null;
+  currentReadSectorsProgress = 0;
+  readSectorCount = 0;
+  readSectorOrder = [];
+  const svg = document.getElementById("read-sectors");
+  if (svg) svg.style.opacity = "0";
+}
+
+function _renderReadSectors() {
+  const svg = document.getElementById("read-sectors");
+  if (!svg || !cy || !currentReadSectorsNodeId) return;
+
+  const node = cy.getElementById(currentReadSectorsNodeId);
+  if (!node || node.length === 0) { clearReadSectors(); return; }
+
+  const pos = node.renderedPosition();
+  const r = node.renderedWidth() / 2;
+  const size = r * 2;
+
+  svg.style.width  = `${size}px`;
+  svg.style.height = `${size}px`;
+  svg.style.left   = `${pos.x - r}px`;
+  svg.style.top    = `${pos.y - r}px`;
+  svg.style.opacity = "1";
+
+  const ring = document.getElementById("read-sectors-ring");
+  ring.setAttribute("cx", String(r));
+  ring.setAttribute("cy", String(r));
+  ring.setAttribute("r", String(r - 1));
+
+  const fill = document.getElementById("read-sectors-fill");
+  const p = currentReadSectorsProgress;
+  const filledCount = Math.floor(p * readSectorCount);
+
+  if (filledCount <= 0) {
+    fill.setAttribute("d", "");
+    return;
+  }
+
+  if (filledCount >= readSectorCount) {
+    // Full circle
+    fill.setAttribute("d",
+      `M ${r},${r} m 0,-${r} a ${r},${r} 0 1,1 0,${r * 2} a ${r},${r} 0 1,1 0,-${r * 2} Z`);
+    return;
+  }
+
+  // Build path from filled sectors (each is a pie wedge)
+  const sliceAngle = (2 * Math.PI) / readSectorCount;
+  let d = "";
+  for (let i = 0; i < filledCount; i++) {
+    const idx = readSectorOrder[i];
+    const startAngle = idx * sliceAngle - Math.PI / 2; // start from 12 o'clock
+    const endAngle = startAngle + sliceAngle;
+    const x1 = r + r * Math.cos(startAngle);
+    const y1 = r + r * Math.sin(startAngle);
+    const x2 = r + r * Math.cos(endAngle);
+    const y2 = r + r * Math.sin(endAngle);
+    const largeArc = sliceAngle > Math.PI ? 1 : 0;
+    d += `M ${r},${r} L ${x1},${y1} A ${r},${r} 0 ${largeArc},1 ${x2},${y2} Z `;
+  }
+  fill.setAttribute("d", d.trim());
 }
 
 function setLine(id, x1, y1, x2, y2) {

--- a/js/log-renderer.js
+++ b/js/log-renderer.js
@@ -83,6 +83,12 @@ export function initLogRenderer() {
   on(E.PROBE_SCAN_CANCELLED, (/** @type {import('./types.js').ProbeScanCancelledPayload} */ { label }) =>
     add(`[PROBE] ${label}: scan cancelled.`, "info"));
 
+  // ── Read scan events ────────────────────────────────────
+  on(E.READ_SCAN_STARTED,    (/** @type {import('./types.js').ReadScanStartedPayload} */ { label, durationMs }) =>
+    add(`[READ] ${label}: extracting data (${Math.round(durationMs / 1000)}s)...`, "info"));
+  on(E.READ_SCAN_CANCELLED,  (/** @type {import('./types.js').ReadScanCancelledPayload} */ { label }) =>
+    add(`[READ] ${label}: extraction cancelled.`, "info"));
+
   // ── Exploit events ───────────────────────────────────────
   on(E.EXPLOIT_STARTED,      (/** @type {ExploitStartedPayload} */      { label, exploitName, durationMs }) =>
     add(`[EXPLOIT] ${label} — ${exploitName}: executing (${Math.round(durationMs / 1000)}s)...`, "info"));

--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,7 @@ import { initState, getState } from "./state.js";
 import { completeReboot } from "./node-orchestration.js";
 import { handleExploitExecTimer, handleExploitNoiseTimer } from "./exploit-exec.js";
 import { handleProbeScanTimer } from "./probe-exec.js";
+import { handleReadScanTimer } from "./read-exec.js";
 import { startIce, handleIceTick, handleIceDetect } from "./ice.js";
 import { initConsole, runCommand } from "./console.js";
 import { on, emitEvent, E } from "./events.js";
@@ -83,6 +84,7 @@ function init() {
   on(TIMER.EXPLOIT_EXEC,   (payload) => handleExploitExecTimer(payload));
   on(TIMER.EXPLOIT_NOISE,  (payload) => handleExploitNoiseTimer(payload));
   on(TIMER.PROBE_SCAN,   (payload) => handleProbeScanTimer(payload));
+  on(TIMER.READ_SCAN,    (payload) => handleReadScanTimer(payload));
 
   on(TIMER.REBOOT_COMPLETE, (payload) => {
     completeReboot(payload.nodeId);

--- a/js/node-actions.js
+++ b/js/node-actions.js
@@ -66,14 +66,25 @@ export const NODE_ACTIONS = Object.freeze([
   {
     id: "read",
     label: "READ",
-    available: (node) =>
+    available: (node, state) =>
       (node.accessLevel === "compromised" || node.accessLevel === "owned") &&
-      !node.read,
+      !node.read &&
+      !node.rebooting &&
+      state.activeRead?.nodeId !== node.id &&
+      state.executingExploit?.nodeId !== node.id,
     desc: (node) =>
       node.accessLevel === "compromised"
         ? "Scan node contents for loot or connections."
         : "Scan node contents.",
-    execute: (node, _state, ctx) => ctx.readNode(node.id),
+    execute: (node, _state, ctx) => ctx.startRead(node.id),
+  },
+
+  {
+    id: "cancel-read",
+    label: "CANCEL READ",
+    available: (node, state) => state.activeRead?.nodeId === node.id,
+    desc: () => "Abort data extraction.",
+    execute: (_node, _state, ctx) => ctx.cancelRead(),
   },
 
   {

--- a/js/node-orchestration.js
+++ b/js/node-orchestration.js
@@ -4,25 +4,13 @@
 // These were previously in state/index.js; moved here to keep state/ pure.
 
 import { getState, ALERT_ORDER } from "./state.js";
-import { setNodeRead, collectMacguffins, setNodeLooted, setNodeEventForwarding, setNodeRebooting } from "./state/node.js";
+import { collectMacguffins, setNodeLooted, setNodeEventForwarding, setNodeRebooting } from "./state/node.js";
 import { setIceAttention } from "./state/ice.js";
 import { setSelectedNode } from "./state/game.js";
 import { addCash, setMissionComplete } from "./state/player.js";
 import { emitEvent, E } from "./events.js";
 import { scheduleEvent, TIMER } from "./timers.js";
 import { rebootIce } from "./ice.js";
-
-export function readNode(nodeId) {
-  const s = getState();
-  const node = s.nodes[nodeId];
-  if (!node) return;
-  if (node.read) {
-    emitEvent(E.LOG_ENTRY, { text: `${node.label}: Already scanned.`, type: "info" });
-    return;
-  }
-  setNodeRead(nodeId);
-  emitEvent(E.NODE_READ, { nodeId, label: node.label, macguffinCount: node.macguffins.length });
-}
 
 export function lootNode(nodeId) {
   const s = getState();

--- a/js/read-exec.js
+++ b/js/read-exec.js
@@ -1,0 +1,97 @@
+// @ts-check
+// Read execution timing — schedules the scan timer, handles cancellation,
+// and resolves reads on completion.
+// Follows the same pattern as probe-exec.js.
+
+/** @typedef {import('./types.js').GameState} GameState */
+
+import { getState } from "./state.js";
+import { setNodeRead } from "./state/node.js";
+import { setActiveRead } from "./state/player.js";
+import { emitEvent, on, E } from "./events.js";
+import { scheduleEvent, cancelEvent, TIMER } from "./timers.js";
+
+// Cancel any running read scan when the player navigates away.
+on(E.PLAYER_NAVIGATED, () => cancelRead());
+
+// Duration table: grade → milliseconds.
+const READ_DURATIONS = { S: 4000, A: 3500, B: 2500, C: 1500, D: 1500, F: 800 };
+
+/**
+ * Returns read scan duration in ms for the given node grade.
+ * @param {string} grade
+ * @returns {number}
+ */
+export function readDuration(grade) {
+  return READ_DURATIONS[grade] ?? 1000;
+}
+
+/**
+ * Begin a read scan — schedules a timer; does not resolve immediately.
+ * Returns true if the scan started, false if blocked by a guard.
+ * @param {string} nodeId
+ * @returns {boolean}
+ */
+export function startRead(nodeId) {
+  const s = getState();
+
+  if (s.activeRead) {
+    emitEvent(E.LOG_ENTRY, {
+      text: "[READ] Scan already in progress — wait or cancel-read.",
+      type: "error",
+    });
+    return false;
+  }
+
+  const node = s.nodes[nodeId];
+  if (!node || node.read || node.rebooting) return false;
+
+  const durationMs = readDuration(node.grade);
+  const timerId = scheduleEvent(
+    TIMER.READ_SCAN,
+    durationMs,
+    { nodeId },
+    { label: "READING" }
+  );
+
+  setActiveRead({ nodeId, timerId });
+  emitEvent(E.READ_SCAN_STARTED, { nodeId, label: node.label, durationMs });
+  return true;
+}
+
+/**
+ * Cancel a running read scan. No-op if nothing is scanning.
+ */
+export function cancelRead() {
+  const s = getState();
+  if (!s.activeRead) return;
+
+  const { nodeId, timerId } = s.activeRead;
+  cancelEvent(timerId);
+  setActiveRead(null);
+
+  emitEvent(E.READ_SCAN_CANCELLED, {
+    nodeId,
+    label: s.nodes[nodeId]?.label ?? nodeId,
+  });
+}
+
+/**
+ * Called by main.js when TIMER.READ_SCAN fires.
+ * Clears read state, marks the node read, emits NODE_READ.
+ * @param {{ nodeId: string }} payload
+ */
+export function handleReadScanTimer({ nodeId }) {
+  setActiveRead(null);
+
+  const s = getState();
+  const node = s.nodes[nodeId];
+  if (!node) return;
+  if (node.read) {
+    emitEvent(E.LOG_ENTRY, { text: `${node.label}: Already scanned.`, type: "info" });
+    return;
+  }
+
+  setNodeRead(nodeId);
+  emitEvent(E.NODE_READ, { nodeId, label: node.label, macguffinCount: node.macguffins.length });
+}

--- a/js/state/index.js
+++ b/js/state/index.js
@@ -114,6 +114,7 @@ export function initState(networkData) {
     lastDisturbedNodeId: null,
     executingExploit: null,
     activeProbe: null,
+    activeRead: null,
     mission: null,
   };
 

--- a/js/state/player.js
+++ b/js/state/player.js
@@ -45,6 +45,13 @@ export function setActiveProbe(data) {
   });
 }
 
+/** Sets state.activeRead (pass null to clear). */
+export function setActiveRead(data) {
+  mutate((s) => {
+    s.activeRead = data;
+  });
+}
+
 /** Marks the current mission as complete. */
 export function setMissionComplete() {
   mutate((s) => {

--- a/js/timers.js
+++ b/js/timers.js
@@ -17,6 +17,7 @@ export const TIMER = {
   EXPLOIT_EXEC:    "starnet:timer:exploit-exec",
   EXPLOIT_NOISE:   "starnet:timer:exploit-noise",
   PROBE_SCAN:      "starnet:timer:probe-scan",
+  READ_SCAN:       "starnet:timer:read-scan",
 };
 
 let currentTick = 0;

--- a/js/types.js
+++ b/js/types.js
@@ -135,6 +135,14 @@
  */
 
 /**
+ * Tracks an in-progress read scan. Null when no read is running.
+ * @typedef {{
+ *   nodeId: string,
+ *   timerId: number,
+ * }} ActiveRead
+ */
+
+/**
  * @typedef {{
  *   targetMacguffinId: string,
  *   targetName: string,
@@ -180,7 +188,8 @@
  *   cancelProbe:   () => void,
  *   startExploit:  (nodeId: string, exploitId: string) => void,
  *   cancelExploit: () => void,
- *   readNode:      (nodeId: string) => void,
+ *   startRead:     (nodeId: string) => void,
+ *   cancelRead:    () => void,
  *   lootNode:      (nodeId: string) => void,
  *   ejectIce:         () => void,
  *   rebootNode:       (nodeId: string) => void,
@@ -262,6 +271,7 @@
  *   mission: MissionState|null,
  *   executingExploit: ExecutingExploit|null,
  *   activeProbe: ActiveProbe|null,
+ *   activeRead: ActiveRead|null,
  * }} GameState
  */
 
@@ -289,6 +299,9 @@
 
 /** @typedef {{ nodeId: string, label: string, durationMs: number }} ProbeScanStartedPayload */
 /** @typedef {{ nodeId: string, label: string }} ProbeScanCancelledPayload */
+
+/** @typedef {{ nodeId: string, label: string, durationMs: number }} ReadScanStartedPayload */
+/** @typedef {{ nodeId: string, label: string }} ReadScanCancelledPayload */
 
 /** @typedef {{ prev: GlobalAlertLevel, next: GlobalAlertLevel }} AlertGlobalRaisedPayload */
 /** @typedef {{ seconds: number }} AlertTraceStartedPayload */

--- a/js/visual-renderer.js
+++ b/js/visual-renderer.js
@@ -12,7 +12,7 @@
 
 import { on, emitEvent, E } from "./events.js";
 import { getAvailableActions } from "./node-actions.js";
-import { updateNodeStyle, getCy, flashNode, addIceNode, syncIceGraph, syncSelection, syncProbeSweep, clearProbeSweep, syncExploitBrackets, clearExploitBrackets, syncIceDetectSweep, clearIceDetectSweep, completeAndClearIceDetectSweep } from "./graph.js";
+import { updateNodeStyle, getCy, flashNode, addIceNode, syncIceGraph, syncSelection, syncProbeSweep, clearProbeSweep, syncReadSectors, clearReadSectors, syncExploitBrackets, clearExploitBrackets, syncIceDetectSweep, clearIceDetectSweep, completeAndClearIceDetectSweep } from "./graph.js";
 import { getVisibleTimers } from "./timers.js";
 import { exploitSortKey } from "./exploits.js";
 
@@ -29,6 +29,10 @@ let execTotalMs = null;
 // Probe scan timing — same pattern, drives the sweep overlay in the graph.
 let probeStartTime = null;
 let probeTotalMs = null;
+
+// Read scan timing — same pattern, drives the sector fill overlay.
+let readStartTime = null;
+let readTotalMs = null;
 
 // Context menu — tracks which node the menu is anchored to for pan/zoom repositioning.
 let contextMenuNodeId = null;
@@ -69,6 +73,12 @@ export function initVisualRenderer() {
   on(E.NODE_PROBED,          () => { probeStartTime = null; probeTotalMs = null; clearProbeSweep(); });
   on(E.RUN_STARTED,          () => { probeStartTime = null; probeTotalMs = null; clearProbeSweep(); });
 
+  // Track read scan start time for the sector fill overlay.
+  on(E.READ_SCAN_STARTED,    ({ durationMs }) => { readStartTime = Date.now(); readTotalMs = durationMs; });
+  on(E.READ_SCAN_CANCELLED,  () => { readStartTime = null; readTotalMs = null; clearReadSectors(); });
+  on(E.NODE_READ,            () => { readStartTime = null; readTotalMs = null; clearReadSectors(); });
+  on(E.RUN_STARTED,          () => { readStartTime = null; readTotalMs = null; clearReadSectors(); });
+
   // Timer-only tick: update countdowns in-place. Exploit progress is updated
   // in-place (not a full re-render) so the cancel overlay stays stable in the DOM.
   on(E.TIMERS_UPDATED, (/** @type {GameState} */ state) => {
@@ -83,6 +93,10 @@ export function initVisualRenderer() {
     if (state.activeProbe && probeStartTime !== null && probeTotalMs !== null) {
       const elapsed = Math.min(Date.now() - probeStartTime, probeTotalMs);
       syncProbeSweep(state.activeProbe.nodeId, elapsed / probeTotalMs);
+    }
+    if (state.activeRead && readStartTime !== null && readTotalMs !== null) {
+      const elapsed = Math.min(Date.now() - readStartTime, readTotalMs);
+      syncReadSectors(state.activeRead.nodeId, elapsed / readTotalMs);
     }
     if (state.executingExploit && execStartTime !== null && execTotalMs !== null) {
       const elapsed = Math.min(Date.now() - execStartTime, execTotalMs);
@@ -541,6 +555,7 @@ function renderIceTimers() {
     const cls = t.label === "ICE DETECTION" ? "ice-timer-detect"
               : t.label === "EXECUTING"      ? "ice-timer-executing"
               : t.label === "SCANNING"       ? "ice-timer-scanning"
+              : t.label === "READING"        ? "ice-timer-scanning"
               : "ice-timer-reboot";
     return `<div class="ice-timer ${cls}">⚠ ${t.label}: ${t.remaining}s</div>`;
   }).join("");

--- a/scripts/playtest.js
+++ b/scripts/playtest.js
@@ -18,6 +18,7 @@ import { initState, serializeState, deserializeState } from "../js/state.js";
 import { completeReboot } from "../js/node-orchestration.js";
 import { handleExploitExecTimer, handleExploitNoiseTimer } from "../js/exploit-exec.js";
 import { handleProbeScanTimer } from "../js/probe-exec.js";
+import { handleReadScanTimer } from "../js/read-exec.js";
 import { startIce, handleIceTick, handleIceDetect } from "../js/ice.js";
 import { on, E } from "../js/events.js";
 import { tick, TIMER } from "../js/timers.js";
@@ -68,6 +69,7 @@ on(TIMER.REBOOT_COMPLETE, (payload) => completeReboot(payload.nodeId));
 on(TIMER.EXPLOIT_EXEC,    (payload) => handleExploitExecTimer(payload));
 on(TIMER.EXPLOIT_NOISE,   (payload) => handleExploitNoiseTimer(payload));
 on(TIMER.PROBE_SCAN,      (payload) => handleProbeScanTimer(payload));
+on(TIMER.READ_SCAN,       (payload) => handleReadScanTimer(payload));
 
 // ── Action dispatcher ──────────────────────────────────────
 // Same path as the browser: starnet:action → getAvailableActions guard → ActionDef.execute()
@@ -101,6 +103,9 @@ on(E.NODE_REBOOTED,        ({ label })                 => out(`[NODE] ${label}: 
 on(E.PROBE_SCAN_STARTED,   ({ label, durationMs }) =>
   out(`[PROBE] ${label}: scanning (${Math.round(durationMs / 1000)}s)...`));
 on(E.PROBE_SCAN_CANCELLED, ({ label }) => out(`[PROBE] ${label}: scan cancelled.`));
+on(E.READ_SCAN_STARTED,    ({ label, durationMs }) =>
+  out(`[READ] ${label}: extracting data (${Math.round(durationMs / 1000)}s)...`));
+on(E.READ_SCAN_CANCELLED,  ({ label }) => out(`[READ] ${label}: extraction cancelled.`));
 on(E.EXPLOIT_STARTED,      ({ label, exploitName, durationMs }) =>
   out(`[EXPLOIT] ${label} — ${exploitName}: executing (${Math.round(durationMs / 1000)}s)...`));
 on(E.EXPLOIT_INTERRUPTED,  ({ exploitName }) => out(`[EXPLOIT] ${exploitName}: interrupted.`));

--- a/tests/node-actions.test.js
+++ b/tests/node-actions.test.js
@@ -28,6 +28,7 @@ function baseState(extra = {}) {
     phase: "playing",
     selectedNodeId: null,
     activeProbe: null,
+    activeRead: null,
     executingExploit: null,
     ice: null,
     traceSecondsRemaining: null,
@@ -318,7 +319,8 @@ function mockCtx(overrides = {}) {
     cancelProbe:   () => {},
     startExploit:  () => {},
     cancelExploit: () => {},
-    readNode:      () => {},
+    startRead:     () => {},
+    cancelRead:    () => {},
     lootNode:      () => {},
     ejectIce:      () => {},
     rebootNode:    () => {},
@@ -362,13 +364,21 @@ describe("action execute() routing", () => {
     assert.ok(called);
   });
 
-  it("read calls ctx.readNode(node.id)", () => {
+  it("read calls ctx.startRead(node.id)", () => {
     const a = action("read");
     const node = lockedNode({ accessLevel: "compromised" });
     let called = null;
-    const ctx = mockCtx({ readNode: (id) => { called = id; } });
+    const ctx = mockCtx({ startRead: (id) => { called = id; } });
     a.execute(node, baseState(), ctx);
     assert.equal(called, node.id);
+  });
+
+  it("cancel-read calls ctx.cancelRead()", () => {
+    const a = action("cancel-read");
+    let called = false;
+    const ctx = mockCtx({ cancelRead: () => { called = true; } });
+    a.execute(lockedNode(), baseState({ activeRead: { nodeId: "test-1", timerId: 1 } }), ctx);
+    assert.ok(called);
   });
 
   it("loot calls ctx.lootNode(node.id)", () => {


### PR DESCRIPTION
Read now takes time scaled by node grade (S: 4s down to F: 0.8s), matching the probe/exploit pattern. A random pie-sector SVG overlay fills in shuffled order as progress advances (green tint, visually distinct from probe cyan and exploit magenta). Fill completes at 90% progress so it looks full just before the timer resolves.

New file: js/read-exec.js (startRead, cancelRead, handleReadScanTimer). Adds cancel-read action, auto-cancels on navigation, wired in harness.