### PR TITLE
Bot census: Monte Carlo balance testing + ICE rework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,38 @@ node scripts/playtest.js "status ice"
 
 ---
 
+## Bot Player and Census
+
+`scripts/bot-player.js` is an automated game-playing agent for balance testing.
+`scripts/bot-census.js` runs it across many seeds and produces LLM-readable reports.
+See `docs/BOT-PLAYER.md` for full documentation.
+
+**`scripts/bot-player.js`, `scripts/playtest.js`, and `js/main.js` are three parallel
+entry points** into the same game engine. All three share timer wiring, action dispatch,
+and event handling. When changing game mechanics, check all three.
+
+**Keep the bot working when changing game mechanics.** The bot reads game state directly
+(`accessLevel`, `visibility`, `vulnerabilities`, `macguffins`) and dispatches actions
+via `emitEvent("starnet:action", ...)`. Changes that affect the bot:
+
+- **New action types** → bot won't use them automatically, but shouldn't break. Consider
+  whether the bot should learn the new action (add to strategy) or ignore it (note in
+  `docs/BOT-PLAYER.md` "What the bot does NOT do").
+- **Changed event names or payloads** → bot stat tracking may miss events. Check the
+  `on(E.*)` handlers in `runBot()`.
+- **New node types** → bot may skip or mishandle them. Check `pickNextNode()` and the
+  `SECURITY_TYPES` / `LOOTABLE_TYPES` sets.
+- **New timed actions** → need `tickUntilEvent` support and timer handler wiring in the
+  one-time init block.
+- **Timer handler changes** → the bot's init block must register the same handlers as
+  `playtest.js`. If a new TIMER type is added, add it to both.
+
+**Run `make bot-census` after balance changes** to verify the difficulty curve hasn't
+regressed. A quick smoke test: `node scripts/bot-census.js --time F --money F --seeds 10`
+should show ~80% success.
+
+---
+
 ## Player Manual
 
 `MANUAL.md` is the player-facing documentation for the game and the **canonical reference

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: serve lint test check census
+.PHONY: serve lint test check census bot-census
 
 # Start local dev server (open http://localhost:3000)
 serve:
@@ -14,7 +14,8 @@ lint:
 		js/alert.js js/timers.js js/ice.js js/log.js js/log-renderer.js js/visual-renderer.js js/store.js js/console.js js/cheats.js \
 		js/node-types.js js/node-lifecycle.js \
 		js/rng.js js/probe-exec.js js/read-exec.js js/loot-exec.js js/navigation.js \
-		js/node-actions.js js/global-actions.js js/action-context.js js/node-orchestration.js
+		js/node-actions.js js/global-actions.js js/action-context.js js/node-orchestration.js \
+		js/store-logic.js
 
 # Run unit + integration tests
 test:
@@ -26,3 +27,10 @@ check: lint test
 # Run network census report across all difficulty combos
 census:
 	node scripts/network-census.js
+
+# Run bot simulation at B/B (override with: make bot-census TC=S MC=S SEEDS=50)
+TC ?= B
+MC ?= B
+SEEDS ?= 100
+bot-census:
+	node scripts/bot-census.js --time $(TC) --money $(MC) --seeds $(SEEDS)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -80,6 +80,12 @@ speed, stealth) would directly address the exploit-duration vs ICE-dwell race.
 
 ### Adversarial / ICE
 - **Defender ICE** — instead of detecting and triggering alert, this ICE variant reverses access levels (owned → compromised → locked) as it dwells on a node; creates territory-holding pressure that complements the existing detection model. Would need new ICE behavior type, reverse-access state mutation, and visual feedback distinct from current ICE presence indicator.
+- **Bot player: eject and reboot** — the bot currently never uses eject (push
+  ICE to adjacent node) or reboot (force ICE to resident, node goes offline).
+  Eject is a simple reflex ("ICE is here, push it away") and worth adding —
+  it buys time without cancelling the current exploit. Reboot is more strategic
+  (requires planning about which node and when) and may be too complex for
+  the dumb bot. Both require tracking ICE position (`iceCurrentNode`).
 - **`cheat ice-move <node>`** — cheat command to teleport ICE directly to a node for testing detection scenarios without waiting for ticks
 - **ICE path tracing via traffic analysis daemon** — ICE movements currently invisible until dwell fires; a "traffic analysis daemon" installed on a compromised node could reveal ICE movement logs as events _(part of the log-verbosity-as-mechanic idea below)_
 - **ICE status readout on owned-node crossings** — when ICE moves through a node you own, the log reports its path but not its behavioral state. A brief status tag (e.g. `[PATROLLING]`, `[ALERTED]`, `[HUNTING]`) in the movement log entry would let the player read ICE intent at a glance — useful for deciding whether to deselect and go dark or commit to an action. Status maps naturally to the existing grade-behavior tiers: D/F = patrolling, B/C with a disturbance target = alerted, A/S or B/C chasing player = hunting.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -46,6 +46,38 @@ the ICE resident node, and `iceResident` behavior needs to move from
 security-monitor to the new node type.
 _Identified during bot census session (2026-03-01)._
 
+### Player Upgrades / Deck Hardware
+The overworld progression system should give players tools that shift the
+balance at higher difficulties. These are equipment/upgrades acquired between
+runs, not in-run pickups.
+
+- **Deck speed** — reduces exploit execution duration. A faster deck means
+  shorter exposure windows during exploits, directly improving survivability
+  against ICE. Could be a multiplier on `exploitDuration()`.
+- **Signal masking / stealth** — increases ICE dwell time before detection.
+  The player's presence is harder to detect, giving more time to complete
+  actions before ICE triggers. Could add a flat bonus to DWELL_TIMES.
+- **Chaff / decoys** — creates false disturbance signals at other nodes,
+  drawing ICE away from the player. ICE investigates the decoy instead of
+  the real exploit noise. Mechanically: set `lastDisturbedNodeId` to a
+  decoy node on demand.
+- **Bot partners (daemons)** — autonomous agents that hack alongside the
+  player, potentially in parallel. Could probe nodes, create distractions,
+  or exploit low-grade targets. Implementation may be simplified (not full
+  bot-player instances) — e.g. a daemon "claims" a node and applies a
+  timed state change without full exploit resolution. The fiction: the
+  player deploys semi-autonomous programs into the network.
+- **ICE scanner** — reveals ICE position and movement direction when the
+  player owns a node ICE passes through. Reduces information asymmetry
+  and enables timing-based play. See also: traffic analysis daemon in the
+  information asymmetry section below.
+
+These upgrades are the intended solution for A/A and S/S difficulty. The base
+game mechanics (evasion, IDS reconfigure) handle C/B; player upgrades extend
+viability to the hardest tiers. Bot census data (2026-03-01) confirms: the
+dumb bot hits 0% at A/A without upgrades, but the mechanical levers (deck
+speed, stealth) would directly address the exploit-duration vs ICE-dwell race.
+
 ### Adversarial / ICE
 - **Defender ICE** — instead of detecting and triggering alert, this ICE variant reverses access levels (owned → compromised → locked) as it dwells on a node; creates territory-holding pressure that complements the existing detection model. Would need new ICE behavior type, reverse-access state mutation, and visual feedback distinct from current ICE presence indicator.
 - **`cheat ice-move <node>`** — cheat command to teleport ICE directly to a node for testing detection scenarios without waiting for ticks

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -33,6 +33,19 @@ tier. A full overhaul will be needed to support:
   dispatch system. This is a significant architectural change — defer until the single-ICE
   prototype is fully playtested and the design is stable.
 
+### ICE Resident Node Relocation
+Currently ICE starts at the security monitor. The fiction would be cleaner if
+ICE started at a node on the far side of the IDS — patrolling the working
+network, reporting back through the IDS chain. Benefits:
+- ICE patrols where the player operates (routing/workstation layer)
+- Detection reports travel through IDS → monitor (severable via reconfigure)
+- Reboot sends ICE to its new resident node, not the monitor
+- Security monitor remains valuable for cancel-trace, but isn't ICE home base
+This is a topology/gen-rules change — the layer processor needs a new role for
+the ICE resident node, and `iceResident` behavior needs to move from
+security-monitor to the new node type.
+_Identified during bot census session (2026-03-01)._
+
 ### Adversarial / ICE
 - **Defender ICE** — instead of detecting and triggering alert, this ICE variant reverses access levels (owned → compromised → locked) as it dwells on a node; creates territory-holding pressure that complements the existing detection model. Would need new ICE behavior type, reverse-access state mutation, and visual feedback distinct from current ICE presence indicator.
 - **`cheat ice-move <node>`** — cheat command to teleport ICE directly to a node for testing detection scenarios without waiting for ticks

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -11,6 +11,11 @@ _Compiled from all dev session notes. Not a prioritized roadmap — just a livin
 - **Persistent inventory between runs** — in the overworld context, exploit loadout carries across LANs; crafting/acquiring a better kit is part of the meta-loop
 - **Balance: starting hand vs. network vulnerability mix** — current hand frequently doesn't match early node vulns; in the overworld context this is solved by pre-run preparation, not hand seeding _(deferred pending overworld design)_
 
+### Reward Scaling with Difficulty
+- **Macguffin value scaling** — higher-difficulty networks cost more to crack (harder nodes, deeper paths, more ICE pressure) but don't contain more valuable loot. Macguffin `cashValue` should scale with `moneyCost` grade so players have incentive to tackle harder networks. This is a game state layer change (`loot.js`), not a generator change.
+- **Risk/reward feedback loop** — the darknet store already costs cash; if harder networks pay more, the player's cash economy becomes meaningful (spend to crack, earn to profit). Currently all cash feels like pure score.
+- _Identified during bot census session (2026-03-01): zero deficit at all difficulties, but no reward differential either._
+
 ### Mission / Objectives
 - **Mission conditions** — secondary objectives like "never exceed yellow alert" or "don't trigger trace"; adds replayability and run variety
 - **Node flavor text** — when you `read` a node, give it cyberpunk lore flavor beyond "X item(s) found"

