### PR TITLE
Add level select dialog

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1079,6 +1079,112 @@ html, body {
   background: rgba(0, 255, 255, 0.08);
 }
 
+/* ── Level select modal ───────────────────────────────────── */
+
+#level-select-modal {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.level-select-box {
+  background: var(--bg);
+  border: 1px solid var(--cyan);
+  box-shadow: 0 0 24px rgba(0, 200, 255, 0.15);
+  width: min(92%, 340px);
+  font-family: var(--font-mono);
+  display: flex;
+  flex-direction: column;
+}
+
+.level-select-header {
+  color: var(--cyan);
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--cyan-dim);
+}
+
+.level-select-form {
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.level-select-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  color: var(--green);
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+}
+
+.level-select-hint {
+  color: var(--cyan-dim);
+  font-size: 0.55rem;
+  letter-spacing: 0.05em;
+}
+
+.level-select-input,
+.level-select-select {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--cyan-dim);
+  color: var(--green);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 0.3rem 0.4rem;
+}
+
+.level-select-input:focus,
+.level-select-select:focus {
+  outline: none;
+  border-color: var(--cyan);
+  box-shadow: 0 0 6px rgba(0, 200, 255, 0.2);
+}
+
+.level-select-select option {
+  background: var(--bg);
+  color: var(--green);
+}
+
+.level-select-actions {
+  padding: 0.5rem 0.75rem;
+  border-top: 1px solid var(--cyan-dim);
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.level-select-btn {
+  background: none;
+  border: 1px solid var(--cyan);
+  color: var(--cyan);
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+}
+
+.level-select-btn:hover {
+  background: rgba(0, 255, 255, 0.08);
+}
+
+.level-select-go {
+  border-color: var(--green);
+  color: var(--green);
+}
+
+.level-select-go:hover {
+  background: rgba(0, 255, 0, 0.08);
+}
+
 /* Exploit zap laser lines — instant attack, slow decay */
 .exploit-zap {
   transition: stroke-opacity 180ms ease-out;

--- a/css/style.css
+++ b/css/style.css
@@ -1095,7 +1095,7 @@ html, body {
   background: var(--bg);
   border: 1px solid var(--cyan);
   box-shadow: 0 0 24px rgba(0, 200, 255, 0.15);
-  width: min(92%, 340px);
+  width: min(92%, 420px);
   font-family: var(--font-mono);
   display: flex;
   flex-direction: column;

--- a/css/style.css
+++ b/css/style.css
@@ -309,7 +309,7 @@ html, body {
   50%       { opacity: 0.4; }
 }
 
-#pause-btn, #save-btn, #load-btn {
+#new-run-btn, #pause-btn, #save-btn, #load-btn {
   background: transparent;
   border: 1px solid var(--cyan);
   color: var(--cyan);
@@ -324,7 +324,7 @@ html, body {
   transition: background 0.15s, box-shadow 0.15s;
 }
 
-#pause-btn:hover, #save-btn:hover, #load-btn:hover {
+#new-run-btn:hover, #pause-btn:hover, #save-btn:hover, #load-btn:hover {
   background: rgba(0, 255, 255, 0.1);
   box-shadow: 0 0 12px rgba(0, 255, 255, 0.5);
 }

--- a/css/style.css
+++ b/css/style.css
@@ -1170,6 +1170,7 @@ html, body {
   letter-spacing: 0.1em;
   padding: 0.25rem 0.75rem;
   cursor: pointer;
+  white-space: nowrap;
 }
 
 .level-select-btn:hover {

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
       <span class="hud-label">WALLET:</span>
       <span class="hud-value" id="wallet">¥0</span>
 
+      <button id="new-run-btn" title="Start a new run with custom parameters">[ NEW RUN ]</button>
       <button id="pause-btn">[ PAUSE ]</button>
       <button id="save-btn" title="Save game state to file">[ SAVE ]</button>
       <label id="load-btn" title="Load game state from file">[ LOAD ]

--- a/js/level-select.js
+++ b/js/level-select.js
@@ -1,0 +1,94 @@
+// @ts-check
+// Level select dialog — lets the player pick seed, timeCost, moneyCost
+// and reload the page with the appropriate URL parameters.
+
+const GRADES = ["F", "D", "C", "B", "A", "S"];
+
+/** Read current URL params (if any) for default values. */
+function currentParams() {
+  const p = new URLSearchParams(location.search);
+  return {
+    seed:  p.get("seed") ?? "",
+    time:  p.get("time")?.toUpperCase() ?? "C",
+    money: p.get("money")?.toUpperCase() ?? "C",
+  };
+}
+
+function gradeOptions(selected) {
+  return GRADES.map(g =>
+    `<option value="${g}" ${g === selected ? "selected" : ""}>${g}</option>`
+  ).join("");
+}
+
+/** Open the level select dialog. */
+export function openLevelSelect() {
+  if (document.getElementById("level-select-modal")) return;
+
+  const cur = currentParams();
+  const defaultSeed = cur.seed || "run-" + Math.floor(Math.random() * 0xFFFF).toString(16).padStart(4, "0");
+
+  const modal = document.createElement("div");
+  modal.id = "level-select-modal";
+  modal.innerHTML = `
+    <div class="level-select-box">
+      <div class="level-select-header">// NEW RUN</div>
+      <div class="level-select-form">
+        <label class="level-select-label">
+          SEED
+          <input type="text" id="ls-seed" class="level-select-input" value="${defaultSeed}" />
+        </label>
+        <label class="level-select-label">
+          TIME COST
+          <select id="ls-time" class="level-select-select">${gradeOptions(cur.time)}</select>
+          <span class="level-select-hint">ICE grade, depth, gates</span>
+        </label>
+        <label class="level-select-label">
+          MONEY COST
+          <select id="ls-money" class="level-select-select">${gradeOptions(cur.money)}</select>
+          <span class="level-select-hint">Node grades, path length</span>
+        </label>
+      </div>
+      <div class="level-select-actions">
+        <button id="ls-random-btn" class="level-select-btn">[ RANDOM SEED ]</button>
+        <button id="ls-go-btn" class="level-select-btn level-select-go">[ JACK IN ]</button>
+        <button id="ls-cancel-btn" class="level-select-btn">[ CANCEL ]</button>
+      </div>
+    </div>
+  `;
+
+  function close() { modal.remove(); }
+
+  function go() {
+    const seed  = /** @type {HTMLInputElement} */ (document.getElementById("ls-seed")).value.trim();
+    const time  = /** @type {HTMLSelectElement} */ (document.getElementById("ls-time")).value;
+    const money = /** @type {HTMLSelectElement} */ (document.getElementById("ls-money")).value;
+    if (!seed) return;
+    const url = new URL(location.href);
+    url.searchParams.set("seed", seed);
+    url.searchParams.set("time", time);
+    url.searchParams.set("money", money);
+    location.href = url.toString();
+  }
+
+  function randomSeed() {
+    const input = /** @type {HTMLInputElement} */ (document.getElementById("ls-seed"));
+    input.value = "run-" + Math.floor(Math.random() * 0xFFFF).toString(16).padStart(4, "0");
+  }
+
+  // Wire events after adding to DOM
+  document.getElementById("graph-container")?.appendChild(modal);
+
+  document.getElementById("ls-go-btn")?.addEventListener("click", go);
+  document.getElementById("ls-cancel-btn")?.addEventListener("click", close);
+  document.getElementById("ls-random-btn")?.addEventListener("click", randomSeed);
+
+  // Enter key submits
+  document.getElementById("ls-seed")?.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") go();
+  });
+
+  // Backdrop click closes
+  modal.addEventListener("click", (e) => {
+    if (!/** @type {Element} */ (e.target).closest(".level-select-box")) close();
+  });
+}

--- a/js/main.js
+++ b/js/main.js
@@ -17,6 +17,7 @@ import { initVisualRenderer } from "./visual-renderer.js";
 import { initLogRenderer } from "./log-renderer.js";
 import { initNodeLifecycle } from "./node-lifecycle.js";
 import { buildActionContext, initActionDispatcher, buildNodeClickHandler } from "./action-context.js";
+import { openLevelSelect } from "./level-select.js";
 
 /** Read seed/time/money from URL search params. Returns null if any are missing. */
 function getNetworkParams() {
@@ -65,6 +66,9 @@ function init() {
     if (document.hidden) pauseTimers();
     else resumeTimers();
   });
+
+  // Wire new run button
+  document.getElementById("new-run-btn").addEventListener("click", openLevelSelect);
 
   // Wire HUD pause button
   let _userPaused = false;


### PR DESCRIPTION
## Summary

[ NEW RUN ] button in the HUD opens a modal dialog to configure seed, timeCost,
and moneyCost grades. JACK IN reloads the page with the appropriate URL parameters
(`?seed=X&time=C&money=B`). Makes the existing procgen URL params discoverable
from the UI without needing to edit the URL bar.

- Random seed generator button
- Defaults to C/C, pre-fills from current URL params if present
- Backdrop click or CANCEL to dismiss
- Matches phosphene aesthetic (cyan borders, monospace, dark overlay)

## Test plan

- [x] `make check` passes (306 tests)
- [x] Dialog opens, shows seed + grade selectors
- [x] JACK IN navigates to correct URL with params
- [x] Generated network loads (different mission, hand, wallet)
- [x] CANCEL dismisses, backdrop click dismisses
- [x] Button styling matches existing HUD buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)