### PR TITLE
feat: ice-host node type + pkill action

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -79,6 +79,7 @@ Each node in the LAN has a **type** that determines what it does and why you wan
 | **Cryptovault**   | Diamond  | Probe        | High-value encrypted storage. Hardest targets.    |
 | **IDS**           | Hexagon  | Owned        | Intrusion Detection System. Must own to see connections. Can be subverted. |
 | **Security Mon.** | Octagon  | Owned        | Aggregates IDS alerts. Must own to see connections. Can cancel trace. |
+| **ICE Host**      | Octagon  | Owned        | The machine running the ICE process. Own it to unlock **pkill**. |
 
 The **Gate** column shows when a node reveals its connections to neighboring nodes.
 "Probe" means probing the node is enough to see what's connected. "Compromised" or
@@ -415,6 +416,7 @@ Actions depend on the selected node's type and access level:
 | `reconfigure`  | IDS node is compromised or owned               | Severs event forwarding to security monitor |
 | `eject`        | Owned node + ICE is present here               | Boots ICE to adjacent node |
 | `reboot`       | Owned node, not currently rebooting            | Forces ICE home, node offline briefly |
+| `pkill`        | Owned ice-host + ICE is active                 | Terminates the ICE process entirely |
 | `cancel-trace` | Owned security-monitor + trace active          | Cancels the trace countdown |
 | `jackout`      | Any time during run                            | End run, collect score |
 
@@ -438,6 +440,7 @@ cancel-loot            Abort an in-progress loot extraction.
 reconfigure [node]     Disable IDS event forwarding.
 eject                  Push ICE off current node to adjacent node.
 reboot [node]          Force ICE home; node goes briefly offline.
+pkill [node]           Terminate ICE process (requires owned ice-host).
 cancel-trace           Abort trace (requires owned security-monitor).
 jackout                End run.
 

--- a/data/network.js
+++ b/data/network.js
@@ -111,6 +111,14 @@ export const NETWORK = {
       x: 680,
       y: 460,
     },
