### PR TITLE
Procedural LAN generation

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -218,6 +218,45 @@ When a node is selected, your hand re-sorts: matching cards first, then usable c
 then worn, then disclosed. Cards that match the selected node's known vulnerabilities
 highlight in cyan.
 
+The numbers shown next to cards in `status hand` are the numbers to use with
+`exploit <n>` — the sort order changes with your selection, so always check
+`status hand` to confirm which card is at which position.
+
+---
+
+## THE DARKNET BROKER
+
+The **WAN node** — the boundary between your tether and the LAN — is more than an exit
+point. A darknet broker operates through it, selling exploit cards mid-run.
+
+### Accessing the Store
+
+Select the WAN node and use the `access-darknet` action (or click the button in the
+sidebar). **The LAN pauses while you shop** — ICE stops moving, timers freeze. You
+can browse without the clock running.
+
+```
+> select wan
+> store           # list available cards and prices
+> buy <index>     # purchase the card at that position
+> deselect        # or select another node to resume
+```
+
+### When to Use It
+
+- Your hand doesn't match the node vulnerabilities you're facing — check the catalog
+  for a better-targeted card
+- Key cards are worn or disclosed mid-run — replenish before tackling hard nodes
+- You've looted enough cash to afford an upgrade and a tough node lies ahead
+
+### What's Available
+
+The broker stocks a rotating catalog of exploit cards at varying prices. Cards cost
+more the higher their rarity and quality. Rare cards with broad vulnerability coverage
+are expensive but powerful against the hardest nodes.
+
+You'll need cash to buy. Loot macguffins first, then shop.
+
 ---
 
 ## THE ALERT SYSTEM
@@ -445,6 +484,10 @@ the high-grade nodes. A disclosed card is deadweight.
 **The security monitor is the kill switch.** If you can own the security monitor,
 you can cancel the trace and work at your own pace. It's usually the hardest node
 on the board — but worth it if you're going for a deep run.
+
+**If your hand doesn't match, shop.** The WAN node is always accessible. If you're
+locked out of a key node because your cards don't match its vulnerabilities, detour
+through the WAN and check the darknet catalog. The LAN freezes while you browse.
 
 **Jack out when the job is done.** There's no shame in a clean exit.
 

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ lint:
 		js/rng.js js/probe-exec.js js/read-exec.js js/loot-exec.js js/navigation.js \
 		js/node-actions.js js/global-actions.js js/action-context.js js/node-orchestration.js
 
-# Run unit + integration tests
+# Run unit + integration tests (js/*.test.js for top-level, js/**/*.test.js for subdirs)
 test:
-	node --test tests/*.test.js js/**/*.test.js
+	node --test tests/*.test.js js/*.test.js js/**/*.test.js
 
 # Full check: lint + test
 check: lint test

--- a/data/node-type-rules.js
+++ b/data/node-type-rules.js
@@ -1,0 +1,101 @@
+// @ts-check
+// Topology rule data for the procedural LAN generator.
+// Each entry describes how a node type participates in network generation.
+// This is pure data — no runtime logic. The generator reads these rules;
+// they are not hard-coded into the algorithm.
+//
+// Fields:
+//   singleton      — at most one of this type per network
+//   depth          — target depth layer (0 = gateway level)
+//   connectsTo     — downstream node types this type connects to (repetition = weight)
+//   gateType       — node gates neighbor reveal (requires owning before connections visible)
+//   leaf           — no outgoing connections to content/routing nodes
+//   security       — part of the IDS/monitor security chain
+//   mustBehindGate — must have a gate-type node on the path from gateway
+//   iceResident    — ICE starts here at run init
+//   minCount       — minimum instances in a generated network (0 = optional)
+//   maxCount       — maximum instances in a generated network
+
+/** @type {Record<string, object>} */
+export const NODE_GEN_RULES = {
+  wan: {
+    singleton:   true,
+    depth:       -1,
+    connectsTo:  ["gateway"],
+    leaf:        false,
+  },
+
+  gateway: {
+    singleton:   true,
+    depth:       0,
+    // router weighted higher than firewall — most paths go through routing layer
+    connectsTo:  ["router", "router", "firewall"],
+    leaf:        false,
+  },
+
+  router: {
+    singleton:   false,
+    depth:       1,
+    connectsTo:  ["workstation", "workstation", "fileserver"],
+    leaf:        false,
+    minCount:    1,
+    maxCount:    2,
+  },
+
+  firewall: {
+    singleton:   false,
+    gateType:    true,
+    depth:       1,
+    connectsTo:  ["fileserver", "cryptovault"],
+    leaf:        false,
+    minCount:    0,
+    maxCount:    1,
+  },
+
+  workstation: {
+    singleton:   false,
+    depth:       2,
+    connectsTo:  [],
+    leaf:        true,
+    minCount:    1,
+    maxCount:    3,
+  },
+
+  fileserver: {
+    singleton:   false,
+    depth:       2,
+    connectsTo:  [],
+    leaf:        true,
+    minCount:    1,
+    maxCount:    2,
+  },
+
+  cryptovault: {
+    singleton:   false,
+    mustBehindGate: true,
+    depth:       3,
+    connectsTo:  [],
+    leaf:        true,
+    minCount:    0,
+    maxCount:    1,
+  },
+
+  ids: {
+    singleton:   false,
+    security:    true,
+    depth:       2,
+    connectsTo:  ["security-monitor"],
+    leaf:        false,
+    minCount:    1,
+    maxCount:    1,
+  },
+
+  "security-monitor": {
+    singleton:   true,
+    security:    true,
+    iceResident: true,
+    depth:       3,
+    connectsTo:  [],
+    leaf:        true,
+  },
+};

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -53,8 +53,13 @@ From session-5 design discussion — reframe log verbosity as something the play
 
 ### Overworld / Meta-loop
 - **Overworld linking LANs** — the dungeon run takes place in a larger world context; structure connecting LAN to LAN (planet internets, star systems, ansible networks)
-- **Procedural or semi-procedural network generation** — random LAN topologies with seeded RNG for reproducibility (roguelike runs); currently static hand-crafted network
+- **Procedural or semi-procedural network generation** — ~~random LAN topologies with seeded RNG for reproducibility (roguelike runs); currently static hand-crafted network~~ _in progress: 2026-03-01-1458-procedural-lan-gen_
 - **Inter-run progression** — player skills, reputation, contacts, persistent exploit inventory carry between runs
+- **Biome system** — node type palette, flavor text, and set piece pool selected by biome (corporate, military, black market, etc.); third axis for the procedural generator after timeCost/moneyCost are stable
+- **LAN generator set pieces (future):**
+  - **Workstation array** — multiple low-grade workstations behind a router for methodical looting
+  - **Lucky break** — a low-grade firewall in front of a cryptovault (the corp cut corners on hardening)
+  - **Security theater** — low-grade fileservers behind a high-grade firewall (counting on perimeter, soft inside)
 
 ### Worldbuilding (from SPEC.md)
 - Sprites, daemons, machine elves as in-network entities / power-ups (semi-autonomous AI anomalies)
@@ -71,6 +76,14 @@ From session-5 design discussion — reframe log verbosity as something the play
 Implemented in `js/rng.js` — Mulberry32 PRNG with 5 named streams (exploit, combat,
 ice, loot, world). String seeds hashed via djb2. All 26 gameplay `Math.random()` calls
 replaced. Deterministic runs verified. Playtest harness supports `--seed`.
+
+### Centralized Grade Constants Module
+All grade-keyed lookup tables (ICE move intervals, dwell times, noise thresholds, node
+grade ranges, etc.) are currently scattered across `ice.js`, `combat.js`, `probe-exec.js`,
+and the generator. A dedicated `js/grades.js` module exporting the grade order, grade-to-index
+mapping, and shared utility functions (gradeToIndex, indexToGrade, gradeRange) would make
+tuning easier and eliminate duplication. Natural time to do this: when the generator's budget
+tables create a third or fourth copy of the grade scale.
 
 ### Snapshot-Based Testing
 With save/load implemented and seeded RNG (above), we can write tests that start from a

--- a/docs/dev-sessions/2026-03-01-1458-procedural-lan-gen/notes.md
+++ b/docs/dev-sessions/2026-03-01-1458-procedural-lan-gen/notes.md
@@ -106,11 +106,110 @@ No module-level state in `js/set-pieces.js`.
 
 ---
 
-## Session Retro Summary
+## Retrospective
 
-**Completed:** All 9 planned phases.
-**Worked well:** The four-layer architecture, snapshot tests, harness flags, URL params.
-**Deferred:** Multiple set pieces (workstation array, lucky break, security theater),
-biome system, ICE grade scaling with difficulty.
-**Bugs found:** None blocking. Minor: `status full` shows "N node(s) revealed" summary
-rather than listing each node's ID — makes harness-guided play slightly awkward.
+### Recap
+
+Built a full procedural LAN generator from scratch across 9 planned phases:
+
+- `js/grades.js` — grade utilities (GRADES, shiftGrade, randomGrade, etc.)
+- `data/node-type-rules.js` — topology rule data (singleton, depth, connectsTo, etc.)
+- `js/network-gen.js` — core generator with budget tables, label pools, layout
+- Validator predicates with retry loop
+- `js/set-pieces.js` — set piece system + `careless-user` piece
+- Harness integration (`--time`, `--money`, `--force-piece` flags)
+- Browser URL param integration (`?seed=&time=&money=`)
+- Snapshot + structural tests (276 passing)
+- Headless playtesting with balance notes
+
+Post-plan additions driven by playtesting: `status full` showing revealed node IDs,
+F depthBudget bump, `startCash`/`startHandSpec` scaling tables, `forcePieces` option.
+
+Late-session RNG consolidation (not in original plan): extracted `makeSeededRng` and
+`shuffleWith` into `js/rng.js`, eliminating duplicate Mulberry32/djb2 code from the
+generator. **This work is uncommitted at session close** — needs to land before the
+branch is merged.
+
+### Divergences from plan
+
+- **Phase 3** originally called for local `djb2`/`makeMulberry32` in the generator.
+  These were later consolidated into `js/rng.js` as `makeSeededRng`/`shuffleWith`.
+  Plan was correct at the time; the refactor emerged naturally once the pattern was
+  repeated a third time (shuffle).
+
+- **Phase 8** snapshots were written to `js/snapshots/` (colocated) rather than
+  `tests/snapshots/` as originally planned. Aligns with the colocated-tests convention
+  established for grades.
+
+- **Post-plan balance tweaks** (cash scaling, hand scaling, F depth, revealed node
+  listing) were added after playtesting. These were genuinely discovered through play
+  and couldn't have been specified upfront — the process worked as intended.
+
+- **`data/node-type-rules.js` is not imported by the generator.** The rules file was
+  created in Phase 2 but `buildNetwork` never adopted it — grade assignments, label
+  pools, and type strings remain hardcoded in the generator. This is the primary
+  technical debt handed off to the biome-bundles session.
+
+### Insights
+
+- **The four-layer architecture held up.** Rules / algorithm / validators / set pieces
+  is a clean separation. The validator retry loop is an elegant escape valve — the
+  algorithm doesn't need to be perfect, just usually correct.
+
+- **Snapshot tests are invaluable for generators.** They caught two regressions during
+  the session (after adding startCash/startHandSpec, and after depthBudget change).
+  Worth the upfront cost of writing them.
+
+- **`data/node-type-rules.js` was created prematurely.** It was designed to be read by
+  the generator but that step was never taken. The rules data and the generator algorithm
+  are effectively in separate universes. This was the seed of the biome-bundles idea —
+  the right fix is to bundle them together, not just import one from the other.
+
+- **Balance can't be designed upfront at this level of fidelity.** Playtesting produced
+  three concrete tweaks that improved the game feel significantly. Iterating after seeing
+  numbers is faster than pre-specifying difficulty curves.
+
+- **The `forcePieces` option was a good mid-session addition.** User spotted the
+  opportunity while the set piece code was being written. Cost: ~15 minutes. Value:
+  makes set pieces testable without seed-hunting. Good instinct to interrupt and add it.
+
+### What data/node-type-rules.js was supposed to be
+
+The rules file was designed with good intentions — decouple topology facts from
+the algorithm — but it became a data orphan. The biome-bundles session should absorb
+it entirely. The lesson: data without a consumer isn't architecture, it's wishful
+thinking. Next time, wire the data file in before moving on.
+
+### Efficiency
+
+- Phases 1–5 went smoothly — the plan was tight and implementation was mostly mechanical.
+- Phases 6–7 (harness/browser integration) required careful coordination between two
+  parallel entry points (`scripts/playtest.js` and `js/main.js`).
+- Phase 9 (playtesting) produced valuable signal quickly. The harness is fast enough
+  that manual play through `tick` and `exploit` commands is genuinely fun.
+- The RNG consolidation at end of session was unplanned but fast (~20 min) and clean.
+  Leaving it uncommitted was a mistake — should have committed immediately.
+
+### Process improvements
+
+- **Commit more frequently.** The RNG consolidation was left uncommitted at session end.
+  Rule: commit before switching contexts.
+- **Wire data files to their consumers in the same phase they're created.** Creating
+  `node-type-rules.js` without reading it in the generator created false confidence
+  that the architecture was sound.
+- **Note the "UNCOMMITTED" status of any work that doesn't land in a commit** before
+  the retro, so it's visible and doesn't get lost across sessions.
+
+### Conversation turns
+
+Approximately 30–35 exchanges across two context windows (session continued from
+a prior summarized conversation).
+
+### Other highlights
+
+- The biome-bundles session was conceived during the retro conversation. Good sign:
+  the current session did enough to surface the right next problem.
+- The `forcePieces` interrupt pattern was a good example of a mid-execution spec
+  change that was worth taking. Small scope, high leverage.
+- 276 tests at session close. Starting count: 224 (before network-gen tests).
+  52 new tests added.

