### PR TITLE
Fix core→ui cross-boundary deps via dependency injection

### DIFF
--- a/js/core/actions/action-context.js
+++ b/js/core/actions/action-context.js
@@ -17,13 +17,13 @@ import { cancelTraceCountdown } from "../alert.js";
 import { getAvailableActions } from "./node-actions.js";
 import { on, emitEvent, E } from "../events.js";
 import { pauseTimers, resumeTimers } from "../timers.js";
-import { openDarknetsStore } from "../../ui/store.js";
 
 /**
  * Build the wired ActionContext — maps abstract ctx methods to concrete state mutators.
+ * @param {(state: import('../types.js').GameState) => void} [openStore] Optional browser-side store opener; no-op in headless contexts.
  * @returns {ActionContext}
  */
-export function buildActionContext() {
+export function buildActionContext(openStore = () => {}) {
   return {
     getState,
     selectNode:       (nodeId) => navigateTo(nodeId),
@@ -43,7 +43,7 @@ export function buildActionContext() {
     cancelTrace:      ()       => cancelTraceCountdown(),
     openDarknetsStore: () => {
       pauseTimers();
-      openDarknetsStore(getState());
+      openStore(getState());
     },
   };
 }

--- a/js/core/actions/action-context.js
+++ b/js/core/actions/action-context.js
@@ -20,10 +20,10 @@ import { pauseTimers, resumeTimers } from "../timers.js";
 
 /**
  * Build the wired ActionContext — maps abstract ctx methods to concrete state mutators.
- * @param {(state: import('../types.js').GameState) => void} [openStore] Optional browser-side store opener; no-op in headless contexts.
+ * @param {(state: import('../types.js').GameState) => void} [openDarknetsStore] Optional browser-side store opener; no-op in headless contexts.
  * @returns {ActionContext}
  */
-export function buildActionContext(openStore = () => {}) {
+export function buildActionContext(openDarknetsStore = () => {}) {
   return {
     getState,
     selectNode:       (nodeId) => navigateTo(nodeId),
@@ -43,7 +43,7 @@ export function buildActionContext(openStore = () => {}) {
     cancelTrace:      ()       => cancelTraceCountdown(),
     openDarknetsStore: () => {
       pauseTimers();
-      openStore(getState());
+      openDarknetsStore(getState());
     },
   };
 }

--- a/js/core/cheats.js
+++ b/js/core/cheats.js
@@ -8,7 +8,6 @@
 // Any use of a cheat command sets state.isCheating = true for the run.
 
 import { getState, revealNeighbors, accessNeighbors } from "./state.js";
-import { saveGame, restoreFromFile } from "../ui/save-load.js";
 import { setNodeAccessLevel, setNodeAlertState, setNodeVisible } from "./state/node.js";
 import { addCash, addCardToHand, applyCardDecay } from "./state/player.js";
 import { setCheating } from "./state/game.js";
@@ -21,8 +20,12 @@ import { generateExploit, generateExploitForVuln } from "./exploits.js";
 const VALID_RARITIES = ["common", "uncommon", "rare"];
 const VALID_ALERTS   = ["green", "yellow", "red", "trace"];
 
-// Returns true if the command was handled (valid cheat verb), false if unknown.
-export function handleCheatCommand(args) {
+/**
+ * Returns true if the command was handled (valid cheat verb), false if unknown.
+ * @param {string[]} args
+ * @param {{ saveGame?: (() => void) | null }} [opts] Browser-side callbacks; omit in headless contexts.
+ */
+export function handleCheatCommand(args, { saveGame = null } = {}) {
   const sub = args[0]?.toLowerCase();
 
   if (sub === "give") {
@@ -39,12 +42,13 @@ export function handleCheatCommand(args) {
     return cheatSummonIce(args.slice(1));
   } else if (sub === "ice-state") {
     return cheatIceState();
-  } else if (sub === "relayout") {
-    return cheatRelayout(args.slice(1));
   } else if (sub === "snapshot") {
-    return cheatSnapshot();
-  } else if (sub === "restore") {
-    return cheatRestore();
+    if (saveGame) {
+      saveGame();
+    } else {
+      addLogEntry("[CHEAT] snapshot: not available in this context.", "error");
+    }
+    return true;
   } else if (sub === "help") {
     return cheatHelp();
   } else {
@@ -282,35 +286,6 @@ function cheatHelp() {
     "  cheat restore               Load game state from file.",
   ];
   lines.forEach((line) => addLogEntry(line, "meta"));
-  return true;
-}
-
-// CHEAT: snapshot — save game state to file
-function cheatSnapshot() {
-  saveGame();
-  return true;
-}
-
-// CHEAT: restore — trigger file picker for load
-function cheatRestore() {
-  // The label click approach won't work from a cheat command (no user gesture).
-  // Fall back to programmatic click — may not work in all browsers.
-  const input = document.getElementById("load-file-input");
-  if (input) input.click();
-  return true;
-}
-
-// CHEAT: relayout [algorithm] — re-run graph layout
-function cheatRelayout(args) {
-  const name = args[0]?.toLowerCase();
-  import("../ui/graph.js").then(({ relayout, getLayoutNames }) => {
-    const used = relayout(name);
-    if (name && used !== name) {
-      addLogEntry(`[CHEAT] Unknown layout "${name}". Options: ${getLayoutNames().join(", ")}`, "error");
-    } else {
-      addLogEntry(`[CHEAT] Graph re-laid out (${used}).`, "success");
-    }
-  });
   return true;
 }
 

--- a/js/ui/console.js
+++ b/js/ui/console.js
@@ -792,9 +792,38 @@ function cmdJackout() {
 }
 
 function cmdCheat(args) {
-  // Forwarded to cheats module — loaded lazily to keep cheat code isolated
+  const sub = args[0]?.toLowerCase();
+
+  // Browser-specific cheats handled here, not in core/cheats.js
+  if (sub === "relayout") {
+    const name = args[1]?.toLowerCase();
+    import("./graph.js").then(({ relayout, getLayoutNames }) => {
+      const used = relayout(name);
+      if (name && used !== name) {
+        addLogEntry(`[CHEAT] Unknown layout "${name}". Options: ${getLayoutNames().join(", ")}`, "error");
+      } else {
+        addLogEntry(`[CHEAT] Graph re-laid out (${used}).`, "success");
+      }
+    });
+    return;
+  }
+
+  if (sub === "restore") {
+    // Programmatic click — may not work in all browsers without a user gesture
+    const input = /** @type {HTMLElement|null} */ (document.getElementById("load-file-input"));
+    if (input) input.click();
+    return;
+  }
+
+  // Everything else forwarded to cheats module — loaded lazily to keep cheat code isolated
   import("../core/cheats.js").then(({ handleCheatCommand }) => {
-    handleCheatCommand(args);
+    if (sub === "snapshot") {
+      import("./save-load.js").then(({ saveGame }) => {
+        handleCheatCommand(args, { saveGame });
+      });
+    } else {
+      handleCheatCommand(args);
+    }
   });
 }
 

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -17,6 +17,7 @@ import { initVisualRenderer } from "./visual-renderer.js";
 import { initLogRenderer } from "./log-renderer.js";
 import { initNodeLifecycle } from "../core/node-lifecycle.js";
 import { buildActionContext, initActionDispatcher, buildNodeClickHandler } from "../core/actions/action-context.js";
+import { openDarknetsStore } from "./store.js";
 import { openLevelSelect } from "./level-select.js";
 
 /** Read seed/time/money from URL search params. Returns null if any are missing. */
@@ -104,7 +105,7 @@ function init() {
     e.target.value = ""; // reset so the same file can be loaded again
   });
 
-  const ctx = buildActionContext();
+  const ctx = buildActionContext(openDarknetsStore);
   initActionDispatcher(ctx);
 
   on(TIMER.ICE_MOVE,     () => handleIceTick());


### PR DESCRIPTION
## Summary

After the `js/` reorganization (PR #11) made the core/ui boundary explicit, three remaining cross-boundary imports were identified where `js/core/` modules statically imported `js/ui/` modules. This PR eliminates all three:

- **`action-context.js → store.js`**: `buildActionContext()` now accepts an optional `openStore` function parameter (no-op default). `main.js` passes the real `openDarknetsStore`; headless scripts (`playtest.js`, `bot-player.js`) get the no-op automatically by calling `buildActionContext()` with no args.

- **`cheats.js → save-load.js`**: Static import removed. `handleCheatCommand` accepts an optional `{ saveGame }` second argument. `console.js` imports `save-load.js` and passes `saveGame` when the user runs `cheat snapshot`.

- **`cheats.js → graph.js` (dynamic) + `cheats.js → document`**: The `relayout` and `restore` cheats moved entirely into `console.js`'s `cmdCheat` handler, which is already browser-specific. `cheats.js` no longer references these cheats.

`js/core/cheats.js` is now a pure JS module with zero `js/ui/` dependencies.

## Test plan

- [x] `make check` — 308/308 tests pass, lint clean
- [x] `node scripts/playtest.js reset && node scripts/playtest.js "status summary"` — harness works

🤖 Generated with [Claude Code](https://claude.com/claude-code)