+    {
+      id: "ice-host",
+      type: "ice-host",
+      label: "ICE-HOST",
+      grade: "A",
+      x: 680,
+      y: 600,
+    },
   ],
 
   edges: [
@@ -125,6 +133,7 @@ export const NETWORK = {
     { source: "firewall", target: "cryptovault" },
     { source: "router-b", target: "ids" },
     { source: "ids", target: "security-monitor" },
+    { source: "security-monitor", target: "ice-host" },
     { source: "workstation-b", target: "cryptovault" },
   ],
 
@@ -132,6 +141,6 @@ export const NETWORK = {
 
   ice: {
     grade: "C",          // D/F=random walk, C/B=disturbance-tracking, A/S=player-seeking
-    startNode: "security-monitor",  // far end of the network; 3 hops from gateway
+    startNode: "ice-host",  // far end of the network; adjacent to security-monitor
   },
 };

--- a/docs/BOT-PLAYER.md
+++ b/docs/BOT-PLAYER.md
@@ -244,6 +244,7 @@ These omissions are intentional — they make the bot a pessimistic baseline:
 
 - **Eject ICE** — never pushes ICE to an adjacent node
 - **Reboot nodes** — never forces ICE back to its resident node
+- **pkill ICE** — never owns the ice-host node to terminate the ICE process
 - **Cancel trace** — never owns the security monitor to cancel an active trace
 - **Strategic node ordering** — beyond the greedy BFS priority, no planning
 - **Anticipate ICE movement** — doesn't track ICE position or time actions

--- a/docs/dev-sessions/2026-03-02-2104-ice-host-pkill/plan.md
+++ b/docs/dev-sessions/2026-03-02-2104-ice-host-pkill/plan.md
@@ -1,0 +1,120 @@
+# Session Plan: ice-host Node + pkill Action
+
+## Phase 1: Types and ActionContext
+
+**1.1** `js/core/types.js` — Add `pkillIce: () => void` to the `ActionContext` typedef.
+
+**1.2** `js/core/actions/action-context.js`:
+- Import `stopIce`, `disableIce` from `../ice.js`
+- Add `pkillIce: () => { stopIce(); disableIce(); }` to `buildActionContext()`
+
+## Phase 2: Node Type Registry
+
+**2.1** `js/core/actions/node-types.js`:
+
+Add `"ice-host"` to `NODE_TYPES`:
+```js
+"ice-host": {
+  gateAccess: "owned",
+  behaviors: [],
+  actions: [
+    {
+      id: "pkill",
+      label: "PKILL ICE",
+      available: (node, state) =>
+        node.accessLevel === "owned" && !!(state.ice?.active),
+      desc: () => "Terminate the ICE process.",
+      execute: (_node, _state, ctx) => ctx.pkillIce(),
+    },
+  ],
+},
+```
+
+Remove `"iceResident"` from `"security-monitor"` behaviors:
+```js
+"security-monitor": {
+  gateAccess: "owned",
+  behaviors: ["monitor"],   // ← removed "iceResident"
+  ...
+```
+
+## Phase 3: Network Generation
+
+**3.1** `js/core/network/biomes/corporate/gen-rules.js`:
+
+Add to `ROLES`:
+```js
+"ice-host": "ice-host",
+```
+
+Add to `NODE_RULES`:
+```js
+"ice-host": {
+  singleton:   true,
+  security:    true,
+  iceResident: true,
+  depth:       4,           // visual hint; actual depth = depthBudget + 1
+  connectsTo:  [],
+  leaf:        true,
+  gradeRole:   "hard",
+  labels:      ["ICE-HOST", "ICE-PROC", "ICE-DAEMON"],
+},
+```
+
+Add to `LAYERS` (immediately after the `monitor` layer):
+```js
+{
+  role:      "ice-host",
+  count:     1,
+  depth:     ({ tc }) => tc.depthBudget + 1,
+  gradeRole: "hard",
+  connectTo: "monitor",    // edge: security-monitor ↔ ice-host
+},
+```
+
+**3.2** `js/core/network/network-gen.js`:
+```js
+ice: {
+  grade:     time.iceGrade,
+  startNode: spawnedByRole["ice-host"][0],   // was: spawnedByRole.monitor[0]
+},
+```
+
+## Phase 4: Bot Player
+
+**4.1** `scripts/bot-player.js`:
+- Add `"ice-host"` to `SECURITY_TYPES` set
+
+**4.2** `docs/BOT-PLAYER.md`:
+- Add to "What the Bot Does NOT Do": `pkill` — never uses pkill to terminate ICE
+
+## Phase 5: Tests
+
+**5.1** Add unit tests in `js/core/actions/node-types.test.js` (or appropriate existing test file):
+- `pkill` available when ice-host is owned and ICE is active
+- `pkill` not available when ICE is inactive
+- `pkill` not available when ice-host is not yet owned
+- `pkill` execute calls `ctx.pkillIce()`
+
+**5.2** Delete and regenerate network-gen snapshot fixtures:
+- `rm tests/fixtures/network-gen-*.json`
+- `make test` — new fixtures will be generated on first run
+- `make test` again — fixtures should be stable
+
+## Phase 6: Documentation
+
+**6.1** `MANUAL.md`:
+- Add `ice-host` to the node types table
+- Add `pkill` to the console commands / node actions reference
+
+**6.2** `docs/BACKLOG.md`:
+- Mark any related item if present
+
+## Commit Strategy
+
+One commit per phase (or combine phases where it makes sense):
+- Phase 1+2: "feat: add ice-host node type with pkill action"
+- Phase 3: "feat: add ice-host to corporate biome, move ICE startNode"
+- Phase 4: "chore: add ice-host to bot SECURITY_TYPES, update BOT-PLAYER.md"
+- Phase 5: "test: pkill unit tests + regenerated network-gen snapshots"
+- Phase 6: "docs: update MANUAL.md with ice-host and pkill"

--- a/docs/dev-sessions/2026-03-02-2104-ice-host-pkill/spec.md
+++ b/docs/dev-sessions/2026-03-02-2104-ice-host-pkill/spec.md
@@ -1,0 +1,100 @@
+# Session Spec: ice-host Node + pkill Action
+
+## Problem / Motivation
+
+ICE is currently "resident" at the security-monitor node. When the player owns the
+security-monitor, the `iceResident` behavior fires automatically and kills ICE as a
+side effect — no deliberate player choice involved.
+
+This is mechanically muddy: owning security-monitor should feel like owning the
+surveillance aggregation point (cancels trace), not like stumbling onto the ICE
+process controller. The ICE host and the security monitor are distinct infrastructure
+pieces that happen to be co-located — and that co-location was an implementation
+shortcut, not a design intention.
+
+Separating them gives the player a clearer mental model and a more interesting optional
+arc: "if I want to kill ICE I need to find where it runs, not just own the alarm
+dashboard."
+
+## New Node Type: `ice-host`
+
+A dedicated node representing the machine on which the ICE AI process runs.
+
+**Properties:**
+- Type string: `"ice-host"`
+- **Not lootable** — no macguffins, no `read` or `loot` actions
+- **Hard grade** — always at `pathGradeMax` difficulty (same as security-monitor)
+- **Singleton** — exactly one per network
+- **Security infrastructure** — excluded from bot full-clear, not a mission target
+- **Located adjacent to security-monitor** — revealed only when security-monitor is
+  owned, so it naturally becomes the next optional objective
+
+**Actions on ice-host:**
+- Standard: probe, exploit (standard access-level unlock sequence)
+- Once owned: `pkill` — explicitly terminate the ICE process
+
+## `pkill` Action
+
+A new node action available on owned `ice-host` nodes when ICE is active.
+
+- **ID**: `"pkill"`
+- **Label**: `"PKILL ICE"`
+- **Available**: `node.type === "ice-host" && node.accessLevel === "owned" && state.ice?.active`
+- **Effect**: calls `ctx.pkillIce()` which stops ICE timers and marks ICE inactive
+- **Console command**: `pkill` (no arguments — acts on selected node)
+- **Log entry**: `[ICE] Process terminated.`
+
+## Topology Changes
+
+### `ice-host` placement in network gen
+
+- The `ice-host` layer spawns **after the `monitor` layer** in the corporate biome
+- `connectTo: "monitor"` — ice-host ← edge → security-monitor
+- Depth: `depthBudget + 1` (one step deeper than security-monitor)
+- Grade role: `"hard"` (pathGradeMax, same as security-monitor)
+- ICE `startNode` moves from `spawnedByRole.monitor[0]` to `spawnedByRole["ice-host"][0]`
+
+### `security-monitor` changes
+
+- Remove `iceResident` behavior — owning security-monitor no longer auto-kills ICE
+- Monitor still cancels trace countdown (the `monitor` behavior remains)
+- The `iceResident` behavior atom stays in the registry (may be reused later) but is
+  removed from the security-monitor node type definition
+
+## Gameplay Arc
+
+```
+[gateway] → [router] → [ids] → [security-monitor] → [ice-host]
+                                        ↕
+                                  own this: cancels trace
+                                                      ↕
+                                              own this + pkill: kills ICE
+```
+
+Player who wants to neutralize ICE now has a clear two-step objective:
+1. Navigate the security region (router → ids → security-monitor)
+2. Probe and own ice-host, then pkill
+
+Skipping the ICE kill is still a valid strategy — jack out early or just tolerate ICE pressure.
+
+## Bot Player Impact
+
+The bot does NOT use `pkill`. The new `ice-host` type should be added to `SECURITY_TYPES`
+in `scripts/bot-player.js` so the bot skips it (same treatment as `ids` and
+`security-monitor`). The `fullClear` calculation should also exclude it.
+
+`docs/BOT-PLAYER.md` should note `pkill` in "What the Bot Does NOT Do."
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `js/core/actions/node-types.js` | Add `"ice-host"` type; remove `iceResident` from `security-monitor` |
+| `js/core/network/biomes/corporate/gen-rules.js` | Add `"ice-host"` role, node rule, and layer |
+| `js/core/network/network-gen.js` | ICE `startNode` → `spawnedByRole["ice-host"][0]` |
+| `js/core/types.js` | Add `pkillIce: () => void` to `ActionContext` |
+| `js/core/actions/action-context.js` | Wire `pkillIce` to `stopIce` + `disableIce` |
+| `scripts/bot-player.js` | Add `"ice-host"` to `SECURITY_TYPES` |
+| `docs/BOT-PLAYER.md` | Add pkill to "What Bot Does NOT Do" |
+| `MANUAL.md` | Add ice-host node type, pkill action |
+| `tests/` | Unit tests for pkill action; regenerate network-gen snapshots |

--- a/js/core/actions/action-context.js
+++ b/js/core/actions/action-context.js
@@ -8,7 +8,7 @@ import { getState, getVersion, endRun } from "../state.js";
 import { reconfigureNode, rebootNode } from "../node-orchestration.js";
 import { startLoot, cancelLoot } from "./loot-exec.js";
 import { startRead, cancelRead } from "./read-exec.js";
-import { ejectIce } from "../ice.js";
+import { ejectIce, stopIce, disableIce } from "../ice.js";
 import { addLogEntry } from "../log.js";
 import { startExploit, cancelExploit } from "./exploit-exec.js";
 import { startProbe, cancelProbe } from "./probe-exec.js";
@@ -41,6 +41,7 @@ export function buildActionContext(openDarknetsStore = () => {}) {
     jackOut:          ()       => endRun("success"),
     reconfigureNode:  (nodeId) => reconfigureNode(nodeId),
     cancelTrace:      ()       => cancelTraceCountdown(),
+    pkillIce:         ()       => { stopIce(); disableIce(); },
     openDarknetsStore: () => {
       pauseTimers();
       openDarknetsStore(getState());

--- a/js/core/actions/node-types.js
+++ b/js/core/actions/node-types.js
@@ -104,7 +104,7 @@ export const NODE_TYPES = {
 
   "security-monitor": {
     gateAccess: "owned",
-    behaviors: ["monitor", "iceResident"],
+    behaviors: ["monitor"],
     actions: [
       {
         id: "cancel-trace",
@@ -155,6 +155,21 @@ export const NODE_TYPES = {
         available: (_node, state) => state.phase === "playing",
         desc: () => "Access the darknet broker to purchase exploit cards.",
         execute: (_node, _state, ctx) => ctx.openDarknetsStore(),
+      },
+    ],
+  },
+
+  "ice-host": {
+    gateAccess: "owned",
+    behaviors: [],
+    actions: [
+      {
+        id: "pkill",
+        label: "PKILL ICE",
+        available: (node, state) =>
+          node.accessLevel === "owned" && !!(state.ice?.active),
+        desc: () => "Terminate the ICE process.",
+        execute: (_node, _state, ctx) => ctx.pkillIce(),
       },
     ],
   },

--- a/js/core/actions/node-types.test.js
+++ b/js/core/actions/node-types.test.js
@@ -101,8 +101,8 @@ describe("hasBehavior", () => {
     assert.ok(hasBehavior(mockNode("security-monitor"), "monitor"));
   });
 
-  it("returns true for iceResident on security-monitor", () => {
-    assert.ok(hasBehavior(mockNode("security-monitor"), "iceResident"));
+  it("returns false for iceResident on security-monitor (ice-host owns that now)", () => {
+    assert.ok(!hasBehavior(mockNode("security-monitor"), "iceResident"));
   });
 
   it("returns true for lootable on fileserver", () => {
@@ -181,6 +181,37 @@ describe("getActions", () => {
     const node = mockNode("security-monitor", "A", { accessLevel: "locked" });
     const actions = getActions(node, mockState(30));
     assert.ok(!actions.find((a) => a.id === "cancel-trace"));
+  });
+
+  it("returns pkill for owned ice-host when ICE is active", () => {
+    const node = mockNode("ice-host", "A", { accessLevel: "owned" });
+    const state = { ...mockState(), ice: { active: true, residentNodeId: "ice-host", attentionNodeId: "ice-host", detectedAtNode: null, detectionCount: 0, dwellTimerId: null, grade: "A" } };
+    const actions = getActions(node, state);
+    assert.ok(actions.find((a) => a.id === "pkill"));
+  });
+
+  it("does not return pkill for ice-host when ICE is inactive", () => {
+    const node = mockNode("ice-host", "A", { accessLevel: "owned" });
+    const state = { ...mockState(), ice: { active: false, residentNodeId: "ice-host", attentionNodeId: "ice-host", detectedAtNode: null, detectionCount: 0, dwellTimerId: null, grade: "A" } };
+    const actions = getActions(node, state);
+    assert.ok(!actions.find((a) => a.id === "pkill"));
+  });
+
+  it("does not return pkill for ice-host when not owned", () => {
+    const node = mockNode("ice-host", "A", { accessLevel: "locked" });
+    const state = { ...mockState(), ice: { active: true, residentNodeId: "ice-host", attentionNodeId: "ice-host", detectedAtNode: null, detectionCount: 0, dwellTimerId: null, grade: "A" } };
+    const actions = getActions(node, state);
+    assert.ok(!actions.find((a) => a.id === "pkill"));
+  });
+
+  it("pkill execute calls ctx.pkillIce()", () => {
+    const node = mockNode("ice-host", "A", { accessLevel: "owned" });
+    const state = { ...mockState(), ice: { active: true, residentNodeId: "ice-host", attentionNodeId: "ice-host", detectedAtNode: null, detectionCount: 0, dwellTimerId: null, grade: "A" } };
+    const actions = getActions(node, state);
+    const pkill = actions.find((a) => a.id === "pkill");
+    let called = false;
+    pkill.execute(node, state, { pkillIce: () => { called = true; } });
+    assert.ok(called);
   });
 
   it("returns empty array for gateway", () => {

--- a/js/core/console-commands/commands.js
+++ b/js/core/console-commands/commands.js
@@ -97,6 +97,15 @@ export const COMMANDS = [
     },
   },
 
+  { verb: "pkill",
+    complete: completeNodeArg,
+    execute(args) {
+      const node = args.length >= 1 ? resolveNode(args[0]) : resolveImplicitNode();
+      if (!node) return;
+      dispatch("pkill", { nodeId: node.id });
+    },
+  },
+
   // ── Cancel commands ────────────────────────────────────────────────────────
 
   { verb: "cancel-probe",
@@ -378,6 +387,7 @@ export const COMMANDS = [
         "  cancel-trace              Abort trace countdown (requires owned security-monitor selected).",
         "  eject                     Push ICE attention to adjacent node.",
         "  reboot [node]             Send ICE home. Node offline briefly.",
+        "  pkill [node]              Terminate ICE process (requires owned ice-host).",
         "  jackout                   Disconnect and end run.",
         "  actions                   List all currently valid actions with context.",
         "  status [noun]             Game state. Nouns: summary ice hand node alert mission",

--- a/js/core/network/biomes/corporate/gen-rules.js
+++ b/js/core/network/biomes/corporate/gen-rules.js
@@ -9,7 +9,8 @@
 export const ROLES = {
   wan:     "wan",
   gateway: "gateway",
-  monitor: "security-monitor",
+  monitor:   "security-monitor",
+  "ice-host": "ice-host",
   sensor:  "ids",
   gate:    "firewall",
   routing: "router",
@@ -138,14 +139,24 @@ export const NODE_RULES = {
   },
 
   "security-monitor": {
+    singleton:  true,
+    security:   true,
+    depth:      3,
+    connectsTo: [],
+    leaf:       false,  // ice-host connects to it
+    gradeRole:  "hard",
+    labels:     ["SEC-MON", "SEC-MON-01", "MON-CORE"],
+  },
+
+  "ice-host": {
     singleton:   true,
     security:    true,
     iceResident: true,
-    depth:       3,
+    depth:       4,
     connectsTo:  [],
     leaf:        true,
     gradeRole:   "hard",
-    labels:      ["SEC-MON", "SEC-MON-01", "MON-CORE"],
+    labels:      ["ICE-HOST", "ICE-PROC", "ICE-DAEMON"],
   },
 };
 
@@ -197,6 +208,13 @@ export const LAYERS = [
     depth:     ({ tc }) => tc.depthBudget,
     gradeRole: "hard",
     connectTo: null,
+  },
+  {
+    role:      "ice-host",
+    count:     1,
+    depth:     ({ tc }) => tc.depthBudget + 1,
+    gradeRole: "hard",
+    connectTo: "monitor",    // ice-host ← edge → security-monitor
   },
   {
     role:       "sensor",

--- a/js/core/network/network-gen.js
+++ b/js/core/network/network-gen.js
@@ -269,7 +269,7 @@ function buildNetwork(rng, tc, mc, forcePieces = [], biome) {
     moneyCost:     mc,
     ice: {
       grade:     time.iceGrade,
-      startNode: spawnedByRole.monitor[0],
+      startNode: spawnedByRole["ice-host"][0],
     },
   };
 }

--- a/js/core/types.js
+++ b/js/core/types.js
@@ -206,6 +206,7 @@
  *   jackOut:          () => void,
  *   reconfigureNode:     (nodeId: string) => void,
  *   cancelTrace:         () => void,
+ *   pkillIce:            () => void,
  *   openDarknetsStore:   () => void,
  * }} ActionContext
  */

--- a/scripts/bot-player.js
+++ b/scripts/bot-player.js
@@ -28,7 +28,7 @@ const DEFAULT_MAX_TICKS = 5000;
 const LOOTABLE_TYPES = new Set(["fileserver", "cryptovault"]);
 
 /** Node types to skip in exploration (security infrastructure). */
-const SECURITY_TYPES = new Set(["ids", "security-monitor"]);
+const SECURITY_TYPES = new Set(["ids", "security-monitor", "ice-host"]);
 
 /**
  * @typedef {{

--- a/tests/fixtures/network-gen-B-B-careless-user.json
+++ b/tests/fixtures/network-gen-B-B-careless-user.json
@@ -25,7 +25,15 @@
       "y": 470
     },
     {
-      "id": "ids-4",
+      "id": "ice-host-4",
+      "type": "ice-host",
+      "label": "ICE-HOST",
+      "grade": "A",
+      "x": 300,
+      "y": 610
+    },
+    {
+      "id": "ids-5",
       "type": "ids",
       "label": "IDS-02",
       "grade": "B",
@@ -33,15 +41,15 @@
       "y": 330
     },
     {
-      "id": "router-5",
+      "id": "router-6",
       "type": "router",
       "label": "RTR-01",
-      "grade": "C",
+      "grade": "A",
       "x": 100,
       "y": 190
     },
     {
-      "id": "router-6",
+      "id": "router-7",
       "type": "router",
       "label": "RTR-02",
       "grade": "A",
@@ -49,7 +57,7 @@
       "y": 190
     },
     {
-      "id": "firewall-7",
+      "id": "firewall-8",
       "type": "firewall",
       "label": "FW-CORE",
       "grade": "A",
@@ -57,7 +65,7 @@
       "y": 190
     },
     {
-      "id": "router-8",
+      "id": "router-9",
       "type": "router",
       "label": "RTR-A",
       "grade": "A",
@@ -65,23 +73,23 @@
       "y": 330
     },
     {
-      "id": "router-9",
+      "id": "router-10",
       "type": "router",
       "label": "RTR-EDGE",
-      "grade": "A",
+      "grade": "B",
       "x": 200,
       "y": 330
     },
     {
-      "id": "fileserver-10",
+      "id": "fileserver-11",
       "type": "fileserver",
       "label": "FS-VAULT",
       "grade": "A",
-      "x": 400,
+      "x": 500,
       "y": 610
     },
     {
-      "id": "cryptovault-11",
+      "id": "cryptovault-12",
       "type": "cryptovault",
       "label": "VAULT-S",
       "grade": "A",
@@ -89,7 +97,7 @@
       "y": 470
     },
     {
-      "id": "workstation-12",
+      "id": "workstation-13",
       "type": "workstation",
       "label": "WS-02",
       "grade": "D",
@@ -97,7 +105,7 @@
       "y": 330
     },
     {
-      "id": "workstation-13",
+      "id": "workstation-14",
       "type": "workstation",
       "label": "WS-GAMMA",
       "grade": "D",
@@ -105,26 +113,26 @@
       "y": 330
     },
     {
-      "id": "workstation-14",
+      "id": "workstation-15",
       "type": "workstation",
       "label": "WS-DELTA",
-      "grade": "C",
+      "grade": "B",
       "x": 800,
       "y": 330
     },
     {
-      "id": "fileserver-15",
+      "id": "fileserver-16",
       "type": "fileserver",
       "label": "FS-01",
-      "grade": "B",
+      "grade": "A",
       "x": 1000,
       "y": 330
     },
     {
-      "id": "firewall-16",
+      "id": "firewall-17",
       "type": "firewall",
       "label": "FW-01",
-      "grade": "A",
+      "grade": "S",
       "x": 700,
       "y": 190
     }
@@ -135,64 +143,68 @@
       "target": "gateway-2"
     },
     {
-      "source": "ids-4",
-      "target": "security-monitor-3"
+      "source": "security-monitor-3",
+      "target": "ice-host-4"
     },
     {
-      "source": "gateway-2",
-      "target": "router-5"
+      "source": "ids-5",
+      "target": "security-monitor-3"
     },
     {
       "source": "gateway-2",
       "target": "router-6"
     },
     {
-      "source": "router-5",
-      "target": "ids-4"
-    },
-    {
       "source": "gateway-2",
-      "target": "firewall-7"
-    },
-    {
-      "source": "firewall-7",
-      "target": "router-8"
-    },
-    {
-      "source": "router-8",
-      "target": "router-9"
-    },
-    {
-      "source": "router-8",
-      "target": "fileserver-10"
-    },
-    {
-      "source": "router-9",
-      "target": "cryptovault-11"
+      "target": "router-7"
     },
     {
       "source": "router-6",
-      "target": "workstation-12"
-    },
-    {
-      "source": "router-5",
-      "target": "workstation-13"
-    },
-    {
-      "source": "workstation-14",
-      "target": "fileserver-15"
-    },
-    {
-      "source": "firewall-16",
-      "target": "fileserver-15"
-    },
-    {
-      "source": "router-5",
-      "target": "workstation-14"
+      "target": "ids-5"
     },
     {
       "source": "gateway-2",
-      "target": "firewall-16"
+      "target": "firewall-8"
+    },
+    {
+      "source": "firewall-8",
+      "target": "router-9"
+    },
+    {
+      "source": "router-9",
+      "target": "router-10"
+    },
+    {
+      "source": "router-10",
+      "target": "fileserver-11"
+    },
+    {
+      "source": "router-9",
+      "target": "cryptovault-12"
+    },
+    {
+      "source": "router-7",
+      "target": "workstation-13"
+    },
+    {
+      "source": "router-6",
+      "target": "workstation-14"
+    },
+    {
+      "source": "workstation-15",
+      "target": "fileserver-16"
+    },
+    {
+      "source": "firewall-17",
+      "target": "fileserver-16"
+    },
+    {
+      "source": "router-7",
+      "target": "workstation-15"
+    },
+    {
+      "source": "gateway-2",
+      "target": "firewall-17"
     }
   ],
   "startNode": "gateway-2",
@@ -209,6 +221,6 @@
   "moneyCost": "B",
   "ice": {
     "grade": "B",
-    "startNode": "security-monitor-3"
+    "startNode": "ice-host-4"
   }
 }

--- a/tests/fixtures/network-gen-B-B.json
+++ b/tests/fixtures/network-gen-B-B.json
@@ -25,63 +25,71 @@
       "y": 470
     },
     {
-      "id": "ids-4",
+      "id": "ice-host-4",
+      "type": "ice-host",
+      "label": "ICE-HOST",
+      "grade": "A",
+      "x": 300,
+      "y": 610
+    },
+    {
+      "id": "ids-5",
       "type": "ids",
       "label": "IDS-01",
       "grade": "B",
-      "x": 0,
+      "x": -200,
       "y": 330
-    },
-    {
-      "id": "router-5",
-      "type": "router",
-      "label": "RTR-A",
-      "grade": "C",
-      "x": 200,
-      "y": 190
     },
     {
       "id": "router-6",
       "type": "router",
-      "label": "RTR-02",
-      "grade": "B",
-      "x": 400,
+      "label": "RTR-A",
+      "grade": "C",
+      "x": 100,
       "y": 190
     },
     {
-      "id": "firewall-7",
+      "id": "router-7",
+      "type": "router",
+      "label": "RTR-02",
+      "grade": "B",
+      "x": 300,
+      "y": 190
+    },
+    {
+      "id": "firewall-8",
       "type": "firewall",
       "label": "FW-CORE",
       "grade": "A",
-      "x": 600,
+      "x": 500,
       "y": 190
     },
     {
-      "id": "router-8",
+      "id": "router-9",
       "type": "router",
       "label": "RTR-01",
+      "grade": "A",
+      "x": 0,
+      "y": 330
+    },
+    {
+      "id": "router-10",
+      "type": "router",
+      "label": "RTR-B",
       "grade": "C",
       "x": 200,
       "y": 330
     },
     {
-      "id": "router-9",
-      "type": "router",
-      "label": "RTR-B",
-      "grade": "B",
-      "x": 400,
-      "y": 330
-    },
-    {
-      "id": "fileserver-10",
+      "id": "fileserver-11",
       "type": "fileserver",
       "label": "FS-ARCHIVE",
       "grade": "A",
-      "x": 400,
+      "x": 500,
       "y": 610
     },
     {
-      "id": "cryptovault-11",
+      "id": "cryptovault-12",
       "type": "cryptovault",
       "label": "VAULT-S",
       "grade": "A",
@@ -89,20 +97,44 @@
       "y": 470
     },
     {
-      "id": "workstation-12",
+      "id": "workstation-13",
       "type": "workstation",
       "label": "WS-BETA",
+      "grade": "D",
+      "x": 400,
+      "y": 330
+    },
+    {
+      "id": "workstation-14",
+      "type": "workstation",
+      "label": "WS-01",
       "grade": "D",
       "x": 600,
       "y": 330
     },
     {
-      "id": "workstation-13",
+      "id": "workstation-15",
       "type": "workstation",
-      "label": "WS-01",
-      "grade": "D",
+      "label": "WS-GAMMA",
+      "grade": "B",
       "x": 800,
       "y": 330
+    },
+    {
+      "id": "fileserver-16",
+      "type": "fileserver",
+      "label": "FS-02",
+      "grade": "A",
+      "x": 1000,
+      "y": 330
+    },
+    {
+      "id": "firewall-17",
+      "type": "firewall",
+      "label": "FW-01",
+      "grade": "S",
+      "x": 700,
+      "y": 190
     }
   ],
   "edges": [
@@ -111,48 +143,68 @@
       "target": "gateway-2"
     },
     {
-      "source": "ids-4",
-      "target": "security-monitor-3"
+      "source": "security-monitor-3",
+      "target": "ice-host-4"
     },
     {
-      "source": "gateway-2",
-      "target": "router-5"
+      "source": "ids-5",
+      "target": "security-monitor-3"
     },
     {
       "source": "gateway-2",
       "target": "router-6"
     },
     {
-      "source": "router-5",
-      "target": "ids-4"
-    },
-    {
       "source": "gateway-2",
-      "target": "firewall-7"
-    },
-    {
-      "source": "firewall-7",
-      "target": "router-8"
-    },
-    {
-      "source": "router-8",
-      "target": "router-9"
-    },
-    {
-      "source": "router-8",
-      "target": "fileserver-10"
-    },
-    {
-      "source": "router-9",
-      "target": "cryptovault-11"
+      "target": "router-7"
     },
     {
       "source": "router-6",
-      "target": "workstation-12"
+      "target": "ids-5"
+    },
+    {
+      "source": "gateway-2",
+      "target": "firewall-8"
+    },
+    {
+      "source": "firewall-8",
+      "target": "router-9"
+    },
+    {
+      "source": "router-9",
+      "target": "router-10"
+    },
+    {
+      "source": "router-10",
+      "target": "fileserver-11"
+    },
+    {
+      "source": "router-10",
+      "target": "cryptovault-12"
     },
     {
       "source": "router-6",
       "target": "workstation-13"
+    },
+    {
+      "source": "router-6",
+      "target": "workstation-14"
+    },
+    {
+      "source": "workstation-15",
+      "target": "fileserver-16"
+    },
+    {
+      "source": "firewall-17",
+      "target": "fileserver-16"
+    },
+    {
+      "source": "router-10",
+      "target": "workstation-15"
+    },
+    {
+      "source": "gateway-2",
+      "target": "firewall-17"
     }
   ],
   "startNode": "gateway-2",
@@ -169,6 +221,6 @@
   "moneyCost": "B",
   "ice": {
     "grade": "B",
-    "startNode": "security-monitor-3"
+    "startNode": "ice-host-4"
   }
 }

--- a/tests/fixtures/network-gen-C-C.json
+++ b/tests/fixtures/network-gen-C-C.json
@@ -25,7 +25,15 @@
       "y": 470
     },
     {
-      "id": "ids-4",
+      "id": "ice-host-4",
+      "type": "ice-host",
+      "label": "ICE-HOST",
+      "grade": "B",
+      "x": 400,
+      "y": 610
+    },
+    {
+      "id": "ids-5",
       "type": "ids",
       "label": "IDS-01",
       "grade": "C",
@@ -33,7 +41,7 @@
       "y": 330
     },
     {
-      "id": "router-5",
+      "id": "router-6",
       "type": "router",
       "label": "RTR-A",
       "grade": "D",
@@ -41,7 +49,7 @@
       "y": 190
     },
     {
-      "id": "router-6",
+      "id": "router-7",
       "type": "router",
       "label": "RTR-02",
       "grade": "C",
@@ -49,7 +57,7 @@
       "y": 190
     },
     {
-      "id": "firewall-7",
+      "id": "firewall-8",
       "type": "firewall",
       "label": "FW-CORE",
       "grade": "B",
@@ -57,23 +65,23 @@
       "y": 190
     },
     {
-      "id": "router-8",
+      "id": "router-9",
       "type": "router",
       "label": "RTR-01",
-      "grade": "D",
+      "grade": "B",
       "x": 300,
       "y": 330
     },
     {
-      "id": "fileserver-9",
+      "id": "fileserver-10",
       "type": "fileserver",
       "label": "FS-ARCHIVE",
-      "grade": "C",
+      "grade": "D",
       "x": 500,
       "y": 470
     },
     {
-      "id": "workstation-10",
+      "id": "workstation-11",
       "type": "workstation",
       "label": "WS-BETA",
       "grade": "F",
@@ -81,7 +89,7 @@
       "y": 330
     },
     {
-      "id": "workstation-11",
+      "id": "workstation-12",
       "type": "workstation",
       "label": "WS-01",
       "grade": "F",
@@ -95,40 +103,44 @@
       "target": "gateway-2"
     },
     {
-      "source": "ids-4",
-      "target": "security-monitor-3"
+      "source": "security-monitor-3",
+      "target": "ice-host-4"
     },
     {
-      "source": "gateway-2",
-      "target": "router-5"
+      "source": "ids-5",
+      "target": "security-monitor-3"
     },
     {
       "source": "gateway-2",
       "target": "router-6"
     },
     {
-      "source": "router-5",
-      "target": "ids-4"
-    },
-    {
       "source": "gateway-2",
-      "target": "firewall-7"
-    },
-    {
-      "source": "firewall-7",
-      "target": "router-8"
-    },
-    {
-      "source": "router-8",
-      "target": "fileserver-9"
+      "target": "router-7"
     },
     {
       "source": "router-6",
-      "target": "workstation-10"
+      "target": "ids-5"
     },
     {
-      "source": "router-5",
+      "source": "gateway-2",
+      "target": "firewall-8"
+    },
+    {
+      "source": "firewall-8",
+      "target": "router-9"
+    },
+    {
+      "source": "router-9",
+      "target": "fileserver-10"
+    },
+    {
+      "source": "router-7",
       "target": "workstation-11"
+    },
+    {
+      "source": "router-7",
+      "target": "workstation-12"
     }
   ],
   "startNode": "gateway-2",
@@ -145,6 +157,6 @@
   "moneyCost": "C",
   "ice": {
     "grade": "C",
-    "startNode": "security-monitor-3"
+    "startNode": "ice-host-4"
   }
 }

--- a/tests/fixtures/network-gen-F-F.json
+++ b/tests/fixtures/network-gen-F-F.json
@@ -25,7 +25,15 @@
       "y": 470
     },
     {
-      "id": "ids-4",
+      "id": "ice-host-4",
+      "type": "ice-host",
+      "label": "ICE-HOST",
+      "grade": "D",
+      "x": 400,
+      "y": 610
+    },
+    {
+      "id": "ids-5",
       "type": "ids",
       "label": "IDS-01",
       "grade": "D",
@@ -33,7 +41,7 @@
       "y": 330
     },
     {
-      "id": "router-5",
+      "id": "router-6",
       "type": "router",
       "label": "RTR-A",
       "grade": "F",
@@ -41,7 +49,7 @@
       "y": 190
     },
     {
-      "id": "router-6",
+      "id": "router-7",
       "type": "router",
       "label": "RTR-02",
       "grade": "F",
@@ -49,15 +57,15 @@
       "y": 190
     },
     {
-      "id": "fileserver-7",
+      "id": "fileserver-8",
       "type": "fileserver",
       "label": "FS-ARCHIVE",
-      "grade": "F",
+      "grade": "D",
       "x": 300,
       "y": 330
     },
     {
-      "id": "workstation-8",
+      "id": "workstation-9",
       "type": "workstation",
       "label": "WS-BETA",
       "grade": "F",
@@ -65,7 +73,7 @@
       "y": 330
     },
     {
-      "id": "workstation-9",
+      "id": "workstation-10",
       "type": "workstation",
       "label": "WS-01",
       "grade": "F",
@@ -79,32 +87,36 @@
       "target": "gateway-2"
     },
     {
-      "source": "ids-4",
-      "target": "security-monitor-3"
+      "source": "security-monitor-3",
+      "target": "ice-host-4"
     },
     {
-      "source": "gateway-2",
-      "target": "router-5"
+      "source": "ids-5",
+      "target": "security-monitor-3"
     },
     {
       "source": "gateway-2",
       "target": "router-6"
     },
     {
-      "source": "router-5",
-      "target": "ids-4"
-    },
-    {
-      "source": "router-5",
-      "target": "fileserver-7"
+      "source": "gateway-2",
+      "target": "router-7"
     },
     {
       "source": "router-6",
-      "target": "workstation-8"
+      "target": "ids-5"
     },
     {
-      "source": "router-5",
+      "source": "router-6",
+      "target": "fileserver-8"
+    },
+    {
+      "source": "router-7",
       "target": "workstation-9"
+    },
+    {
+      "source": "router-7",
+      "target": "workstation-10"
     }
   ],
   "startNode": "gateway-2",
@@ -120,6 +132,6 @@
   "moneyCost": "F",
   "ice": {
     "grade": "F",
-    "startNode": "security-monitor-3"
+    "startNode": "ice-host-4"
   }
 }

--- a/tests/fixtures/network-gen-S-S.json
+++ b/tests/fixtures/network-gen-S-S.json
@@ -25,7 +25,15 @@
       "y": 750
     },
     {
-      "id": "ids-4",
+      "id": "ice-host-4",
+      "type": "ice-host",
+      "label": "ICE-HOST",
+      "grade": "S",
+      "x": 400,
+      "y": 890
+    },
+    {
+      "id": "ids-5",
       "type": "ids",
       "label": "IDS-01",
       "grade": "S",
@@ -33,55 +41,55 @@
       "y": 610
     },
     {
-      "id": "router-5",
+      "id": "router-6",
       "type": "router",
       "label": "RTR-A",
       "grade": "A",
-      "x": 100,
+      "x": 200,
       "y": 190
     },
     {
-      "id": "router-6",
+      "id": "router-7",
       "type": "router",
       "label": "RTR-02",
       "grade": "A",
-      "x": 300,
+      "x": 400,
       "y": 190
     },
     {
-      "id": "firewall-7",
+      "id": "firewall-8",
       "type": "firewall",
       "label": "FW-CORE",
       "grade": "S",
-      "x": 500,
+      "x": 600,
       "y": 190
-    },
-    {
-      "id": "router-8",
-      "type": "router",
-      "label": "RTR-01",
-      "grade": "A",
-      "x": -200,
-      "y": 330
     },
     {
       "id": "router-9",
       "type": "router",
-      "label": "RTR-B",
-      "grade": "A",
+      "label": "RTR-01",
+      "grade": "S",
       "x": 0,
       "y": 330
     },
     {
       "id": "router-10",
       "type": "router",
-      "label": "RTR-EDGE",
-      "grade": "S",
+      "label": "RTR-B",
+      "grade": "A",
       "x": 200,
       "y": 330
     },
     {
-      "id": "fileserver-11",
+      "id": "router-11",
+      "type": "router",
+      "label": "RTR-EDGE",
+      "grade": "S",
+      "x": 400,
+      "y": 330
+    },
+    {
+      "id": "fileserver-12",
       "type": "fileserver",
       "label": "FS-ARCHIVE",
       "grade": "S",
@@ -89,7 +97,7 @@
       "y": 750
     },
     {
-      "id": "cryptovault-12",
+      "id": "cryptovault-13",
       "type": "cryptovault",
       "label": "VAULT-S",
       "grade": "S",
@@ -97,17 +105,9 @@
       "y": 750
     },
     {
-      "id": "workstation-13",
-      "type": "workstation",
-      "label": "WS-BETA",
-      "grade": "B",
-      "x": 400,
-      "y": 330
-    },
-    {
       "id": "workstation-14",
       "type": "workstation",
-      "label": "WS-01",
+      "label": "WS-BETA",
       "grade": "B",
       "x": 600,
       "y": 330
@@ -115,26 +115,10 @@
     {
       "id": "workstation-15",
       "type": "workstation",
-      "label": "WS-GAMMA",
-      "grade": "A",
+      "label": "WS-01",
+      "grade": "B",
       "x": 800,
       "y": 330
-    },
-    {
-      "id": "fileserver-16",
-      "type": "fileserver",
-      "label": "FS-02",
-      "grade": "S",
-      "x": 1000,
-      "y": 330
-    },
-    {
-      "id": "firewall-17",
-      "type": "firewall",
-      "label": "FW-01",
-      "grade": "S",
-      "x": 700,
-      "y": 190
     }
   ],
   "edges": [
@@ -143,68 +127,56 @@
       "target": "gateway-2"
     },
     {
-      "source": "ids-4",
-      "target": "security-monitor-3"
+      "source": "security-monitor-3",
+      "target": "ice-host-4"
     },
     {
-      "source": "gateway-2",
-      "target": "router-5"
+      "source": "ids-5",
+      "target": "security-monitor-3"
     },
     {
       "source": "gateway-2",
       "target": "router-6"
     },
     {
-      "source": "router-5",
-      "target": "ids-4"
+      "source": "gateway-2",
+      "target": "router-7"
+    },
+    {
+      "source": "router-6",
+      "target": "ids-5"
     },
     {
       "source": "gateway-2",
-      "target": "firewall-7"
+      "target": "firewall-8"
     },
     {
-      "source": "firewall-7",
-      "target": "router-8"
-    },
-    {
-      "source": "router-8",
+      "source": "firewall-8",
       "target": "router-9"
     },
     {
-      "source": "router-8",
+      "source": "router-9",
       "target": "router-10"
     },
     {
-      "source": "router-9",
-      "target": "fileserver-11"
-    },
-    {
-      "source": "router-9",
-      "target": "cryptovault-12"
-    },
-    {
-      "source": "router-5",
-      "target": "workstation-13"
-    },
-    {
-      "source": "router-5",
-      "target": "workstation-14"
-    },
-    {
-      "source": "workstation-15",
-      "target": "fileserver-16"
-    },
-    {
-      "source": "firewall-17",
-      "target": "fileserver-16"
+      "source": "router-10",
+      "target": "router-11"
     },
     {
       "source": "router-10",
-      "target": "workstation-15"
+      "target": "fileserver-12"
     },
     {
-      "source": "gateway-2",
-      "target": "firewall-17"
+      "source": "router-9",
+      "target": "cryptovault-13"
+    },
+    {
+      "source": "router-6",
+      "target": "workstation-14"
+    },
+    {
+      "source": "router-7",
+      "target": "workstation-15"
     }
   ],
   "startNode": "gateway-2",
@@ -222,6 +194,6 @@
   "moneyCost": "S",
   "ice": {
     "grade": "S",
-    "startNode": "security-monitor-3"
+    "startNode": "ice-host-4"
   }
 }

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -75,9 +75,9 @@ describe("Node initialization", () => {
   });
 });
 
-// ── Lifecycle: iceResident ────────────────────────────────────────────────────
+// ── Lifecycle: ICE resident — owning security-monitor does NOT stop ICE ───────
 
-describe("Lifecycle: iceResident — owning security-monitor stops ICE", () => {
+describe("Lifecycle: owning security-monitor does NOT stop ICE", () => {
   beforeEach(() => {
     clearAll();
     initState(NETWORK);
@@ -88,20 +88,11 @@ describe("Lifecycle: iceResident — owning security-monitor stops ICE", () => {
     assert.ok(getState().ice?.active);
   });
 
-  it("owning security-monitor sets ice.active to false", () => {
+  it("owning security-monitor leaves ICE active", () => {
     const s = getState();
     s.nodes["security-monitor"].accessLevel = "owned";
     emitEvent(E.NODE_ACCESSED, { nodeId: "security-monitor", label: "SEC-MON", prev: "locked", next: "owned" });
-    assert.equal(getState().ice?.active, false);
-  });
-
-  it("owning security-monitor emits ICE_DISABLED", () => {
-    const s = getState();
-    const fired = withEvents(E.ICE_DISABLED, () => {
-      s.nodes["security-monitor"].accessLevel = "owned";
-      emitEvent(E.NODE_ACCESSED, { nodeId: "security-monitor", label: "SEC-MON", prev: "locked", next: "owned" });
-    });
-    assert.equal(fired.length, 1);
+    assert.ok(getState().ice?.active, "ICE should remain active after owning security-monitor");
   });
 
   it("owning a non-resident node does not stop ICE", () => {


### PR DESCRIPTION
## Summary

- Adds a new `ice-host` node type: the machine running the ICE process, located adjacent to the security-monitor deep in the security region
- Adds a `pkill` action on owned ice-host nodes: explicitly terminates the ICE process
- Removes the automatic `iceResident` side effect from `security-monitor` — owning it no longer kills ICE
- ICE now starts at ice-host (not security-monitor) in both procedural and static networks

## Mechanics

Three ways to neutralize the trace threat now have clean separation:

| Action | Effect |
|---|---|
| Reconfigure IDS | Severs detection → alert chain (proactive) |
| pkill ICE | Kills the ICE process entirely (proactive) |
| Own security-monitor | Cancels in-progress trace countdown (reactive) |

## Test plan

- [ ] `make check` passes (392 tests, 0 failures)
- [ ] `pkill` unit tests: available when ice-host owned + ICE active; unavailable otherwise
- [ ] Integration tests updated: owning security-monitor no longer kills ICE
- [ ] Network-gen snapshots regenerated to include ice-host node
- [ ] Playtest smoke: `cheat own-all` → `select ice-host` → `pkill` → ICE status INACTIVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)