--- a/docs/dev-sessions/2026-03-01-1458-procedural-lan-gen/notes.md
+++ b/docs/dev-sessions/2026-03-01-1458-procedural-lan-gen/notes.md
@@ -1,0 +1,116 @@
+# Notes: Procedural LAN Generation
+
+## Session Progress
+
+All 9 phases completed. Generator is wired into both the headless harness
+(`--time` / `--money` flags) and the browser (`?seed=&time=&money=` URL params).
+276 tests passing.
+
+---
+
+## Headless Playtest Results
+
+### Easy Run — F/F seed:"easy-test"
+
+Network: 7 nodes. Completed in ~400 simulated ticks with no ICE pressure.
+
+**Observations:**
+- Network topology is clean: wan → gateway → router → fileserver + workstation + ids chain
+- F-grade ICE barely moved; not a meaningful threat at this difficulty
+- Hand had good coverage; 72% match rate on gateway allowed easy entry
+- ¥5,994 looted, alert stayed GREEN throughout — very forgiving
+- **Too easy at F/F:** Node count (7) feels thin; ICE is invisible
+
+**Potential tuning:**
+- Add a minimum of 2 workstations at F so there's something to explore beyond the direct path
+- Consider raising F depthBudget from 2 to 2 (keep), but place fileserver slightly deeper
+- F/F ICE could still be a nuisance — consider setting iceGrade to E if/when a grade is added below F
+
+### Medium Run — B/B seed:"mid-test"
+
+Network: 11 nodes. Mission not completed — ran out of matching cards before owning fileserver.
+
+**Observations:**
+- The firewall (path-traversal only vuln) forced darknet store visit — this is correct behavior
+- TimingOracle was the sole match, failed 3× at 48% success rate and was disclosed
+- Darknet store purchase (¥250 for path-traversal card) was intuitive and effective
+- ICE B-grade patrolled visibly and triggered detection pressure (~4s warning twice)
+- Alert stayed GREEN throughout (ICE moved away before detection fired both times)
+- Firewall "owned" eventually but fileserver needed 3 more exploits; card uses ran low
+- Mission not completed on jackout — correct, jackout is escape not success
+
+**Key insight — mission target at depth 3:**
+The B/B fileserver (targetDepth=3) requires: gateway → firewall → fileserver, each
+needing 2+ exploits. That's 6+ exploits on the critical path. With 6 cards at 3–8
+uses each and B-grade nodes at ~50% success rate, expected failures = ~6 more uses.
+A 6-card hand may not have enough total uses for a clean B/B run. The darknet store
+is essential — not just for vuln matching but for use replenishment.
+
+**Potential tuning:**
+- Starting cash (¥1,000) feels tight for B/B. Consider giving ¥1,500 for B/C or higher
+- Or reduce B fileserver to 2 exploits needed by reducing its pathGradeMax
+- The careless-user set piece did NOT fire this run (rng ≥ 0.6). When it does fire,
+  it may change the routing significantly — needs explicit playtesting with a seed
+  that triggers it
+
+### Careless-User Set Piece
+
+Not observed in F/F (ineligible — requires moneyCost ≥ C) or the B/B test run
+(40% miss probability). The set piece implementation looks correct; needs a seed
+that exercises the 60% path to be fully validated through play.
+
+**To observe it:**
+```bash
+# try seeds until careless-user fires (check node count > 11 for B/B)
+node scripts/playtest.js --seed "foo" --time B --money B reset
+```
+
+---
+
+## Balance Notes & Backlog Items
+
+- **F/F feels thin** — 7 nodes, trivial ICE, complete in ~5 minutes. Consider
+  adding a minimum workstation count or a soft "always add 1 extra router" rule.
+- **B/B cash pressure** — starting ¥1,000 is tight when one card purchase is ¥250
+  and you need 3+ purchases for a hard run. Log as balance backlog item.
+- **Card count scaling** — starting hand size (6) may need to scale with difficulty.
+  At S/S, 6 cards will almost certainly not be enough. Consider deal 8 cards at A+.
+- **ICE at F/F** — effectively absent. A grade-F ICE with a very long move timer
+  (> 30 ticks) is basically invisible. May want ICE to be off entirely at F/F.
+- **Exploit success% at B-grade nodes** — 48–52% is about right for a medium
+  difficulty match. Feels appropriately tense.
+- **Determinism confirmed** — same seed, same params → same network every time.
+  The snapshot tests cover this and will catch regressions.
+
+---
+
+## Technical Notes
+
+### Colocated tests
+
+Moved grades tests to `js/grades.test.js` (colocated with `js/grades.js`).
+Added `js/*.test.js` to Makefile test glob (the existing `js/**/*.test.js` pattern
+only matched subdirectories under `/bin/sh`, not top-level `js/*.test.js`).
+
+### Generator architecture
+
+The four-layer split (rules / algorithm / validators / set pieces) worked cleanly.
+The validator retry loop never fired during playtesting — the algorithm reliably
+produces valid networks on the first attempt for all difficulty combinations tested.
+
+### Set piece integration
+
+The `applySetPiece` API passes `makeId` and `nextLabel` closures from the generator,
+so set piece nodes integrate seamlessly into the main ID sequence and label pools.
+No module-level state in `js/set-pieces.js`.
+
+---
+
+## Session Retro Summary
+
+**Completed:** All 9 planned phases.
+**Worked well:** The four-layer architecture, snapshot tests, harness flags, URL params.
+**Deferred:** Multiple set pieces (workstation array, lucky break, security theater),
+biome system, ICE grade scaling with difficulty.
+**Bugs found:** None blocking. Minor: `status full` shows "N node(s) revealed" summary
+rather than listing each node's ID — makes harness-guided play slightly awkward.

--- a/docs/dev-sessions/2026-03-01-1458-procedural-lan-gen/plan.md
+++ b/docs/dev-sessions/2026-03-01-1458-procedural-lan-gen/plan.md
@@ -1,0 +1,447 @@
+# Plan: Procedural LAN Generation
+
+## Overview
+
+Eight implementation phases, each producing testable, integrated code.
+No phase leaves orphaned code — every step wires into the existing engine.
+
+The generator lives in `js/network-gen.js` and produces a NETWORK-shaped object
+compatible with the existing `initState(network)` API. It uses its own local seeded
+RNG (not the global `js/rng.js`) so it is fully self-contained and does not affect
+gameplay randomness.
+
+---
+
+## Phase 1 — `js/grades.js`: Grade Utilities
+
+**Builds on:** nothing new — pure utility module.
+
+**After this phase:** a shared grade vocabulary usable by the generator, future
+balance tuning, and any other module that needs to reason about the S/A/B/C/D/F scale.
+
+### Prompt
+
+Create `js/grades.js` with the following exports:
+
+```js
+// Ordered ascending: F=0 (easiest) ... S=5 (hardest)
+export const GRADES = ["F", "D", "C", "B", "A", "S"];
+
+// Reverse lookup: grade letter → index
+export const GRADE_INDEX = Object.fromEntries(GRADES.map((g, i) => [g, i]));
+
+// Parse a grade string, return the canonical letter or null if invalid.
+export function parseGrade(s) { ... }
+
+// Return a sub-array of GRADES between minGrade and maxGrade (inclusive).
+export function gradeRange(minGrade, maxGrade) { ... }
+
+// Pick a random grade between minGrade and maxGrade using the provided rng() callback.
+export function randomGrade(rng, minGrade, maxGrade) { ... }
+
+// Clamp a grade index to valid bounds, return grade letter.
+export function clampGrade(index) { ... }
+
+// Return the grade N steps above/below a given grade (clamped).
+export function shiftGrade(grade, delta) { ... }
+```
+
+Write unit tests in `tests/grades.test.js` covering: GRADES order, gradeRange edge
+cases (same min/max, full range, single-grade range), shiftGrade clamping at both ends.
+
+---
+
+## Phase 2 — `data/node-type-rules.js`: Topology Rule Data
+
+**Builds on:** Phase 1 (uses grade constants for defaults).
+
+**After this phase:** the topology grammar is expressed as data. The generator
+(Phase 3) reads this file rather than hard-coding structural knowledge.
+
+### Prompt
+
+Create `data/node-type-rules.js` exporting `NODE_GEN_RULES` — a plain object keyed
+by node type. Each entry describes how that type participates in generation:
+
+```js
+export const NODE_GEN_RULES = {
+  wan:              { singleton: true, depth: -1, connectsTo: ["gateway"] },
+  gateway:          { singleton: true, depth: 0,  connectsTo: ["router", "firewall", "router"] },
+  router:           { depth: 1, connectsTo: ["workstation", "fileserver", "workstation"],
+                      minCount: 1, maxCount: 2 },
+  firewall:         { gateType: true, depth: 1,
+                      connectsTo: ["fileserver", "cryptovault"],
+                      minCount: 0, maxCount: 1 },
+  workstation:      { leaf: true, depth: 2, minCount: 1, maxCount: 3 },
+  fileserver:       { leaf: true, depth: 2, minCount: 1, maxCount: 2 },
+  cryptovault:      { leaf: true, mustBehindGate: true, depth: 3,
+                      minCount: 0, maxCount: 1 },
+  ids:              { security: true, depth: 2,
+                      connectsTo: ["security-monitor"] },
+  "security-monitor": { singleton: true, security: true, leaf: true,
+                        depth: 3, iceResident: true },
+};
+```
+
+Fields:
+- `singleton` — at most one of this type in the network
+- `depth` — target depth layer (0 = gateway level); used for layout and grade scaling
+- `connectsTo` — downstream node types this type may connect to (weighted by repetition)
+- `gateType` — node gates neighbor reveal (matches `gateAccess` in `node-types.js`)
+- `leaf` — no outgoing connections to non-security nodes
+- `security` — part of the IDS/monitor chain
+- `mustBehindGate` — must have a gate-type node on the path from gateway
+- `iceResident` — ICE starts here
+- `minCount` / `maxCount` — how many of this type the algorithm may place
+
+No runtime logic in this file — pure data.
+
+---
+
+## Phase 3 — `js/network-gen.js`: Core Generator
+
+**Builds on:** Phases 1–2. Produces a valid NETWORK object.
+
+**After this phase:** `generateNetwork("seed", "C", "B")` returns a NETWORK object
+that can be passed directly to `initState()`. The static network is still used by
+the browser/harness — integration comes in Phases 6–7.
+
+### Prompt
+
+Create `js/network-gen.js`. The generator is self-contained: it includes its own
+mini Mulberry32 RNG initialized from the seed string (using djb2 hash), with no
+dependency on the global `js/rng.js`.
+
+**RNG helpers (module-private):**
+
+```js
+function djb2(str) { /* standard djb2 hash → int32 */ }
+function makeMulberry32(seed32) {
+  let s = seed32;
+  return () => { /* advance one step, return [0,1) float */ };
+}
+```
+
+**Budget tables (module-level constants):**
+
+```js
+// timeCost grade → { iceGrade, depthBudget, gateCount }
+const TIME_BUDGET = {
+  F: { iceGrade: "F", depthBudget: 2, gateCount: 0 },
+  D: { iceGrade: "D", depthBudget: 2, gateCount: 1 },
+  C: { iceGrade: "C", depthBudget: 3, gateCount: 1 },
+  B: { iceGrade: "B", depthBudget: 3, gateCount: 2 },
+  A: { iceGrade: "A", depthBudget: 4, gateCount: 2 },
+  S: { iceGrade: "S", depthBudget: 5, gateCount: 3 },
+};
+
+// moneyCost grade → { pathGradeMin, pathGradeMax, targetDepth }
+const MONEY_BUDGET = {
+  F: { pathGradeMin: "F", pathGradeMax: "D", targetDepth: 1 },
+  D: { pathGradeMin: "F", pathGradeMax: "C", targetDepth: 1 },
+  C: { pathGradeMin: "D", pathGradeMax: "B", targetDepth: 2 },
+  B: { pathGradeMin: "C", pathGradeMax: "A", targetDepth: 3 },
+  A: { pathGradeMin: "B", pathGradeMax: "S", targetDepth: 3 },
+  S: { pathGradeMin: "A", pathGradeMax: "S", targetDepth: 4 },
+};
+```
+
+**Label pools (module-level, per node type):**
+
+```js
+const LABELS = {
+  gateway:          ["INET-GW-01", "INET-GW-02", "GW-MAIN"],
+  router:           ["RTR-A", "RTR-B", "RTR-CORE", "RTR-EDGE"],
+  firewall:         ["FW-CORE", "FW-PERIMETER", "FW-DMZ"],
+  workstation:      ["WS-ALPHA", "WS-BETA", "WS-GAMMA", "WS-DELTA"],
+  fileserver:       ["FS-VAULT", "FS-ARCHIVE", "FS-DATA"],
+  cryptovault:      ["CRYPT-X9", "CRYPT-01", "VAULT-S"],
+  ids:              ["IDS-01", "IDS-02", "IDS-EDGE"],
+  "security-monitor": ["SEC-MON", "SEC-MON-01"],
+  wan:              ["WAN"],
+};
+```
+
+**Layout:** use a simple depth-layered layout. For each depth layer, distribute nodes
+evenly across a fixed horizontal band. Depth 0 (gateway) at y=50; each additional
+depth adds ~140px. Nodes in a layer spaced ~200px apart, centered around x=400.
+
+**`generateNetwork(seed, timeCost, moneyCost)` algorithm:**
+
+1. Validate inputs — `timeCost` and `moneyCost` must be valid grades; throw on invalid.
+2. Initialize local RNG from `djb2(seed + "-network")`.
+3. Look up `TIME_BUDGET[timeCost]` and `MONEY_BUDGET[moneyCost]`.
+4. Assemble fixed anchors: wan (depth -1), gateway (depth 0), security-monitor (deepest layer).
+5. Place security chain: ids node at depth (depthBudget − 1), connected to security-monitor.
+6. Place routing layer: 1–2 router nodes at depth 1 (count driven by depthBudget/gateCount).
+7. Place gate node(s): if gateCount ≥ 1, add a firewall at depth 1 connected to gateway.
+8. Place mission target: one fileserver at targetDepth, connected through a router (or
+   through the firewall if gateCount ≥ 2 and targetDepth is deep).
+9. Optionally place cryptovault behind firewall (if gateCount ≥ 2 and moneyCost ≥ B).
+10. Place filler: 1–2 workstations connected through a router.
+11. Connect ids to one router (ids watches the routing layer).
+12. Assign grades:
+    - Gateway: one step below pathGradeMin (always a soft entry).
+    - Routers: pathGradeMin.
+    - Firewall: pathGradeMax.
+    - Fileserver (mission target): randomGrade(rng, pathGradeMin, pathGradeMax).
+    - Workstations: grade below pathGradeMin (soft targets).
+    - IDS: one step above pathGradeMin.
+    - Security-monitor: pathGradeMax.
+13. Assign labels from per-type pools (randomPick, no repeats within a run).
+14. Compute x/y positions from depth layers.
+15. Return:
+    ```js
+    { nodes, edges, startNode: "gateway", ice: { grade: iceGrade, startNode: <security-monitor id> } }
+    ```
+
+Export only `generateNetwork`. No other public exports needed at this stage.
+
+---
+
+## Phase 4 — Validator Predicates
+
+**Builds on:** Phase 3. Wraps the generator in a retry loop.
+
+**After this phase:** the generator is robust — it retries on structurally invalid
+output and throws a clear error if all attempts fail.
+
+### Prompt
+
+Add a private `validate(network)` function to `js/network-gen.js` that runs a set
+of predicate checks on the generated network. Each predicate returns `null` on pass
+or a string description of the failure:
+
+```js
+const VALIDATORS = [
+  hasAnchors,           // wan, gateway, security-monitor all present
+  idsAdjacentToMonitor, // at least one ids node connects to security-monitor
+  missionTargetExists,  // at least one fileserver or cryptovault present
+  noOrphanNodes,        // every node has at least one edge
+  gatewayReachesTarget, // BFS from gateway reaches at least one lootable node
+];
+```
+
+Implement `gatewayReachesTarget` as a BFS over the edges array — does not need to
+simulate gating, just structural reachability.
+
+In `generateNetwork`, wrap the build algorithm in a retry loop (max 10 attempts).
+On each attempt, run `validate()`. If all validators pass, return the network.
+If all attempts fail, throw an error listing the last failure reason.
+
+Add tests in `tests/network-gen.test.js`:
+- All validators pass for a minimal hand-built valid network
+- `idsAdjacentToMonitor` fails when ids is not connected to security-monitor
+- `gatewayReachesTarget` fails when target is disconnected
+
+---
+
+## Phase 5 — Set Piece: `careless-user`
+
+**Builds on:** Phase 3–4. Adds the set piece facility and the first concrete piece.
+
+**After this phase:** `generateNetwork` can optionally embed the `careless-user`
+subgraph, blending it into the node/edge arrays before validation runs.
+
+### Prompt
+
+Create `js/set-pieces.js`. A set piece is a plain object:
+
+```js
+{
+  id: "careless-user",
+  // Nodes local to the set piece (ids relative to the piece, not the full network)
+  nodes: [
+    { localId: "ws", type: "workstation", gradeOffset: -1 },   // soft — below base grade
+    { localId: "fs", type: "fileserver",  gradeOffset: 0  },   // at base grade
+    { localId: "fw", type: "firewall",    gradeOffset: +1 },   // hardened
+  ],
+  // Edges internal to the set piece
+  edges: [
+    { source: "ws", target: "fs" },   // the exposure
+    { source: "fw", target: "fs" },   // the firewall still protects (hard path)
+  ],
+  // How the set piece attaches to the main graph
+  // type: the node type in the main graph to attach to
+  // localId: which piece node gets the external connection
+  externalAttachments: [
+    { attachTo: "router",  localId: "ws", direction: "downstream" },
+    { attachTo: "gateway", localId: "fw", direction: "downstream" },
+  ],
+}
+```
+
+Export `SET_PIECES` (the registry) and `applySetPiece(piece, network, rng, baseGrade)`
+which:
+1. Instantiates piece nodes with real ids (e.g. `sp-ws-1`, `sp-fs-1`, `sp-fw-1`)
+2. Assigns grades using `gradeOffset` relative to `baseGrade` (clamped to valid range)
+3. Assigns labels from per-type pools (same label pools as the generator)
+4. Attaches to the main graph via `externalAttachments` (finds a matching node by type,
+   adds an edge from that node to the piece node)
+5. Merges the piece's nodes and edges into the network's arrays
+6. Returns the mutated network
+
+In `js/network-gen.js`, add set piece selection: if `moneyCost ≥ C` and `rng() < 0.6`,
+apply the `careless-user` piece using the routing layer grade as `baseGrade`. If the
+set piece fileserver is the only fileserver, it becomes the mission target.
+
+---
+
+## Phase 6 — Harness Integration
+
+**Builds on:** Phases 3–5. Wires the generator into `scripts/playtest.js`.
+
+**After this phase:** the harness can generate and play through a procedural LAN
+from the command line.
+
+### Prompt
+
+Update `scripts/playtest.js`:
+
+1. Add `--time <grade>` and `--money <grade>` to the argument parser (alongside the
+   existing `--seed` and `--state` flags).
+
+2. At the top of the file, after argument parsing, determine which network to use:
+   ```js
+   import { generateNetwork } from "../js/network-gen.js";
+   // ...
+   const network = (timeArg && moneyArg)
+     ? generateNetwork(seedArg ?? "default", timeArg, moneyArg)
+     : NETWORK;
+   ```
+
+3. Replace all hardcoded `NETWORK` references in the file with the `network` variable.
+
+4. Update the `reset` command output to report generation parameters when present:
+   ```
+   [SYS] Initialized. Seed: "abc". Network: 9 nodes (generated: time=C money=B).
+   ```
+
+5. Update the usage/help block to document the new flags.
+
+Verify by running:
+```bash
+node scripts/playtest.js --seed test --time F --money F reset
+node scripts/playtest.js --seed test --time F --money F "status full"
+node scripts/playtest.js --seed test --time C --money B reset
+node scripts/playtest.js --seed test --time C --money B "status full"
+```
+
+---
+
+## Phase 7 — Browser URL Parameter Integration
+
+**Builds on:** Phase 6. Wires the generator into the browser entry point.
+
+**After this phase:** opening `index.html?seed=abc&time=C&money=B` loads a generated
+LAN. No params = static `data/network.js` as before.
+
+### Prompt
+
+Update `js/main.js`:
+
+1. Import `generateNetwork` from `js/network-gen.js`.
+2. Add a `getNetworkParams()` helper that reads URL search params:
+   ```js
+   function getNetworkParams() {
+     const p = new URLSearchParams(location.search);
+     const seed  = p.get("seed");
+     const time  = p.get("time")?.toUpperCase();
+     const money = p.get("money")?.toUpperCase();
+     if (seed && time && money) return { seed, timeCost: time, moneyCost: money };
+     return null;
+   }
+   ```
+3. In the `init()` function (and `run-again` handler), determine which network to use:
+   ```js
+   const params = getNetworkParams();
+   const network = params
+     ? generateNetwork(params.seed, params.timeCost, params.moneyCost)
+     : NETWORK;
+   initState(network, params?.seed);
+   ```
+4. If `generateNetwork` throws (invalid params), fall back to the static network and
+   log a warning to the browser console.
+
+Test by opening the browser at:
+- `index.html` — static network, no change
+- `index.html?seed=hello&time=F&money=F` — easy generated network
+- `index.html?seed=hello&time=B&money=B` — medium generated network
+
+---
+
+## Phase 8 — Snapshot & Structural Tests
+
+**Builds on:** Phases 3–5. Locks determinism and structural correctness.
+
+**After this phase:** a failing snapshot or structural test means the generator
+drifted — caught before the change lands.
+
+### Prompt
+
+Create `tests/network-gen.test.js`:
+
+**Determinism tests:**
+- Call `generateNetwork("testseed", "C", "B")` twice in the same test and assert
+  the two results are deeply equal (JSON.stringify comparison is fine).
+- Repeat for ("abc", "F", "F") and ("xyz", "S", "S").
+
+**Structural tests (run for each of F/F, C/C, B/B, S/S):**
+- Network has a `wan`, `gateway`, and `security-monitor` node
+- Network has at least one `fileserver` or `cryptovault`
+- `security-monitor` is adjacent to an `ids` node (check edges)
+- All nodes referenced in edges exist in the nodes array
+- BFS from `startNode` reaches at least one lootable node type
+
+**Snapshot tests:**
+For each of the following parameter sets, generate a network and compare against
+a stored JSON snapshot:
+- `("snap-seed", "F", "F")`
+- `("snap-seed", "C", "C")`
+- `("snap-seed", "B", "B")`
+- `("snap-seed", "S", "S")`
+
+On first run, write the snapshot to `tests/snapshots/network-gen-{params}.json`.
+On subsequent runs, compare and fail if the output differs.
+
+Use Node's `fs` module to read/write snapshots. If the file doesn't exist, create it
+(test passes on first run). If it exists, assert equality.
+
+---
+
+## Phase 9 — Headless Playtesting & Balance Notes
+
+**Builds on:** Phase 6 (harness flags). Human-driven validation.
+
+**After this phase:** we have documented evidence that generated LANs at F/F and B/B
+are actually playable, and notes on what to tune.
+
+### Prompt
+
+Run each scenario below through the playtest harness and record observations in
+`docs/dev-sessions/2026-03-01-1458-procedural-lan-gen/notes.md`.
+
+**Easy run (F/F):**
+```bash
+node scripts/playtest.js --seed "easy-test" --time F --money F reset
+node scripts/playtest.js --seed "easy-test" --time F --money F "status full"
+# play through: probe gateway, exploit nodes, loot mission target, jackout
+```
+Questions to answer: Is the network reachable with a default hand? Is it too easy
+(too few nodes, trivial ICE)? Does the careless-user set piece appear and is it
+noticeable?
+
+**Medium run (B/B):**
+```bash
+node scripts/playtest.js --seed "mid-test" --time B --money B reset
+node scripts/playtest.js --seed "mid-test" --time B --money B "status full"
+# play through: probe, exploit, manage ICE, use cheat give matching if needed
+```
+Questions to answer: Does ICE B-grade pressure feel meaningful? Are the critical path
+grades appropriately hard? Is the network depth satisfying to explore?
+
+**Regression check:**
+Run `make check` and confirm all 224+ tests pass. Confirm snapshot tests capture
+consistent output. Run both scenarios twice with the same seed to confirm determinism.
+
+Record any balance observations, bugs, or design notes in `notes.md` for the retro.

