### PR TITLE
feat: macguffin value scaling by moneyCost difficulty grade

### DIFF
--- a/js/core/loot.js
+++ b/js/core/loot.js
@@ -69,9 +69,19 @@ const MACGUFFIN_TYPES = [
 
 import { RNG, randomInt, randomPick, randomId } from "./rng.js";
 
-export function generateMacguffin() {
+/**
+ * Value multiplier per moneyCost grade.
+ * F/D = baseline, scaling up to ~4× at S so harder networks pay meaningfully more.
+ */
+const VALUE_MULT = { F: 1, D: 1.5, C: 2, B: 3, A: 4, S: 5 };
+
+/**
+ * @param {string} [moneyCost] - Grade letter; defaults to "F" (baseline).
+ */
+export function generateMacguffin(moneyCost = "F") {
+  const mult = VALUE_MULT[moneyCost] ?? 1;
   const type = randomPick(RNG.LOOT, MACGUFFIN_TYPES);
-  const value = randomInt(RNG.LOOT, type.cashRange[0], type.cashRange[1]);
+  const value = Math.round(randomInt(RNG.LOOT, type.cashRange[0], type.cashRange[1]) * mult);
   return {
     id: `${type.id}-${randomId(RNG.LOOT)}`,
     typeId: type.id,

--- a/js/core/network/network-gen.js
+++ b/js/core/network/network-gen.js
@@ -266,6 +266,7 @@ function buildNetwork(rng, tc, mc, forcePieces = [], biome) {
     startNode:     spawnedByRole.gateway[0],
     startCash:     CASH_BUDGET[mc],
     startHandSpec: HAND_BUDGET[mc],
+    moneyCost:     mc,
     ice: {
       grade:     time.iceGrade,
       startNode: spawnedByRole.monitor[0],

--- a/js/core/state/index.js
+++ b/js/core/state/index.js
@@ -104,6 +104,7 @@ export function initState(networkData, seedString) {
 
   state = {
     seed: getSeed(),
+    moneyCost: networkData.moneyCost ?? "F",
     nodes,
     adjacency,
     player: { cash: networkData.startCash ?? 1000, hand: generateStartingHand(networkData.startHandSpec) },
@@ -124,9 +125,10 @@ export function initState(networkData, seedString) {
   };
 
   // Dispatch onInit to behavior atoms — lootable assigns macguffins here
+  const moneyCostGrade = state.moneyCost;
   Object.values(nodes).forEach((node) => {
     const typeDef = resolveNode(node);
-    const ctx = { typeDef, generateMacguffin };
+    const ctx = { typeDef, generateMacguffin: () => generateMacguffin(moneyCostGrade) };
     getBehaviors(node).forEach((atom) => atom.onInit?.(node, state, ctx));
   });
 

--- a/js/core/types.js
+++ b/js/core/types.js
@@ -268,6 +268,7 @@
  * Never mutate directly — always use exported state mutation functions.
  * @typedef {{
  *   seed: string,
+ *   moneyCost: Grade,
  *   nodes: Object.<string, NodeState>,
  *   adjacency: Object.<string, string[]>,
  *   player: PlayerState,

--- a/tests/fixtures/network-gen-B-B-careless-user.json
+++ b/tests/fixtures/network-gen-B-B-careless-user.json
@@ -206,6 +206,7 @@
     "rare",
     "rare"
   ],
+  "moneyCost": "B",
   "ice": {
     "grade": "B",
     "startNode": "security-monitor-3"

--- a/tests/fixtures/network-gen-B-B.json
+++ b/tests/fixtures/network-gen-B-B.json
@@ -166,6 +166,7 @@
     "rare",
     "rare"
   ],
+  "moneyCost": "B",
   "ice": {
     "grade": "B",
     "startNode": "security-monitor-3"

--- a/tests/fixtures/network-gen-C-C.json
+++ b/tests/fixtures/network-gen-C-C.json
@@ -142,6 +142,7 @@
     "rare",
     "rare"
   ],
+  "moneyCost": "C",
   "ice": {
     "grade": "C",
     "startNode": "security-monitor-3"

--- a/tests/fixtures/network-gen-F-F.json
+++ b/tests/fixtures/network-gen-F-F.json
@@ -117,6 +117,7 @@
     "uncommon",
     "rare"
   ],
+  "moneyCost": "F",
   "ice": {
     "grade": "F",
     "startNode": "security-monitor-3"

--- a/tests/fixtures/network-gen-S-S.json
+++ b/tests/fixtures/network-gen-S-S.json
@@ -219,6 +219,7 @@
     "rare",
     "rare"
   ],
+  "moneyCost": "S",
   "ice": {
     "grade": "S",
     "startNode": "security-monitor-3"


### PR DESCRIPTION
## Summary

- Harder networks now pay proportionally more loot, creating a meaningful risk/reward curve
- Multipliers: F=1× D=1.5× C=2× B=3× A=4× S=5×
- `network-gen.js` now includes `moneyCost` in the returned network object
- `state.moneyCost` stored at init time; threaded into `generateMacguffin()` via `onInit` ctx
- `generateMacguffin(moneyCost)` scales the random cash roll by a `VALUE_MULT` lookup
- `GameState` typedef updated with `moneyCost: Grade`
- Network-gen snapshots regenerated to include `moneyCost` field

Identified as a gap in the 2026-03-01 bot census session: zero deficit at all difficulties but no reward differential. Previously all cash felt like pure score regardless of how hard the network was to crack.

## Test plan

- [ ] `make check` passes
- [ ] `node scripts/playtest.js --time F --money F reset` + loot a node — values in the ¥200–3600 range
- [ ] `node scripts/playtest.js --time B --money B reset` + loot a node — values ~3× higher
- [ ] `node scripts/playtest.js --time S --money S reset` + loot a node — values in the ¥7k–30k range

🤖 Generated with [Claude Code](https://claude.com/claude-code)