--- a/docs/BOT-PLAYER.md
+++ b/docs/BOT-PLAYER.md
@@ -1,0 +1,275 @@
+# Bot Player
+
+The bot player (`scripts/bot-player.js`) is an automated game-playing agent that
+runs a complete Starnet LAN dungeon from initialization to jackout. It uses a
+fixed greedy strategy — deliberately simple so that difficulty differences show up
+in results rather than strategy variance. The bot establishes a pessimistic lower
+bound on completion rates: a skilled human player should beat it at every
+difficulty level.
+
+The bot census CLI (`scripts/bot-census.js`) runs the bot many times across
+parameterized difficulties and produces LLM-readable reports.
+
+---
+
+## Quick Start
+
+```bash
+# Run 100 simulated games at B/B difficulty
+node scripts/bot-census.js --time B --money B
+
+# Run with evasion strategy (recommended — much better at C+ ICE)
+node scripts/bot-census.js --time B --money B --evasion
+
+# Quick test with fewer seeds
+node scripts/bot-census.js --time C --money C --seeds 20 --evasion
+
+# Makefile shortcut (defaults: B/B, 100 seeds)
+make bot-census
+make bot-census TC=S MC=S SEEDS=50
+```
+
+---
+
+## Bot Strategy
+
+### Node Selection Priority
+
+Each iteration of the main loop, the bot picks the next node to work on:
+
+1. **Current node** — if the bot's current position (gateway at start) is
+   unowned, work on it first.
+2. **IDS reconfiguration** (evasion mode only) — if a visible IDS node is not
+   yet reconfigured, prioritize owning and reconfiguring it. This severs the
+   ICE detection → alert chain, which is the key counterplay to ICE pressure.
+3. **Nearest lootable target** — BFS through owned nodes to find the closest
+   fileserver or cryptovault that isn't yet owned.
+4. **Nearest unowned node** — any visible, non-security, non-wan node.
+5. **Null** — nothing reachable; the bot jacks out.
+
+The BFS only traverses through owned nodes (the bot can't see past nodes it
+doesn't control). Hidden nodes behind firewalls are invisible until the gate
+is owned.
+
+### Per-Node Action Sequence
+
+For each target node:
+
+1. **Select** — navigate to the node (makes it accessible if revealed).
+2. **Probe** — if not already probed, scan for vulnerabilities. Ticks forward
+   until `NODE_PROBED` fires. In evasion mode, cancels and hides if ICE arrives
+   mid-probe.
+3. **Exploit** — pick the best card and attack:
+   - **Card selection**: prefer cards matching a known vulnerability, then
+     highest quality, then most uses remaining.
+   - **Proactive store** (evasion mode): if no card matches any known vuln, buy
+     a matching card from the darknet store before exploiting.
+   - Ticks forward until `EXPLOIT_SUCCESS` or `EXPLOIT_FAILURE` fires.
+   - Repeats until the node is owned or no usable cards remain.
+4. **Read** — if owned and not yet read, extract data. Ticks until `NODE_READ`.
+5. **Loot** — if read and has uncollected macguffins, extract loot. Ticks until
+   `NODE_LOOTED`.
+6. **Reconfigure** (evasion, IDS nodes) — if the owned node is an IDS, disable
+   event forwarding to sever the alert chain.
+
+### When Stuck
+
+If the bot has no usable cards for the current node:
+
+1. Look for a known vulnerability and buy a matching card from the darknet store.
+2. If the store purchase fails (can't afford), try a different node.
+3. If no nodes are reachable, jack out with failure reason `"no-cards"`.
+
+---
+
+## Evasion Mode
+
+Enabled with the `--evasion` flag (or `{ evasion: true }` option). Adds ICE
+avoidance behaviors that significantly improve success rates at C+ difficulty.
+
+### Deselect Between Actions
+
+After each timed action completes (probe, exploit, read, loot), the bot
+immediately deselects. ICE can only detect the player when co-located on the
+same node — deselecting removes the player's presence.
+
+### Cancel-on-ICE-Arrival
+
+During exploit and probe execution, the bot monitors for `ICE_MOVED` events.
+If ICE arrives at the player's current node mid-action:
+
+1. Cancel the current action (`cancel-exploit` or `cancel-probe`).
+2. Deselect to hide.
+3. **Patience**: wait for 3 ICE move events. This gives ICE time to arrive at
+   the disturbance source, investigate, clear the signal, and wander away.
+4. Set the current node as `avoidNodeId` — the next iteration will prefer a
+   different target.
+
+### Node Avoidance
+
+After an ICE encounter, the bot avoids the node where ICE was last seen and
+picks a different target if one is available. This prevents the bot from
+immediately re-triggering disturbance at the same location. The avoidance
+clears once any node is successfully owned.
+
+### IDS Reconfiguration
+
+In evasion mode, the bot prioritizes owning and reconfiguring IDS nodes before
+pursuing the mission target. Reconfiguring an IDS severs the ICE detection →
+security monitor → global alert chain, preventing detections from escalating
+to trace.
+
+---
+
+## Tick Advancement
+
+The bot drives the game clock directly via `tick()`. After dispatching any timed
+action, it ticks in small increments (default: 1 tick = 100ms virtual time)
+until the completion event fires. This gives realistic tick counts and lets ICE
+pressure manifest naturally.
+
+Two tick-loop variants:
+
+- **`tickUntilEvent`** — ticks until a specific event fires or budget is
+  exceeded. Used for non-evasion mode and for read/loot actions.
+- **`tickUntilEventOrIce`** — same, but also breaks if ICE arrives at the
+  player's node (`ICE_MOVED` to selected node). Used in evasion mode for
+  probe and exploit.
+
+A per-run tick cap (default: 5000 ticks) prevents infinite loops. If the bot
+hasn't completed within the cap, the run ends with failure reason `"tick-cap"`.
+
+---
+
+## Stats Collected
+
+Each `runBot()` call returns a `BotRunStats` object:
+
+### Outcome
+| Field | Type | Description |
+|-------|------|-------------|
+| `missionSuccess` | boolean | Target macguffin looted and jacked out |
+| `fullClear` | boolean | All non-security, non-wan nodes owned |
+| `failReason` | string/null | `"trace"`, `"no-cards"`, `"stuck"`, `"tick-cap"`, or null |
+
+### Resources
+| Field | Type | Description |
+|-------|------|-------------|
+| `cardUsesConsumed` | number | Total exploit attempts (success + failure) |
+| `cardsBurned` | number | Cards fully depleted or disclosed |
+| `storeVisits` | number | Darknet store purchases |
+| `cashSpent` | number | Total darknet expenditure |
+| `cashRemaining` | number | Cash at jackout |
+
+### Time / Pressure
+| Field | Type | Description |
+|-------|------|-------------|
+| `totalTicks` | number | Virtual ticks elapsed at jackout |
+| `peakAlert` | string | Highest global alert reached (`"green"`, `"yellow"`, `"red"`) |
+| `traceFired` | boolean | Whether trace countdown started |
+| `iceDetections` | number | Times ICE detection event fired |
+
+### Exploration
+| Field | Type | Description |
+|-------|------|-------------|
+| `nodesOwned` | number | Nodes at "owned" access (excluding wan) |
+| `nodesTotal` | number | Total nodes (excluding wan) |
+
+### Timeline Breakpoints
+| Field | Type | Description |
+|-------|------|-------------|
+| `tickFirstNodeOwned` | number | Tick when first non-gateway node reached "owned" (-1 = never) |
+| `tickFirstDetection` | number | Tick when first ICE detection fired (-1 = never) |
+| `tickTraceStarted` | number | Tick when trace countdown began (-1 = never) |
+| `tickMissionComplete` | number | Tick when mission target was looted (-1 = never) |
+
+---
+
+## Census CLI
+
+`scripts/bot-census.js` runs the bot across many seeds and aggregates stats.
+
+### Arguments
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--time <grade>` | required | timeCost grade (F through S) |
+| `--money <grade>` | required | moneyCost grade (F through S) |
+| `--seeds <N>` | 100 | Number of simulation runs |
+| `--seed-prefix <str>` | `"bot"` | Seed prefix (seeds are `{prefix}-0` through `{prefix}-{N-1}`) |
+| `--evasion` | off | Enable evasion mode |
+
+### Report Format
+
+The report is text-based and designed for LLM readability:
+
+```
+=== BOT SIMULATION: B/B [EVASION] ===
+Seeds: bot-0 through bot-99 (100 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     N/100 (pct%)
+Avg ticks:        X (succeeded) / Y (failed)
+Failure reasons:  trace=N  no-cards=N  stuck=N  tick-cap=N
+
+--- FULL EXPLORATION ---
+Full clear rate:  N/100 (pct%)
+Avg nodes owned:  X / Y total (pct%)
+
+--- RESOURCE USAGE (succeeded runs) ---
+              Min    Avg    Max
+Card uses:    X      X      X
+Cards burned: X      X      X
+Store visits: X      X      X
+Cash spent:   X      X      X
+Cash left:    X      X      X
+
+--- PRESSURE ---
+Peak alert:   GREEN=N  YELLOW=N  RED=N
+Trace fired:  N/100
+ICE detects:  avg X  max X
+
+--- TIMELINE (avg tick when event first occurs) ---
+First node owned:    X (N/100 runs)
+First ICE detection: X (N/100 runs)
+Trace started:       X (N/100 runs)
+Mission complete:    X (N/100 runs)
+```
+
+---
+
+## What the Bot Does NOT Do
+
+These omissions are intentional — they make the bot a pessimistic baseline:
+
+- **Eject ICE** — never pushes ICE to an adjacent node
+- **Reboot nodes** — never forces ICE back to its resident node
+- **Cancel trace** — never owns the security monitor to cancel an active trace
+- **Strategic node ordering** — beyond the greedy BFS priority, no planning
+- **Anticipate ICE movement** — doesn't track ICE position or time actions
+  around patrol cycles (only reacts when ICE arrives)
+- **Manage card decay** — doesn't preserve high-value cards for hard nodes
+- **Multi-attempt strategies** — if an exploit fails, retries with the same
+  approach; doesn't switch tactics based on failure history
+
+---
+
+## Architecture Notes
+
+### Event Handler Lifecycle
+
+The game engine registers event handlers at module import time (ice.js,
+exploit-exec.js, alert.js, etc.). The bot does **not** call `clearHandlers()`
+between runs — doing so would destroy these module-level handlers.
+
+Instead:
+- **One-time init** (first `runBot` call): registers timer handlers and action
+  dispatcher. These persist across runs.
+- **Per-run handlers**: stat tracking listeners are registered at the start of
+  each run and explicitly removed via `off()` at the end.
+- `initState()` resets all game state between runs.
+
+### Determinism
+
+Same seed + same difficulty + same options = identical stats. The bot uses the
+game's seeded PRNG and drives the clock deterministically via `tick()`.

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-BB.txt
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-BB.txt
@@ -1,0 +1,24 @@
+=== BOT SIMULATION: B/B ===
+Seeds: bot-0 through bot-99 (100 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     1/100 (1%)
+Avg ticks:        819 (succeeded) / 555 (failed)
+Failure reasons:  trace=99
+
+--- FULL EXPLORATION ---
+Full clear rate:  0/100 (0%)
+Avg nodes owned:  1.4 / 13.1 total (11%)
+
+--- RESOURCE USAGE (1 succeeded runs) ---
+              Min    Avg    Max
+Card uses:     7.0     7.0    7.0
+Cards burned:  0.0     0.0    0.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    9534    9534   9534
+
+--- PRESSURE ---
+Peak alert:   GREEN=0  YELLOW=0  RED=100
+Trace fired:  100/100
+ICE detects:  avg 2.0  max 2

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-CC.txt
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-CC.txt
@@ -1,0 +1,24 @@
+=== BOT SIMULATION: C/C ===
+Seeds: bot-0 through bot-99 (100 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     5/100 (5%)
+Avg ticks:        1043 (succeeded) / 606 (failed)
+Failure reasons:  trace=95
+
+--- FULL EXPLORATION ---
+Full clear rate:  0/100 (0%)
+Avg nodes owned:  1.9 / 11.1 total (17%)
+
+--- RESOURCE USAGE (5 succeeded runs) ---
+              Min    Avg    Max
+Card uses:     7.0     9.0   13.0
+Cards burned:  0.0     0.0    0.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    2192    9339   19049
+
+--- PRESSURE ---
+Peak alert:   GREEN=0  YELLOW=0  RED=100
+Trace fired:  100/100
+ICE detects:  avg 2.0  max 2

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-DD.txt
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-DD.txt
@@ -1,0 +1,24 @@
+=== BOT SIMULATION: D/D ===
+Seeds: bot-0 through bot-99 (100 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     82/100 (82%)
+Avg ticks:        1610 (succeeded) / 1939 (failed)
+Failure reasons:  trace=16  tick-cap=2
+
+--- FULL EXPLORATION ---
+Full clear rate:  75/100 (75%)
+Avg nodes owned:  5.3 / 8.0 total (66%)
+
+--- RESOURCE USAGE (82 succeeded runs) ---
+              Min    Avg    Max
+Card uses:    10.0    13.5   27.0
+Cards burned:  0.0     0.1    2.0
+Store visits:  0.0     0.0    1.0
+Cash spent:      0       0      0
+Cash left:    2218    9464   21618
+
+--- PRESSURE ---
+Peak alert:   GREEN=36  YELLOW=29  RED=35
+Trace fired:  22/100
+ICE detects:  avg 1.2  max 3

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-FF.txt
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-FF.txt
@@ -1,0 +1,24 @@
+=== BOT SIMULATION: F/F ===
+Seeds: bot-0 through bot-99 (100 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     97/100 (97%)
+Avg ticks:        1415 (succeeded) / 2576 (failed)
+Failure reasons:  trace=2  tick-cap=1
+
+--- FULL EXPLORATION ---
+Full clear rate:  96/100 (96%)
+Avg nodes owned:  5.9 / 8.0 total (73%)
+
+--- RESOURCE USAGE (97 succeeded runs) ---
+              Min    Avg    Max
+Card uses:    11.0    13.0   20.0
+Cards burned:  0.0     0.0    1.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    2218    9578   21618
+
+--- PRESSURE ---
+Peak alert:   GREEN=48  YELLOW=40  RED=12
+Trace fired:  2/100
+ICE detects:  avg 0.7  max 3

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-asymmetric.txt
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-asymmetric.txt
@@ -1,0 +1,50 @@
+=== ASYMMETRIC: F/C and C/F, 50 seeds ===
+=== BOT SIMULATION: F/C ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     33/50 (66%)
+Avg ticks:        2168 (succeeded) / 2895 (failed)
+Failure reasons:  trace=13  tick-cap=4
+
+--- FULL EXPLORATION ---
+Full clear rate:  27/50 (54%)
+Avg nodes owned:  5.2 / 9.0 total (58%)
+
+--- RESOURCE USAGE (33 succeeded runs) ---
+              Min    Avg    Max
+Card uses:    10.0    15.2   20.0
+Cards burned:  0.0     0.2    1.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    2468    7931   19578
+
+--- PRESSURE ---
+Peak alert:   GREEN=17  YELLOW=12  RED=21
+Trace fired:  16/50
+ICE detects:  avg 1.4  max 3
+
+=== BOT SIMULATION: C/F ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     5/50 (10%)
+Avg ticks:        1100 (succeeded) / 659 (failed)
+Failure reasons:  trace=45
+
+--- FULL EXPLORATION ---
+Full clear rate:  2/50 (4%)
+Avg nodes owned:  2.6 / 9.0 total (29%)
+
+--- RESOURCE USAGE (5 succeeded runs) ---
+              Min    Avg    Max
+Card uses:     7.0    11.0   15.0
+Cards burned:  0.0     0.0    0.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    1942    9637   19328
+
+--- PRESSURE ---
+Peak alert:   GREEN=0  YELLOW=2  RED=48
+Trace fired:  48/50
+ICE detects:  avg 2.0  max 2

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-ice-cliff.txt
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-ice-cliff.txt
@@ -1,0 +1,149 @@
+=== ICE CLIFF: varying timeCost, moneyCost=D, 50 seeds ===
+
+=== BOT SIMULATION: F/D ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     44/50 (88%)
+Avg ticks:        1481 (succeeded) / 2040 (failed)
+Failure reasons:  trace=5  tick-cap=1
+
+--- FULL EXPLORATION ---
+Full clear rate:  43/50 (86%)
+Avg nodes owned:  5.5 / 8.0 total (69%)
+
+--- RESOURCE USAGE (44 succeeded runs) ---
+              Min    Avg    Max
+Card uses:    11.0    13.1   16.0
+Cards burned:  0.0     0.0    1.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    2218    7931   19328
+
+--- PRESSURE ---
+Peak alert:   GREEN=20  YELLOW=18  RED=12
+Trace fired:  5/50
+ICE detects:  avg 0.9  max 3
+
+=== BOT SIMULATION: D/D ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     40/50 (80%)
+Avg ticks:        1579 (succeeded) / 1330 (failed)
+Failure reasons:  trace=10
+
+--- FULL EXPLORATION ---
+Full clear rate:  37/50 (74%)
+Avg nodes owned:  5.3 / 8.0 total (66%)
+
+--- RESOURCE USAGE (40 succeeded runs) ---
+              Min    Avg    Max
+Card uses:    10.0    13.2   19.0
+Cards burned:  0.0     0.1    1.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    2218    7971   19328
+
+--- PRESSURE ---
+Peak alert:   GREEN=19  YELLOW=12  RED=19
+Trace fired:  12/50
+ICE detects:  avg 1.2  max 3
+
+=== BOT SIMULATION: C/D ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     4/50 (8%)
+Avg ticks:        1047 (succeeded) / 609 (failed)
+Failure reasons:  trace=46
+
+--- FULL EXPLORATION ---
+Full clear rate:  0/50 (0%)
+Avg nodes owned:  2.2 / 9.0 total (24%)
+
+--- RESOURCE USAGE (4 succeeded runs) ---
+              Min    Avg    Max
+Card uses:     7.0    10.5   14.0
+Cards burned:  0.0     0.0    0.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    1942    8088   17148
+
+--- PRESSURE ---
+Peak alert:   GREEN=0  YELLOW=0  RED=50
+Trace fired:  50/50
+ICE detects:  avg 2.0  max 2
+
+=== BOT SIMULATION: B/D ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     1/50 (2%)
+Avg ticks:        939 (succeeded) / 525 (failed)
+Failure reasons:  trace=49
+
+--- FULL EXPLORATION ---
+Full clear rate:  0/50 (0%)
+Avg nodes owned:  1.8 / 9.0 total (20%)
+
+--- RESOURCE USAGE (1 succeeded runs) ---
+              Min    Avg    Max
+Card uses:     9.0     9.0    9.0
+Cards burned:  0.0     0.0    0.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    1960    1960   1960
+
+--- PRESSURE ---
+Peak alert:   GREEN=0  YELLOW=0  RED=50
+Trace fired:  50/50
+ICE detects:  avg 2.0  max 2
+
+=== BOT SIMULATION: A/D ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     0/50 (0%)
+Avg ticks:        — (succeeded) / 90 (failed)
+Failure reasons:  trace=50
+
+--- FULL EXPLORATION ---
+Full clear rate:  0/50 (0%)
+Avg nodes owned:  0.0 / 9.0 total (0%)
+
+--- RESOURCE USAGE (all runs — no successes) ---
+              Min    Avg    Max
+Card uses:     1.0     1.1    2.0
+Cards burned:  0.0     0.0    0.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+
+--- PRESSURE ---
+Peak alert:   GREEN=0  YELLOW=50  RED=0
+Trace fired:  50/50
+ICE detects:  avg 1.0  max 1
+
+=== BOT SIMULATION: S/D ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     0/50 (0%)
+Avg ticks:        — (succeeded) / 75 (failed)
+Failure reasons:  trace=50
+
+--- FULL EXPLORATION ---
+Full clear rate:  0/50 (0%)
+Avg nodes owned:  0.0 / 9.0 total (0%)
+
+--- RESOURCE USAGE (all runs — no successes) ---
+              Min    Avg    Max
+Card uses:     1.0     1.0    1.0
+Cards burned:  0.0     0.0    0.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+
+--- PRESSURE ---
+Peak alert:   GREEN=0  YELLOW=50  RED=0
+Trace fired:  50/50
+ICE detects:  avg 1.0  max 1

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-money-curve.txt
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-money-curve.txt
@@ -1,0 +1,150 @@
+=== MONEY CURVE: varying moneyCost, timeCost=F, 50 seeds ===
+
+=== BOT SIMULATION: F/F ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     47/50 (94%)
+Avg ticks:        1460 (succeeded) / 2576 (failed)
+Failure reasons:  trace=2  tick-cap=1
+
+--- FULL EXPLORATION ---
+Full clear rate:  46/50 (92%)
+Avg nodes owned:  5.7 / 8.0 total (72%)
+
+--- RESOURCE USAGE (47 succeeded runs) ---
+              Min    Avg    Max
+Card uses:    11.0    13.0   20.0
+Cards burned:  0.0     0.0    1.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    2218    8111   19328
+
+--- PRESSURE ---
+Peak alert:   GREEN=22  YELLOW=21  RED=7
+Trace fired:  2/50
+ICE detects:  avg 0.7  max 3
+
+=== BOT SIMULATION: F/D ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     44/50 (88%)
+Avg ticks:        1481 (succeeded) / 2040 (failed)
+Failure reasons:  trace=5  tick-cap=1
+
+--- FULL EXPLORATION ---
+Full clear rate:  43/50 (86%)
+Avg nodes owned:  5.5 / 8.0 total (69%)
+
+--- RESOURCE USAGE (44 succeeded runs) ---
+              Min    Avg    Max
+Card uses:    11.0    13.1   16.0
+Cards burned:  0.0     0.0    1.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    2218    7931   19328
+
+--- PRESSURE ---
+Peak alert:   GREEN=20  YELLOW=18  RED=12
+Trace fired:  5/50
+ICE detects:  avg 0.9  max 3
+
+=== BOT SIMULATION: F/C ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     33/50 (66%)
+Avg ticks:        2168 (succeeded) / 2895 (failed)
+Failure reasons:  trace=13  tick-cap=4
+
+--- FULL EXPLORATION ---
+Full clear rate:  27/50 (54%)
+Avg nodes owned:  5.2 / 9.0 total (58%)
+
+--- RESOURCE USAGE (33 succeeded runs) ---
+              Min    Avg    Max
+Card uses:    10.0    15.2   20.0
+Cards burned:  0.0     0.2    1.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    2468    7931   19578
+
+--- PRESSURE ---
+Peak alert:   GREEN=17  YELLOW=12  RED=21
+Trace fired:  16/50
+ICE detects:  avg 1.4  max 3
+
+=== BOT SIMULATION: F/B ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     18/50 (36%)
+Avg ticks:        2924 (succeeded) / 3073 (failed)
+Failure reasons:  trace=22  tick-cap=10
+
+--- FULL EXPLORATION ---
+Full clear rate:  5/50 (10%)
+Avg nodes owned:  3.9 / 10.0 total (39%)
+
+--- RESOURCE USAGE (18 succeeded runs) ---
+              Min    Avg    Max
+Card uses:    10.0    18.7   30.0
+Cards burned:  0.0     0.7    3.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    4362    8598   19828
+
+--- PRESSURE ---
+Peak alert:   GREEN=9  YELLOW=8  RED=33
+Trace fired:  24/50
+ICE detects:  avg 2.0  max 3
+
+=== BOT SIMULATION: F/A ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     9/50 (18%)
+Avg ticks:        2940 (succeeded) / 3217 (failed)
+Failure reasons:  tick-cap=12  trace=29
+
+--- FULL EXPLORATION ---
+Full clear rate:  2/50 (4%)
+Avg nodes owned:  2.6 / 10.0 total (26%)
+
+--- RESOURCE USAGE (9 succeeded runs) ---
+              Min    Avg    Max
+Card uses:    10.0    17.0   22.0
+Cards burned:  0.0     0.4    1.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+Cash left:    5517    8272   13835
+
+--- PRESSURE ---
+Peak alert:   GREEN=3  YELLOW=8  RED=39
+Trace fired:  32/50
+ICE detects:  avg 2.4  max 3
+
+=== BOT SIMULATION: F/S ===
+Seeds: bot-0 through bot-49 (50 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     0/50 (0%)
+Avg ticks:        — (succeeded) / 2920 (failed)
+Failure reasons:  tick-cap=10  trace=40
+
+--- FULL EXPLORATION ---
+Full clear rate:  0/50 (0%)
+Avg nodes owned:  1.3 / 10.0 total (13%)
+
+--- RESOURCE USAGE (all runs — no successes) ---
+              Min    Avg    Max
+Card uses:     1.0     6.3   17.0
+Cards burned:  0.0     1.2    2.0
+Store visits:  0.0     0.0    0.0
+Cash spent:      0       0      0
+
+--- PRESSURE ---
+Peak alert:   GREEN=2  YELLOW=4  RED=44
+Trace fired:  40/50
+ICE detects:  avg 2.6  max 3

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-timeline.txt
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-timeline.txt
@@ -1,0 +1,15 @@
+=== TIMELINE COMPARISON ===
+Shows when key events happen (in ticks) to visualize the ICE race condition.
+
+ICE grade vs bot speed (moneyCost=D, 50 seeds each):
+
+Grade  1stOwned  1stDetect  Trace   Mission  Success
+F/D    486       635        1447    986      88%
+D/D    479       511        1583    1203     80%
+C/D    425       363        643     719      8%
+B/D    411       290        532     805      2%
+
+Key finding: at C-grade ICE, first detection (tick 363) happens BEFORE
+the bot owns its first non-gateway node (tick 425). The bot loses the race
+regardless of node difficulty — even at F-grade nodes (C/F: detect at 348,
+first owned at 427, 10% success).

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/notes.md
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/notes.md
@@ -1,0 +1,14 @@
+# Notes: Census Metrics v2
+
+## Future work: move ICE resident node
+
+Currently ICE starts at the security monitor. The fiction would be cleaner if
+ICE started at a node on the far side of the IDS — patrolling the working
+network, reporting back through the IDS chain. This would mean:
+- ICE patrols where the player operates (routing/workstation layer)
+- Detection reports travel through IDS → monitor (severable via reconfigure)
+- Reboot sends ICE to its new resident node, not the monitor
+- Security monitor remains valuable for cancel-trace, but isn't ICE home base
+
+This is a topology/gen-rules change with implications for network layout and
+the layer-processor. Separate session.

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/notes.md
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/notes.md
@@ -1,48 +1,196 @@
 # Notes: Census Metrics v2
 
-## Future work: move ICE resident node
+## Session Summary
 
-Currently ICE starts at the security monitor. The fiction would be cleaner if
-ICE started at a node on the far side of the IDS — patrolling the working
-network, reporting back through the IDS chain. This would mean:
-- ICE patrols where the player operates (routing/workstation layer)
-- Detection reports travel through IDS → monitor (severable via reconfigure)
-- Reboot sends ICE to its new resident node, not the monitor
-- Security monitor remains valuable for cancel-trace, but isn't ICE home base
+Built a Monte Carlo bot player that simulates full game runs headlessly,
+then used it to find and fix multiple balance problems. The bot drove several
+game mechanic changes that wouldn't have been discovered through static
+topology analysis alone.
 
-This is a topology/gen-rules change with implications for network layout and
-the layer-processor. Separate session.
+---
 
-## Future work: ICE behavior improvements
+## Key Actions
 
-### High-value-target patrol (augment random walk)
-Instead of pure random walk at F/D, ICE patrols a fixed route through
-high-value nodes (fileservers, cryptovaults, firewalls). Predictable but
-unavoidable — the player has to time actions around the patrol schedule.
-Could augment any grade as a base behavior underneath the tracking modes.
+### Store extraction (Phase 1-2)
+- Created `js/store-logic.js` with `buyFromStore()` — headless buy path
+- Refactored `store.js` (DOM) and `console.js` to delegate to it
+- Verified harness `store`/`buy` commands work (already did via console.js)
 
-### Multi-signal tracking
-ICE tracks disturbance (like C/B) but also responds to alert level. Higher
-global alert → ICE moves faster or covers more ground. Failing exploits →
-noise → ICE investigates → detection → alert rises → ICE gets more aggressive.
-Creates a feedback loop that punishes sloppy play.
+### Bot player (Phase 3-4)
+- Created `scripts/bot-player.js` with `runBot()` — plays a full game
+- Greedy strategy: BFS node selection, best-card picking, store fallback
+- Stat collection: mission success, exploration, resources, ICE pressure
+- Timeline breakpoints: tick of first node owned, detection, trace, mission
 
-### Area lockdown ICE type
-When this ICE type detects, it "locks" the region — nearby nodes get reduced
-detection dwell time, creating a danger radius the player must avoid. This
-is a different ICE type entirely (not a grade variant). Good candidate for
-the future multiple-ICE-instance feature.
+### Bot census CLI (Phase 5)
+- Created `scripts/bot-census.js` — runs N simulations, prints LLM-legible report
+- `--evasion` flag for ICE avoidance mode
+- `make bot-census` target with TC/MC/SEEDS overrides
 
-### Reward scaling with difficulty
-Currently higher-difficulty networks cost more to crack (harder nodes, deeper
-paths, more ICE pressure) but don't contain more valuable loot. Macguffin
-values are set in the game state layer (loot.js), not the generator. Scaling
-rewards with moneyCost would give players incentive to tackle harder networks
-and offset the increased card/cash expenditure. This is a game state change,
-not a generator change — separate session.
+### Balance discoveries and fixes (Phase 6)
+Iterative cycle: run census → identify problem → fix → re-measure.
 
-### A/S player tracking removed
-The old A/S behavior (pathfind directly to `selectedNodeId`) was removed
-because it felt like cheating — ICE had perfect knowledge of the player's
-location regardless of player actions. Replaced with faster disturbance
-tracking, which preserves player agency (go quiet to lose ICE).
+1. **ICE cliff at D→C**: 80%→8% without evasion. Root cause: C-grade ICE
+   detects (45 ticks dwell) before exploit completes (47+ ticks).
+
+2. **Evasion strategy**: cancel-exploit on ICE arrival, deselect to hide.
+   Result: C cliff eliminated (8%→78%). A/S still 0% — instant detection.
+
+3. **A/S instant detection removed**: S dwell null→800ms, A null→1500ms.
+   Still 0% because A/S ICE pathfound directly to player's selected node.
+
+4. **direct-trace bug**: IDS reconfigure didn't block S/A grade detection.
+   The `direct-trace` behavior bypassed `eventForwardingDisabled` check.
+
+5. **ICE→IDS chain**: `recordIceDetection` directly escalated global alert,
+   bypassing the IDS→monitor chain. Fixed to route through IDS, making
+   reconfigure the key counterplay. Stale `prev` reference in alert emit fixed.
+
+6. **A/S player tracking removed**: omniscient pathfinding to `selectedNodeId`
+   replaced with faster disturbance tracking. Fair: ICE responds to player
+   actions (noise), not player presence.
+
+7. **Exploit duration reduced**: 3-12s → 2-7s. Players need time to finish
+   before ICE arrives.
+
+8. **A/S ICE slowed**: A 3000ms→5000ms, S 2500ms→4000ms move intervals.
+
+9. **C/B dwell bumped**: C 4500ms→5500ms, B 3500ms→4500ms. Gives window for
+   common exploits to complete.
+
+10. **Bot patience**: wait 3 ICE moves after evasion before retrying. Lets
+    ICE investigate disturbance, clear signal, wander away.
+
+11. **Bot proactive store**: buy matching cards before exploiting unmatched.
+
+### Event handler cleanup issue
+`clearHandlers()` destroys module-level event handlers registered at import
+time (ice.js, *-exec.js, alert.js, node-lifecycle.js). Fixed by not calling
+clearHandlers in the bot — one-time init for timer wiring, per-run cleanup
+of stat handlers only. Added `initAlertHandlers()` and `initIceHandlers()`
+exports for future use.
+
+---
+
+## Final Difficulty Curves
+
+### Diagonal (TC=MC, evasion bot)
+```
+F/F: 82%  D/D: 74%  C/C: 28%  B/B: 6%  A/A: 0%  S/S: 0%
+```
+
+### ICE ladder (fixed moneyCost=D, evasion bot)
+```
+F: 76%  D: 74%  C: 62%  B: 54%  A: 10%  S: 8%
+```
+
+### Money ladder (fixed timeCost=F, no evasion — from earlier session)
+```
+F: 94%  D: 88%  C: 66%  B: 36%  A: 18%  S: 0%
+```
+
+### Bot limits on the diagonal
+
+The dumb bot hits a wall at A/A and S/S. The binding constraints:
+
+**A/A (0%):** Disturbance-tracking ICE with 5000ms moves and 1500ms dwell.
+Each exploit creates noise, drawing ICE. The evasion cycle (cancel + wait
+3 moves = ~150 ticks per attempt) means ~5-8 attempts to own one node, at
+~200+ ticks each. The critical path has 4+ nodes. Total: 4000+ ticks.
+Tick cap (5000) runs out before mission completes. A patient player who
+times exploits around ICE patrol gaps and uses IDS reconfigure to sever
+the alert chain would do better.
+
+**S/S (0%):** Same as A/A but tighter: 4000ms moves, 800ms dwell, harder
+nodes (pathGradeMin A, pathGradeMax S). Each node needs more exploits and
+each exploit has lower success probability. The bot's card resources run
+out even with store purchases.
+
+**What would help at A/A and S/S:**
+- Player upgrades that reduce exploit duration (faster deck hardware)
+- Stealth upgrades that increase ICE dwell time (signal masking)
+- Ability to pre-scout ICE position before committing to an action
+- ICE distraction tools (decoys that create false disturbance signals)
+- These are all potential player progression mechanics for the overworld
+
+**The bot as a balance floor:** The dumb bot's completion rates represent
+a pessimistic lower bound. A skilled human player who learns ICE patrol
+patterns, times actions, manages IDS proactively, and uses eject/reboot
+tactically should significantly outperform these numbers at every grade.
+A/A should be hard but achievable; S/S should require mastery plus good
+preparation (overworld upgrades).
+
+---
+
+## Divergences from Plan
+
+1. **Phase 6 became the entire second half of the session.** The plan called
+   for "run B/B + F/F, document findings." Instead, we iteratively discovered
+   and fixed 11 balance issues across ~8 commit cycles. The bot census was
+   the catalyst — every run revealed something new to fix.
+
+2. **Game mechanic changes not in the plan.** ICE→IDS chain, A/S behavior
+   rework, exploit duration, dwell tuning — all emerged from bot data. The
+   plan only anticipated "run census, document findings."
+
+3. **Event handler architecture issue.** clearHandlers vs module-level
+   registration was an unexpected obstacle. Solved pragmatically (don't
+   clear) with initXxxHandlers() as a cleaner future path.
+
+4. **Store extraction was simpler than planned.** The buy logic was already
+   headless in console.js — just needed extraction into a shared module.
+   store.js refactor was straightforward.
+
+---
+
+## Key Insights
+
+- **The bot is a balance debugger, not just a measurement tool.** Every run
+  reveals something: the ICE cliff, the detection-before-exploit race, the
+  omniscient player tracking, the direct-trace bypass. The iterative
+  measure→fix→remeasure cycle is the core value, not the final numbers.
+
+- **ICE balance is fundamentally a race condition.** Exploit duration vs ICE
+  dwell time determines whether the player can act. All the tuning levers
+  (dwell, move interval, exploit speed) shift this race. The bot makes the
+  race visible.
+
+- **IDS reconfigure should be the central security puzzle.** Routing ICE
+  through the IDS chain makes reconfigure meaningful at every difficulty.
+  The old direct escalation made IDS a minor optimization. Now it's the key.
+
+- **Player tracking was bad design.** Omniscient pathfinding to selectedNodeId
+  removed player agency entirely. Disturbance tracking is fair because the
+  player controls when they make noise. This is a better game regardless of
+  balance numbers.
+
+- **Module-level event handlers and clearHandlers() don't mix.** Several
+  modules register handlers at import time. A multi-run harness needs either
+  init functions per module or scoped handler groups. Added initAlertHandlers
+  and initIceHandlers as a pattern; the remaining modules (exec, lifecycle)
+  should follow in a future cleanup.
+
+---
+
+## Future Work
+
+See session notes above for detailed items:
+- Move ICE resident node (topology change)
+- High-value-target patrol (augment random walk)
+- Multi-signal tracking (alert-responsive ICE speed)
+- Area lockdown ICE type
+- Reward scaling with difficulty (backlog updated)
+- Player upgrades for A/S survivability (deck speed, signal masking, decoys)
+- Module init function cleanup (clearHandlers compatibility)
+
+---
+
+## Stats
+
+- Tests: 304 (unchanged — bot tests from earlier, no new game logic tests)
+- Branch commits: 13
+- Files changed: bot-player.js, bot-census.js, store-logic.js + test,
+  store.js, console.js, action-context.js, ice.js, alert.js, node-types.js,
+  exploit-exec.js, BACKLOG.md, session docs
+- Census reports saved: FF, DD, CC, BB, ICE cliff, money curve, asymmetric,
+  timeline analysis

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/notes.md
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/notes.md
@@ -33,6 +33,14 @@ detection dwell time, creating a danger radius the player must avoid. This
 is a different ICE type entirely (not a grade variant). Good candidate for
 the future multiple-ICE-instance feature.
 
+### Reward scaling with difficulty
+Currently higher-difficulty networks cost more to crack (harder nodes, deeper
+paths, more ICE pressure) but don't contain more valuable loot. Macguffin
+values are set in the game state layer (loot.js), not the generator. Scaling
+rewards with moneyCost would give players incentive to tackle harder networks
+and offset the increased card/cash expenditure. This is a game state change,
+not a generator change — separate session.
+
 ### A/S player tracking removed
 The old A/S behavior (pathfind directly to `selectedNodeId`) was removed
 because it felt like cheating — ICE had perfect knowledge of the player's

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/notes.md
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/notes.md
@@ -12,3 +12,29 @@ network, reporting back through the IDS chain. This would mean:
 
 This is a topology/gen-rules change with implications for network layout and
 the layer-processor. Separate session.
+
+## Future work: ICE behavior improvements
+
+### High-value-target patrol (augment random walk)
+Instead of pure random walk at F/D, ICE patrols a fixed route through
+high-value nodes (fileservers, cryptovaults, firewalls). Predictable but
+unavoidable — the player has to time actions around the patrol schedule.
+Could augment any grade as a base behavior underneath the tracking modes.
+
+### Multi-signal tracking
+ICE tracks disturbance (like C/B) but also responds to alert level. Higher
+global alert → ICE moves faster or covers more ground. Failing exploits →
+noise → ICE investigates → detection → alert rises → ICE gets more aggressive.
+Creates a feedback loop that punishes sloppy play.
+
+### Area lockdown ICE type
+When this ICE type detects, it "locks" the region — nearby nodes get reduced
+detection dwell time, creating a danger radius the player must avoid. This
+is a different ICE type entirely (not a grade variant). Good candidate for
+the future multiple-ICE-instance feature.
+
+### A/S player tracking removed
+The old A/S behavior (pathfind directly to `selectedNodeId`) was removed
+because it felt like cheating — ICE had perfect knowledge of the player's
+location regardless of player actions. Replaced with faster disturbance
+tracking, which preserves player agency (go quiet to lose ICE).

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/plan.md
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/plan.md
@@ -1,0 +1,403 @@
+# Plan: Census Metrics v2 — Monte Carlo Bot Simulation
+
+## Overview
+
+Six phases. The first two extract the store logic and wire it properly. Phases
+3–4 build the bot. Phase 5 builds the census CLI and report. Phase 6 runs it
+against B/B and documents findings.
+
+Each phase ends with `make check` passing and no orphaned code.
+
+---
+
+## Phase 1 — Extract headless store buy function
+
+**Builds on:** existing `js/store.js`, `js/console.js`, `js/state/index.js`.
+
+**After this phase:** a `buyFromStore(vulnId)` function exists in a new
+`js/store-logic.js` module. It encapsulates the buy flow (catalog lookup →
+affordability check → card generation → state mutation). The console.js
+`cmdBuy` and DOM `store.js` both call it.
+
+### Prompt
+
+Create `js/store-logic.js`:
+
+```js
+import { getState, buyExploit } from "./state.js";
+import { generateExploitForVuln, getStoreCatalog } from "./exploits.js";
+
+/**
+ * Buy an exploit card from the darknet broker by catalog index (1-based)
+ * or vuln ID string. Returns the card on success, null on failure.
+ *
+ * This is the headless buy path — no DOM, no UI. Both the modal store
+ * and the console `buy` command delegate to this function.
+ *
+ * @param {number | string} indexOrVulnId — 1-based catalog index or vuln ID string
+ * @returns {{ card: import('./types.js').ExploitCard, price: number } | null}
+ */
+export function buyFromStore(indexOrVulnId) { ... }
+```
+
+Implementation:
+1. Call `getStoreCatalog()` to get the catalog
+2. Resolve the item — if `indexOrVulnId` is a number, use as 1-based index;
+   if a string, find by `vulnId` match
+3. If item not found, return null
+4. Call `generateExploitForVuln(item.vulnId)` to create the card
+5. Call `buyExploit(card, item.price)` — returns false if can't afford
+6. If success, return `{ card, price: item.price }`; if can't afford, return null
+
+Refactor `js/console.js` `cmdBuy`:
+- Replace inline catalog lookup + `generateExploitForVuln` + `buyExploit`
+  with a call to `buyFromStore(indexOrVulnId)`
+- Keep the `resolveWanAccess()` guard and log messages in `cmdBuy`
+- Remove the `buyExploit` import from console.js (no longer needed directly)
+
+Refactor `js/store.js`:
+- Import `buyFromStore` from `store-logic.js`
+- In the buy button click handler, replace inline `generateExploitForVuln` +
+  `onBuy(card, price)` with `buyFromStore(item.vulnId)`
+- The `onBuy` callback from `action-context.js` is no longer needed — the
+  store logic handles state mutation directly
+- Update `openDarknetsStore` signature: remove the `onBuy` parameter
+- Update `action-context.js` to match: `openDarknetsStore(getState())` instead
+  of passing the `onBuy` callback
+
+Add a test in `js/store-logic.test.js`:
+- Init state with a known network, give player cash
+- Call `buyFromStore(1)` — verify card returned, cash deducted, card in hand
+- Call `buyFromStore("some-vuln-id")` — verify lookup by vuln ID works
+- Call with insufficient cash — verify null returned, cash unchanged
+
+`make check` passes.
+
+---
+
+## Phase 2 — Wire `buy` command in playtest harness
+
+**Builds on:** Phase 1.
+
+**After this phase:** the playtest harness supports `store` and `buy` commands
+natively (not just via console.js). The bot will use `buyFromStore` directly,
+but this phase ensures the harness is symmetric with the browser.
+
+### Prompt
+
+Update `scripts/playtest.js`:
+
+The console.js `cmdBuy` already handles `buy` and `cmdStore` handles `store`.
+These work through `runCommand()` which the harness already delegates to. But
+the harness overrides `openDarknetsStore` with a log message stub (line 101).
+
+Verify that `store` and `buy` commands work through the existing `runCommand`
+path:
+```bash
+node scripts/playtest.js --seed test --time B --money B reset
+node scripts/playtest.js --seed test --time B --money B "select wan-1"
+node scripts/playtest.js --seed test --time B --money B "store"
+node scripts/playtest.js --seed test --time B --money B "buy 1"
+```
+
+If the commands already work (they should — console.js handles them), no code
+changes needed in this phase. Just verify and document.
+
+If there's an issue (e.g. `resolveWanAccess` requires selection state that
+doesn't persist properly), fix it.
+
+`make check` passes.
+
+---
+
+## Phase 3 — Bot game runner (single run)
+
+**Builds on:** Phases 1–2, plus existing playtest.js wiring pattern.
+
+**After this phase:** `scripts/bot-player.js` exports a `runBot(network, seed)`
+function that plays a single game from init to jackout and returns a stats
+object. No CLI yet.
+
+### Prompt
+
+Create `scripts/bot-player.js`. This module exports a single function:
+
+```js
+/**
+ * Run one automated game from init to completion.
+ * @param {object} network — return value of generateNetwork()
+ * @param {string} seed
+ * @param {{ tickIncrement?: number, maxTicks?: number }} [options]
+ * @returns {BotRunStats}
+ */
+export function runBot(network, seed, options = {}) { ... }
+```
+
+**Setup (same wiring as playtest.js):**
+1. `initState(network, seed)`
+2. `startIce()`
+3. Timer wiring: register handlers for all TIMER events (ICE_MOVE, ICE_DETECT,
+   TRACE_TICK, REBOOT_COMPLETE, EXPLOIT_EXEC, EXPLOIT_NOISE, PROBE_SCAN,
+   READ_SCAN, LOOT_EXTRACT)
+4. `initNodeLifecycle()`
+5. Build action context and init dispatcher
+6. Register event listeners for stat collection (count ICE detections, track
+   peak alert, detect trace)
+
+**Important: event listener cleanup.** The `on()` function in events.js adds
+persistent listeners. Running 100 bot games would accumulate 100× listeners.
+Check if events.js has an `off()` or cleanup mechanism. If not, add one
+(`off(type, fn)` to remove a specific listener, or `offAll()` / scoped
+listener groups). This is critical for the census loop.
+
+**Bot strategy loop:**
+
+```js
+const { tickIncrement = 1, maxTicks = 5000 } = options;
+let totalTicks = 0;
+let missionDone = false;
+let traceFired = false;
+// ... stat accumulators
+
+while (totalTicks < maxTicks) {
+  const state = getState();
+  if (state.phase !== "playing") break;
+  if (traceFired) { jackOut(); break; }
+
+  // 1. Pick next target node
+  const target = pickNextNode(state);
+  if (!target) {
+    // Stuck — no reachable unowned nodes
+    if (missionDone) break;  // full exploration done or stuck
+    jackOut(); break;         // can't reach mission target
+  }
+
+  // 2. Navigate to target
+  selectNode(target.id);
+
+  // 3. Probe if needed
+  if (!target.probed) {
+    startProbe(target.id);
+    totalTicks += tickUntilEvent(E.NODE_PROBED, tickIncrement, maxTicks - totalTicks);
+  }
+
+  // 4. Exploit until owned
+  while (target.access !== "owned" && totalTicks < maxTicks) {
+    const card = pickBestCard(state, target);
+    if (!card) {
+      // Try to buy from store
+      const bought = tryBuyCard(state, target);
+      if (!bought) { failReason = "no-cards"; jackOut(); break outer; }
+      continue;
+    }
+    startExploit(target.id, card.id);
+    totalTicks += tickUntilEvent([E.EXPLOIT_SUCCESS, E.EXPLOIT_FAILURE],
+                                 tickIncrement, maxTicks - totalTicks);
+    // Re-read state after exploit resolves
+  }
+
+  // 5. Read + loot if lootable and owned
+  if (target.access === "owned" && isLootable(target)) {
+    startRead(target.id);
+    totalTicks += tickUntilEvent(E.NODE_READ, tickIncrement, maxTicks - totalTicks);
+    startLoot(target.id);
+    totalTicks += tickUntilEvent(E.NODE_LOOTED, tickIncrement, maxTicks - totalTicks);
+    if (isMissionTarget(target)) missionDone = true;
+  }
+}
+
+// Jack out if still playing
+if (getState().phase === "playing") jackOut();
+
+return collectStats(...);
+```
+
+**Helper functions (private to the module):**
+
+- `pickNextNode(state)` — implements the greedy priority:
+  1. Adjacent unowned lootable node
+  2. Nearest unowned adjacent node (BFS from current position through owned nodes)
+  3. null if nothing reachable
+  Note: "adjacent" means the bot can see/reach the node. Hidden nodes behind
+  gates are not visible until the gate is owned.
+
+- `pickBestCard(state, target)` — from `state.player.hand`, find best card:
+  1. Filter to cards with uses > 0 and not disclosed
+  2. Prefer cards matching a known vuln on this node
+  3. Among matches (or all if no matches): highest quality, then most uses
+  4. Return card or null
+
+- `tryBuyCard(state, target)` — attempt darknet store purchase:
+  1. Find a known vuln on the target node
+  2. Call `buyFromStore(vulnId)`
+  3. Return true if successful, false if can't afford or no known vulns
+
+- `tickUntilEvent(eventType, increment, budget)` — tick in increments,
+  listening for the event. Return total ticks consumed. Safety: if budget
+  exceeded, stop ticking. eventType can be a single type or array of types
+  (for exploit which fires either SUCCESS or FAILURE).
+
+- `isLootable(node)` — type is fileserver or cryptovault
+- `isMissionTarget(node, state)` — node is the mission's target node
+
+**Stats returned (`BotRunStats`):**
+
+```js
+{
+  missionSuccess: boolean,
+  fullClear: boolean,
+  failReason: null | "trace" | "no-cards" | "stuck",
+  cardUsesConsumed: number,
+  cardsBurned: number,
+  storeVisits: number,
+  cashSpent: number,
+  cashRemaining: number,
+  totalTicks: number,
+  peakAlert: string,
+  traceFired: boolean,
+  iceDetections: number,
+  nodesOwned: number,
+  nodesTotal: number,
+}
+```
+
+Write a test in `scripts/bot-player.test.js`:
+- Run bot against a generated F/F network — should succeed (easy difficulty)
+- Run bot against B/B — should complete without crashing (may or may not succeed)
+- Verify stats object has all expected fields
+- Verify determinism: same seed + difficulty = same stats
+
+Add `scripts/*.test.js` to the Makefile test glob (already done in prior session).
+
+`make check` passes.
+
+---
+
+## Phase 4 — Bot node selection and card picking
+
+**Builds on:** Phase 3 skeleton.
+
+**After this phase:** the bot's `pickNextNode` and `pickBestCard` are robust
+and tested independently.
+
+### Prompt
+
+This phase may be folded into Phase 3 if the helpers are straightforward
+enough. If Phase 3 is getting large, split the helpers into this phase.
+
+Key things to get right:
+
+**`pickNextNode` — visibility awareness:**
+The bot can only see nodes that are visible (`visibility !== "hidden"`). Nodes
+behind firewalls are hidden until the firewall is owned. The BFS must only
+traverse visible nodes, and only consider nodes that are not yet owned.
+
+The BFS should start from the currently selected node (or gateway if nothing
+selected) and explore through owned nodes to find unowned visible nodes.
+Priority: lootable first (fileserver/cryptovault), then any type.
+
+**`pickBestCard` — matching logic:**
+A card "matches" a node if any of the card's `targetVulnTypes` appears in the
+node's `vulnerabilities` array (filtering out patched and hidden vulns).
+Only probed nodes have known vulns.
+
+Test `pickNextNode` with a hand-crafted state:
+- Network with gateway (owned) → router (visible, unowned) → fileserver (hidden)
+- Bot should pick router (fileserver is hidden behind a gate)
+- After owning router, fileserver becomes visible, bot picks fileserver
+
+Test `pickBestCard`:
+- Node with known vuln "buffer-overflow"
+- Hand has matching card (quality 0.5) and non-matching card (quality 0.8)
+- Bot should pick the matching card despite lower quality
+
+`make check` passes.
+
+---
+
+## Phase 5 — Bot census CLI and report
+
+**Builds on:** Phases 3–4 (working bot).
+
+**After this phase:** `node scripts/bot-census.js --time B --money B` runs
+100 simulated games and prints the LLM-legible report.
+
+### Prompt
+
+Create `scripts/bot-census.js`. CLI script that:
+
+1. Parses arguments:
+   - `--time <grade>` and `--money <grade>` (required)
+   - `--seeds <N>` (default 100)
+   - `--seed-prefix <string>` (default "bot")
+
+2. For each seed (`{prefix}-0` through `{prefix}-{N-1}`):
+   - `generateNetwork(seed, tc, mc)` → network
+   - `runBot(network, seed)` → stats
+   - Collect stats into arrays
+
+3. Print the report:
+
+```
+=== BOT SIMULATION: B/B ===
+Seeds: bot-0 through bot-99 (100 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     N/100 (pct%)
+Avg ticks:        X (succeeded) / Y (failed)
+Failure reasons:  trace=N  no-cards=N  stuck=N
+
+--- FULL EXPLORATION ---
+Full clear rate:  N/100 (pct%)
+Avg nodes owned:  X / Y total (pct%)
+
+--- RESOURCE USAGE (succeeded runs) ---
+              Min    Avg    Max
+Card uses:    X      X      X
+Cards burned: X      X      X
+Store visits: X      X      X
+Cash spent:   X      X      X
+Cash left:    X      X      X
+
+--- PRESSURE ---
+Peak alert:   GREEN=N  YELLOW=N  RED=N
+Trace fired:  N/100
+ICE detects:  avg X  max X
+```
+
+4. Add a `bot-census` target to the Makefile:
+```make
+bot-census:
+	node scripts/bot-census.js --time B --money B
+```
+
+Verify by running:
+```bash
+node scripts/bot-census.js --time B --money B --seeds 10
+```
+
+`make check` passes.
+
+---
+
+## Phase 6 — Run B/B census and document findings
+
+**Builds on:** Phase 5.
+
+**After this phase:** we have a B/B bot census report saved and documented.
+
+### Prompt
+
+1. Run: `node scripts/bot-census.js --time B --money B`
+2. Save output to `docs/dev-sessions/2026-03-01-2012-census-metrics-v2/bot-census-BB.txt`
+3. Also run F/F for comparison:
+   `node scripts/bot-census.js --time F --money F`
+   Save to `bot-census-FF.txt`
+4. Review findings with Les. Key questions:
+   - What's the mission success rate at B/B? Is it reasonable?
+   - Does trace fire at B/B? How often?
+   - Is the store needed? How often?
+   - How does F/F compare?
+5. Document observations in `notes.md`
+
+This phase is collaborative — the data drives the conversation.

--- a/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/spec.md
+++ b/docs/dev-sessions/2026-03-01-2012-census-metrics-v2/spec.md
@@ -1,0 +1,246 @@
+# Spec: Census Metrics v2 — Monte Carlo Bot Simulation
+
+## Goal
+
+Build an automated bot that plays through generated LANs in a tight headless
+loop, collecting per-run statistics across many seeds. The bot establishes a
+pessimistic lower bound on completion rates and resource costs — a skilled
+human should beat it. Parameterized by difficulty so we can sweep the full
+matrix later, starting with B/B.
+
+Also: extract the darknet store's buy logic into a headless function, fixing
+the current DOM-only coupling. The store should be fully accessible to
+headless gameplay per the "GUI and console are symmetric" design principle.
+
+---
+
+## Background
+
+The census tool (session 2026-03-01-1721) measures topology and resource
+*budgets* — what the network looks like and what it theoretically costs. But it
+can't answer:
+
+- Can a player actually complete this difficulty?
+- How often does trace fire?
+- How many darknet store visits are needed?
+- What's the real tick-to-complete under ICE pressure?
+
+These require simulating gameplay, not just analyzing topology. The bot fills
+this gap by playing many runs with a fixed greedy strategy and collecting
+distributional data.
+
+---
+
+## Darknet Store Extraction
+
+### Problem
+
+`js/store.js` is DOM-coupled — `openDarknetsStore()` creates modal elements.
+The playtest harness and the bot both need headless store access.
+
+### Solution
+
+Extract a `buyExploitForVuln(state, vulnId)` function (or similar) that:
+1. Looks up the vuln in the store catalog
+2. Checks if the player can afford it
+3. Generates the exploit card
+4. Deducts cash and adds the card to the player's hand
+5. Returns the card (or null if can't afford)
+
+This function lives in the game logic layer (not store.js's DOM layer). The
+DOM store and the headless bot both call it. The playtest harness gains
+`buy <vulnId>` command support as a side effect.
+
+---
+
+## Bot Design
+
+### Goal modes
+
+Each run attempts both, measured independently:
+
+1. **Mission completion** — reach the target (fileserver/cryptovault), loot it,
+   jackout. Binary success/fail.
+2. **Full exploration** — after mission completion (or if mission is already
+   done), continue owning every reachable non-security node. Measures total
+   network cost.
+
+The bot always attempts mission first. If it succeeds, it continues exploring
+until all reachable nodes are owned or it gets stuck/traced. If mission fails,
+exploration stats are still recorded (nodes owned at time of failure/jackout).
+
+### Strategy
+
+Greedy, consistent, not optimal. The bot is deliberately simple so difficulty
+differences show up in results rather than strategy variance.
+
+**Node selection priority:**
+1. If an adjacent unowned lootable node exists (fileserver/cryptovault), target it
+2. Otherwise, pick the nearest unowned adjacent node (BFS from current position)
+3. If all adjacent nodes are owned, move to an owned node adjacent to an unowned one
+
+**Per-node action sequence:**
+1. Select node
+2. Probe (if not already probed) — tick until probe completes
+3. Pick best exploit card:
+   - Prefer: matching a known vuln on this node
+   - Then: highest quality
+   - Then: most uses remaining
+4. Exploit — tick until exploit resolves (success or failure event)
+5. Repeat exploit until node is owned or no usable cards remain for this node
+6. If owned and lootable: read (tick to complete), then loot (tick to complete)
+7. Move to next node per selection priority
+
+**When stuck (no usable cards for any reachable unowned node):**
+1. Find a known vuln on any adjacent unowned node
+2. Visit darknet store, buy a card matching that vuln
+3. If can't afford anything, jackout (run failed — reason: "no-cards")
+
+**Tick advancement:**
+After starting any timed action (probe, exploit, read, loot), tick in small
+increments until the relevant completion event fires. The increment is a
+configurable constant (default 1 tick) — can be increased if performance is
+an issue. This gives realistic tick counts and lets ICE pressure manifest
+naturally.
+
+**Trace handling:**
+If trace fires (alert reaches RED, 60-second countdown begins), jackout
+immediately. Run recorded as failure with reason "trace".
+
+**Stuck detection:**
+A per-run tick cap (e.g. 5000 ticks) prevents infinite loops. If the bot
+hasn't completed or jacked out within the cap, the run ends as failure with
+reason "stuck". Additionally, if the bot's action selection finds no valid
+move (no reachable unowned nodes, can't afford store), it jacks out
+immediately rather than spinning.
+
+### What the bot does NOT do
+
+- Reconfigure IDS nodes (no alert management)
+- Eject ICE (no ICE avoidance)
+- Reboot nodes
+- Make strategic choices about node ordering beyond the greedy priority
+- Retry failed nodes with different strategies
+
+These omissions are intentional — they make the bot a pessimistic baseline.
+
+---
+
+## Stats Collected Per Run
+
+**Outcome:**
+- `missionSuccess`: boolean — target looted and jackout
+- `fullClear`: boolean — all reachable non-security nodes owned
+- `failReason`: null | "trace" | "no-cards" | "stuck"
+
+**Resource consumption:**
+- `cardUsesConsumed`: number — total exploit attempts
+- `cardsBurned`: number — cards fully depleted or disclosed
+- `storeVisits`: number — darknet store purchases
+- `cashSpent`: number — total darknet store expenditure
+- `cashRemaining`: number — cash at jackout
+
+**Time/pressure:**
+- `totalTicks`: number — ticks elapsed at jackout
+- `peakAlert`: "GREEN" | "YELLOW" | "RED"
+- `traceFired`: boolean
+- `iceDetections`: number — times ICE detection event fired
+
+**Exploration:**
+- `nodesOwned`: number
+- `nodesTotal`: number
+- `critPathNodesOwned`: number
+- `critPathNodesTotal`: number
+
+---
+
+## Report Format
+
+Text-based, LLM-legible. Parameterized by difficulty.
+
+```
+=== BOT SIMULATION: B/B ===
+Seeds: bot-0 through bot-99 (100 runs)
+
+--- MISSION COMPLETION ---
+Success rate:     73/100 (73%)
+Avg ticks:        342 (succeeded) / 189 (failed)
+Failure reasons:  trace=15  no-cards=8  stuck=4
+
+--- FULL EXPLORATION ---
+Full clear rate:  41/100 (41%)
+Avg nodes owned:  9.2 / 13.1 total (70%)
+
+--- RESOURCE USAGE (succeeded runs) ---
+              Min    Avg    Max
+Card uses:    8      14.3   22
+Cards burned: 0      1.8    5
+Store visits: 0      1.2    4
+Cash spent:   0      425    1250
+Cash left:    250    1075   1500
+
+--- PRESSURE ---
+Peak alert:   GREEN=31  YELLOW=42  RED=27
+Trace fired:  15/100
+ICE detects:  avg 2.4  max 7
+```
+
+### CLI Usage
+
+```bash
+node scripts/bot-census.js --time B --money B              # 100 runs at B/B
+node scripts/bot-census.js --time B --money B --seeds 50   # 50 runs
+node scripts/bot-census.js --time F --money F --time S --money S  # sweep (future)
+```
+
+---
+
+## Architecture
+
+### Files
+
+- `js/store-logic.js` (new) — headless buy function extracted from store.js
+- `js/store.js` — refactored to use store-logic.js for the actual purchase
+- `scripts/bot-player.js` (new) — the bot strategy module (exported function)
+- `scripts/bot-census.js` (new) — CLI harness: init, run bot, collect stats, print report
+
+### Bot loop (single run)
+
+```
+1. generateNetwork(seed, tc, mc) → network
+2. initState(network, seed)
+3. startIce()
+4. Wire timer handlers (same as playtest.js)
+5. Run bot strategy loop:
+   a. Observe state → pick next action
+   b. Dispatch action via emitEvent("starnet:action", ...)
+   c. Tick until action completes (watch for completion events)
+   d. Check termination conditions (mission done, stuck, trace)
+6. Collect stats from final state + event log
+7. Return stats object
+```
+
+### Driving ticks
+
+The bot ticks 1-at-a-time after dispatching an action, watching for the
+completion event. A safety cap (e.g. 2000 ticks) prevents infinite loops
+if an event never fires.
+
+---
+
+## Scope
+
+### In scope
+- Headless store extraction (store-logic.js)
+- Console `buy` command wired through playtest harness + browser console
+- Bot player strategy module
+- Bot census CLI with parameterized difficulty
+- Stats collection and LLM-legible report
+- B/B as initial test case
+
+### Out of scope
+- Smart strategies (IDS reconfiguration, ICE avoidance, node reboot)
+- Full matrix sweep automation (the CLI supports it, but analysis is future)
+- Browser integration of headless store beyond refactoring store.js to use
+  the extracted logic
+- Comparison mode (before/after reports — just run twice and read both)

--- a/js/action-context.js
+++ b/js/action-context.js
@@ -4,7 +4,7 @@
 
 /** @typedef {import('./types.js').ActionContext} ActionContext */
 
-import { getState, getVersion, endRun, buyExploit } from "./state.js";
+import { getState, getVersion, endRun } from "./state.js";
 import { reconfigureNode, rebootNode } from "./node-orchestration.js";
 import { startLoot, cancelLoot } from "./loot-exec.js";
 import { startRead, cancelRead } from "./read-exec.js";
@@ -43,7 +43,7 @@ export function buildActionContext() {
     cancelTrace:      ()       => cancelTraceCountdown(),
     openDarknetsStore: () => {
       pauseTimers();
-      openDarknetsStore(getState(), (card, price) => buyExploit(card, price));
+      openDarknetsStore(getState());
     },
   };
 }

--- a/js/alert.js
+++ b/js/alert.js
@@ -21,28 +21,37 @@ const DETECTION_TRACE_THRESHOLD = { S: 1, A: 1, B: 2, C: 2, D: 3, F: 3 };
 
 // ── Event-driven hooks ────────────────────────────────────
 
-// When any node alert raises, propagate if it's a detection node; otherwise
-// recompute global alert directly. Runs synchronously before STATE_CHANGED fires.
-on(E.NODE_ALERT_RAISED, ({ nodeId }) => {
-  const s = getState();
-  const node = s.nodes[nodeId];
-  if (!node) return;
-  const ctx = { propagateAlertEvent, startTraceCountdown, recomputeGlobalAlert };
-  const handled = getBehaviors(node).some((atom) => {
-    if (atom.onAlertRaised) { atom.onAlertRaised(node, s, ctx); return true; }
-    return false;
+/**
+ * Register alert event handlers. Called at module load and can be re-called
+ * after clearHandlers() (e.g. in the bot census loop).
+ */
+export function initAlertHandlers() {
+  // When any node alert raises, propagate if it's a detection node; otherwise
+  // recompute global alert directly. Runs synchronously before STATE_CHANGED fires.
+  on(E.NODE_ALERT_RAISED, ({ nodeId }) => {
+    const s = getState();
+    const node = s.nodes[nodeId];
+    if (!node) return;
+    const ctx = { propagateAlertEvent, startTraceCountdown, recomputeGlobalAlert };
+    const handled = getBehaviors(node).some((atom) => {
+      if (atom.onAlertRaised) { atom.onAlertRaised(node, s, ctx); return true; }
+      return false;
+    });
+    if (!handled) recomputeGlobalAlert();
   });
-  if (!handled) recomputeGlobalAlert();
-});
 
-// Reconfiguring a node — dispatch onReconfigured atom, then recompute.
-on(E.NODE_RECONFIGURED, ({ nodeId }) => {
-  const s = getState();
-  const node = s.nodes[nodeId];
-  if (!node) return;
-  const ctx = { recomputeGlobalAlert };
-  getBehaviors(node).forEach((atom) => atom.onReconfigured?.(node, s, ctx));
-});
+  // Reconfiguring a node — dispatch onReconfigured atom, then recompute.
+  on(E.NODE_RECONFIGURED, ({ nodeId }) => {
+    const s = getState();
+    const node = s.nodes[nodeId];
+    if (!node) return;
+    const ctx = { recomputeGlobalAlert };
+    getBehaviors(node).forEach((atom) => atom.onReconfigured?.(node, s, ctx));
+  });
+}
+
+// Register on first import
+initAlertHandlers();
 
 // ── Propagation ───────────────────────────────────────────
 
@@ -162,32 +171,32 @@ export function forceGlobalAlert(level) {
 
 // ── ICE detection ─────────────────────────────────────────
 
+/**
+ * Record an ICE detection event. Instead of directly escalating global alert,
+ * ICE reports through the IDS chain: raise alert on all IDS nodes, which then
+ * propagate to the security monitor via the normal forwarding path. If the IDS
+ * is reconfigured (eventForwardingDisabled), the report goes nowhere.
+ *
+ * This makes IDS reconfiguration the key counterplay to ICE pressure.
+ */
 export function recordIceDetection(nodeId) {
   const s = getState();
   if (!s.ice?.active) return;
   setIceDetectedAt(nodeId);
   incrementIceDetectionCount();
 
-  // Each detection escalates global alert one step (capped at red).
-  // The threshold check below handles the jump to trace.
-  const curIdx = GLOBAL_ALERT_ORDER.indexOf(s.globalAlert);
-  const redIdx = GLOBAL_ALERT_ORDER.indexOf("red");
-  if (curIdx < redIdx) {
-    const prev = s.globalAlert;
-    setGlobalAlert(GLOBAL_ALERT_ORDER[curIdx + 1]);
-    emitEvent(E.ALERT_GLOBAL_RAISED, { prev, next: getState().globalAlert });
-  }
-
-  // Re-read state after mutations
-  const updated = getState();
-  if (updated.traceSecondsRemaining !== null) return;
-  const threshold = DETECTION_TRACE_THRESHOLD[updated.ice.grade] ?? 2;
-  if (updated.ice.detectionCount >= threshold) {
-    if (updated.globalAlert !== "trace") {
-      const prev = updated.globalAlert;
-      setGlobalAlert("trace");
-      emitEvent(E.ALERT_GLOBAL_RAISED, { prev, next: "trace" });
+  // Raise alert on all IDS (detection) nodes — they propagate to the monitor.
+  // This replaces the old direct global alert escalation.
+  const detectors = Object.entries(s.nodes).filter(
+    ([, n]) => hasBehavior(n, "detection") || hasBehavior(n, "direct-trace")
+  );
+  for (const [detId, det] of detectors) {
+    const prevAlert = det.alertState;
+    const idx = ALERT_ORDER.indexOf(prevAlert);
+    if (idx < ALERT_ORDER.length - 1) {
+      const nextAlert = ALERT_ORDER[idx + 1];
+      setNodeAlertState(detId, nextAlert);
+      emitEvent(E.NODE_ALERT_RAISED, { nodeId: detId, label: det.label, prev: prevAlert, next: nextAlert });
     }
-    startTraceCountdown();
   }
 }

--- a/js/console.js
+++ b/js/console.js
@@ -6,13 +6,14 @@
 /** @typedef {import('./types.js').NodeState} NodeState */
 /** @typedef {import('./types.js').ExploitCard} ExploitCard */
 
-import { getState, isIceVisible, buyExploit } from "./state.js";
+import { getState, isIceVisible } from "./state.js";
 import { addLogEntry, getRecentLog } from "./log.js";
 import { emitEvent, on, E } from "./events.js";
 import { getVisibleTimers } from "./timers.js";
-import { exploitSortKey, getStoreCatalog, generateExploitForVuln } from "./exploits.js";
+import { exploitSortKey, getStoreCatalog } from "./exploits.js";
 import { getActions } from "./node-types.js";
 import { getAvailableActions } from "./node-actions.js";
+import { buyFromStore } from "./store-logic.js";
 
 const VERBS = ["select", "deselect", "probe", "exploit", "eject", "reboot", "read", "loot", "reconfigure", "cancel-probe", "cancel-exploit", "cancel-read", "cancel-loot", "cancel-trace", "jackout", "status", "actions", "store", "buy", "log", "help", "cheat"];
 const STATUS_NOUNS = ["summary", "ice", "hand", "node", "alert", "mission"];
@@ -679,29 +680,23 @@ function cmdStore() {
 
 function cmdBuy(args) {
   if (!resolveWanAccess()) return;
-  const s = getState();
   if (!args[0]) { addLogEntry("Usage: buy <index>", "error"); return; }
-  const catalog = getStoreCatalog();
   const num = parseInt(args[0], 10);
-  let item = null;
-  if (!isNaN(num) && num >= 1 && num <= catalog.length) {
-    item = catalog[num - 1];
-  } else {
-    const lower = args[0].toLowerCase();
-    const matches = catalog.filter((c) => c.vulnId.startsWith(lower));
-    if (matches.length === 1) { item = matches[0]; }
-    else if (matches.length > 1) { addLogEntry(`Ambiguous: ${matches.map((m) => m.vulnId).join(", ")}`, "error"); return; }
-    else { addLogEntry(`Unknown item: ${args[0]}`, "error"); return; }
-  }
-  if (s.player.cash < item.price) {
-    addLogEntry(`Insufficient funds. Need ¥${item.price}, have ¥${s.player.cash.toLocaleString()}.`, "error");
+  const key = !isNaN(num) ? num : args[0];
+  const result = buyFromStore(key);
+  if (!result) {
+    const s = getState();
+    // Distinguish "not found" from "can't afford"
+    const catalog = getStoreCatalog();
+    const item = !isNaN(num) ? catalog[num - 1] : catalog.find((c) => c.vulnId.toLowerCase().startsWith(args[0].toLowerCase()));
+    if (item && s.player.cash < item.price) {
+      addLogEntry(`Insufficient funds. Need ¥${item.price}, have ¥${s.player.cash.toLocaleString()}.`, "error");
+    } else {
+      addLogEntry(`Unknown item: ${args[0]}`, "error");
+    }
     return;
   }
-  const card = generateExploitForVuln(item.vulnId);
-  const success = buyExploit(card, item.price);
-  if (success) {
-    addLogEntry(`Purchased: ${card.name}  [${item.rarity}]  targets:${item.vulnId}  cost:¥${item.price}`, "success");
-  }
+  addLogEntry(`Purchased: ${result.card.name}  [${result.card.rarity}]  targets:${result.vulnId}  cost:¥${result.price}`, "success");
 }
 
 function cmdLog(args) {

--- a/js/exploit-exec.js
+++ b/js/exploit-exec.js
@@ -18,9 +18,10 @@ const NOISE_INTERVAL_FRACTION = 0.1;
 on(E.PLAYER_NAVIGATED, () => cancelExploit());
 
 // Duration formula: higher quality = longer execution (more complex payload).
-// Range: 3s (quality=0) to 12s (quality=1).
+// Range: 2s (quality=0) to 7s (quality=1). Tuned down from 3-12s to give
+// players a realistic window to complete exploits between ICE patrols.
 export function exploitDuration(quality) {
-  return Math.round((3 + quality * 9) * 1000); // ms
+  return Math.round((2 + quality * 5) * 1000); // ms
 }
 
 /**

--- a/js/ice.js
+++ b/js/ice.js
@@ -27,7 +27,8 @@ const MOVE_INTERVALS = { S: 4000, A: 5000, B: 6000, C: 7000, D: 12000, F: 14000 
 
 // Grade → dwell time before detection (ms).
 // S/A get very short dwells — tight but evadable with fast reactions.
-const DWELL_TIMES = { S: 800, A: 1500, B: 3500, C: 4500, D: 9000, F: 10000 };
+// C/B bumped from 4500/3500 to give players a window to complete exploits.
+const DWELL_TIMES = { S: 800, A: 1500, B: 4500, C: 5500, D: 9000, F: 10000 };
 
 // Grade → noise tick at which ICE first responds to an executing exploit.
 // Exploit emits ticks 1–9 at 10%–90% of duration; 10% intervals.

--- a/js/ice.js
+++ b/js/ice.js
@@ -24,8 +24,9 @@ function handleIceDeparture() {
 // Grade → movement interval (ms); must be longer than the corresponding DWELL_TIMES entry
 const MOVE_INTERVALS = { S: 2500, A: 3000, B: 6000, C: 7000, D: 12000, F: 14000 };
 
-// Grade → dwell time before detection (ms); null = instant detection
-const DWELL_TIMES = { S: null, A: null, B: 3500, C: 4500, D: 9000, F: 10000 };
+// Grade → dwell time before detection (ms).
+// S/A get very short dwells — tight but evadable with fast reactions.
+const DWELL_TIMES = { S: 800, A: 1500, B: 3500, C: 4500, D: 9000, F: 10000 };
 
 // Grade → noise tick at which ICE first responds to an executing exploit.
 // Exploit emits ticks 1–9 at 10%–90% of duration; 10% intervals.

--- a/js/ice.js
+++ b/js/ice.js
@@ -122,8 +122,10 @@ export function handleIceTick() {
   if (grade === "D" || grade === "F") {
     // Random walk
     nextNode = randomPick(RNG.ICE, neighbors);
-  } else if (grade === "C" || grade === "B") {
-    // Move toward last disturbed node, fall back to random.
+  } else {
+    // C/B/A/S: move toward last disturbed node, fall back to random.
+    // All grades above D use disturbance tracking — higher grades just move
+    // faster (via MOVE_INTERVALS) and detect sooner (via DWELL_TIMES).
     // Skip pathfinding if ICE already detected at that node — prevents oscillation.
     const target = s.lastDisturbedNodeId;
     const alreadyDetectedTarget = s.ice.detectedAtNode === target;
@@ -141,15 +143,6 @@ export function handleIceTick() {
           });
         }
       }
-      nextNode = randomPick(RNG.ICE, neighbors);
-    }
-  } else {
-    // A/S: pathfind directly to player's selected node, fall back to random
-    const target = s.selectedNodeId;
-    if (target && target !== attentionNodeId) {
-      nextNode = nextHopToward(attentionNodeId, target, s.adjacency)
-        ?? randomPick(RNG.ICE, neighbors);
-    } else {
       nextNode = randomPick(RNG.ICE, neighbors);
     }
   }

--- a/js/ice.js
+++ b/js/ice.js
@@ -21,8 +21,9 @@ function handleIceDeparture() {
   setIceDetectedAt(null);
 }
 
-// Grade → movement interval (ms); must be longer than the corresponding DWELL_TIMES entry
-const MOVE_INTERVALS = { S: 2500, A: 3000, B: 6000, C: 7000, D: 12000, F: 14000 };
+// Grade → movement interval (ms); must be longer than the corresponding DWELL_TIMES entry.
+// A/S slowed from 2500/3000 to give players a narrow window for exploit completion.
+const MOVE_INTERVALS = { S: 4000, A: 5000, B: 6000, C: 7000, D: 12000, F: 14000 };
 
 // Grade → dwell time before detection (ms).
 // S/A get very short dwells — tight but evadable with fast reactions.
@@ -44,36 +45,42 @@ export function stopIce() {
   cancelAllByType(TIMER.ICE_DETECT);
 }
 
-// React to player navigation: cancel pending detection dwell, reset the detection
-// lock so ICE can re-detect on a revisit, and start a new dwell if ICE is already
-// at the node the player just entered. nodeId is null on deselect.
-on(E.PLAYER_NAVIGATED, ({ nodeId }) => {
-  const s = getState();
-  cancelAllByType(TIMER.ICE_DETECT);
-  if (nodeId !== null) {
-    // Moving to a new node — reset lock so ICE can detect on any future visit
-    setIceDetectedAt(null);
-    // ICE already here: start detection immediately
-    if (s.ice?.active && s.ice.attentionNodeId === nodeId) {
-      checkIceDetection(nodeId);
+/**
+ * Register ICE event handlers. Called at module load and can be re-called
+ * after clearHandlers() (e.g. in the bot census loop).
+ */
+export function initIceHandlers() {
+  // React to player navigation: cancel pending detection dwell, reset the detection
+  // lock so ICE can re-detect on a revisit, and start a new dwell if ICE is already
+  // at the node the player just entered. nodeId is null on deselect.
+  on(E.PLAYER_NAVIGATED, ({ nodeId }) => {
+    const s = getState();
+    cancelAllByType(TIMER.ICE_DETECT);
+    if (nodeId !== null) {
+      setIceDetectedAt(null);
+      if (s.ice?.active && s.ice.attentionNodeId === nodeId) {
+        checkIceDetection(nodeId);
+      }
     }
-  }
-  // On deselect (nodeId === null): only cancel the dwell, don't reset detection lock
-});
+  });
 
-// Eject and reboot forcibly move ICE off its current node — treat as a departure.
-on(E.ICE_EJECTED,  handleIceDeparture);
-on(E.ICE_REBOOTED, handleIceDeparture);
+  // Eject and reboot forcibly move ICE off its current node — treat as a departure.
+  on(E.ICE_EJECTED,  handleIceDeparture);
+  on(E.ICE_REBOOTED, handleIceDeparture);
 
-// Respond to exploit execution noise based on ICE sensitivity.
-on(E.EXPLOIT_NOISE, ({ nodeId, tick }) => {
-  const s = getState();
-  if (!s.ice?.active || s.phase !== "playing") return;
-  const threshold = ICE_NOISE_THRESHOLD[s.ice.grade] ?? 5;
-  if (tick < threshold) return;
-  if (s.lastDisturbedNodeId === nodeId) return; // already routing here
-  setLastDisturbedNode(nodeId);
-});
+  // Respond to exploit execution noise based on ICE sensitivity.
+  on(E.EXPLOIT_NOISE, ({ nodeId, tick }) => {
+    const s = getState();
+    if (!s.ice?.active || s.phase !== "playing") return;
+    const threshold = ICE_NOISE_THRESHOLD[s.ice.grade] ?? 5;
+    if (tick < threshold) return;
+    if (s.lastDisturbedNodeId === nodeId) return;
+    setLastDisturbedNode(nodeId);
+  });
+}
+
+// Register on first import
+initIceHandlers();
 
 
 function isPlayerVisible(nodeState) {

--- a/js/node-types.js
+++ b/js/node-types.js
@@ -67,9 +67,11 @@ export const BEHAVIORS = {
   },
 
   // High-grade detection variant: skips alert propagation, triggers trace directly.
+  // Respects eventForwardingDisabled — reconfiguring an S/A IDS node disables this.
   "direct-trace": {
     id: "direct-trace",
     onAlertRaised: (node, state, ctx) => {
+      if (node.eventForwardingDisabled) return;
       ctx.startTraceCountdown();
     },
   },

--- a/js/store-logic.js
+++ b/js/store-logic.js
@@ -1,0 +1,42 @@
+// @ts-check
+// Headless darknet broker buy logic.
+// Both the DOM store modal (store.js) and the console buy command (console.js)
+// delegate to this module. No DOM dependencies.
+
+import { buyExploit } from "./state.js";
+import { generateExploitForVuln, getStoreCatalog } from "./exploits.js";
+
+/**
+ * Buy an exploit card from the darknet broker by catalog index (1-based)
+ * or vulnerability ID string.
+ *
+ * @param {number | string} indexOrVulnId — 1-based catalog index or vuln ID string
+ * @returns {{ card: import('./types.js').ExploitCard, price: number, vulnId: string } | null}
+ */
+export function buyFromStore(indexOrVulnId) {
+  const catalog = getStoreCatalog();
+  let item = null;
+
+  if (typeof indexOrVulnId === "number") {
+    if (indexOrVulnId >= 1 && indexOrVulnId <= catalog.length) {
+      item = catalog[indexOrVulnId - 1];
+    }
+  } else {
+    const lower = String(indexOrVulnId).toLowerCase();
+    const matches = catalog.filter((c) => c.vulnId.toLowerCase() === lower);
+    if (matches.length === 1) item = matches[0];
+    // If no exact match, try prefix
+    if (!item) {
+      const prefix = catalog.filter((c) => c.vulnId.toLowerCase().startsWith(lower));
+      if (prefix.length === 1) item = prefix[0];
+    }
+  }
+
+  if (!item) return null;
+
+  const card = generateExploitForVuln(item.vulnId);
+  const success = buyExploit(card, item.price);
+  if (!success) return null;
+
+  return { card, price: item.price, vulnId: item.vulnId };
+}

--- a/js/store-logic.test.js
+++ b/js/store-logic.test.js
@@ -1,0 +1,57 @@
+// @ts-check
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { buyFromStore } from "./store-logic.js";
+import { getStoreCatalog } from "./exploits.js";
+import { initState, getState } from "./state.js";
+import { NETWORK } from "../data/network.js";
+
+describe("buyFromStore", () => {
+  beforeEach(() => {
+    initState(NETWORK);
+  });
+
+  it("buys by catalog index (1-based)", () => {
+    const catalog = getStoreCatalog();
+    const before = getState().player.cash;
+    const result = buyFromStore(1);
+    assert.ok(result, "expected successful purchase");
+    assert.equal(result.vulnId, catalog[0].vulnId);
+    assert.equal(result.price, catalog[0].price);
+    assert.equal(getState().player.cash, before - result.price);
+    // Card should be in hand
+    const hand = getState().player.hand;
+    assert.ok(hand.some((c) => c.id === result.card.id));
+  });
+
+  it("buys by vuln ID string", () => {
+    const catalog = getStoreCatalog();
+    const vulnId = catalog[0].vulnId;
+    const result = buyFromStore(vulnId);
+    assert.ok(result, "expected successful purchase");
+    assert.equal(result.vulnId, vulnId);
+  });
+
+  it("returns null for invalid index", () => {
+    assert.equal(buyFromStore(999), null);
+    assert.equal(buyFromStore(0), null);
+  });
+
+  it("returns null for unknown vuln ID", () => {
+    assert.equal(buyFromStore("nonexistent-vuln"), null);
+  });
+
+  it("returns null when player can't afford", () => {
+    // Drain cash
+    const s = getState();
+    const catalog = getStoreCatalog();
+    // Buy until broke
+    while (s.player.cash >= catalog[0].price) {
+      const r = buyFromStore(1);
+      if (!r) break;
+    }
+    // Now should fail
+    const result = buyFromStore(1);
+    assert.equal(result, null);
+  });
+});

--- a/js/store.js
+++ b/js/store.js
@@ -1,19 +1,20 @@
 // @ts-check
-// Darknet broker store — modal UI and catalog logic.
+// Darknet broker store — DOM modal UI.
+// Buy logic lives in store-logic.js; this module only handles the modal rendering.
 
 /** @typedef {import('./types.js').GameState} GameState */
 
 import { emitEvent, E } from "./events.js";
 import { resumeTimers } from "./timers.js";
-import { generateExploitForVuln, getStoreCatalog } from "./exploits.js";
+import { getStoreCatalog } from "./exploits.js";
+import { buyFromStore } from "./store-logic.js";
 
 /**
  * Open the darknet broker store modal. Pauses timers while open.
  * Called by ActionContext.openDarknetsStore() after it pauses timers.
  * @param {GameState} state
- * @param {(card: import('./types.js').ExploitCard, price: number) => boolean} onBuy
  */
-export function openDarknetsStore(state, onBuy) {
+export function openDarknetsStore(state) {
   const existing = document.getElementById("darknet-store-modal");
   if (existing) return; // already open
 
@@ -36,7 +37,7 @@ export function openDarknetsStore(state, onBuy) {
             return `<div class="store-card-row">
               <span class="store-item-name">${item.name} <span class="store-item-rarity rarity-${item.rarity}">[${item.rarity}]</span> <span class="store-item-vuln">${item.vulnId}</span></span>
               <span class="store-item-price">¥${item.price}</span>
-              <button class="store-buy-btn" data-vuln-id="${item.vulnId}" data-price="${item.price}" data-index="${i + 1}" ${canAfford ? "" : "disabled"}>[ BUY ]</button>
+              <button class="store-buy-btn" data-vuln-id="${item.vulnId}" data-index="${i + 1}" ${canAfford ? "" : "disabled"}>[ BUY ]</button>
             </div>`;
           }).join("")}
         </div>
@@ -50,17 +51,12 @@ export function openDarknetsStore(state, onBuy) {
     modal.querySelectorAll(".store-buy-btn:not([disabled])").forEach((btn) => {
       btn.addEventListener("click", () => {
         const el = /** @type {HTMLElement} */ (btn);
-        const vulnId = el.dataset.vulnId;
-        const price = Number(el.dataset.price);
-        const index = el.dataset.index;
-        const card = generateExploitForVuln(vulnId);
+        const index = Number(el.dataset.index);
         emitEvent(E.COMMAND_ISSUED, { cmd: `buy ${index}` });
-        const success = onBuy(card, price);
-        if (success) {
-          emitEvent(E.LOG_ENTRY, { text: `Purchased: ${card.name}  [${card.rarity}]  targets:${vulnId}  cost:¥${price}`, type: "success" });
-          // STATE_CHANGED fires from buyExploit() → re-renders hand + wallet HUD.
-          // Re-render the modal in-place with the updated cash.
-          renderModal(currentCash - price);
+        const result = buyFromStore(index);
+        if (result) {
+          emitEvent(E.LOG_ENTRY, { text: `Purchased: ${result.card.name}  [${result.card.rarity}]  targets:${result.vulnId}  cost:¥${result.price}`, type: "success" });
+          renderModal(currentCash - result.price);
         }
       });
     });

--- a/scripts/bot-census.js
+++ b/scripts/bot-census.js
@@ -20,6 +20,7 @@ function parseArgs(argv) {
   let mc = null;
   let seeds = 100;
   let seedPrefix = "bot";
+  let evasion = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--time" && args[i + 1]) {
@@ -31,15 +32,17 @@ function parseArgs(argv) {
       if (isNaN(seeds) || seeds < 1) seeds = 100;
     } else if (args[i] === "--seed-prefix" && args[i + 1]) {
       seedPrefix = args[++i];
+    } else if (args[i] === "--evasion") {
+      evasion = true;
     }
   }
 
   if (!tc || !mc) {
-    console.error("Usage: node scripts/bot-census.js --time <grade> --money <grade> [--seeds N] [--seed-prefix str]");
+    console.error("Usage: node scripts/bot-census.js --time <grade> --money <grade> [--seeds N] [--evasion]");
     process.exit(1);
   }
 
-  return { tc, mc, seeds, seedPrefix };
+  return { tc, mc, seeds, seedPrefix, evasion };
 }
 
 // ── Stats aggregation ────────────────────────────────────────────────────────
@@ -73,7 +76,7 @@ function pct(n, total) {
  * @param {number} seedCount
  * @param {string} seedPrefix
  */
-function printReport(results, tc, mc, seedCount, seedPrefix) {
+function printReport(results, tc, mc, seedCount, seedPrefix, evasionMode = false) {
   const total = results.length;
   const succeeded = results.filter(r => r.missionSuccess);
   const failed = results.filter(r => !r.missionSuccess);
@@ -117,7 +120,7 @@ function printReport(results, tc, mc, seedCount, seedPrefix) {
   const iceStats = stats(results.map(r => r.iceDetections));
 
   // Print
-  console.log(`=== BOT SIMULATION: ${tc}/${mc} ===`);
+  console.log(`=== BOT SIMULATION: ${tc}/${mc}${evasionMode ? " [EVASION]" : ""} ===`);
   console.log(`Seeds: ${seedPrefix}-0 through ${seedPrefix}-${seedCount - 1} (${seedCount} runs)`);
   console.log();
 
@@ -175,7 +178,7 @@ function printReport(results, tc, mc, seedCount, seedPrefix) {
 
 // ── Main ─────────────────────────────────────────────────────────────────────
 
-const { tc, mc, seeds, seedPrefix } = parseArgs(process.argv);
+const { tc, mc, seeds, seedPrefix, evasion } = parseArgs(process.argv);
 
 /** @type {import('./bot-player.js').BotRunStats[]} */
 const results = [];
@@ -183,8 +186,8 @@ const results = [];
 for (let i = 0; i < seeds; i++) {
   const seed = `${seedPrefix}-${i}`;
   const network = generateNetwork(seed, tc, mc);
-  const stats = runBot(network, seed);
+  const stats = runBot(network, seed, { evasion });
   results.push(stats);
 }
 
-printReport(results, tc, mc, seeds, seedPrefix);
+printReport(results, tc, mc, seeds, seedPrefix, evasion);

--- a/scripts/bot-census.js
+++ b/scripts/bot-census.js
@@ -158,6 +158,19 @@ function printReport(results, tc, mc, seedCount, seedPrefix) {
   console.log(`Peak alert:   GREEN=${alertCounts.green}  YELLOW=${alertCounts.yellow}  RED=${alertCounts.red}`);
   console.log(`Trace fired:  ${traceFired}/${total}`);
   console.log(`ICE detects:  avg ${fmt(iceStats.avg)}  max ${iceStats.max}`);
+  console.log();
+
+  // Timeline: when key events happen (ticks). -1 means "never happened"
+  const withDetection = results.filter(r => r.tickFirstDetection >= 0);
+  const withTrace     = results.filter(r => r.tickTraceStarted >= 0);
+  const withOwned     = results.filter(r => r.tickFirstNodeOwned >= 0);
+  const withMission   = results.filter(r => r.tickMissionComplete >= 0);
+
+  console.log(`--- TIMELINE (avg tick when event first occurs) ---`);
+  console.log(`First node owned:    ${withOwned.length > 0 ? fmt(stats(withOwned.map(r => r.tickFirstNodeOwned)).avg, 0) : "—"} (${withOwned.length}/${total} runs)`);
+  console.log(`First ICE detection: ${withDetection.length > 0 ? fmt(stats(withDetection.map(r => r.tickFirstDetection)).avg, 0) : "—"} (${withDetection.length}/${total} runs)`);
+  console.log(`Trace started:       ${withTrace.length > 0 ? fmt(stats(withTrace.map(r => r.tickTraceStarted)).avg, 0) : "—"} (${withTrace.length}/${total} runs)`);
+  console.log(`Mission complete:    ${withMission.length > 0 ? fmt(stats(withMission.map(r => r.tickMissionComplete)).avg, 0) : "—"} (${withMission.length}/${total} runs)`);
 }
 
 // ── Main ─────────────────────────────────────────────────────────────────────

--- a/scripts/bot-census.js
+++ b/scripts/bot-census.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// @ts-check
+// Bot census — Monte Carlo simulation across difficulty combinations.
+// Runs an automated greedy bot many times per difficulty and prints
+// an LLM-readable report of completion rates and resource distributions.
+//
+// Usage:
+//   node scripts/bot-census.js --time B --money B              # 100 runs at B/B
+//   node scripts/bot-census.js --time B --money B --seeds 50   # 50 runs
+//   node scripts/bot-census.js --time F --money F              # easy baseline
+
+import { generateNetwork } from "../js/network-gen.js";
+import { runBot } from "./bot-player.js";
+
+// ── Argument parsing ─────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  let tc = null;
+  let mc = null;
+  let seeds = 100;
+  let seedPrefix = "bot";
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--time" && args[i + 1]) {
+      tc = args[++i].toUpperCase();
+    } else if (args[i] === "--money" && args[i + 1]) {
+      mc = args[++i].toUpperCase();
+    } else if (args[i] === "--seeds" && args[i + 1]) {
+      seeds = parseInt(args[++i], 10);
+      if (isNaN(seeds) || seeds < 1) seeds = 100;
+    } else if (args[i] === "--seed-prefix" && args[i + 1]) {
+      seedPrefix = args[++i];
+    }
+  }
+
+  if (!tc || !mc) {
+    console.error("Usage: node scripts/bot-census.js --time <grade> --money <grade> [--seeds N] [--seed-prefix str]");
+    process.exit(1);
+  }
+
+  return { tc, mc, seeds, seedPrefix };
+}
+
+// ── Stats aggregation ────────────────────────────────────────────────────────
+
+/**
+ * @param {number[]} arr
+ * @returns {{ min: number, max: number, avg: number }}
+ */
+function stats(arr) {
+  if (arr.length === 0) return { min: 0, max: 0, avg: 0 };
+  const min = Math.min(...arr);
+  const max = Math.max(...arr);
+  const avg = arr.reduce((s, v) => s + v, 0) / arr.length;
+  return { min, max, avg };
+}
+
+function fmt(n, decimals = 1) {
+  return n.toFixed(decimals);
+}
+
+function pct(n, total) {
+  return total > 0 ? Math.round((n / total) * 100) : 0;
+}
+
+// ── Report formatting ────────────────────────────────────────────────────────
+
+/**
+ * @param {import('./bot-player.js').BotRunStats[]} results
+ * @param {string} tc
+ * @param {string} mc
+ * @param {number} seedCount
+ * @param {string} seedPrefix
+ */
+function printReport(results, tc, mc, seedCount, seedPrefix) {
+  const total = results.length;
+  const succeeded = results.filter(r => r.missionSuccess);
+  const failed = results.filter(r => !r.missionSuccess);
+
+  // Failure reasons
+  const failReasons = {};
+  for (const r of failed) {
+    const reason = r.failReason ?? "unknown";
+    failReasons[reason] = (failReasons[reason] ?? 0) + 1;
+  }
+  const failStr = Object.entries(failReasons)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("  ") || "none";
+
+  // Full clear
+  const fullClears = results.filter(r => r.fullClear).length;
+  const nodeStats = stats(results.map(r => r.nodesOwned));
+  const nodeTotals = stats(results.map(r => r.nodesTotal));
+
+  // Resource stats (succeeded runs)
+  const sUses   = stats(succeeded.map(r => r.cardUsesConsumed));
+  const sBurned = stats(succeeded.map(r => r.cardsBurned));
+  const sStore  = stats(succeeded.map(r => r.storeVisits));
+  const sCash   = stats(succeeded.map(r => r.cashSpent));
+  const sLeft   = stats(succeeded.map(r => r.cashRemaining));
+
+  // Resource stats (all runs)
+  const aUses   = stats(results.map(r => r.cardUsesConsumed));
+  const aBurned = stats(results.map(r => r.cardsBurned));
+  const aStore  = stats(results.map(r => r.storeVisits));
+  const aCash   = stats(results.map(r => r.cashSpent));
+
+  // Ticks
+  const succTicks = stats(succeeded.map(r => r.totalTicks));
+  const failTicks = stats(failed.map(r => r.totalTicks));
+
+  // Pressure
+  const alertCounts = { green: 0, yellow: 0, red: 0 };
+  for (const r of results) alertCounts[r.peakAlert] = (alertCounts[r.peakAlert] ?? 0) + 1;
+  const traceFired = results.filter(r => r.traceFired).length;
+  const iceStats = stats(results.map(r => r.iceDetections));
+
+  // Print
+  console.log(`=== BOT SIMULATION: ${tc}/${mc} ===`);
+  console.log(`Seeds: ${seedPrefix}-0 through ${seedPrefix}-${seedCount - 1} (${seedCount} runs)`);
+  console.log();
+
+  console.log(`--- MISSION COMPLETION ---`);
+  console.log(`Success rate:     ${succeeded.length}/${total} (${pct(succeeded.length, total)}%)`);
+  if (succeeded.length > 0) {
+    console.log(`Avg ticks:        ${fmt(succTicks.avg, 0)} (succeeded) / ${failed.length > 0 ? fmt(failTicks.avg, 0) : "—"} (failed)`);
+  } else {
+    console.log(`Avg ticks:        — (succeeded) / ${failed.length > 0 ? fmt(failTicks.avg, 0) : "—"} (failed)`);
+  }
+  console.log(`Failure reasons:  ${failStr}`);
+  console.log();
+
+  console.log(`--- FULL EXPLORATION ---`);
+  console.log(`Full clear rate:  ${fullClears}/${total} (${pct(fullClears, total)}%)`);
+  console.log(`Avg nodes owned:  ${fmt(nodeStats.avg)} / ${fmt(nodeTotals.avg)} total (${pct(nodeStats.avg, nodeTotals.avg)}%)`);
+  console.log();
+
+  if (succeeded.length > 0) {
+    console.log(`--- RESOURCE USAGE (${succeeded.length} succeeded runs) ---`);
+    console.log(`              Min    Avg    Max`);
+    console.log(`Card uses:    ${fmt(sUses.min).padStart(4)}   ${fmt(sUses.avg).padStart(5)}   ${fmt(sUses.max).padStart(4)}`);
+    console.log(`Cards burned: ${fmt(sBurned.min).padStart(4)}   ${fmt(sBurned.avg).padStart(5)}   ${fmt(sBurned.max).padStart(4)}`);
+    console.log(`Store visits: ${fmt(sStore.min).padStart(4)}   ${fmt(sStore.avg).padStart(5)}   ${fmt(sStore.max).padStart(4)}`);
+    console.log(`Cash spent:   ${fmt(sCash.min, 0).padStart(4)}   ${fmt(sCash.avg, 0).padStart(5)}   ${fmt(sCash.max, 0).padStart(4)}`);
+    console.log(`Cash left:    ${fmt(sLeft.min, 0).padStart(4)}   ${fmt(sLeft.avg, 0).padStart(5)}   ${fmt(sLeft.max, 0).padStart(4)}`);
+  } else {
+    console.log(`--- RESOURCE USAGE (all runs — no successes) ---`);
+    console.log(`              Min    Avg    Max`);
+    console.log(`Card uses:    ${fmt(aUses.min).padStart(4)}   ${fmt(aUses.avg).padStart(5)}   ${fmt(aUses.max).padStart(4)}`);
+    console.log(`Cards burned: ${fmt(aBurned.min).padStart(4)}   ${fmt(aBurned.avg).padStart(5)}   ${fmt(aBurned.max).padStart(4)}`);
+    console.log(`Store visits: ${fmt(aStore.min).padStart(4)}   ${fmt(aStore.avg).padStart(5)}   ${fmt(aStore.max).padStart(4)}`);
+    console.log(`Cash spent:   ${fmt(aCash.min, 0).padStart(4)}   ${fmt(aCash.avg, 0).padStart(5)}   ${fmt(aCash.max, 0).padStart(4)}`);
+  }
+  console.log();
+
+  console.log(`--- PRESSURE ---`);
+  console.log(`Peak alert:   GREEN=${alertCounts.green}  YELLOW=${alertCounts.yellow}  RED=${alertCounts.red}`);
+  console.log(`Trace fired:  ${traceFired}/${total}`);
+  console.log(`ICE detects:  avg ${fmt(iceStats.avg)}  max ${iceStats.max}`);
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+const { tc, mc, seeds, seedPrefix } = parseArgs(process.argv);
+
+/** @type {import('./bot-player.js').BotRunStats[]} */
+const results = [];
+
+for (let i = 0; i < seeds; i++) {
+  const seed = `${seedPrefix}-${i}`;
+  const network = generateNetwork(seed, tc, mc);
+  const stats = runBot(network, seed);
+  results.push(stats);
+}
+
+printReport(results, tc, mc, seeds, seedPrefix);

--- a/scripts/bot-player.js
+++ b/scripts/bot-player.js
@@ -11,7 +11,7 @@ import { handleExploitExecTimer, handleExploitNoiseTimer } from "../js/exploit-e
 import { handleProbeScanTimer } from "../js/probe-exec.js";
 import { handleReadScanTimer } from "../js/read-exec.js";
 import { handleLootExtractTimer } from "../js/loot-exec.js";
-import { on, off, emitEvent, E, clearHandlers } from "../js/events.js";
+import { on, off, emitEvent, E } from "../js/events.js";
 import { tick, TIMER } from "../js/timers.js";
 import { initLog } from "../js/log.js";
 import { initNodeLifecycle } from "../js/node-lifecycle.js";
@@ -64,29 +64,30 @@ export function runBot(network, seed, options = {}) {
   const { tickIncrement = DEFAULT_TICK_INCREMENT, maxTicks = DEFAULT_MAX_TICKS, evasion = false } = options;
 
   // ── Setup ────────────────────────────────────────────────
-  clearHandlers();
+  // One-time init: timer wiring + action dispatcher. These persist across runs
+  // because we don't call clearHandlers() (module-level handlers must survive).
+  if (!runBot._initialized) {
+    initNodeLifecycle();
+    on(TIMER.ICE_MOVE,        ()        => handleIceTick());
+    on(TIMER.ICE_DETECT,      (payload) => handleIceDetect(payload));
+    on(TIMER.TRACE_TICK,      ()        => handleTraceTick());
+    on(TIMER.REBOOT_COMPLETE, (payload) => completeReboot(payload.nodeId));
+    on(TIMER.EXPLOIT_EXEC,    (payload) => handleExploitExecTimer(payload));
+    on(TIMER.EXPLOIT_NOISE,   (payload) => handleExploitNoiseTimer(payload));
+    on(TIMER.PROBE_SCAN,      (payload) => handleProbeScanTimer(payload));
+    on(TIMER.READ_SCAN,       (payload) => handleReadScanTimer(payload));
+    on(TIMER.LOOT_EXTRACT,    (payload) => handleLootExtractTimer(payload));
+    const ctx = {
+      ...buildActionContext(),
+      openDarknetsStore: () => {},
+    };
+    initActionDispatcher(ctx);
+    runBot._initialized = true;
+  }
+
   initLog();
-  initNodeLifecycle();
   initState(network, seed);
   startIce();
-
-  // Timer wiring (same as playtest.js)
-  on(TIMER.ICE_MOVE,        ()        => handleIceTick());
-  on(TIMER.ICE_DETECT,      (payload) => handleIceDetect(payload));
-  on(TIMER.TRACE_TICK,      ()        => handleTraceTick());
-  on(TIMER.REBOOT_COMPLETE, (payload) => completeReboot(payload.nodeId));
-  on(TIMER.EXPLOIT_EXEC,    (payload) => handleExploitExecTimer(payload));
-  on(TIMER.EXPLOIT_NOISE,   (payload) => handleExploitNoiseTimer(payload));
-  on(TIMER.PROBE_SCAN,      (payload) => handleProbeScanTimer(payload));
-  on(TIMER.READ_SCAN,       (payload) => handleReadScanTimer(payload));
-  on(TIMER.LOOT_EXTRACT,    (payload) => handleLootExtractTimer(payload));
-
-  // Action dispatcher
-  const ctx = {
-    ...buildActionContext(),
-    openDarknetsStore: () => {},  // bot uses buyFromStore directly
-  };
-  initActionDispatcher(ctx);
 
   // ── Stat tracking via events ─────────────────────────────
   let traceFired = false;
@@ -248,9 +249,35 @@ export function runBot(network, seed, options = {}) {
   let avoidNodeId = null;
 
   /**
+   * Check if there's an IDS node that should be reconfigured.
+   * Returns the IDS node ID if one is reachable and not yet disabled, null otherwise.
+   * @returns {string | null}
+   */
+  function findReconfigurableIDS() {
+    if (!evasion) return null;
+    const state = getState();
+    // Look for IDS nodes that are visible, reachable, and not yet reconfigured
+    for (const [id, node] of Object.entries(state.nodes)) {
+      if (node.type !== "ids") continue;
+      if (node.visibility === "hidden") continue;
+      if (node.eventForwardingDisabled) continue;
+      // IDS needs to be compromised or owned to reconfigure. If not yet, we need to
+      // own it first. Either way, it's a target.
+      if (node.accessLevel === "owned" && !node.eventForwardingDisabled) {
+        // Can reconfigure immediately — but that's handled in the main loop
+        return id;
+      }
+      if (node.accessLevel !== "owned") {
+        // Need to own it first
+        return id;
+      }
+    }
+    return null;
+  }
+
+  /**
    * Find the next node to target.
-   * Priority: adjacent lootable > nearest unowned > null (stuck)
-   * Only considers visible, non-security nodes.
+   * Priority: IDS to reconfigure (evasion) > lootable > nearest unowned > null
    * @returns {{ id: string } | null}
    */
   function pickNextNode() {
@@ -264,6 +291,10 @@ export function runBot(network, seed, options = {}) {
         !SECURITY_TYPES.has(currentNode.type)) {
       return { id: currentId };
     }
+
+    // Evasion: prioritize IDS reconfiguration
+    const idsTarget = findReconfigurableIDS();
+    if (idsTarget) return { id: idsTarget };
 
     // BFS from currentId through owned nodes to find nearest unowned visible node
     /** @type {Map<string, string|null>} */
@@ -305,8 +336,6 @@ export function runBot(network, seed, options = {}) {
     // Prefer nodes that aren't the one we just fled from
     let targetId = bestLootable ?? bestAny;
     if (evasion && targetId === avoidNodeId) {
-      // Try to find an alternative — re-BFS skipping the avoided node
-      // But only if there IS an alternative; otherwise use the avoided node anyway
       const alt = bestLootable && bestLootable !== avoidNodeId ? bestLootable
         : bestAny && bestAny !== avoidNodeId ? bestAny : null;
       if (alt) targetId = alt;
@@ -480,6 +509,16 @@ export function runBot(network, seed, options = {}) {
     // Successfully worked on this node — clear avoidance
     if (getState().nodes[target.id]?.accessLevel === "owned") avoidNodeId = null;
 
+    // Reconfigure IDS nodes when owned (evasion strategy)
+    const workedNode = getState().nodes[target.id];
+    if (evasion && workedNode?.type === "ids" &&
+        (workedNode.accessLevel === "compromised" || workedNode.accessLevel === "owned") &&
+        !workedNode.eventForwardingDisabled) {
+      dispatchAction("select", { nodeId: target.id });
+      dispatchAction("reconfigure", { nodeId: target.id });
+      if (evasion) dispatchAction("deselect");
+    }
+
     // Check if mission is complete
     const ms = getState().mission;
     if (ms?.complete) missionDone = true;
@@ -515,6 +554,15 @@ export function runBot(network, seed, options = {}) {
   const fullClear = clearableOwned === clearableTotal;
 
   const cashSpent = startingCash - endState.player.cash;
+
+  // Clean up per-run stat handlers so they don't stack on subsequent runs
+  off(E.ALERT_GLOBAL_RAISED, onAlertRaised);
+  off(E.ALERT_TRACE_STARTED, onTraceStarted);
+  off(E.ICE_DETECTED, onIceDetected);
+  off(E.EXPLOIT_STARTED, onExploitStarted);
+  off(E.EXPLOIT_DISCLOSED, onExploitDisclosed);
+  off(E.NODE_ACCESSED, onNodeAccessed);
+  off(E.MISSION_COMPLETE, onMissionComplete);
 
   return {
     missionSuccess: missionDone,

--- a/scripts/bot-player.js
+++ b/scripts/bot-player.js
@@ -453,15 +453,29 @@ export function runBot(network, seed, options = {}) {
       if (!freshNode || freshNode.accessLevel === "owned") break;
       if (traceFired) { failReason = "trace"; dispatchAction("jackout"); break outer; }
 
-      const card = pickBestCard(freshNode);
+      let card = pickBestCard(freshNode);
       if (!card) {
-        // Try darknet store
+        // No usable cards — try darknet store
         if (!tryBuyCard(freshNode)) {
-          // Can't buy either — try next node, or fail
           failReason = "no-cards";
           break;
         }
-        continue;  // retry with new card
+        card = pickBestCard(freshNode);
+        if (!card) { failReason = "no-cards"; break; }
+      }
+
+      // Proactive store: if our best card doesn't match any known vuln and
+      // the node has been probed, buy a matching card for better success rate
+      if (evasion && freshNode.probed && getState().player.cash >= 100) {
+        const knownVulns = new Set(
+          (freshNode.vulnerabilities ?? []).filter(v => !v.patched && !v.hidden).map(v => v.id)
+        );
+        const hasMatch = card.targetVulnTypes?.some(t => knownVulns.has(t));
+        if (!hasMatch && knownVulns.size > 0) {
+          if (tryBuyCard(freshNode)) {
+            card = pickBestCard(freshNode) ?? card;
+          }
+        }
       }
 
       dispatchAction("select", { nodeId: target.id }); // re-select for exploit (may have deselected)

--- a/scripts/bot-player.js
+++ b/scripts/bot-player.js
@@ -1,0 +1,406 @@
+// @ts-check
+// Bot player — automated greedy strategy for balance testing.
+// Plays a single game from init to jackout and returns stats.
+// No DOM dependencies. Uses the same action context as playtest.js.
+
+import { initState, getState, getVersion } from "../js/state.js";
+import { startIce, handleIceTick, handleIceDetect } from "../js/ice.js";
+import { handleTraceTick } from "../js/alert.js";
+import { completeReboot } from "../js/node-orchestration.js";
+import { handleExploitExecTimer, handleExploitNoiseTimer } from "../js/exploit-exec.js";
+import { handleProbeScanTimer } from "../js/probe-exec.js";
+import { handleReadScanTimer } from "../js/read-exec.js";
+import { handleLootExtractTimer } from "../js/loot-exec.js";
+import { on, off, emitEvent, E, clearHandlers } from "../js/events.js";
+import { tick, TIMER } from "../js/timers.js";
+import { initLog } from "../js/log.js";
+import { initNodeLifecycle } from "../js/node-lifecycle.js";
+import { buildActionContext, initActionDispatcher } from "../js/action-context.js";
+import { buyFromStore } from "../js/store-logic.js";
+
+/** Default tick increment for tick-until-event loops. */
+const DEFAULT_TICK_INCREMENT = 1;
+
+/** Default maximum ticks before forcing a run to end. */
+const DEFAULT_MAX_TICKS = 5000;
+
+/** Node types that are lootable targets. */
+const LOOTABLE_TYPES = new Set(["fileserver", "cryptovault"]);
+
+/** Node types to skip in exploration (security infrastructure). */
+const SECURITY_TYPES = new Set(["ids", "security-monitor"]);
+
+/**
+ * @typedef {{
+ *   missionSuccess: boolean,
+ *   fullClear: boolean,
+ *   failReason: null | "trace" | "no-cards" | "stuck" | "tick-cap",
+ *   cardUsesConsumed: number,
+ *   cardsBurned: number,
+ *   storeVisits: number,
+ *   cashSpent: number,
+ *   cashRemaining: number,
+ *   totalTicks: number,
+ *   peakAlert: string,
+ *   traceFired: boolean,
+ *   iceDetections: number,
+ *   nodesOwned: number,
+ *   nodesTotal: number,
+ * }} BotRunStats
+ */
+
+/**
+ * Run one automated game from init to completion.
+ * @param {object} network — return value of generateNetwork()
+ * @param {string} seed
+ * @param {{ tickIncrement?: number, maxTicks?: number }} [options]
+ * @returns {BotRunStats}
+ */
+export function runBot(network, seed, options = {}) {
+  const { tickIncrement = DEFAULT_TICK_INCREMENT, maxTicks = DEFAULT_MAX_TICKS } = options;
+
+  // ── Setup ────────────────────────────────────────────────
+  clearHandlers();
+  initLog();
+  initNodeLifecycle();
+  initState(network, seed);
+  startIce();
+
+  // Timer wiring (same as playtest.js)
+  on(TIMER.ICE_MOVE,        ()        => handleIceTick());
+  on(TIMER.ICE_DETECT,      (payload) => handleIceDetect(payload));
+  on(TIMER.TRACE_TICK,      ()        => handleTraceTick());
+  on(TIMER.REBOOT_COMPLETE, (payload) => completeReboot(payload.nodeId));
+  on(TIMER.EXPLOIT_EXEC,    (payload) => handleExploitExecTimer(payload));
+  on(TIMER.EXPLOIT_NOISE,   (payload) => handleExploitNoiseTimer(payload));
+  on(TIMER.PROBE_SCAN,      (payload) => handleProbeScanTimer(payload));
+  on(TIMER.READ_SCAN,       (payload) => handleReadScanTimer(payload));
+  on(TIMER.LOOT_EXTRACT,    (payload) => handleLootExtractTimer(payload));
+
+  // Action dispatcher
+  const ctx = {
+    ...buildActionContext(),
+    openDarknetsStore: () => {},  // bot uses buyFromStore directly
+  };
+  initActionDispatcher(ctx);
+
+  // ── Stat tracking via events ─────────────────────────────
+  let traceFired = false;
+  let peakAlert = "green";
+  let iceDetections = 0;
+  let cardUsesConsumed = 0;
+  let cardsBurned = 0;
+  let startingCash = getState().player.cash;
+  let storeVisitCount = 0;
+
+  const alertOrder = ["green", "yellow", "red"];
+
+  function onAlertRaised({ next }) {
+    if (alertOrder.indexOf(next) > alertOrder.indexOf(peakAlert)) peakAlert = next;
+  }
+  function onTraceStarted() { traceFired = true; }
+  function onIceDetected() { iceDetections++; }
+  function onExploitStarted() { cardUsesConsumed++; }
+  function onExploitDisclosed() { cardsBurned++; }
+
+  on(E.ALERT_GLOBAL_RAISED, onAlertRaised);
+  on(E.ALERT_TRACE_STARTED, onTraceStarted);
+  on(E.ICE_DETECTED, onIceDetected);
+  on(E.EXPLOIT_STARTED, onExploitStarted);
+  on(E.EXPLOIT_DISCLOSED, onExploitDisclosed);
+
+  // ── Tick-until-event helper ──────────────────────────────
+  let totalTicks = 0;
+  /** @type {Set<string>} */
+  let firedEvents = new Set();
+
+  function onEventFired(type) {
+    return (/** @type {any} */ _payload) => { firedEvents.add(type); };
+  }
+
+  /**
+   * Tick until one of the given event types fires, or budget exceeded.
+   * @param {string | string[]} eventTypes
+   * @param {number} budget — max ticks to spend
+   * @returns {number} ticks consumed
+   */
+  function tickUntilEvent(eventTypes, budget) {
+    const types = Array.isArray(eventTypes) ? eventTypes : [eventTypes];
+    firedEvents = new Set();
+    const handlers = types.map(t => {
+      const h = onEventFired(t);
+      on(t, h);
+      return { type: t, handler: h };
+    });
+
+    let spent = 0;
+    while (spent < budget && !types.some(t => firedEvents.has(t))) {
+      tick(tickIncrement);
+      spent += tickIncrement;
+      totalTicks += tickIncrement;
+      // Check if trace fired during ticking
+      if (traceFired) break;
+      if (getState().phase !== "playing") break;
+    }
+
+    for (const { type, handler } of handlers) off(type, handler);
+    return spent;
+  }
+
+  // ── Action dispatch helpers ──────────────────────────────
+
+  function dispatchAction(actionId, payload = {}) {
+    emitEvent("starnet:action", { actionId, fromConsole: false, ...payload });
+  }
+
+  // ── Bot strategy ─────────────────────────────────────────
+  let missionDone = false;
+  /** @type {null | string} */
+  let failReason = null;
+
+  /**
+   * Find the next node to target.
+   * Priority: adjacent lootable > nearest unowned > null (stuck)
+   * Only considers visible, non-security nodes.
+   * @returns {{ id: string } | null}
+   */
+  function pickNextNode() {
+    const state = getState();
+    const currentId = state.selectedNodeId || network.startNode;
+
+    // First check: is the current node (gateway at start) itself unowned?
+    const currentNode = state.nodes[currentId];
+    if (currentNode && currentNode.accessLevel !== "owned" &&
+        currentNode.visibility !== "hidden" && currentNode.type !== "wan" &&
+        !SECURITY_TYPES.has(currentNode.type)) {
+      return { id: currentId };
+    }
+
+    // BFS from currentId through owned nodes to find nearest unowned visible node
+    /** @type {Map<string, string|null>} */
+    const parent = new Map();
+    parent.set(currentId, null);
+    const queue = [currentId];
+    /** @type {string | null} */
+    let bestLootable = null;
+    /** @type {string | null} */
+    let bestAny = null;
+
+    while (queue.length > 0) {
+      const cur = /** @type {string} */ (queue.shift());
+
+      for (const neighbor of (state.adjacency[cur] ?? [])) {
+        if (parent.has(neighbor)) continue;
+        const nNode = state.nodes[neighbor];
+        if (!nNode || nNode.visibility === "hidden") continue;
+        parent.set(neighbor, cur);
+
+        // Is this neighbor a valid target?
+        if (nNode.accessLevel !== "owned" && !SECURITY_TYPES.has(nNode.type) &&
+            nNode.type !== "wan") {
+          if (!bestLootable && LOOTABLE_TYPES.has(nNode.type)) bestLootable = neighbor;
+          if (!bestAny) bestAny = neighbor;
+          if (bestLootable) break;
+          // Don't expand through unowned nodes — bot can't see their neighbors
+          continue;
+        }
+
+        // Expand through owned nodes
+        if (nNode.accessLevel === "owned") {
+          queue.push(neighbor);
+        }
+      }
+      if (bestLootable) break;
+    }
+
+    const targetId = bestLootable ?? bestAny;
+    return targetId ? { id: targetId } : null;
+  }
+
+  /**
+   * Pick the best exploit card for a node.
+   * Prefers matching vuln, then highest quality, then most uses.
+   * @param {object} node — state node
+   * @returns {{ id: string, name: string } | null}
+   */
+  function pickBestCard(node) {
+    const state = getState();
+    const hand = state.player.hand;
+    const usable = hand.filter(c => c.usesRemaining > 0 && c.status !== "disclosed");
+    if (usable.length === 0) return null;
+
+    // Known vulns on this node (non-patched, non-hidden)
+    const knownVulns = new Set(
+      (node.vulnerabilities ?? [])
+        .filter(v => !v.patched && !v.hidden)
+        .map(v => v.id)
+    );
+
+    // Partition into matching and non-matching
+    const matching = usable.filter(c =>
+      c.targetVulnTypes?.some(t => knownVulns.has(t))
+    );
+    const pool = matching.length > 0 ? matching : usable;
+
+    // Sort: highest quality first, then most uses
+    pool.sort((a, b) => (b.quality - a.quality) || (b.usesRemaining - a.usesRemaining));
+    return pool[0];
+  }
+
+  /**
+   * Try to buy a card from the darknet store matching a vuln on the given node.
+   * @param {object} node
+   * @returns {boolean}
+   */
+  function tryBuyCard(node) {
+    const knownVulns = (node.vulnerabilities ?? [])
+      .filter(v => !v.patched && !v.hidden)
+      .map(v => v.id);
+
+    for (const vulnId of knownVulns) {
+      const result = buyFromStore(vulnId);
+      if (result) { storeVisitCount++; return true; }
+    }
+    return false;
+  }
+
+  // ── Main loop ────────────────────────────────────────────
+
+  // Select starting node (gateway)
+  dispatchAction("select", { nodeId: network.startNode });
+
+  outer:
+  while (totalTicks < maxTicks && getState().phase === "playing") {
+    if (traceFired) {
+      failReason = "trace";
+      dispatchAction("jackout");
+      break;
+    }
+
+    const target = pickNextNode();
+    if (!target) {
+      // Nothing left to do
+      if (!missionDone) failReason = "stuck";
+      break;
+    }
+
+    const state = getState();
+    const targetNode = state.nodes[target.id];
+    if (!targetNode) break;
+
+    // Navigate to target
+    dispatchAction("select", { nodeId: target.id });
+
+    // Probe if needed
+    if (!targetNode.probed) {
+      dispatchAction("probe", { nodeId: target.id });
+      tickUntilEvent(E.NODE_PROBED, maxTicks - totalTicks);
+      if (traceFired || getState().phase !== "playing") {
+        if (traceFired) { failReason = "trace"; dispatchAction("jackout"); }
+        break;
+      }
+    }
+
+    // Exploit until owned
+    while (totalTicks < maxTicks && getState().phase === "playing") {
+      const freshNode = getState().nodes[target.id];
+      if (!freshNode || freshNode.accessLevel === "owned") break;
+      if (traceFired) { failReason = "trace"; dispatchAction("jackout"); break outer; }
+
+      const card = pickBestCard(freshNode);
+      if (!card) {
+        // Try darknet store
+        if (!tryBuyCard(freshNode)) {
+          // Can't buy either — try next node, or fail
+          failReason = "no-cards";
+          break;
+        }
+        continue;  // retry with new card
+      }
+
+      dispatchAction("exploit", { nodeId: target.id, exploitId: card.id });
+      tickUntilEvent([E.EXPLOIT_SUCCESS, E.EXPLOIT_FAILURE], maxTicks - totalTicks);
+      if (traceFired) { failReason = "trace"; dispatchAction("jackout"); break outer; }
+      if (getState().phase !== "playing") break outer;
+    }
+
+    // If we broke out of exploit loop due to no-cards, try next node
+    if (failReason === "no-cards") {
+      // Check if there are other approachable nodes
+      failReason = null;  // reset — will be set again if truly stuck
+      continue;
+    }
+
+    // Read + loot any owned node (macguffins can be on any type, including workstations)
+    const ownedNode = getState().nodes[target.id];
+    if (ownedNode?.accessLevel === "owned" && !ownedNode.read) {
+      dispatchAction("select", { nodeId: target.id }); // ensure selected for read
+      dispatchAction("read", { nodeId: target.id });
+      tickUntilEvent(E.NODE_READ, maxTicks - totalTicks);
+      if (traceFired) { failReason = "trace"; dispatchAction("jackout"); break; }
+      if (getState().phase !== "playing") break;
+    }
+
+    const readNode = getState().nodes[target.id];
+    const hasLoot = readNode?.macguffins?.some(m => !m.collected);
+    if (readNode?.accessLevel === "owned" && readNode.read && hasLoot && !readNode.looted) {
+      dispatchAction("select", { nodeId: target.id }); // ensure selected for loot
+      dispatchAction("loot", { nodeId: target.id });
+      tickUntilEvent(E.NODE_LOOTED, maxTicks - totalTicks);
+      if (traceFired) { failReason = "trace"; dispatchAction("jackout"); break; }
+      if (getState().phase !== "playing") break;
+    }
+
+    // Check if mission is complete
+    const ms = getState().mission;
+    if (ms?.complete) missionDone = true;
+  }
+
+  // Ensure run ends
+  const finalState = getState();
+  if (finalState.phase === "playing") {
+    if (totalTicks >= maxTicks && !failReason) failReason = "tick-cap";
+    dispatchAction("jackout");
+  }
+
+  // ── Collect stats ────────────────────────────────────────
+  const endState = getState();
+
+  // Count owned nodes (excluding wan which is pre-accessible)
+  let nodesOwned = 0;
+  let nodesTotal = 0;
+  for (const [, node] of Object.entries(endState.nodes)) {
+    if (node.type === "wan") continue;
+    nodesTotal++;
+    if (node.accessLevel === "owned") nodesOwned++;
+  }
+
+  // Full clear = all non-security, non-wan nodes owned
+  let clearableTotal = 0;
+  let clearableOwned = 0;
+  for (const [, node] of Object.entries(endState.nodes)) {
+    if (node.type === "wan" || SECURITY_TYPES.has(node.type)) continue;
+    clearableTotal++;
+    if (node.accessLevel === "owned") clearableOwned++;
+  }
+  const fullClear = clearableOwned === clearableTotal;
+
+  const cashSpent = startingCash - endState.player.cash;
+
+  return {
+    missionSuccess: missionDone,
+    fullClear,
+    failReason: missionDone ? failReason : (failReason ?? "no-cards"),
+    cardUsesConsumed,
+    cardsBurned,
+    storeVisits: storeVisitCount,
+    cashSpent: Math.max(0, cashSpent),
+    cashRemaining: endState.player.cash,
+    totalTicks,
+    peakAlert,
+    traceFired,
+    iceDetections,
+    nodesOwned,
+    nodesTotal,
+  };
+}

--- a/scripts/bot-player.js
+++ b/scripts/bot-player.js
@@ -244,6 +244,8 @@ export function runBot(network, seed, options = {}) {
   let missionDone = false;
   /** @type {null | string} */
   let failReason = null;
+  /** @type {string | null} Node to avoid after ICE encounter */
+  let avoidNodeId = null;
 
   /**
    * Find the next node to target.
@@ -300,7 +302,15 @@ export function runBot(network, seed, options = {}) {
       if (bestLootable) break;
     }
 
-    const targetId = bestLootable ?? bestAny;
+    // Prefer nodes that aren't the one we just fled from
+    let targetId = bestLootable ?? bestAny;
+    if (evasion && targetId === avoidNodeId) {
+      // Try to find an alternative — re-BFS skipping the avoided node
+      // But only if there IS an alternative; otherwise use the avoided node anyway
+      const alt = bestLootable && bestLootable !== avoidNodeId ? bestLootable
+        : bestAny && bestAny !== avoidNodeId ? bestAny : null;
+      if (alt) targetId = alt;
+    }
     return targetId ? { id: targetId } : null;
   }
 
@@ -386,7 +396,8 @@ export function runBot(network, seed, options = {}) {
         const { interrupted } = tickUntilEventOrIce(E.NODE_PROBED, maxTicks - totalTicks);
         if (interrupted && !traceFired && getState().phase === "playing") {
           evadeIce("cancel-probe");
-          continue; // retry probe
+          avoidNodeId = target.id;
+          break; // break probe loop → outer loop picks a different node
         }
         dispatchAction("deselect");
       } else {
@@ -424,9 +435,10 @@ export function runBot(network, seed, options = {}) {
           [E.EXPLOIT_SUCCESS, E.EXPLOIT_FAILURE], maxTicks - totalTicks
         );
         if (interrupted && !traceFired && getState().phase === "playing") {
-          // ICE arrived — cancel exploit and hide
+          // ICE arrived — cancel exploit and hide, then switch nodes if possible
           evadeIce("cancel-exploit");
-          continue; // retry the exploit loop (pick card again, re-select, etc.)
+          avoidNodeId = target.id;
+          break; // break exploit loop → outer loop picks a different node
         }
         dispatchAction("deselect");
       } else {
@@ -464,6 +476,9 @@ export function runBot(network, seed, options = {}) {
       if (traceFired) { failReason = "trace"; dispatchAction("jackout"); break; }
       if (getState().phase !== "playing") break;
     }
+
+    // Successfully worked on this node — clear avoidance
+    if (getState().nodes[target.id]?.accessLevel === "owned") avoidNodeId = null;
 
     // Check if mission is complete
     const ms = getState().mission;

--- a/scripts/bot-player.js
+++ b/scripts/bot-player.js
@@ -229,16 +229,24 @@ export function runBot(network, seed, options = {}) {
     emitEvent("starnet:action", { actionId, fromConsole: false, ...payload });
   }
 
+  /** Number of ICE_MOVED events to wait after evading — gives ICE time to
+   *  investigate the disturbance, find nothing, clear the signal, and wander. */
+  const EVASION_PATIENCE = 3;
+
   /**
-   * Cancel current action, deselect, and wait for ICE to leave.
+   * Cancel current action, deselect, and wait for ICE to complete its
+   * investigation cycle. Waits for multiple ICE moves so ICE has time to
+   * arrive at the disturbance, clear it, and wander away.
    * @param {string} cancelAction — "cancel-exploit", "cancel-probe", etc.
    */
   function evadeIce(cancelAction) {
     dispatchAction(cancelAction);
     dispatchAction("deselect");
-    // Tick until ICE moves away (ICE_MOVED fires) or budget runs out
     iceAtPlayerNode = false;
-    tickUntilEvent(E.ICE_MOVED, Math.min(500, maxTicks - totalTicks));
+    // Wait for several ICE moves to let the investigation cycle complete
+    for (let i = 0; i < EVASION_PATIENCE && totalTicks < maxTicks; i++) {
+      tickUntilEvent(E.ICE_MOVED, Math.min(500, maxTicks - totalTicks));
+    }
   }
 
   // ── Bot strategy ─────────────────────────────────────────

--- a/scripts/bot-player.js
+++ b/scripts/bot-player.js
@@ -57,11 +57,11 @@ const SECURITY_TYPES = new Set(["ids", "security-monitor"]);
  * Run one automated game from init to completion.
  * @param {object} network — return value of generateNetwork()
  * @param {string} seed
- * @param {{ tickIncrement?: number, maxTicks?: number }} [options]
+ * @param {{ tickIncrement?: number, maxTicks?: number, evasion?: boolean }} [options]
  * @returns {BotRunStats}
  */
 export function runBot(network, seed, options = {}) {
-  const { tickIncrement = DEFAULT_TICK_INCREMENT, maxTicks = DEFAULT_MAX_TICKS } = options;
+  const { tickIncrement = DEFAULT_TICK_INCREMENT, maxTicks = DEFAULT_MAX_TICKS, evasion = false } = options;
 
   // ── Setup ────────────────────────────────────────────────
   clearHandlers();
@@ -176,10 +176,68 @@ export function runBot(network, seed, options = {}) {
     return spent;
   }
 
+  // ── ICE proximity tracking (for evasion) ────────────────
+  let iceAtPlayerNode = false;
+
+  if (evasion) {
+    on(E.ICE_MOVED, ({ toId }) => {
+      const s = getState();
+      iceAtPlayerNode = (s.selectedNodeId && toId === s.selectedNodeId);
+    });
+    // Also detect when ICE is already at node when we select it
+    on(E.ICE_DETECT_PENDING, () => {
+      iceAtPlayerNode = true;
+    });
+  }
+
+  /**
+   * Tick until one of the given event types fires, ICE arrives (if evading),
+   * or budget exceeded. Returns { spent, interrupted }.
+   * @param {string | string[]} eventTypes
+   * @param {number} budget
+   * @returns {{ spent: number, interrupted: boolean }}
+   */
+  function tickUntilEventOrIce(eventTypes, budget) {
+    const types = Array.isArray(eventTypes) ? eventTypes : [eventTypes];
+    firedEvents = new Set();
+    iceAtPlayerNode = false;
+    const handlers = types.map(t => {
+      const h = onEventFired(t);
+      on(t, h);
+      return { type: t, handler: h };
+    });
+
+    let spent = 0;
+    let interrupted = false;
+    while (spent < budget && !types.some(t => firedEvents.has(t))) {
+      tick(tickIncrement);
+      spent += tickIncrement;
+      totalTicks += tickIncrement;
+      if (traceFired) break;
+      if (getState().phase !== "playing") break;
+      if (evasion && iceAtPlayerNode) { interrupted = true; break; }
+    }
+
+    for (const { type, handler } of handlers) off(type, handler);
+    return { spent, interrupted };
+  }
+
   // ── Action dispatch helpers ──────────────────────────────
 
   function dispatchAction(actionId, payload = {}) {
     emitEvent("starnet:action", { actionId, fromConsole: false, ...payload });
+  }
+
+  /**
+   * Cancel current action, deselect, and wait for ICE to leave.
+   * @param {string} cancelAction — "cancel-exploit", "cancel-probe", etc.
+   */
+  function evadeIce(cancelAction) {
+    dispatchAction(cancelAction);
+    dispatchAction("deselect");
+    // Tick until ICE moves away (ICE_MOVED fires) or budget runs out
+    iceAtPlayerNode = false;
+    tickUntilEvent(E.ICE_MOVED, Math.min(500, maxTicks - totalTicks));
   }
 
   // ── Bot strategy ─────────────────────────────────────────
@@ -320,14 +378,25 @@ export function runBot(network, seed, options = {}) {
     // Navigate to target
     dispatchAction("select", { nodeId: target.id });
 
-    // Probe if needed
-    if (!targetNode.probed) {
+    // Probe if needed (with retry on ICE interruption)
+    while (!getState().nodes[target.id]?.probed && totalTicks < maxTicks) {
+      dispatchAction("select", { nodeId: target.id });
       dispatchAction("probe", { nodeId: target.id });
-      tickUntilEvent(E.NODE_PROBED, maxTicks - totalTicks);
-      if (traceFired || getState().phase !== "playing") {
-        if (traceFired) { failReason = "trace"; dispatchAction("jackout"); }
-        break;
+      if (evasion) {
+        const { interrupted } = tickUntilEventOrIce(E.NODE_PROBED, maxTicks - totalTicks);
+        if (interrupted && !traceFired && getState().phase === "playing") {
+          evadeIce("cancel-probe");
+          continue; // retry probe
+        }
+        dispatchAction("deselect");
+      } else {
+        tickUntilEvent(E.NODE_PROBED, maxTicks - totalTicks);
       }
+      break;
+    }
+    if (traceFired || getState().phase !== "playing") {
+      if (traceFired) { failReason = "trace"; dispatchAction("jackout"); }
+      break;
     }
 
     // Exploit until owned
@@ -347,8 +416,22 @@ export function runBot(network, seed, options = {}) {
         continue;  // retry with new card
       }
 
+      dispatchAction("select", { nodeId: target.id }); // re-select for exploit (may have deselected)
       dispatchAction("exploit", { nodeId: target.id, exploitId: card.id });
-      tickUntilEvent([E.EXPLOIT_SUCCESS, E.EXPLOIT_FAILURE], maxTicks - totalTicks);
+
+      if (evasion) {
+        const { interrupted } = tickUntilEventOrIce(
+          [E.EXPLOIT_SUCCESS, E.EXPLOIT_FAILURE], maxTicks - totalTicks
+        );
+        if (interrupted && !traceFired && getState().phase === "playing") {
+          // ICE arrived — cancel exploit and hide
+          evadeIce("cancel-exploit");
+          continue; // retry the exploit loop (pick card again, re-select, etc.)
+        }
+        dispatchAction("deselect");
+      } else {
+        tickUntilEvent([E.EXPLOIT_SUCCESS, E.EXPLOIT_FAILURE], maxTicks - totalTicks);
+      }
       if (traceFired) { failReason = "trace"; dispatchAction("jackout"); break outer; }
       if (getState().phase !== "playing") break outer;
     }
@@ -363,9 +446,10 @@ export function runBot(network, seed, options = {}) {
     // Read + loot any owned node (macguffins can be on any type, including workstations)
     const ownedNode = getState().nodes[target.id];
     if (ownedNode?.accessLevel === "owned" && !ownedNode.read) {
-      dispatchAction("select", { nodeId: target.id }); // ensure selected for read
+      dispatchAction("select", { nodeId: target.id });
       dispatchAction("read", { nodeId: target.id });
       tickUntilEvent(E.NODE_READ, maxTicks - totalTicks);
+      if (evasion) dispatchAction("deselect");
       if (traceFired) { failReason = "trace"; dispatchAction("jackout"); break; }
       if (getState().phase !== "playing") break;
     }
@@ -373,9 +457,10 @@ export function runBot(network, seed, options = {}) {
     const readNode = getState().nodes[target.id];
     const hasLoot = readNode?.macguffins?.some(m => !m.collected);
     if (readNode?.accessLevel === "owned" && readNode.read && hasLoot && !readNode.looted) {
-      dispatchAction("select", { nodeId: target.id }); // ensure selected for loot
+      dispatchAction("select", { nodeId: target.id });
       dispatchAction("loot", { nodeId: target.id });
       tickUntilEvent(E.NODE_LOOTED, maxTicks - totalTicks);
+      if (evasion) dispatchAction("deselect");
       if (traceFired) { failReason = "trace"; dispatchAction("jackout"); break; }
       if (getState().phase !== "playing") break;
     }

--- a/scripts/bot-player.js
+++ b/scripts/bot-player.js
@@ -46,6 +46,10 @@ const SECURITY_TYPES = new Set(["ids", "security-monitor"]);
  *   iceDetections: number,
  *   nodesOwned: number,
  *   nodesTotal: number,
+ *   tickFirstNodeOwned: number,
+ *   tickFirstDetection: number,
+ *   tickTraceStarted: number,
+ *   tickMissionComplete: number,
  * }} BotRunStats
  */
 
@@ -93,21 +97,46 @@ export function runBot(network, seed, options = {}) {
   let startingCash = getState().player.cash;
   let storeVisitCount = 0;
 
+  // Timing breakpoints (tick at which event first occurs)
+  let tickFirstNodeOwned = -1;   // first non-gateway node owned
+  let tickFirstDetection = -1;   // first ICE detection
+  let tickTraceStarted = -1;     // trace countdown started
+  let tickMissionComplete = -1;  // mission target looted
+  let gatewayOwnedCount = 0;     // track when we're past gateway
+
   const alertOrder = ["green", "yellow", "red"];
 
   function onAlertRaised({ next }) {
     if (alertOrder.indexOf(next) > alertOrder.indexOf(peakAlert)) peakAlert = next;
   }
-  function onTraceStarted() { traceFired = true; }
-  function onIceDetected() { iceDetections++; }
+  function onTraceStarted() {
+    traceFired = true;
+    if (tickTraceStarted < 0) tickTraceStarted = totalTicks;
+  }
+  function onIceDetected() {
+    iceDetections++;
+    if (tickFirstDetection < 0) tickFirstDetection = totalTicks;
+  }
   function onExploitStarted() { cardUsesConsumed++; }
   function onExploitDisclosed() { cardsBurned++; }
+  function onNodeAccessed({ nodeId }) {
+    const n = getState().nodes[nodeId];
+    if (n?.accessLevel === "owned" && n.type !== "gateway") {
+      gatewayOwnedCount++;
+      if (tickFirstNodeOwned < 0) tickFirstNodeOwned = totalTicks;
+    }
+  }
+  function onMissionComplete() {
+    if (tickMissionComplete < 0) tickMissionComplete = totalTicks;
+  }
 
   on(E.ALERT_GLOBAL_RAISED, onAlertRaised);
   on(E.ALERT_TRACE_STARTED, onTraceStarted);
   on(E.ICE_DETECTED, onIceDetected);
   on(E.EXPLOIT_STARTED, onExploitStarted);
   on(E.EXPLOIT_DISCLOSED, onExploitDisclosed);
+  on(E.NODE_ACCESSED, onNodeAccessed);
+  on(E.MISSION_COMPLETE, onMissionComplete);
 
   // ── Tick-until-event helper ──────────────────────────────
   let totalTicks = 0;
@@ -402,5 +431,9 @@ export function runBot(network, seed, options = {}) {
     iceDetections,
     nodesOwned,
     nodesTotal,
+    tickFirstNodeOwned,
+    tickFirstDetection,
+    tickTraceStarted,
+    tickMissionComplete,
   };
 }

--- a/scripts/bot-player.test.js
+++ b/scripts/bot-player.test.js
@@ -53,3 +53,29 @@ describe("runBot", () => {
     assert.ok(stats.totalTicks <= 50, `expected ≤50 ticks, got ${stats.totalTicks}`);
   });
 });
+
+// ── Smoke tests: difficulty curve sanity ─────────────────────────────────────
+// These run 20 seeds each and verify the bot's success rate hasn't regressed.
+// Catches broken mechanics (F/F) and ICE balance drift (C/C).
+
+describe("bot smoke: difficulty curve", () => {
+  it("F/F evasion: ≥70% success over 20 seeds", () => {
+    let successes = 0;
+    for (let i = 0; i < 20; i++) {
+      const net = generateNetwork(`smoke-ff-${i}`, "F", "F");
+      const stats = runBot(net, `smoke-ff-${i}`, { evasion: true });
+      if (stats.missionSuccess) successes++;
+    }
+    assert.ok(successes >= 14, `F/F: expected ≥70% success, got ${successes}/20 (${successes * 5}%)`);
+  });
+
+  it("C/C evasion: ≥10% success over 20 seeds", () => {
+    let successes = 0;
+    for (let i = 0; i < 20; i++) {
+      const net = generateNetwork(`smoke-cc-${i}`, "C", "C");
+      const stats = runBot(net, `smoke-cc-${i}`, { evasion: true });
+      if (stats.missionSuccess) successes++;
+    }
+    assert.ok(successes >= 2, `C/C: expected ≥10% success, got ${successes}/20 (${successes * 5}%)`);
+  });
+});

--- a/scripts/bot-player.test.js
+++ b/scripts/bot-player.test.js
@@ -1,0 +1,55 @@
+// @ts-check
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { generateNetwork } from "../js/network-gen.js";
+import { runBot } from "./bot-player.js";
+
+describe("runBot", () => {
+  it("completes F/F mission successfully", () => {
+    const net = generateNetwork("bot-test-ff", "F", "F");
+    const stats = runBot(net, "bot-test-ff");
+    assert.equal(stats.missionSuccess, true, "F/F mission should succeed");
+    assert.ok(stats.totalTicks > 0, "should consume ticks");
+    assert.ok(stats.nodesOwned > 0, "should own at least some nodes");
+    assert.equal(stats.traceFired, false, "trace should not fire at F/F");
+  });
+
+  it("runs B/B without crashing", () => {
+    const net = generateNetwork("bot-test-bb", "B", "B");
+    const stats = runBot(net, "bot-test-bb");
+    // May or may not succeed — just verify it completes and returns valid stats
+    assert.ok(typeof stats.missionSuccess === "boolean");
+    assert.ok(typeof stats.totalTicks === "number");
+    assert.ok(stats.totalTicks > 0);
+    assert.ok(stats.nodesTotal > 0);
+  });
+
+  it("returns all expected stat fields", () => {
+    const net = generateNetwork("bot-test-fields", "C", "C");
+    const stats = runBot(net, "bot-test-fields");
+    const expectedFields = [
+      "missionSuccess", "fullClear", "failReason",
+      "cardUsesConsumed", "cardsBurned", "storeVisits",
+      "cashSpent", "cashRemaining", "totalTicks",
+      "peakAlert", "traceFired", "iceDetections",
+      "nodesOwned", "nodesTotal",
+    ];
+    for (const field of expectedFields) {
+      assert.ok(field in stats, `missing field: ${field}`);
+    }
+  });
+
+  it("is deterministic: same seed + difficulty = same stats", () => {
+    const net1 = generateNetwork("bot-det", "C", "C");
+    const net2 = generateNetwork("bot-det", "C", "C");
+    const stats1 = runBot(net1, "bot-det");
+    const stats2 = runBot(net2, "bot-det");
+    assert.deepStrictEqual(stats1, stats2);
+  });
+
+  it("respects tick cap", () => {
+    const net = generateNetwork("bot-tick-cap", "S", "S");
+    const stats = runBot(net, "bot-tick-cap", { maxTicks: 50 });
+    assert.ok(stats.totalTicks <= 50, `expected ≤50 ticks, got ${stats.totalTicks}`);
+  });
+});


### PR DESCRIPTION
## Summary

Monte Carlo bot player that simulates full game runs headlessly, used to find and fix 11 balance issues through iterative measure→fix→remeasure cycles.

### New tools
- **`scripts/bot-player.js`** — automated greedy player with evasion, IDS reconfigure, proactive store usage
- **`scripts/bot-census.js`** — runs N simulations per difficulty, LLM-readable reports (`make bot-census`)
- **`js/store-logic.js`** — headless darknet store buy, used by bot + console + DOM store
- **`docs/BOT-PLAYER.md`** — comprehensive bot documentation

### Balance changes (driven by bot data)
- ICE detection routes through IDS→monitor chain (IDS reconfigure now blocks ICE reports)
- Fixed `direct-trace` bug: S/A IDS reconfigure was silently bypassed
- A/S ICE: removed omniscient player tracking, replaced with faster disturbance tracking
- Exploit duration: 3-12s → 2-7s
- ICE A/S: no longer instant detection (S=800ms, A=1500ms dwell)
- ICE A/S: slowed movement (A=5000ms, S=4000ms intervals)
- ICE C/B: bumped dwell times (C=5500ms, B=4500ms)
- `initAlertHandlers()` / `initIceHandlers()` exported for re-registration

### Final difficulty curves (evasion bot)
```
Diagonal:  F/F:82%  D/D:74%  C/C:28%  B/B:6%   A/A:0%  S/S:0%
ICE only:  F:76%    D:74%    C:62%    B:54%    A:10%   S:8%
Money only: F:82%   D:76%    C:40%    B:24%    A:6%    S:0%
```

### Backlog additions
- Reward scaling with difficulty
- ICE resident node relocation
- Player upgrades: deck speed, stealth, chaff, bot partners

## Test plan

- [x] `make check` passes (304 tests)
- [x] `make bot-census` produces expected report
- [x] Bot deterministic (same seed = same stats)
- [x] Store buy works in harness, console, and DOM
- [x] Census reports saved in session docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)