--- a/docs/dev-sessions/2026-03-01-1458-procedural-lan-gen/spec.md
+++ b/docs/dev-sessions/2026-03-01-1458-procedural-lan-gen/spec.md
@@ -1,0 +1,203 @@
+# Spec: Procedural LAN Generation
+
+## Goal
+
+Replace the single hand-crafted `data/network.js` with a generator that produces a
+`NETWORK`-shaped object from three parameters: `seed`, `timeCost`, and `moneyCost`.
+The generated LAN is fully deterministic — same inputs always produce the same network.
+The static `data/network.js` is preserved as a fallback when no parameters are provided.
+
+---
+
+## Inputs
+
+| Parameter   | Type            | Description |
+|-------------|-----------------|-------------|
+| `seed`      | string          | Passed to `js/rng.js` — determines all random choices in generation |
+| `timeCost`  | grade (S–D, F)  | Controls how time-expensive the LAN is to complete |
+| `moneyCost` | grade (S–D, F)  | Controls how money-expensive the LAN is to complete |
+
+Grade scale (ascending difficulty): **F < D < C < B < A < S**
+
+URL parameter form: `?seed=abc123&time=B&money=C`
+
+Harness flag form: `--seed abc123 --time B --money C`
+(`--seed` already exists; `--time` and `--money` are new)
+
+---
+
+## Output
+
+A `NETWORK`-shaped object — identical schema to what `data/network.js` currently
+exports. No new required fields in the first pass. Any schema additions must be
+backward-compatible with the existing game engine.
+
+The object includes:
+- `nodes[]` — array of node definitions with `id`, `type`, `grade`, `label`, `x`, `y`
+- `edges[]` — array of `{ source, target }` pairs
+- `startNode` — id of the gateway node
+- `iceGrade` — grade of the ICE entity (if present)
+
+---
+
+## Difficulty Budget Model
+
+The two cost axes drive different aspects of network composition:
+
+### Time Cost (ICE grade, depth, gate count)
+
+| timeCost | ICE grade | Network depth | Gate density |
+|----------|-----------|---------------|--------------|
+| F        | F         | Shallow (2–3 hops from gateway to target) | 0–1 gates |
+| D        | D         | Shallow–medium | 1 gate |
+| C        | C         | Medium (3–4 hops) | 1–2 gates |
+| B        | B         | Medium–deep | 2 gates |
+| A        | A         | Deep (4–5 hops) | 2–3 gates |
+| S        | S         | Deep | 3+ gates |
+
+*Gates: firewall, IDS, security-monitor nodes that require owning before revealing connections.*
+
+### Money Cost (node grades on critical path, mission target depth)
+
+| moneyCost | Critical path grades | Target depth |
+|-----------|---------------------|--------------|
+| F         | F–D                 | Shallow (1–2 nodes from gateway) |
+| D         | D–C                 | Shallow |
+| C         | C–B                 | Medium |
+| B         | B–A                 | Medium–deep |
+| A         | A–S                 | Deep |
+| S         | S                   | Deep (hardest nodes between player and target) |
+
+### Interaction
+
+ICE grade has a **secondary money cost** — ICE interruptions consume card uses without
+progress. High timeCost indirectly raises money pressure. The axes are not fully
+independent, but they represent the primary drivers of each cost type.
+
+---
+
+## Architecture: Rules, Algorithm, Validators, Set Pieces
+
+The generator is structured as four distinct layers:
+
+1. **Data-driven topology rules** — declarative facts about node types: what they connect
+   to, what gate level they require, what depth range they belong in. Extensible without
+   touching generator code. New node type = new rule entry.
+
+2. **Generator algorithm** — procedural code that consults the topology rules to build a
+   candidate network. The algorithm is stable; the rules it reads are not hard-coded into it.
+
+3. **Validator predicates** — functions that *check* structural properties of a generated
+   candidate (e.g. `missionTargetReachable`, `idsAdjacentToMonitor`). Run after generation;
+   trigger a retry if any fail. Composable and easy to add without modifying the algorithm.
+
+4. **Set pieces** — handcrafted subgraphs for topologies too complex or narratively specific
+   to express as data rules. Set pieces are the escape hatch: anything that would require
+   behavioral logic in the rules layer gets expressed as a set piece instead. They participate
+   in macro topology as a unit (a "super-node") and may intentionally violate standard rules.
+
+This split keeps the rules system simple, the algorithm stable, and complex cases handled
+manually — rather than making the rules system Turing-complete.
+
+---
+
+## Topology Rules
+
+The generator uses these rules to assemble the network. They formalize what is currently
+implicit in the static `data/network.js`.
+
+**Fixed anchors (always present):**
+- One `wan` node — always accessible, connects only to the gateway
+- One `gateway` node — player entry point, connects to wan and to the first routing layer
+- One `security-monitor` node — the ICE resident, at the deep end of the security chain
+
+**Structural rules:**
+- `router` nodes connect between the gateway and workstations/fileservers
+- `firewall` nodes gate access to high-value nodes (fileserver, cryptovault); connections
+  beyond a firewall are not revealed until the firewall is owned
+- `ids` nodes must be adjacent to a `security-monitor`; they watch the routing layer
+  (connected to at least one router or similar mid-tier node)
+- `cryptovault` nodes must be behind at least one gate (firewall preferred)
+- `security-monitor` connects only to `ids` nodes (dead end for the player)
+- No direct gateway → cryptovault edge
+- The mission target must be reachable via a chain of nodes all owned by the player
+
+**Grade placement:**
+- Nodes near the gateway tend toward lower grades (soft entry)
+- Nodes deeper in the network scale up toward the configured `moneyCost` grade range
+- ICE grade is set directly from `timeCost`
+
+---
+
+## Set Pieces
+
+Set pieces are named, parameterized prefab subgraphs. They participate in macro-level
+topology as a unit (a "super-node") and may intentionally violate standard topology rules
+to represent interesting real-world configurations.
+
+### In scope: `careless-user`
+
+A workstation that has been inadvertently bridged to a fileserver that is otherwise
+protected by a firewall. The workstation connects to the gateway (or a router near
+the gateway), bypassing the firewall's gate. This creates a soft alternate path into
+a node that should be hard to reach.
+
+**Nodes:** `workstation` (low grade) + `fileserver` (medium grade) + `firewall`
+(present but not required to reach the fileserver via this path)
+
+**Connections:**
+- `workstation` ← router/gateway (standard)
+- `workstation` → `fileserver` (the exposure — bypasses firewall)
+- `fileserver` ← `firewall` (still present; players who don't find the exposure face the hard path)
+
+**Topology rule violation:** fileserver is normally behind a gate; here it is also
+accessible via a soft path. This is the intentional narrative point.
+
+**Parameters:** workstation grade, fileserver grade, firewall grade (tuned by moneyCost)
+
+### Future set pieces (out of scope for this session)
+
+- **Workstation array** — multiple low-grade workstations behind a router for methodical looting
+- **Lucky break** — a low-grade firewall in front of a cryptovault (the corp cut corners)
+- **Security theater** — low-grade fileservers behind a high-grade firewall (counting on the perimeter)
+
+---
+
+## Fallback Behaviour
+
+When no generation parameters are provided:
+- Browser: static `data/network.js` is used
+- Harness: static `data/network.js` is used (existing behaviour preserved)
+
+When parameters are provided, the generator runs and its output replaces the static network.
+
+---
+
+## Testing
+
+**Determinism:** The same `{ seed, timeCost, moneyCost }` must always produce an
+identical `NETWORK` object. Verified by snapshot tests.
+
+**Snapshot tests:** Capture the generated network for a set of representative
+`{ seed, timeCost, moneyCost }` combinations and assert the output does not drift
+across code changes.
+
+**Headless playtesting:** After generation, run representative scenarios through the
+playtest harness:
+- F/F (easy): should be completable quickly with a default hand
+- B/B (medium): should require some card management and ICE avoidance
+- S/S (hard): should require the darknet store and careful routing
+
+**Structural validation:** The generator must produce a network that passes basic sanity
+checks — connected graph, reachable mission target, no orphaned nodes.
+
+---
+
+## Out of Scope
+
+- Biome system (node type palette, flavor, set piece selection by biome)
+- Solvability guarantees (the darknet store is the escape valve for bad hands)
+- Multiple ICE instances or ICE type variants
+- Additional set pieces beyond `careless-user`
+- Overworld integration
+- Grade scale expansion (E grade, etc.)

--- a/docs/dev-sessions/2026-03-01-1621-biome-bundles/notes.md
+++ b/docs/dev-sessions/2026-03-01-1621-biome-bundles/notes.md
@@ -1,0 +1,3 @@
+# Notes: Biome Bundle Refactor
+
+_Session started: 2026-03-01_

--- a/docs/dev-sessions/2026-03-01-1621-biome-bundles/plan.md
+++ b/docs/dev-sessions/2026-03-01-1621-biome-bundles/plan.md
@@ -1,0 +1,3 @@
+# Plan: Biome Bundle Refactor
+
+_Status: draft_

--- a/docs/dev-sessions/2026-03-01-1621-biome-bundles/spec.md
+++ b/docs/dev-sessions/2026-03-01-1621-biome-bundles/spec.md
@@ -1,0 +1,83 @@
+# Spec: Biome Bundle Refactor
+
+_Status: draft_
+
+## Goal
+
+Introduce a **biome bundle** — a self-contained module that packages everything
+needed to describe a LAN generation profile: node type generation rules, structural
+validators, set pieces, and label pools. The current "corporate" LAN is the only
+biome and is implicitly defined across several files; this session makes it explicit
+and lays the foundation for future biome variants.
+
+## Background
+
+The procedural LAN generator (`js/network-gen.js`) currently hard-codes node type
+strings, grade assignments, label pools, and structural validators. A parallel data
+file (`data/node-type-rules.js`) exists but is not imported by the generator — the
+two are disconnected.
+
+The long-term vision is a plugin-style architecture where each biome bundles:
+- Generation rules (layer definitions with behavior atoms for count/depth/grade/connectivity)
+- Structural validators
+- Set pieces
+- Label pools
+
+This session implements the **generation rules + validators + set pieces + labels**
+portion. Node type *gameplay* behaviors (combat, loot, alert) remain in `js/node-types.js`
+for now — migrating those is a separate, heavier session.
+
+## Scope
+
+### In scope
+
+1. **`data/node-type-rules.js` → biome bundle**
+   Move `NODE_GEN_RULES` into the biome. Add `gradeRole` and `labels` fields.
+   Add `minMoneyGrade` to optional nodes (cryptovault).
+
+2. **Biome layer definitions with behavior atoms**
+   Each layer carries small functions for `count`, `depth`, `connectTo` — replacing
+   the hardcoded logic currently in `buildNetwork`. The generator becomes a
+   generic layer-processor loop.
+
+3. **Validators colocated with biome**
+   Move `VALIDATORS` from `network-gen.js` into the bundle. Validators reference
+   biome roles rather than hardcoded type strings.
+
+4. **Set pieces colocated with biome**
+   Move `SET_PIECES` from `js/set-pieces.js` into the bundle (or reference them
+   from it). Set piece eligibility attached to the biome.
+
+5. **`buildNetwork` becomes a thin execution engine**
+   Accepts a biome object, iterates layers, resolves behavior atoms — no hardcoded
+   type names or topology decisions.
+
+### Out of scope
+
+- Node type *gameplay* behaviors (combat, loot, alert, IDS detection)
+- Multiple biome variants (just establish the structure with "corporate")
+- Biome registration/discovery system (no dynamic import, no registry yet)
+- Browser/harness biome selection at runtime
+
+## Target structure
+
+```
+js/
+  biomes/
+    corporate/
+      index.js       — exports the full CORPORATE_BIOME bundle
+      gen-rules.js   — layer definitions, role map, grade roles, label pools
+      validators.js  — structural validators (biome-aware, role-based)
+      set-pieces.js  — set piece definitions for this biome
+```
+
+`data/node-type-rules.js` is retired (contents absorbed into the biome bundle).
+`js/set-pieces.js` is retired (contents move to `js/biomes/corporate/set-pieces.js`).
+
+## Success criteria
+
+- `make check` passes throughout
+- `buildNetwork` contains no hardcoded node type strings
+- Validators reference `biome.roles` rather than literal type names
+- Adding a new biome requires only creating a new bundle under `js/biomes/` and
+  passing it to `generateNetwork` — no changes to the engine

--- a/js/console.js
+++ b/js/console.js
@@ -504,7 +504,7 @@ function cmdStatusFull() {
   // Network
   lines.push(`### NETWORK`);
   const accessible = Object.values(s.nodes).filter((n) => n.visibility === "accessible");
-  const revealedCount = Object.values(s.nodes).filter((n) => n.visibility === "revealed").length;
+  const revealed = Object.values(s.nodes).filter((n) => n.visibility === "revealed");
 
   accessible.forEach((node) => {
     const selected = node.id === s.selectedNodeId ? "  [SELECTED]" : "";
@@ -519,7 +519,9 @@ function cmdStatusFull() {
     }
   });
 
-  if (revealedCount > 0) lines.push(`- ${revealedCount} node(s) revealed (inaccessible)`);
+  revealed.forEach((node) => {
+    lines.push(`- ${node.id}  [${node.type}]  revealed`);
+  });
 
   // Hand
   lines.push(`### HAND`);

--- a/js/exploits.js
+++ b/js/exploits.js
@@ -238,15 +238,14 @@ export function getStoreCatalog() {
   }));
 }
 
-export function generateStartingHand() {
-  return [
-    generateExploit("common"),
-    generateExploit("common"),
-    generateExploit("uncommon"),
-    generateExploit("uncommon"),
-    generateExploit("uncommon"),
-    generateExploit("rare"),
-  ];
+/** Default hand composition — used when no network-provided spec is available. */
+const DEFAULT_HAND_SPEC = ["common", "common", "uncommon", "uncommon", "uncommon", "rare"];
+
+/**
+ * @param {string[]} [spec] - array of rarity strings; defaults to DEFAULT_HAND_SPEC
+ */
+export function generateStartingHand(spec = DEFAULT_HAND_SPEC) {
+  return spec.map((rarity) => generateExploit(rarity));
 }
 
 // ── Node vulnerability generation ────────────────────────

--- a/js/grades.js
+++ b/js/grades.js
@@ -1,0 +1,64 @@
+// @ts-check
+// Grade scale utilities — shared by the generator, balance tables, and future modules.
+// Grade order: F (easiest) < D < C < B < A < S (hardest).
+
+/** Ordered grade array, ascending difficulty. */
+export const GRADES = ["F", "D", "C", "B", "A", "S"];
+
+/** @type {Record<string, number>} Grade letter → index (0=F, 5=S). */
+export const GRADE_INDEX = Object.fromEntries(GRADES.map((g, i) => [g, i]));
+
+/**
+ * Parse a grade string. Returns the canonical uppercase letter, or null if invalid.
+ * @param {string | null | undefined} s
+ * @returns {string | null}
+ */
+export function parseGrade(s) {
+  if (!s) return null;
+  const upper = String(s).toUpperCase();
+  return GRADE_INDEX[upper] !== undefined ? upper : null;
+}
+
+/**
+ * Return the sub-array of GRADES between minGrade and maxGrade (inclusive).
+ * @param {string} minGrade
+ * @param {string} maxGrade
+ * @returns {string[]}
+ */
+export function gradeRange(minGrade, maxGrade) {
+  const lo = GRADE_INDEX[minGrade] ?? 0;
+  const hi = GRADE_INDEX[maxGrade] ?? GRADES.length - 1;
+  return GRADES.slice(Math.min(lo, hi), Math.max(lo, hi) + 1);
+}
+
+/**
+ * Clamp a grade index to valid bounds and return the grade letter.
+ * @param {number} index
+ * @returns {string}
+ */
+export function clampGrade(index) {
+  return GRADES[Math.max(0, Math.min(GRADES.length - 1, Math.round(index)))];
+}
+
+/**
+ * Return the grade N steps above (+) or below (-) the given grade, clamped.
+ * @param {string} grade
+ * @param {number} delta
+ * @returns {string}
+ */
+export function shiftGrade(grade, delta) {
+  return clampGrade((GRADE_INDEX[grade] ?? 0) + delta);
+}
+
+/**
+ * Pick a random grade between minGrade and maxGrade (inclusive) using rng().
+ * rng() must return a [0,1) float.
+ * @param {() => number} rng
+ * @param {string} minGrade
+ * @param {string} maxGrade
+ * @returns {string}
+ */
+export function randomGrade(rng, minGrade, maxGrade) {
+  const range = gradeRange(minGrade, maxGrade);
+  return range[Math.floor(rng() * range.length)];
+}

--- a/js/grades.test.js
+++ b/js/grades.test.js
@@ -1,0 +1,112 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  GRADES, GRADE_INDEX, parseGrade, gradeRange, clampGrade, shiftGrade, randomGrade,
+} from "./grades.js";
+
+describe("GRADES", () => {
+  it("has 6 entries in ascending order", () => {
+    assert.deepEqual(GRADES, ["F", "D", "C", "B", "A", "S"]);
+  });
+
+  it("GRADE_INDEX maps each letter to its position", () => {
+    assert.equal(GRADE_INDEX["F"], 0);
+    assert.equal(GRADE_INDEX["D"], 1);
+    assert.equal(GRADE_INDEX["S"], 5);
+  });
+});
+
+describe("parseGrade", () => {
+  it("accepts valid uppercase letters", () => {
+    assert.equal(parseGrade("F"), "F");
+    assert.equal(parseGrade("S"), "S");
+    assert.equal(parseGrade("B"), "B");
+  });
+
+  it("normalises lowercase", () => {
+    assert.equal(parseGrade("c"), "C");
+    assert.equal(parseGrade("a"), "A");
+  });
+
+  it("returns null for invalid input", () => {
+    assert.equal(parseGrade("E"), null);
+    assert.equal(parseGrade("Z"), null);
+    assert.equal(parseGrade(""), null);
+    assert.equal(parseGrade(null), null);
+    assert.equal(parseGrade(undefined), null);
+  });
+});
+
+describe("gradeRange", () => {
+  it("returns a single-element array when min === max", () => {
+    assert.deepEqual(gradeRange("C", "C"), ["C"]);
+  });
+
+  it("returns full range F–S", () => {
+    assert.deepEqual(gradeRange("F", "S"), ["F", "D", "C", "B", "A", "S"]);
+  });
+
+  it("returns a mid-range slice", () => {
+    assert.deepEqual(gradeRange("C", "A"), ["C", "B", "A"]);
+  });
+
+  it("handles reversed min/max by normalising", () => {
+    // Higher index as minGrade should still return the range
+    const r = gradeRange("A", "C");
+    assert.deepEqual(r, ["C", "B", "A"]);
+  });
+});
+
+describe("clampGrade", () => {
+  it("clamps negative index to F", () => {
+    assert.equal(clampGrade(-5), "F");
+  });
+
+  it("clamps high index to S", () => {
+    assert.equal(clampGrade(99), "S");
+  });
+
+  it("rounds fractional index", () => {
+    assert.equal(clampGrade(1.7), "C"); // rounds to 2 = "C"
+  });
+});
+
+describe("shiftGrade", () => {
+  it("shifts up by delta", () => {
+    assert.equal(shiftGrade("F", 1), "D");
+    assert.equal(shiftGrade("C", 2), "A");
+  });
+
+  it("shifts down by delta", () => {
+    assert.equal(shiftGrade("S", -1), "A");
+    assert.equal(shiftGrade("B", -2), "D");
+  });
+
+  it("clamps at F when shifting below minimum", () => {
+    assert.equal(shiftGrade("F", -5), "F");
+  });
+
+  it("clamps at S when shifting above maximum", () => {
+    assert.equal(shiftGrade("S", 5), "S");
+  });
+});
+
+describe("randomGrade", () => {
+  it("returns a grade within the specified range", () => {
+    // Use a deterministic rng that cycles through [0, 0.5, 0.99]
+    const values = [0, 0.5, 0.99];
+    let i = 0;
+    const rng = () => values[i++ % values.length];
+    for (let n = 0; n < 9; n++) {
+      const g = randomGrade(rng, "C", "A");
+      assert.ok(["C", "B", "A"].includes(g), `expected C/B/A, got ${g}`);
+    }
+  });
+
+  it("always returns the same grade when min === max", () => {
+    const rng = () => Math.random();
+    for (let n = 0; n < 10; n++) {
+      assert.equal(randomGrade(rng, "B", "B"), "B");
+    }
+  });
+});

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 // @ts-nocheck — main.js is DOM event wiring; CustomEvent.detail typing noise outweighs benefit here.
 import { NETWORK } from "../data/network.js";
+import { generateNetwork } from "./network-gen.js";
 import { initGraph, getCy, addIceNode, fitGraph } from "./graph.js";
 import { initState, getState } from "./state.js";
 import { completeReboot } from "./node-orchestration.js";
@@ -17,15 +18,38 @@ import { initLogRenderer } from "./log-renderer.js";
 import { initNodeLifecycle } from "./node-lifecycle.js";
 import { buildActionContext, initActionDispatcher, buildNodeClickHandler } from "./action-context.js";
 
+/** Read seed/time/money from URL search params. Returns null if any are missing. */
+function getNetworkParams() {
+  const p = new URLSearchParams(location.search);
+  const seed  = p.get("seed");
+  const time  = p.get("time")?.toUpperCase();
+  const money = p.get("money")?.toUpperCase();
+  if (seed && time && money) return { seed, timeCost: time, moneyCost: money };
+  return null;
+}
+
+/** Active network for this session — generated from URL params or static fallback. */
+let network = NETWORK;
+{
+  const params = getNetworkParams();
+  if (params) {
+    try {
+      network = generateNetwork(params.seed, params.timeCost, params.moneyCost);
+    } catch (err) {
+      console.warn("[starnet] generateNetwork failed, using static network:", err);
+    }
+  }
+}
+
 function init() {
   initLogRenderer();
-  const cy = initGraph(NETWORK, buildNodeClickHandler(), () => {
+  const cy = initGraph(network, buildNodeClickHandler(), () => {
     emitEvent("starnet:action", { actionId: "deselect" });
   });
   addIceNode();
   initConsole();
   initVisualRenderer();  // must subscribe before initState fires STATE_CHANGED
-  initState(NETWORK);
+  initState(network);
   fitGraph(cy);
   startIce();
   setInterval(() => {
@@ -93,7 +117,7 @@ function init() {
   });
 
   on("starnet:action:run-again", () => {
-    initState(NETWORK);
+    initState(network);
     const cy = getCy();
     if (cy) fitGraph(cy);
     addIceNode();

--- a/js/network-gen.js
+++ b/js/network-gen.js
@@ -2,33 +2,12 @@
 // Procedural LAN generator.
 // generateNetwork(seed, timeCost, moneyCost) → NETWORK-shaped object.
 //
-// Self-contained: uses its own local Mulberry32 RNG seeded from the seed string.
-// Does NOT depend on js/rng.js so it doesn't affect gameplay randomness.
+// Uses makeSeededRng() from js/rng.js — an independent instance that does NOT
+// advance any named gameplay stream, so generation doesn't affect run randomness.
 
 import { GRADES, GRADE_INDEX, parseGrade, shiftGrade, randomGrade, clampGrade } from "./grades.js";
 import { SET_PIECES, applySetPiece } from "./set-pieces.js";
-
-// ── Local RNG ─────────────────────────────────────────────────────────────────
-
-/** djb2 string hash → signed int32. */
-function djb2(str) {
-  let hash = 5381;
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
-  }
-  return hash;
-}
-
-/** Create a self-contained Mulberry32 RNG returning [0,1) floats. */
-function makeMulberry32(seed32) {
-  let s = seed32 | 0;
-  return function rng() {
-    s = (s + 0x6D2B79F5) | 0;
-    let t = Math.imul(s ^ (s >>> 15), 1 | s);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
+import { makeSeededRng, shuffleWith } from "./rng.js";
 
 /** Pick a random element from an array. */
 function pick(rng, arr) {
@@ -161,7 +140,7 @@ export function generateNetwork(seed, timeCost, moneyCost, options = {}) {
   const MAX_ATTEMPTS = 10;
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     // Each attempt gets a fresh RNG derived from seed + attempt index.
-    const rng = makeMulberry32(djb2(`${seed}-network-${attempt}`));
+    const rng = makeSeededRng(`${seed}-network-${attempt}`);
     const candidate = buildNetwork(rng, tc, mc, forcePieces);
     const failure = validate(candidate);
     if (!failure) return candidate;
@@ -183,7 +162,7 @@ function buildNetwork(rng, tc, mc, forcePieces = []) {
   const labelPools = {};
   for (const [type, labels] of Object.entries(LABEL_POOLS)) {
     labelPools[type] = [...labels];
-    shuffle(rng, labelPools[type]);
+    shuffleWith(rng, labelPools[type]);
   }
 
   function nextLabel(type) {
@@ -320,13 +299,6 @@ function buildNetwork(rng, tc, mc, forcePieces = []) {
 
 // ── Utility ───────────────────────────────────────────────────────────────────
 
-/** Fisher-Yates shuffle (mutates). */
-function shuffle(rng, arr) {
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
-  }
-}
 
 // ── Validators ────────────────────────────────────────────────────────────────
 

--- a/js/network-gen.js
+++ b/js/network-gen.js
@@ -1,0 +1,362 @@
+// @ts-check
+// Procedural LAN generator.
+// generateNetwork(seed, timeCost, moneyCost) → NETWORK-shaped object.
+//
+// Self-contained: uses its own local Mulberry32 RNG seeded from the seed string.
+// Does NOT depend on js/rng.js so it doesn't affect gameplay randomness.
+
+import { GRADES, GRADE_INDEX, parseGrade, shiftGrade, randomGrade, clampGrade } from "./grades.js";
+
+// ── Local RNG ─────────────────────────────────────────────────────────────────
+
+/** djb2 string hash → signed int32. */
+function djb2(str) {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
+  }
+  return hash;
+}
+
+/** Create a self-contained Mulberry32 RNG returning [0,1) floats. */
+function makeMulberry32(seed32) {
+  let s = seed32 | 0;
+  return function rng() {
+    s = (s + 0x6D2B79F5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Pick a random element from an array. */
+function pick(rng, arr) {
+  return arr[Math.floor(rng() * arr.length)];
+}
+
+/** Pick and remove a random element from an array (mutates). */
+function pickRemove(rng, arr) {
+  const i = Math.floor(rng() * arr.length);
+  return arr.splice(i, 1)[0];
+}
+
+// ── Budget tables ─────────────────────────────────────────────────────────────
+
+/** timeCost grade → ICE grade, network depth budget, gate count. */
+const TIME_BUDGET = {
+  F: { iceGrade: "F", depthBudget: 2, gateCount: 0 },
+  D: { iceGrade: "D", depthBudget: 2, gateCount: 1 },
+  C: { iceGrade: "C", depthBudget: 3, gateCount: 1 },
+  B: { iceGrade: "B", depthBudget: 3, gateCount: 2 },
+  A: { iceGrade: "A", depthBudget: 4, gateCount: 2 },
+  S: { iceGrade: "S", depthBudget: 5, gateCount: 3 },
+};
+
+/** moneyCost grade → grade range for critical path nodes, target depth. */
+const MONEY_BUDGET = {
+  F: { pathGradeMin: "F", pathGradeMax: "D", targetDepth: 1 },
+  D: { pathGradeMin: "F", pathGradeMax: "C", targetDepth: 1 },
+  C: { pathGradeMin: "D", pathGradeMax: "B", targetDepth: 2 },
+  B: { pathGradeMin: "C", pathGradeMax: "A", targetDepth: 3 },
+  A: { pathGradeMin: "B", pathGradeMax: "S", targetDepth: 3 },
+  S: { pathGradeMin: "A", pathGradeMax: "S", targetDepth: 4 },
+};
+
+// ── Label pools ───────────────────────────────────────────────────────────────
+
+const LABEL_POOLS = {
+  wan:                ["WAN"],
+  gateway:            ["INET-GW-01", "INET-GW-02", "GW-MAIN", "GW-EDGE"],
+  router:             ["RTR-A", "RTR-B", "RTR-CORE", "RTR-EDGE", "RTR-01", "RTR-02"],
+  firewall:           ["FW-CORE", "FW-PERIMETER", "FW-DMZ", "FW-01"],
+  workstation:        ["WS-ALPHA", "WS-BETA", "WS-GAMMA", "WS-DELTA", "WS-01", "WS-02", "WS-03"],
+  fileserver:         ["FS-VAULT", "FS-ARCHIVE", "FS-DATA", "FS-01", "FS-02"],
+  cryptovault:        ["CRYPT-X9", "CRYPT-01", "VAULT-S", "VAULT-01"],
+  ids:                ["IDS-01", "IDS-02", "IDS-EDGE"],
+  "security-monitor": ["SEC-MON", "SEC-MON-01", "MON-CORE"],
+};
+
+// ── Layout ────────────────────────────────────────────────────────────────────
+
+const LAYOUT_CENTER_X = 400;
+const LAYOUT_LAYER_HEIGHT = 140;
+const LAYOUT_NODE_SPACING = 200;
+const LAYOUT_DEPTH_OFFSET_Y = 50; // y for depth 0
+
+/** Compute x,y positions for a set of nodes, grouped by depth layer. */
+function assignPositions(nodes) {
+  /** @type {Map<number, string[]>} depth → nodeIds */
+  const layers = new Map();
+  for (const node of nodes) {
+    const d = node._depth ?? 0;
+    if (!layers.has(d)) layers.set(d, []);
+    layers.get(d).push(node.id);
+  }
+
+  /** @type {Map<string, {x:number, y:number}>} */
+  const positions = new Map();
+  for (const [depth, ids] of layers) {
+    const y = LAYOUT_DEPTH_OFFSET_Y + depth * LAYOUT_LAYER_HEIGHT;
+    const totalWidth = (ids.length - 1) * LAYOUT_NODE_SPACING;
+    ids.forEach((id, i) => {
+      positions.set(id, {
+        x: LAYOUT_CENTER_X - totalWidth / 2 + i * LAYOUT_NODE_SPACING,
+        y,
+      });
+    });
+  }
+  return positions;
+}
+
+// ── Generator ─────────────────────────────────────────────────────────────────
+
+/**
+ * Generate a NETWORK-shaped object from seed + difficulty parameters.
+ *
+ * @param {string} seed
+ * @param {string} timeCost  - grade letter S/A/B/C/D/F
+ * @param {string} moneyCost - grade letter S/A/B/C/D/F
+ * @returns {object} NETWORK-compatible object
+ */
+export function generateNetwork(seed, timeCost, moneyCost) {
+  const tc = parseGrade(timeCost);
+  const mc = parseGrade(moneyCost);
+  if (!tc) throw new Error(`generateNetwork: invalid timeCost "${timeCost}"`);
+  if (!mc) throw new Error(`generateNetwork: invalid moneyCost "${moneyCost}"`);
+
+  const MAX_ATTEMPTS = 10;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    // Each attempt gets a fresh RNG derived from seed + attempt index.
+    const rng = makeMulberry32(djb2(`${seed}-network-${attempt}`));
+    const candidate = buildNetwork(rng, tc, mc);
+    const failure = validate(candidate);
+    if (!failure) return candidate;
+    if (attempt === MAX_ATTEMPTS - 1) {
+      throw new Error(`generateNetwork: failed after ${MAX_ATTEMPTS} attempts. Last failure: ${failure}`);
+    }
+  }
+  // Unreachable, but satisfies type checker
+  throw new Error("generateNetwork: unexpected exit");
+}
+
+/** Build one candidate network. May produce an invalid result — caller validates. */
+function buildNetwork(rng, tc, mc) {
+  const time   = TIME_BUDGET[tc];
+  const money  = MONEY_BUDGET[mc];
+
+  // Label pools — shuffled copies so we pick without repeating
+  /** @type {Record<string, string[]>} */
+  const labelPools = {};
+  for (const [type, labels] of Object.entries(LABEL_POOLS)) {
+    labelPools[type] = [...labels];
+    shuffle(rng, labelPools[type]);
+  }
+
+  function nextLabel(type) {
+    const pool = labelPools[type];
+    if (!pool || pool.length === 0) {
+      // Fallback: numbered label
+      return `${type.toUpperCase()}-X`;
+    }
+    return pool.pop();
+  }
+
+  // ── Node and edge accumulators ──────────────────────────────────────────────
+  /** @type {Array<{id:string, type:string, label:string, grade:string, _depth:number}>} */
+  const nodes = [];
+  /** @type {Array<{source:string, target:string}>} */
+  const edges = [];
+  let nodeSeq = 0;
+  function makeId(type) { return `${type}-${++nodeSeq}`; }
+
+  function addNode(type, grade, depth) {
+    const id = makeId(type);
+    nodes.push({ id, type, label: nextLabel(type), grade, _depth: depth });
+    return id;
+  }
+
+  function addEdge(source, target) {
+    edges.push({ source, target });
+  }
+
+  // ── Grade helpers ───────────────────────────────────────────────────────────
+  const { pathGradeMin, pathGradeMax } = money;
+
+  function entryGrade()  { return shiftGrade(pathGradeMin, -1); }
+  function softGrade()   { return shiftGrade(pathGradeMin, -1); }
+  function pathGrade()   { return randomGrade(rng, pathGradeMin, pathGradeMax); }
+  function hardGrade()   { return shiftGrade(pathGradeMax, 0); }
+
+  // ── Fixed anchors ───────────────────────────────────────────────────────────
+  const wanId     = addNode("wan",              "D",          -1);
+  const gatewayId = addNode("gateway",          entryGrade(), 0);
+  const monitorId = addNode("security-monitor", hardGrade(),  time.depthBudget);
+
+  addEdge(wanId, gatewayId);
+
+  // ── Security chain ──────────────────────────────────────────────────────────
+  // ids attaches to a router (added below); for now record it and wire later
+  const idsDepth = Math.max(1, time.depthBudget - 1);
+  const idsId    = addNode("ids", shiftGrade(pathGradeMin, 1), idsDepth);
+  addEdge(idsId, monitorId);
+
+  // ── Routing layer ───────────────────────────────────────────────────────────
+  // Number of routers: 1 for shallow networks, 2 for deeper ones
+  const routerCount = time.depthBudget >= 3 ? 2 : 1;
+  const routerIds = [];
+  for (let i = 0; i < routerCount; i++) {
+    const rid = addNode("router", pathGrade(), 1);
+    routerIds.push(rid);
+    addEdge(gatewayId, rid);
+  }
+
+  // Wire IDS to first router
+  addEdge(routerIds[0], idsId);
+
+  // ── Gate node(s) ────────────────────────────────────────────────────────────
+  let firewallId = null;
+  if (time.gateCount >= 1) {
+    firewallId = addNode("firewall", hardGrade(), 1);
+    addEdge(gatewayId, firewallId);
+  }
+
+  // ── Mission target (fileserver) ─────────────────────────────────────────────
+  // Depth: clamp targetDepth to available depth budget
+  const fsDepth = Math.min(money.targetDepth, time.depthBudget);
+  const fsGrade = pathGrade();
+  const fileserverId = addNode("fileserver", fsGrade, fsDepth);
+
+  // Connect fileserver: through firewall if available and deep enough, else through router
+  if (firewallId && fsDepth >= 2) {
+    addEdge(firewallId, fileserverId);
+  } else {
+    addEdge(pick(rng, routerIds), fileserverId);
+  }
+
+  // ── Cryptovault (optional — high difficulty only) ───────────────────────────
+  if (firewallId && GRADE_INDEX[mc] >= GRADE_INDEX["B"]) {
+    const cvId = addNode("cryptovault", hardGrade(), time.depthBudget);
+    addEdge(firewallId, cvId);
+  }
+
+  // ── Filler workstations ──────────────────────────────────────────────────────
+  const wsCount = routerCount === 1 ? 1 : 2;
+  for (let i = 0; i < wsCount; i++) {
+    const wsId = addNode("workstation", softGrade(), 2);
+    addEdge(pick(rng, routerIds), wsId);
+  }
+
+  // ── Assign x,y positions ────────────────────────────────────────────────────
+  const positions = assignPositions(nodes);
+
+  // ── Build final node array (strip internal _depth field) ────────────────────
+  const finalNodes = nodes.map(({ id, type, label, grade, _depth }) => {
+    const pos = positions.get(id) ?? { x: 400, y: 400 };
+    void _depth; // used only for layout
+    return { id, type, label, grade, x: pos.x, y: pos.y };
+  });
+
+  return {
+    nodes: finalNodes,
+    edges,
+    startNode: gatewayId,
+    ice: {
+      grade:     time.iceGrade,
+      startNode: monitorId,
+    },
+  };
+}
+
+// ── Utility ───────────────────────────────────────────────────────────────────
+
+/** Fisher-Yates shuffle (mutates). */
+function shuffle(rng, arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
+// ── Validators ────────────────────────────────────────────────────────────────
+
+/** Run all structural validators. Returns null on pass, or a failure description. */
+function validate(network) {
+  for (const predicate of VALIDATORS) {
+    const result = predicate(network);
+    if (result) return result;
+  }
+  return null;
+}
+
+/** Build an adjacency map from edge list. */
+function buildAdjacency(network) {
+  /** @type {Record<string, string[]>} */
+  const adj = {};
+  for (const { source, target } of network.edges) {
+    (adj[source] ??= []).push(target);
+    (adj[target] ??= []).push(source);
+  }
+  return adj;
+}
+
+const VALIDATORS = [
+  /** wan, gateway, security-monitor all present. */
+  function hasAnchors(network) {
+    const types = new Set(network.nodes.map((n) => n.type));
+    if (!types.has("wan"))              return "missing wan node";
+    if (!types.has("gateway"))          return "missing gateway node";
+    if (!types.has("security-monitor")) return "missing security-monitor node";
+    return null;
+  },
+
+  /** At least one ids node connects to security-monitor. */
+  function idsAdjacentToMonitor(network) {
+    const monitorIds = network.nodes.filter((n) => n.type === "security-monitor").map((n) => n.id);
+    const hasLink = network.edges.some(
+      ({ source, target }) =>
+        (monitorIds.includes(target) && network.nodes.find((n) => n.id === source)?.type === "ids") ||
+        (monitorIds.includes(source) && network.nodes.find((n) => n.id === target)?.type === "ids")
+    );
+    return hasLink ? null : "no ids node adjacent to security-monitor";
+  },
+
+  /** At least one lootable node type (fileserver or cryptovault) exists. */
+  function missionTargetExists(network) {
+    const types = network.nodes.map((n) => n.type);
+    return types.includes("fileserver") || types.includes("cryptovault")
+      ? null
+      : "no lootable node (fileserver or cryptovault)";
+  },
+
+  /** Every node has at least one edge. */
+  function noOrphanNodes(network) {
+    const adj = buildAdjacency(network);
+    for (const node of network.nodes) {
+      if (!adj[node.id] || adj[node.id].length === 0) {
+        return `orphan node: ${node.id} (${node.type})`;
+      }
+    }
+    return null;
+  },
+
+  /** BFS from startNode reaches at least one fileserver or cryptovault. */
+  function gatewayReachesTarget(network) {
+    const adj = buildAdjacency(network);
+    const visited = new Set([network.startNode]);
+    const queue = [network.startNode];
+    while (queue.length) {
+      const cur = queue.shift();
+      const node = network.nodes.find((n) => n.id === cur);
+      if (node && (node.type === "fileserver" || node.type === "cryptovault")) {
+        return null; // reachable
+      }
+      for (const neighbor of (adj[cur] || [])) {
+        if (!visited.has(neighbor)) {
+          visited.add(neighbor);
+          queue.push(neighbor);
+        }
+      }
+    }
+    return "no lootable node reachable from startNode";
+  },
+];

--- a/js/network-gen.js
+++ b/js/network-gen.js
@@ -45,12 +45,40 @@ function pickRemove(rng, arr) {
 
 /** timeCost grade → ICE grade, network depth budget, gate count. */
 const TIME_BUDGET = {
-  F: { iceGrade: "F", depthBudget: 2, gateCount: 0 },
+  F: { iceGrade: "F", depthBudget: 3, gateCount: 0 },
   D: { iceGrade: "D", depthBudget: 2, gateCount: 1 },
   C: { iceGrade: "C", depthBudget: 3, gateCount: 1 },
   B: { iceGrade: "B", depthBudget: 3, gateCount: 2 },
   A: { iceGrade: "A", depthBudget: 4, gateCount: 2 },
   S: { iceGrade: "S", depthBudget: 5, gateCount: 3 },
+};
+
+/**
+ * moneyCost grade → starting hand composition (array of rarity strings).
+ * Harder LANs have tougher node vulns, so the player needs more and better cards.
+ * F/D: standard 6-card hand. C+: extra rares. A/S: no commons, 8 cards.
+ */
+const HAND_BUDGET = {
+  F: ["common", "common", "uncommon", "uncommon", "uncommon", "rare"],
+  D: ["common", "common", "uncommon", "uncommon", "uncommon", "rare"],
+  C: ["common", "common", "uncommon", "uncommon", "uncommon", "rare", "rare"],
+  B: ["common", "uncommon", "uncommon", "uncommon", "uncommon", "rare", "rare"],
+  A: ["uncommon", "uncommon", "uncommon", "uncommon", "uncommon", "rare", "rare", "rare"],
+  S: ["uncommon", "uncommon", "uncommon", "uncommon", "uncommon", "rare", "rare", "rare"],
+};
+
+/**
+ * moneyCost grade → suggested starting cash for the player.
+ * Reflects what a player at this tier would reasonably have accumulated from prior runs.
+ * Higher difficulties expect the player to have a bigger wallet for card replenishment.
+ */
+const CASH_BUDGET = {
+  F: 1000,
+  D: 1000,
+  C: 1250,
+  B: 1500,
+  A: 2000,
+  S: 2500,
 };
 
 /** moneyCost grade → grade range for critical path nodes, target depth. */
@@ -117,19 +145,24 @@ function assignPositions(nodes) {
  * @param {string} seed
  * @param {string} timeCost  - grade letter S/A/B/C/D/F
  * @param {string} moneyCost - grade letter S/A/B/C/D/F
+ * @param {{ forcePieces?: string[] }} [options]
+ *   forcePieces: set piece IDs to apply unconditionally (bypasses rng check).
+ *   Intended for headless playtesting and integration tests — not for general play.
  * @returns {object} NETWORK-compatible object
  */
-export function generateNetwork(seed, timeCost, moneyCost) {
+export function generateNetwork(seed, timeCost, moneyCost, options = {}) {
   const tc = parseGrade(timeCost);
   const mc = parseGrade(moneyCost);
   if (!tc) throw new Error(`generateNetwork: invalid timeCost "${timeCost}"`);
   if (!mc) throw new Error(`generateNetwork: invalid moneyCost "${moneyCost}"`);
 
+  const forcePieces = options.forcePieces ?? [];
+
   const MAX_ATTEMPTS = 10;
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     // Each attempt gets a fresh RNG derived from seed + attempt index.
     const rng = makeMulberry32(djb2(`${seed}-network-${attempt}`));
-    const candidate = buildNetwork(rng, tc, mc);
+    const candidate = buildNetwork(rng, tc, mc, forcePieces);
     const failure = validate(candidate);
     if (!failure) return candidate;
     if (attempt === MAX_ATTEMPTS - 1) {
@@ -141,7 +174,7 @@ export function generateNetwork(seed, timeCost, moneyCost) {
 }
 
 /** Build one candidate network. May produce an invalid result — caller validates. */
-function buildNetwork(rng, tc, mc) {
+function buildNetwork(rng, tc, mc, forcePieces = []) {
   const time   = TIME_BUDGET[tc];
   const money  = MONEY_BUDGET[mc];
 
@@ -249,7 +282,8 @@ function buildNetwork(rng, tc, mc) {
 
   // ── Set piece (optional) ────────────────────────────────────────────────────
   // careless-user: eligible when moneyCost ≥ C and there's a firewall in the network
-  if (GRADE_INDEX[mc] >= GRADE_INDEX["C"] && firewallId && rng() < 0.6) {
+  const forceCareless = forcePieces.includes("careless-user");
+  if (GRADE_INDEX[mc] >= GRADE_INDEX["C"] && firewallId && (forceCareless || rng() < 0.6)) {
     const baseGrade = pathGrade();
     applySetPiece(
       SET_PIECES["careless-user"],
@@ -275,6 +309,8 @@ function buildNetwork(rng, tc, mc) {
     nodes: finalNodes,
     edges,
     startNode: gatewayId,
+    startCash: CASH_BUDGET[mc],
+    startHandSpec: HAND_BUDGET[mc],
     ice: {
       grade:     time.iceGrade,
       startNode: monitorId,

--- a/js/network-gen.js
+++ b/js/network-gen.js
@@ -6,6 +6,7 @@
 // Does NOT depend on js/rng.js so it doesn't affect gameplay randomness.
 
 import { GRADES, GRADE_INDEX, parseGrade, shiftGrade, randomGrade, clampGrade } from "./grades.js";
+import { SET_PIECES, applySetPiece } from "./set-pieces.js";
 
 // ── Local RNG ─────────────────────────────────────────────────────────────────
 
@@ -244,6 +245,20 @@ function buildNetwork(rng, tc, mc) {
   for (let i = 0; i < wsCount; i++) {
     const wsId = addNode("workstation", softGrade(), 2);
     addEdge(pick(rng, routerIds), wsId);
+  }
+
+  // ── Set piece (optional) ────────────────────────────────────────────────────
+  // careless-user: eligible when moneyCost ≥ C and there's a firewall in the network
+  if (GRADE_INDEX[mc] >= GRADE_INDEX["C"] && firewallId && rng() < 0.6) {
+    const baseGrade = pathGrade();
+    applySetPiece(
+      SET_PIECES["careless-user"],
+      { nodes, edges },
+      rng,
+      baseGrade,
+      nextLabel,
+      makeId,
+    );
   }
 
   // ── Assign x,y positions ────────────────────────────────────────────────────

--- a/js/network-gen.test.js
+++ b/js/network-gen.test.js
@@ -1,0 +1,165 @@
+// @ts-check
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { generateNetwork } from "./network-gen.js";
+
+// ── Determinism tests ──────────────────────────────────────────────────────────
+
+describe("generateNetwork: determinism", () => {
+  it("produces identical output for the same inputs (testseed C/B)", () => {
+    const a = generateNetwork("testseed", "C", "B");
+    const b = generateNetwork("testseed", "C", "B");
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(a)), JSON.parse(JSON.stringify(b)));
+  });
+
+  it("produces identical output for the same inputs (abc F/F)", () => {
+    const a = generateNetwork("abc", "F", "F");
+    const b = generateNetwork("abc", "F", "F");
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(a)), JSON.parse(JSON.stringify(b)));
+  });
+
+  it("produces identical output for the same inputs (xyz S/S)", () => {
+    const a = generateNetwork("xyz", "S", "S");
+    const b = generateNetwork("xyz", "S", "S");
+    assert.deepStrictEqual(JSON.parse(JSON.stringify(a)), JSON.parse(JSON.stringify(b)));
+  });
+
+  it("produces different outputs for different seeds", () => {
+    const a = generateNetwork("seed-one", "C", "C");
+    const b = generateNetwork("seed-two", "C", "C");
+    // Networks will almost certainly differ; if they somehow don't, that's fine too.
+    // This test just confirms the call doesn't throw.
+    assert.ok(a.nodes.length > 0);
+    assert.ok(b.nodes.length > 0);
+  });
+});
+
+// ── Structural tests ───────────────────────────────────────────────────────────
+
+/** @param {string} seed @param {string} tc @param {string} mc */
+function structural(seed, tc, mc) {
+  describe(`generateNetwork: structure (${tc}/${mc})`, () => {
+    const net = generateNetwork(seed, tc, mc);
+
+    it("has wan, gateway, security-monitor nodes", () => {
+      const types = new Set(net.nodes.map((n) => n.type));
+      assert.ok(types.has("wan"),              "missing wan");
+      assert.ok(types.has("gateway"),          "missing gateway");
+      assert.ok(types.has("security-monitor"), "missing security-monitor");
+    });
+
+    it("has at least one fileserver or cryptovault", () => {
+      const types = net.nodes.map((n) => n.type);
+      assert.ok(
+        types.includes("fileserver") || types.includes("cryptovault"),
+        "no lootable node"
+      );
+    });
+
+    it("security-monitor is adjacent to an ids node", () => {
+      const monitorIds = net.nodes
+        .filter((n) => n.type === "security-monitor")
+        .map((n) => n.id);
+      const hasLink = net.edges.some(
+        ({ source, target }) =>
+          (monitorIds.includes(target) && net.nodes.find((n) => n.id === source)?.type === "ids") ||
+          (monitorIds.includes(source) && net.nodes.find((n) => n.id === target)?.type === "ids")
+      );
+      assert.ok(hasLink, "no ids→security-monitor edge");
+    });
+
+    it("all edge node references exist in nodes array", () => {
+      const nodeIds = new Set(net.nodes.map((n) => n.id));
+      for (const { source, target } of net.edges) {
+        assert.ok(nodeIds.has(source), `edge source ${source} not in nodes`);
+        assert.ok(nodeIds.has(target), `edge target ${target} not in nodes`);
+      }
+    });
+
+    it("BFS from startNode reaches at least one lootable node", () => {
+      /** @type {Record<string, string[]>} */
+      const adj = {};
+      for (const { source, target } of net.edges) {
+        (adj[source] ??= []).push(target);
+        (adj[target] ??= []).push(source);
+      }
+      const visited = new Set([net.startNode]);
+      const queue = [net.startNode];
+      let found = false;
+      while (queue.length && !found) {
+        const cur = queue.shift();
+        const node = net.nodes.find((n) => n.id === cur);
+        if (node && (node.type === "fileserver" || node.type === "cryptovault")) {
+          found = true;
+          break;
+        }
+        for (const nb of (adj[cur] ?? [])) {
+          if (!visited.has(nb)) { visited.add(nb); queue.push(nb); }
+        }
+      }
+      assert.ok(found, "no lootable node reachable from startNode");
+    });
+
+    it("no node has grade 'undefined' or null", () => {
+      for (const node of net.nodes) {
+        assert.ok(node.grade && node.grade !== "undefined", `node ${node.id} has bad grade: ${node.grade}`);
+      }
+    });
+  });
+}
+
+structural("struct-seed", "F", "F");
+structural("struct-seed", "C", "C");
+structural("struct-seed", "B", "B");
+structural("struct-seed", "S", "S");
+
+// ── Snapshot tests ─────────────────────────────────────────────────────────────
+
+const SNAP_DIR = new URL("./snapshots", import.meta.url).pathname;
+
+/** @param {string} label @param {object} net */
+function snapshot(label, net) {
+  const file = `${SNAP_DIR}/network-gen-${label}.json`;
+  const actual = JSON.stringify(net, null, 2);
+  if (!existsSync(file)) {
+    mkdirSync(SNAP_DIR, { recursive: true });
+    writeFileSync(file, actual, "utf8");
+    return; // first run — write and pass
+  }
+  const expected = readFileSync(file, "utf8");
+  assert.strictEqual(actual, expected, `snapshot mismatch for ${label}`);
+}
+
+describe("generateNetwork: snapshots", () => {
+  it("snap-seed F/F is stable", () => {
+    snapshot("F-F", generateNetwork("snap-seed", "F", "F"));
+  });
+  it("snap-seed C/C is stable", () => {
+    snapshot("C-C", generateNetwork("snap-seed", "C", "C"));
+  });
+  it("snap-seed B/B is stable", () => {
+    snapshot("B-B", generateNetwork("snap-seed", "B", "B"));
+  });
+  it("snap-seed S/S is stable", () => {
+    snapshot("S-S", generateNetwork("snap-seed", "S", "S"));
+  });
+});
+
+// ── Input validation ───────────────────────────────────────────────────────────
+
+describe("generateNetwork: input validation", () => {
+  it("throws on invalid timeCost", () => {
+    assert.throws(
+      () => generateNetwork("seed", "E", "C"),
+      /invalid timeCost/
+    );
+  });
+
+  it("throws on invalid moneyCost", () => {
+    assert.throws(
+      () => generateNetwork("seed", "C", "Z"),
+      /invalid moneyCost/
+    );
+  });
+});

--- a/js/rng.js
+++ b/js/rng.js
@@ -102,6 +102,21 @@ export function randomPick(stream, arr) {
 }
 
 /**
+ * In-place Fisher-Yates shuffle using a raw RNG function. Returns the array.
+ * @template T
+ * @param {() => number} rngFn
+ * @param {T[]} arr
+ * @returns {T[]}
+ */
+export function shuffleWith(rngFn, arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rngFn() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+/**
  * In-place Fisher-Yates shuffle using the named stream. Returns the array.
  * @template T
  * @param {string} stream
@@ -109,11 +124,7 @@ export function randomPick(stream, arr) {
  * @returns {T[]}
  */
 export function shuffle(stream, arr) {
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(random(stream) * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
-  }
-  return arr;
+  return shuffleWith(() => random(stream), arr);
 }
 
 /**
@@ -158,6 +169,23 @@ export function deserializeRng(data) {
     streams[name].state = data.streams[name] ?? 0;
     streams[name].forced = [];
   }
+}
+
+// ── Standalone factory ───────────────────────────────────
+
+/**
+ * Create an independent Mulberry32 RNG seeded from a string.
+ * Does NOT touch any named gameplay stream — safe to use in generators.
+ * @param {string} seedString
+ * @returns {() => number}
+ */
+export function makeSeededRng(seedString) {
+  let state = hashString(seedString);
+  return function rng() {
+    const { next, value } = advance(state);
+    state = next;
+    return value;
+  };
 }
 
 // ── Test helpers (prefixed with _ to signal test-only) ───

--- a/js/set-pieces.js
+++ b/js/set-pieces.js
@@ -1,0 +1,104 @@
+// @ts-check
+// Set piece definitions — named, parameterized prefab subgraphs for the LAN generator.
+// Set pieces are the escape hatch for topologies too complex to express as topology rules.
+// Each piece participates in macro-level topology as a unit ("super-node") and may
+// intentionally violate standard topology rules to represent interesting configurations.
+
+import { shiftGrade } from "./grades.js";
+
+/**
+ * A single node in a set piece definition.
+ * @typedef {{ localId: string, type: string, gradeOffset: number, depth: number }} PieceNodeDef
+ */
+
+/**
+ * An edge internal to a set piece (references localIds, not real network ids).
+ * @typedef {{ source: string, target: string }} PieceEdgeDef
+ */
+
+/**
+ * How a set piece node attaches to the main graph.
+ * attachTo: the type of main-graph node to connect from (picks one at random if multiple)
+ * localId: which piece node receives the connection
+ * @typedef {{ attachTo: string, localId: string }} ExternalAttachment
+ */
+
+/**
+ * A set piece definition.
+ * @typedef {{
+ *   id: string,
+ *   nodes: PieceNodeDef[],
+ *   edges: PieceEdgeDef[],
+ *   externalAttachments: ExternalAttachment[],
+ * }} SetPiece
+ */
+
+/** @type {Record<string, SetPiece>} */
+export const SET_PIECES = {
+  /**
+   * careless-user — a workstation inadvertently bridged to a fileserver that is
+   * otherwise behind a firewall. Creates a soft alternate path to a protected node.
+   *
+   * Narrative: the sysadmin connected the departmental workstation to the file store
+   * for convenience, not realising the firewall was supposed to gate that access.
+   *
+   * Topology rule violation: fileserver is accessible both through the firewall
+   * (hard path) and through the workstation (soft path that bypasses the gate).
+   */
+  "careless-user": {
+    id: "careless-user",
+    nodes: [
+      { localId: "ws", type: "workstation", gradeOffset: -1, depth: 2 }, // soft entry
+      { localId: "fs", type: "fileserver",  gradeOffset:  0, depth: 2 }, // base grade
+      { localId: "fw", type: "firewall",    gradeOffset: +1, depth: 1 }, // hardened gate
+    ],
+    edges: [
+      { source: "ws", target: "fs" }, // the exposure — bypasses firewall
+      { source: "fw", target: "fs" }, // firewall still present (hard path)
+    ],
+    externalAttachments: [
+      { attachTo: "router",  localId: "ws" }, // router → workstation (soft entry point)
+      { attachTo: "gateway", localId: "fw" }, // gateway → firewall (hard entry point)
+    ],
+  },
+};
+
+/**
+ * Apply a set piece to a network (mutates network.nodes and network.edges in place).
+ *
+ * The caller provides makeId and nextLabel so the piece integrates seamlessly into
+ * the generator's existing ID sequence and label pools — no module-level state here.
+ *
+ * @param {SetPiece} piece
+ * @param {{ nodes: Array<object>, edges: Array<{source:string,target:string}> }} network
+ * @param {() => number} rng
+ * @param {string} baseGrade   - grade to use as reference for gradeOffset
+ * @param {(type: string) => string} nextLabel  - draws from generator's label pools
+ * @param {(type: string) => string} makeId     - draws from generator's node ID sequence
+ * @returns void
+ */
+export function applySetPiece(piece, network, rng, baseGrade, nextLabel, makeId) {
+  // Map localId → real network id
+  /** @type {Record<string, string>} */
+  const idMap = {};
+
+  for (const { localId, type, gradeOffset, depth } of piece.nodes) {
+    const id = makeId(type);
+    idMap[localId] = id;
+    const grade = shiftGrade(baseGrade, gradeOffset);
+    network.nodes.push({ id, type, label: nextLabel(type), grade, _depth: depth });
+  }
+
+  // Internal edges
+  for (const { source, target } of piece.edges) {
+    network.edges.push({ source: idMap[source], target: idMap[target] });
+  }
+
+  // External attachments — find a main-graph node of the given type, add an edge
+  for (const { attachTo, localId } of piece.externalAttachments) {
+    const candidates = network.nodes.filter((n) => /** @type {any} */(n).type === attachTo);
+    if (candidates.length === 0) continue;
+    const host = /** @type {any} */ (candidates[Math.floor(rng() * candidates.length)]);
+    network.edges.push({ source: host.id, target: idMap[localId] });
+  }
+}

--- a/js/snapshots/network-gen-B-B.json
+++ b/js/snapshots/network-gen-B-B.json
@@ -1,0 +1,179 @@
+{
+  "nodes": [
+    {
+      "id": "wan-1",
+      "type": "wan",
+      "label": "WAN",
+      "grade": "D",
+      "x": 400,
+      "y": -90
+    },
+    {
+      "id": "gateway-2",
+      "type": "gateway",
+      "label": "INET-GW-02",
+      "grade": "D",
+      "x": 400,
+      "y": 50
+    },
+    {
+      "id": "security-monitor-3",
+      "type": "security-monitor",
+      "label": "SEC-MON-01",
+      "grade": "A",
+      "x": 200,
+      "y": 470
+    },
+    {
+      "id": "ids-4",
+      "type": "ids",
+      "label": "IDS-01",
+      "grade": "B",
+      "x": 0,
+      "y": 330
+    },
+    {
+      "id": "router-5",
+      "type": "router",
+      "label": "RTR-A",
+      "grade": "C",
+      "x": 100,
+      "y": 190
+    },
+    {
+      "id": "router-6",
+      "type": "router",
+      "label": "RTR-02",
+      "grade": "B",
+      "x": 300,
+      "y": 190
+    },
+    {
+      "id": "firewall-7",
+      "type": "firewall",
+      "label": "FW-CORE",
+      "grade": "A",
+      "x": 500,
+      "y": 190
+    },
+    {
+      "id": "fileserver-8",
+      "type": "fileserver",
+      "label": "FS-ARCHIVE",
+      "grade": "C",
+      "x": 400,
+      "y": 470
+    },
+    {
+      "id": "cryptovault-9",
+      "type": "cryptovault",
+      "label": "VAULT-S",
+      "grade": "A",
+      "x": 600,
+      "y": 470
+    },
+    {
+      "id": "workstation-10",
+      "type": "workstation",
+      "label": "WS-BETA",
+      "grade": "D",
+      "x": 200,
+      "y": 330
+    },
+    {
+      "id": "workstation-11",
+      "type": "workstation",
+      "label": "WS-01",
+      "grade": "D",
+      "x": 400,
+      "y": 330
+    },
+    {
+      "id": "workstation-12",
+      "type": "workstation",
+      "label": "WS-GAMMA",
+      "grade": "B",
+      "x": 600,
+      "y": 330
+    },
+    {
+      "id": "fileserver-13",
+      "type": "fileserver",
+      "label": "FS-02",
+      "grade": "A",
+      "x": 800,
+      "y": 330
+    },
+    {
+      "id": "firewall-14",
+      "type": "firewall",
+      "label": "FW-01",
+      "grade": "S",
+      "x": 700,
+      "y": 190
+    }
+  ],
+  "edges": [
+    {
+      "source": "wan-1",
+      "target": "gateway-2"
+    },
+    {
+      "source": "ids-4",
+      "target": "security-monitor-3"
+    },
+    {
+      "source": "gateway-2",
+      "target": "router-5"
+    },
+    {
+      "source": "gateway-2",
+      "target": "router-6"
+    },
+    {
+      "source": "router-5",
+      "target": "ids-4"
+    },
+    {
+      "source": "gateway-2",
+      "target": "firewall-7"
+    },
+    {
+      "source": "firewall-7",
+      "target": "fileserver-8"
+    },
+    {
+      "source": "firewall-7",
+      "target": "cryptovault-9"
+    },
+    {
+      "source": "router-5",
+      "target": "workstation-10"
+    },
+    {
+      "source": "router-6",
+      "target": "workstation-11"
+    },
+    {
+      "source": "workstation-12",
+      "target": "fileserver-13"
+    },
+    {
+      "source": "firewall-14",
+      "target": "fileserver-13"
+    },
+    {
+      "source": "router-6",
+      "target": "workstation-12"
+    },
+    {
+      "source": "gateway-2",
+      "target": "firewall-14"
+    }
+  ],
+  "startNode": "gateway-2",
+  "ice": {
+    "grade": "B",
+    "startNode": "security-monitor-3"
+  }
+}

--- a/js/snapshots/network-gen-B-B.json
+++ b/js/snapshots/network-gen-B-B.json
@@ -172,6 +172,16 @@
     }
   ],
   "startNode": "gateway-2",
+  "startCash": 1500,
+  "startHandSpec": [
+    "common",
+    "uncommon",
+    "uncommon",
+    "uncommon",
+    "uncommon",
+    "rare",
+    "rare"
+  ],
   "ice": {
     "grade": "B",
     "startNode": "security-monitor-3"

--- a/js/snapshots/network-gen-C-C.json
+++ b/js/snapshots/network-gen-C-C.json
@@ -1,0 +1,167 @@
+{
+  "nodes": [
+    {
+      "id": "wan-1",
+      "type": "wan",
+      "label": "WAN",
+      "grade": "D",
+      "x": 400,
+      "y": -90
+    },
+    {
+      "id": "gateway-2",
+      "type": "gateway",
+      "label": "INET-GW-02",
+      "grade": "F",
+      "x": 400,
+      "y": 50
+    },
+    {
+      "id": "security-monitor-3",
+      "type": "security-monitor",
+      "label": "SEC-MON-01",
+      "grade": "B",
+      "x": 400,
+      "y": 470
+    },
+    {
+      "id": "ids-4",
+      "type": "ids",
+      "label": "IDS-01",
+      "grade": "C",
+      "x": -100,
+      "y": 330
+    },
+    {
+      "id": "router-5",
+      "type": "router",
+      "label": "RTR-A",
+      "grade": "D",
+      "x": 100,
+      "y": 190
+    },
+    {
+      "id": "router-6",
+      "type": "router",
+      "label": "RTR-02",
+      "grade": "C",
+      "x": 300,
+      "y": 190
+    },
+    {
+      "id": "firewall-7",
+      "type": "firewall",
+      "label": "FW-CORE",
+      "grade": "B",
+      "x": 500,
+      "y": 190
+    },
+    {
+      "id": "fileserver-8",
+      "type": "fileserver",
+      "label": "FS-ARCHIVE",
+      "grade": "D",
+      "x": 100,
+      "y": 330
+    },
+    {
+      "id": "workstation-9",
+      "type": "workstation",
+      "label": "WS-BETA",
+      "grade": "F",
+      "x": 300,
+      "y": 330
+    },
+    {
+      "id": "workstation-10",
+      "type": "workstation",
+      "label": "WS-01",
+      "grade": "F",
+      "x": 500,
+      "y": 330
+    },
+    {
+      "id": "workstation-11",
+      "type": "workstation",
+      "label": "WS-GAMMA",
+      "grade": "C",
+      "x": 700,
+      "y": 330
+    },
+    {
+      "id": "fileserver-12",
+      "type": "fileserver",
+      "label": "FS-02",
+      "grade": "B",
+      "x": 900,
+      "y": 330
+    },
+    {
+      "id": "firewall-13",
+      "type": "firewall",
+      "label": "FW-01",
+      "grade": "A",
+      "x": 700,
+      "y": 190
+    }
+  ],
+  "edges": [
+    {
+      "source": "wan-1",
+      "target": "gateway-2"
+    },
+    {
+      "source": "ids-4",
+      "target": "security-monitor-3"
+    },
+    {
+      "source": "gateway-2",
+      "target": "router-5"
+    },
+    {
+      "source": "gateway-2",
+      "target": "router-6"
+    },
+    {
+      "source": "router-5",
+      "target": "ids-4"
+    },
+    {
+      "source": "gateway-2",
+      "target": "firewall-7"
+    },
+    {
+      "source": "firewall-7",
+      "target": "fileserver-8"
+    },
+    {
+      "source": "router-5",
+      "target": "workstation-9"
+    },
+    {
+      "source": "router-6",
+      "target": "workstation-10"
+    },
+    {
+      "source": "workstation-11",
+      "target": "fileserver-12"
+    },
+    {
+      "source": "firewall-13",
+      "target": "fileserver-12"
+    },
+    {
+      "source": "router-6",
+      "target": "workstation-11"
+    },
+    {
+      "source": "gateway-2",
+      "target": "firewall-13"
+    }
+  ],
+  "startNode": "gateway-2",
+  "ice": {
+    "grade": "C",
+    "startNode": "security-monitor-3"
+  }
+}

--- a/js/snapshots/network-gen-C-C.json
+++ b/js/snapshots/network-gen-C-C.json
@@ -160,6 +160,16 @@
     }
   ],
   "startNode": "gateway-2",
+  "startCash": 1250,
+  "startHandSpec": [
+    "common",
+    "common",
+    "uncommon",
+    "uncommon",
+    "uncommon",
+    "rare",
+    "rare"
+  ],
   "ice": {
     "grade": "C",
     "startNode": "security-monitor-3"

--- a/js/snapshots/network-gen-F-F.json
+++ b/js/snapshots/network-gen-F-F.json
@@ -21,8 +21,8 @@
       "type": "security-monitor",
       "label": "SEC-MON-01",
       "grade": "D",
-      "x": 300,
-      "y": 330
+      "x": 400,
+      "y": 470
     },
     {
       "id": "ids-4",
@@ -30,18 +30,26 @@
       "label": "IDS-01",
       "grade": "D",
       "x": 200,
-      "y": 190
+      "y": 330
     },
     {
       "id": "router-5",
       "type": "router",
       "label": "RTR-A",
       "grade": "F",
+      "x": 200,
+      "y": 190
+    },
+    {
+      "id": "router-6",
+      "type": "router",
+      "label": "RTR-02",
+      "grade": "F",
       "x": 400,
       "y": 190
     },
     {
-      "id": "fileserver-6",
+      "id": "fileserver-7",
       "type": "fileserver",
       "label": "FS-ARCHIVE",
       "grade": "F",
@@ -49,11 +57,19 @@
       "y": 190
     },
     {
-      "id": "workstation-7",
+      "id": "workstation-8",
       "type": "workstation",
       "label": "WS-BETA",
       "grade": "F",
-      "x": 500,
+      "x": 400,
+      "y": 330
+    },
+    {
+      "id": "workstation-9",
+      "type": "workstation",
+      "label": "WS-01",
+      "grade": "F",
+      "x": 600,
       "y": 330
     }
   ],
@@ -71,19 +87,36 @@
       "target": "router-5"
     },
     {
+      "source": "gateway-2",
+      "target": "router-6"
+    },
+    {
       "source": "router-5",
       "target": "ids-4"
     },
     {
       "source": "router-5",
-      "target": "fileserver-6"
+      "target": "fileserver-7"
+    },
+    {
+      "source": "router-6",
+      "target": "workstation-8"
     },
     {
       "source": "router-5",
-      "target": "workstation-7"
+      "target": "workstation-9"
     }
   ],
   "startNode": "gateway-2",
+  "startCash": 1000,
+  "startHandSpec": [
+    "common",
+    "common",
+    "uncommon",
+    "uncommon",
+    "uncommon",
+    "rare"
+  ],
   "ice": {
     "grade": "F",
     "startNode": "security-monitor-3"

--- a/js/snapshots/network-gen-F-F.json
+++ b/js/snapshots/network-gen-F-F.json
@@ -1,0 +1,91 @@
+{
+  "nodes": [
+    {
+      "id": "wan-1",
+      "type": "wan",
+      "label": "WAN",
+      "grade": "D",
+      "x": 400,
+      "y": -90
+    },
+    {
+      "id": "gateway-2",
+      "type": "gateway",
+      "label": "INET-GW-02",
+      "grade": "F",
+      "x": 400,
+      "y": 50
+    },
+    {
+      "id": "security-monitor-3",
+      "type": "security-monitor",
+      "label": "SEC-MON-01",
+      "grade": "D",
+      "x": 300,
+      "y": 330
+    },
+    {
+      "id": "ids-4",
+      "type": "ids",
+      "label": "IDS-01",
+      "grade": "D",
+      "x": 200,
+      "y": 190
+    },
+    {
+      "id": "router-5",
+      "type": "router",
+      "label": "RTR-A",
+      "grade": "F",
+      "x": 400,
+      "y": 190
+    },
+    {
+      "id": "fileserver-6",
+      "type": "fileserver",
+      "label": "FS-ARCHIVE",
+      "grade": "F",
+      "x": 600,
+      "y": 190
+    },
+    {
+      "id": "workstation-7",
+      "type": "workstation",
+      "label": "WS-BETA",
+      "grade": "F",
+      "x": 500,
+      "y": 330
+    }
+  ],
+  "edges": [
+    {
+      "source": "wan-1",
+      "target": "gateway-2"
+    },
+    {
+      "source": "ids-4",
+      "target": "security-monitor-3"
+    },
+    {
+      "source": "gateway-2",
+      "target": "router-5"
+    },
+    {
+      "source": "router-5",
+      "target": "ids-4"
+    },
+    {
+      "source": "router-5",
+      "target": "fileserver-6"
+    },
+    {
+      "source": "router-5",
+      "target": "workstation-7"
+    }
+  ],
+  "startNode": "gateway-2",
+  "ice": {
+    "grade": "F",
+    "startNode": "security-monitor-3"
+  }
+}

--- a/js/snapshots/network-gen-S-S.json
+++ b/js/snapshots/network-gen-S-S.json
@@ -1,0 +1,179 @@
+{
+  "nodes": [
+    {
+      "id": "wan-1",
+      "type": "wan",
+      "label": "WAN",
+      "grade": "D",
+      "x": 400,
+      "y": -90
+    },
+    {
+      "id": "gateway-2",
+      "type": "gateway",
+      "label": "INET-GW-02",
+      "grade": "B",
+      "x": 400,
+      "y": 50
+    },
+    {
+      "id": "security-monitor-3",
+      "type": "security-monitor",
+      "label": "SEC-MON-01",
+      "grade": "S",
+      "x": 300,
+      "y": 750
+    },
+    {
+      "id": "ids-4",
+      "type": "ids",
+      "label": "IDS-01",
+      "grade": "S",
+      "x": 300,
+      "y": 610
+    },
+    {
+      "id": "router-5",
+      "type": "router",
+      "label": "RTR-A",
+      "grade": "A",
+      "x": 100,
+      "y": 190
+    },
+    {
+      "id": "router-6",
+      "type": "router",
+      "label": "RTR-02",
+      "grade": "A",
+      "x": 300,
+      "y": 190
+    },
+    {
+      "id": "firewall-7",
+      "type": "firewall",
+      "label": "FW-CORE",
+      "grade": "S",
+      "x": 500,
+      "y": 190
+    },
+    {
+      "id": "fileserver-8",
+      "type": "fileserver",
+      "label": "FS-ARCHIVE",
+      "grade": "A",
+      "x": 500,
+      "y": 610
+    },
+    {
+      "id": "cryptovault-9",
+      "type": "cryptovault",
+      "label": "VAULT-S",
+      "grade": "S",
+      "x": 500,
+      "y": 750
+    },
+    {
+      "id": "workstation-10",
+      "type": "workstation",
+      "label": "WS-BETA",
+      "grade": "B",
+      "x": 100,
+      "y": 330
+    },
+    {
+      "id": "workstation-11",
+      "type": "workstation",
+      "label": "WS-01",
+      "grade": "B",
+      "x": 300,
+      "y": 330
+    },
+    {
+      "id": "workstation-12",
+      "type": "workstation",
+      "label": "WS-GAMMA",
+      "grade": "A",
+      "x": 500,
+      "y": 330
+    },
+    {
+      "id": "fileserver-13",
+      "type": "fileserver",
+      "label": "FS-02",
+      "grade": "S",
+      "x": 700,
+      "y": 330
+    },
+    {
+      "id": "firewall-14",
+      "type": "firewall",
+      "label": "FW-01",
+      "grade": "S",
+      "x": 700,
+      "y": 190
+    }
+  ],
+  "edges": [
+    {
+      "source": "wan-1",
+      "target": "gateway-2"
+    },
+    {
+      "source": "ids-4",
+      "target": "security-monitor-3"
+    },
+    {
+      "source": "gateway-2",
+      "target": "router-5"
+    },
+    {
+      "source": "gateway-2",
+      "target": "router-6"
+    },
+    {
+      "source": "router-5",
+      "target": "ids-4"
+    },
+    {
+      "source": "gateway-2",
+      "target": "firewall-7"
+    },
+    {
+      "source": "firewall-7",
+      "target": "fileserver-8"
+    },
+    {
+      "source": "firewall-7",
+      "target": "cryptovault-9"
+    },
+    {
+      "source": "router-5",
+      "target": "workstation-10"
+    },
+    {
+      "source": "router-6",
+      "target": "workstation-11"
+    },
+    {
+      "source": "workstation-12",
+      "target": "fileserver-13"
+    },
+    {
+      "source": "firewall-14",
+      "target": "fileserver-13"
+    },
+    {
+      "source": "router-6",
+      "target": "workstation-12"
+    },
+    {
+      "source": "gateway-2",
+      "target": "firewall-14"
+    }
+  ],
+  "startNode": "gateway-2",
+  "ice": {
+    "grade": "S",
+    "startNode": "security-monitor-3"
+  }
+}

--- a/js/snapshots/network-gen-S-S.json
+++ b/js/snapshots/network-gen-S-S.json
@@ -172,6 +172,17 @@
     }
   ],
   "startNode": "gateway-2",
+  "startCash": 2500,
+  "startHandSpec": [
+    "uncommon",
+    "uncommon",
+    "uncommon",
+    "uncommon",
+    "uncommon",
+    "rare",
+    "rare",
+    "rare"
+  ],
   "ice": {
     "grade": "S",
     "startNode": "security-monitor-3"

--- a/js/state/index.js
+++ b/js/state/index.js
@@ -106,7 +106,7 @@ export function initState(networkData, seedString) {
     seed: getSeed(),
     nodes,
     adjacency,
-    player: { cash: 1000, hand: generateStartingHand() },
+    player: { cash: networkData.startCash ?? 1000, hand: generateStartingHand(networkData.startHandSpec) },
     globalAlert: "green",
     traceSecondsRemaining: null,
     traceTimerId: null,

--- a/scripts/playtest.js
+++ b/scripts/playtest.js
@@ -14,6 +14,7 @@
 
 import { readFileSync, writeFileSync, existsSync } from "fs";
 import { NETWORK } from "../data/network.js";
+import { generateNetwork } from "../js/network-gen.js";
 import { initState, getState, serializeState, deserializeState } from "../js/state.js";
 import { completeReboot } from "../js/node-orchestration.js";
 import { handleExploitExecTimer, handleExploitNoiseTimer } from "../js/exploit-exec.js";
@@ -39,6 +40,8 @@ initNodeLifecycle();
 let stateFile = "scripts/playtest-state.json";
 let cmdStr = null;
 let seedArg = null;
+let timeArg = null;
+let moneyArg = null;
 
 {
   const argv = process.argv.slice(2);
@@ -47,14 +50,24 @@ let seedArg = null;
       stateFile = argv[++i];
     } else if (argv[i] === "--seed" && argv[i + 1]) {
       seedArg = argv[++i];
+    } else if (argv[i] === "--time" && argv[i + 1]) {
+      timeArg = argv[++i].toUpperCase();
+    } else if (argv[i] === "--money" && argv[i + 1]) {
+      moneyArg = argv[++i].toUpperCase();
     } else if (cmdStr === null) {
       cmdStr = argv[i];
     }
   }
 }
 
+// ── Network selection ───────────────────────────────────────
+// Use generated network when --time and --money are both present; otherwise static.
+const network = (timeArg && moneyArg)
+  ? generateNetwork(seedArg ?? "default", timeArg, moneyArg)
+  : NETWORK;
+
 if (!cmdStr) {
-  console.error("Usage: node scripts/playtest.js [--state <file>] <command>");
+  console.error("Usage: node scripts/playtest.js [--state <file>] [--seed <s>] [--time <grade>] [--money <grade>] <command>");
   console.error("Commands: reset  tick <n>  select <node>  deselect");
   console.error("          probe [node]  exploit <node> <card>  read [node]");
   console.error("          loot [node]  reconfigure [node]  jackout");
@@ -148,9 +161,12 @@ function runCmd(raw) {
 
   // Harness-only commands
   if (verb === "reset") {
-    initState(NETWORK, seedArg ?? undefined);
+    initState(network, seedArg ?? undefined);
     startIce();
-    out(`[SYS] Initialized. Seed: "${getState().seed}". Network: ${NETWORK.nodes.length} nodes.`);
+    const genInfo = (timeArg && moneyArg)
+      ? ` (generated: time=${timeArg} money=${moneyArg})`
+      : "";
+    out(`[SYS] Initialized. Seed: "${getState().seed}". Network: ${network.nodes.length} nodes${genInfo}.`);
     return;
   }
   if (verb === "tick") {

--- a/scripts/playtest.js
+++ b/scripts/playtest.js
@@ -42,6 +42,8 @@ let cmdStr = null;
 let seedArg = null;
 let timeArg = null;
 let moneyArg = null;
+/** @type {string[]} */
+const forcePiecesArg = [];
 
 {
   const argv = process.argv.slice(2);
@@ -54,6 +56,8 @@ let moneyArg = null;
       timeArg = argv[++i].toUpperCase();
     } else if (argv[i] === "--money" && argv[i + 1]) {
       moneyArg = argv[++i].toUpperCase();
+    } else if (argv[i] === "--force-piece" && argv[i + 1]) {
+      forcePiecesArg.push(argv[++i]);
     } else if (cmdStr === null) {
       cmdStr = argv[i];
     }
@@ -63,11 +67,11 @@ let moneyArg = null;
 // ── Network selection ───────────────────────────────────────
 // Use generated network when --time and --money are both present; otherwise static.
 const network = (timeArg && moneyArg)
-  ? generateNetwork(seedArg ?? "default", timeArg, moneyArg)
+  ? generateNetwork(seedArg ?? "default", timeArg, moneyArg, { forcePieces: forcePiecesArg })
   : NETWORK;
 
 if (!cmdStr) {
-  console.error("Usage: node scripts/playtest.js [--state <file>] [--seed <s>] [--time <grade>] [--money <grade>] <command>");
+  console.error("Usage: node scripts/playtest.js [--state <file>] [--seed <s>] [--time <grade>] [--money <grade>] [--force-piece <id>] <command>");
   console.error("Commands: reset  tick <n>  select <node>  deselect");
   console.error("          probe [node]  exploit <node> <card>  read [node]");
   console.error("          loot [node]  reconfigure [node]  jackout");


### PR DESCRIPTION
## Summary

- Adds `js/network-gen.js`: procedural LAN generator driven by `seed`, `timeCost`, and `moneyCost` grade parameters — fully deterministic, same inputs always produce the same network
- Introduces `js/grades.js` (grade utilities) and `data/node-type-rules.js` (topology rule data)
- Adds `js/set-pieces.js` with the `careless-user` set piece — a workstation bridged to a firewall-gated fileserver, creating a soft alternate path
- Wires the generator into the headless harness (`--time`, `--money`, `--force-piece` flags) and browser (URL params `?seed=&time=&money=`)
- 52 new tests: determinism, structural validators, snapshot tests for F/F, C/C, B/B, S/S
- Balance tuning from playtesting: `startCash` and `startHandSpec` scale with difficulty, F depthBudget bumped to 3, `status full` lists revealed node IDs
- Consolidates Mulberry32/djb2 RNG primitives into `js/rng.js` as `makeSeededRng()` and `shuffleWith()` — generator no longer duplicates these
- Scaffolds the next session (`biome-bundles`) which will move hardcoded node type strings, grade assignments, validators, and set pieces into self-contained biome bundle modules

## Test plan

- [ ] `make check` — 276 tests pass
- [ ] `node scripts/playtest.js --seed test --time F --money F reset && node scripts/playtest.js --seed test --time F --money F "status full"` — easy generated network
- [ ] `node scripts/playtest.js --seed test --time B --money B reset && node scripts/playtest.js --seed test --time B --money B "status full"` — medium generated network
- [ ] Browser: `index.html?seed=hello&time=F&money=F` and `index.html?seed=hello&time=B&money=B`

🤖 Generated with [Claude Code](https://claude.com/claude-code)