### PR TITLE
Set-piece playground + playtest.js extensions

### DIFF
--- a/css/playground.css
+++ b/css/playground.css
@@ -1,0 +1,152 @@
+/* Playground-specific styles — layered on top of game styles */
+
+.playground-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.toolbar-label {
+  color: var(--green);
+  font-size: 0.8rem;
+}
+
+.toolbar-label select {
+  background: #0a0a0f;
+  color: var(--cyan);
+  border: 1px solid var(--cyan);
+  font-family: inherit;
+  font-size: 0.75rem;
+  padding: 2px 4px;
+}
+
+.toolbar-sep {
+  color: #333;
+  margin: 0 2px;
+}
+
+.toggle-label {
+  color: var(--green);
+  font-size: 0.75rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.toggle-label input[type="checkbox"] {
+  accent-color: var(--cyan);
+}
+
+/* Message log pane — separate from game log, shows structured trace */
+#message-log-pane {
+  max-height: 150px;
+  overflow-y: auto;
+  border-top: 1px solid #1a1a2a;
+  border-bottom: 1px solid #1a1a2a;
+  font-size: 0.7rem;
+  padding: 4px 8px;
+}
+
+#message-log-pane .log-entry {
+  font-size: 0.7rem;
+  opacity: 0.8;
+}
+
+.log-msg { color: var(--cyan); }
+.log-attr { color: #aa88ff; }
+.log-trigger { color: #ff8844; }
+
+/* Inspector panel */
+.inspector-panel {
+  border-top: 1px solid #1a1a2a;
+  padding: 8px;
+  font-size: 0.75rem;
+  overflow-y: auto;
+  max-height: 300px;
+}
+
+.inspector-header {
+  color: var(--green);
+  font-size: 0.7rem;
+  margin-bottom: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+#inspector-content {
+  color: #aaa;
+  white-space: pre-wrap;
+  font-family: inherit;
+}
+
+.inspector-section {
+  margin-top: 6px;
+}
+
+.inspector-section-title {
+  color: var(--cyan);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  margin-bottom: 2px;
+}
+
+.inspector-row {
+  display: flex;
+  gap: 8px;
+}
+
+.inspector-key {
+  color: #888;
+  min-width: 120px;
+}
+
+.inspector-val {
+  color: var(--green);
+}
+
+.inspector-val.internal {
+  color: #666;
+}
+
+/* JSON panel */
+.json-panel {
+  border-top: 1px solid #1a1a2a;
+  padding: 8px;
+  max-height: 250px;
+  overflow-y: auto;
+}
+
+.json-content {
+  color: #888;
+  font-size: 0.65rem;
+  font-family: inherit;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.json-refresh-btn {
+  font-size: 0.65rem;
+  background: none;
+  border: 1px solid #333;
+  color: var(--cyan);
+  cursor: pointer;
+  padding: 1px 6px;
+}
+
+.json-refresh-btn:hover {
+  border-color: var(--cyan);
+}
+
+/* Playground sidebar — denser than game sidebar */
+.playground-sidebar {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Message flash on nodes */
+.message-flash {
+  border-color: #ff8844 !important;
+  border-width: 3px !important;
+}

--- a/docs/dev-sessions/2026-03-04-1018-set-piece-playground/notes.md
+++ b/docs/dev-sessions/2026-03-04-1018-set-piece-playground/notes.md
@@ -7,3 +7,20 @@
 - buildSetPieceMiniNetwork instantiates a named set-piece, wraps nodes, connects gateway to external ports
 - All 15 set-pieces wrap successfully without error
 - 8 unit tests, all 505 tests pass
+
+## Phase 2+3: Playground Page + Game Init ✓
+
+- Created playground.html with toolbar (source dropdown, tick controls, toggles),
+  graph panel, message log, game log + console, inspector, JSON viewer, hand strip
+- Created css/playground.css for playground-specific styles
+- Created js/playground/main.js — full game init with Cytoscape, console, action
+  dispatcher, timers, graph bridge, dynamic actions, visual renderer
+- Dropdown populates from listSetPieces() + network registry
+- Inspector panel shows selected node's full state, operators, actions
+- Message trace log wired to NODE_STATE_CHANGED and MESSAGE_PROPAGATED events
+- JSON inspector with refresh button
+- Tick controls (×1, ×10, ×100, auto, pause)
+- Toggle checkboxes for messages, internal state, hidden attrs
+- All game actions work (select, probe, exploit, etc.)
+- URL params: ?piece=, ?network=, ?file=
+- Browser-tested: idsRelayChain loads, gateway selectable, inspector works

--- a/docs/dev-sessions/2026-03-04-1018-set-piece-playground/notes.md
+++ b/docs/dev-sessions/2026-03-04-1018-set-piece-playground/notes.md
@@ -1,1 +1,9 @@
 # Session Notes: Set-Piece Playground & Playthrough Harness
+
+## Phase 1: Mini-Network Builder ✓
+
+- Created `js/core/node-graph/mini-network.js` with buildMiniNetwork, buildSetPieceMiniNetwork, listSetPieces
+- buildMiniNetwork wraps raw NodeGraphDef with gateway + WAN + createGameNode
+- buildSetPieceMiniNetwork instantiates a named set-piece, wraps nodes, connects gateway to external ports
+- All 15 set-pieces wrap successfully without error
+- 8 unit tests, all 505 tests pass

--- a/docs/dev-sessions/2026-03-04-1018-set-piece-playground/notes.md
+++ b/docs/dev-sessions/2026-03-04-1018-set-piece-playground/notes.md
@@ -24,3 +24,26 @@
 - All game actions work (select, probe, exploit, etc.)
 - URL params: ?piece=, ?network=, ?file=
 - Browser-tested: idsRelayChain loads, gateway selectable, inspector works
+
+## Phase 4: Debug Commands ✓
+
+- Created js/playground/debug-commands.js with inject, set, inspect, triggers,
+  messages, qualities, graph, nodes, edges commands
+- Value parsing for set command (bool, number, null, string)
+- Browser-tested: nodes, triggers, set, inject all work correctly
+
+## Phase 6: Dev Overlay Toggles ✓
+
+- Toggle checkboxes wired in Phase 2 (messages, internal state, hidden attrs)
+- Added message propagation highlights (flashNode on message delivery)
+- Added ACTION_RESOLVED logging in message trace
+- Filter init/tick noise from trace
+
+## Phase 7: playtest.js Extensions ✓
+
+- Added --piece and --graph flags to playtest.js
+- --piece wraps named set-piece via buildSetPieceMiniNetwork
+- --graph loads JSON file via buildMiniNetwork
+- Fixed dynamic action discovery after state restore (emit STATE_CHANGED)
+- Tested: `node scripts/playtest.js --piece idsRelayChain reset` → 4 nodes, probe works
+- All 505 tests pass

--- a/docs/dev-sessions/2026-03-04-1018-set-piece-playground/notes.md
+++ b/docs/dev-sessions/2026-03-04-1018-set-piece-playground/notes.md
@@ -1,0 +1,1 @@
+# Session Notes: Set-Piece Playground & Playthrough Harness

--- a/docs/dev-sessions/2026-03-04-1018-set-piece-playground/plan.md
+++ b/docs/dev-sessions/2026-03-04-1018-set-piece-playground/plan.md
@@ -1,0 +1,277 @@
+# Session Plan: Set-Piece Playground & Playthrough Harness
+
+## Overview
+
+Build incrementally: start with a minimal rendering page, add interactivity layer
+by layer, then extend playtest.js. Each phase produces a working artifact.
+
+**Dependency chain:**
+```
+Phase 1: Mini-network builder (shared module)
+Phase 2: Minimal playground.html (renders a set-piece in Cytoscape)
+Phase 3: Game init + console (full game actions work)
+Phase 4: Debug commands (inject, set, inspect, triggers, etc.)
+Phase 5: Inspector panel + JSON viewer
+Phase 6: Dev overlay toggles (message trace, internal state)
+Phase 7: playtest.js --piece and --graph flags
+```
+
+---
+
+## Phase 1: Mini-Network Builder
+
+**Goal:** Shared module that wraps a set-piece or raw NodeGraphDef in a playable
+micro-network. Used by both playground.html and playtest.js.
+
+### Step 1.1: Create `js/core/node-graph/mini-network.js`
+
+```js
+export function buildMiniNetwork(graphDef, opts = {}) → { graphDef, meta }
+export function buildSetPieceMiniNetwork(pieceName) → { graphDef, meta }
+```
+
+**`buildMiniNetwork(graphDef, opts)`:**
+- Takes a raw `{ nodes, edges, triggers }`
+- Adds a gateway node (accessible, grade F, connected to first node)
+- Adds a WAN node (darknet store)
+- Wraps nodes via `createGameNode()` if they have no traits
+- Returns `{ graphDef, meta: { name, startNode: "gateway", startCash: 0, ... } }`
+
+**`buildSetPieceMiniNetwork(pieceName)`:**
+- Looks up `SET_PIECES[pieceName]`
+- Calls `instantiate()` with a simple prefix
+- Wraps nodes via `createGameNode()`
+- Connects gateway to set-piece external ports
+- Merges triggers
+- Returns same format
+
+### Step 1.2: Tests
+
+Minimal test: `buildSetPieceMiniNetwork("idsRelayChain")` returns valid graphDef
+with gateway + set-piece nodes + edges.
+
+**Checkpoint:** `make check` passes. Module exists, tested, not wired anywhere yet.
+
+---
+
+## Phase 2: Minimal Playground Page
+
+**Goal:** `playground.html` that renders a set-piece in Cytoscape. No interactivity
+yet — just visual rendering.
+
+### Step 2.1: Create `playground.html`
+
+Minimal HTML page:
+- Loads `dist/vendor.js` (Cytoscape bundle)
+- Loads `css/style.css` (reuse game styles)
+- Has `<div id="cy">` for the graph
+- Has a simple toolbar: set-piece dropdown
+- Entry point: `<script type="module" src="js/playground/main.js">`
+
+### Step 2.2: Create `js/playground/main.js`
+
+Playground-specific init:
+- Parse URL params (`?piece=`, `?network=`, `?file=`)
+- Build network from selected source (using mini-network builder)
+- Call `initGame()` to set up full game state + NodeGraph
+- Call `initGraph()` to render in Cytoscape
+- Call `syncInitialNodes()` to show initial visible nodes
+- Wire the set-piece dropdown to reload with different piece
+
+Reuses from the game:
+- `js/ui/graph.js` — Cytoscape init + styling
+- `js/core/state/index.js` — initGame
+- `js/core/node-graph/mini-network.js` — wrapping
+- `data/networks/*.js` — for ?network= mode
+
+Does NOT load: visual-renderer.js overlays (probe sweep etc), store.js, level-select.js.
+
+### Step 2.3: Populate dropdown
+
+Build dropdown from `Object.keys(SET_PIECES)` + network names. Selecting an item
+reloads the page with the appropriate URL param.
+
+**Checkpoint:** Open `playground.html?piece=idsRelayChain` in browser, see the
+set-piece rendered as a Cytoscape graph with game-styled nodes.
+
+---
+
+## Phase 3: Game Init + Console
+
+**Goal:** Full game actions work in the playground. Player can select nodes, probe,
+exploit, etc. Console input works.
+
+### Step 3.1: Wire console
+
+- Add console input HTML (same pattern as game: `<input id="console-input">`)
+- Import and call `initConsole()` from `js/ui/console.js`
+- Import and call `initDynamicActions()` for graph action discovery
+- Wire `buildActionContext()` + `initActionDispatcher()`
+
+### Step 3.2: Wire timer + tick
+
+- Set up `setInterval(() => tick(1), TICK_MS)` for real-time ticking
+- Register timer handlers: ICE_MOVE, ICE_DETECT, TRACE_TICK
+- Wire graph bridge: `initGraphBridge()`
+
+### Step 3.3: Wire basic event logging
+
+- Add a log pane (simple `<div id="log-entries">`)
+- Import and call `initLogRenderer()` OR create a simpler log that just
+  shows raw events. The game's log-renderer already handles ACTION_FEEDBACK
+  and ACTION_RESOLVED — reuse it.
+
+### Step 3.4: Add message log pane
+
+- Separate from the game log — this shows structured message trace
+- Subscribe to graph `onEvent("message-delivered", ...)`
+- Format: `[MSG] type → nodeId (operators: relay, flag)`
+- Subscribe to `onEvent("node-state-changed", ...)`
+- Format: `[ATTR] nodeId.attr: oldVal → newVal`
+
+**Checkpoint:** Can type `select gateway`, `probe`, `exploit 1` etc in the playground
+console. Actions execute, timed-action operator ticks, log shows events.
+
+---
+
+## Phase 4: Debug Commands
+
+**Goal:** Playground-specific console commands for circuit debugging.
+
+### Step 4.1: Create `js/playground/debug-commands.js`
+
+Register debug commands using the existing command registry:
+
+- `inject <nodeId> <msgType> [key=val...]` — `graph.sendMessage(nodeId, msg)`
+- `set <nodeId> <attr> <value>` — `graph.setNodeAttr(nodeId, attr, parsed)`
+- `inspect <nodeId>` — dump all attrs, operators, internal state to log
+- `triggers` — list triggers with condition state
+- `messages [on|off]` — toggle verbose message trace
+- `qualities` — dump quality store
+- `graph` — dump full graph snapshot as JSON to log
+
+### Step 4.2: Wire debug commands in playground init
+
+Import and call `registerDebugCommands()` after `initConsole()`.
+
+### Step 4.3: Value parsing for `set` command
+
+Parse value strings: `"true"` → true, `"false"` → false, numeric strings → numbers,
+`"null"` → null, otherwise keep as string.
+
+**Checkpoint:** Can type `inject ids-1 alert`, `set monitor accessLevel owned`,
+`inspect gateway`, `triggers` in the playground console.
+
+---
+
+## Phase 5: Inspector Panel + JSON Viewer
+
+**Goal:** Click a node → see its full state. Read-only JSON pane shows graph state.
+
+### Step 5.1: Inspector panel HTML
+
+Add right sidebar with:
+- Node detail section (populated on selection)
+- Sections: Attributes, Operators, Actions, Traits, Internal State
+
+### Step 5.2: Wire inspector to node selection
+
+Subscribe to `E.PLAYER_NAVIGATED` or node click events. When a node is selected:
+- Read `graph.getNodeState(nodeId)` for all attributes
+- Read node's operators and actions from the resolved NodeDef
+- Format and render in the inspector panel
+- Auto-update on `E.STATE_CHANGED` / `E.NODE_STATE_CHANGED`
+
+### Step 5.3: JSON inspector pane
+
+Add a collapsible pane (below the node inspector or as a tab) that shows:
+- `JSON.stringify(graph.snapshot(), null, 2)`
+- Updates on demand (button) or auto-refresh toggle
+- Monospace, pre-formatted, scrollable
+
+**Checkpoint:** Click a node in the playground graph, see all its attributes and
+operators in the inspector. JSON pane shows full graph state.
+
+---
+
+## Phase 6: Dev Overlay Toggles
+
+**Goal:** Toggle switches that show/hide debug information on the graph and in logs.
+
+### Step 6.1: Toolbar toggle switches
+
+Add toggle buttons to the toolbar:
+- Messages (on/off) — show message propagation in the message log
+- Internal state (on/off) — show `_clock_ticks`, `_allof_state` etc in inspector
+- Hidden attrs (on/off) — show attributes normally hidden from player
+
+### Step 6.2: Message propagation highlights
+
+When "Messages" is on and a message is delivered:
+- Briefly highlight the receiving node (CSS class flash)
+- Briefly highlight the edge the message traveled along
+- Log the message in the message log pane
+
+Uses the existing `onEvent("message-delivered", ...)` callback from the NodeGraph.
+
+### Step 6.3: Internal state filtering
+
+The inspector shows all attributes by default. When "Internal state" is off,
+filter out attributes starting with `_` (convention for operator internal state).
+
+When "Hidden attrs" is off, filter out attributes that a player wouldn't see
+(forwardingEnabled, lootCount, gateAccess, etc. — or just show everything and
+let the toggle control whether `_` prefixed attrs appear).
+
+**Checkpoint:** Toggle "Messages" on, inject an alert message, see it propagate
+visually through the graph. Toggle "Internal state" off, internal operator
+attributes disappear from the inspector.
+
+---
+
+## Phase 7: playtest.js Extensions
+
+**Goal:** `--piece` and `--graph` flags for the headless harness.
+
+### Step 7.1: Import mini-network builder
+
+Add imports for `buildMiniNetwork` and `buildSetPieceMiniNetwork` to playtest.js.
+
+### Step 7.2: Parse new flags
+
+Add `--piece <name>` and `--graph <path>` to arg parsing. When present, use the
+mini-network builder instead of the network registry.
+
+For `--graph`: read the JSON file, parse it, pass to `buildMiniNetwork()`.
+For `--piece`: pass the name to `buildSetPieceMiniNetwork()`.
+
+### Step 7.3: Verify LLM-legible output
+
+Run a quick playtest with `--piece idsRelayChain` and verify the output is
+clean, consistent, and parseable. ACTION_FEEDBACK and ACTION_RESOLVED events
+should produce readable log lines.
+
+**Checkpoint:** `node scripts/playtest.js --piece idsRelayChain reset` initializes
+a mini-network with the IDS relay chain. Standard commands work.
+
+---
+
+## Risk Notes
+
+- **Cytoscape layout with small graphs.** Cola layout may behave oddly with 3-5
+  nodes. May need to switch to a simpler layout (grid, circle) for small graphs.
+
+- **Graph.js coupling.** `initGraph()` expects a specific data format and sets up
+  overlays, ICE node, etc. The playground may need to skip some of that. Check
+  whether `addIceNode()` crashes when there's no ICE.
+
+- **Console.js DOM coupling.** `initConsole()` expects specific DOM elements
+  (`#console-input`). The playground HTML must provide them with matching IDs.
+
+- **Visual-renderer.js side effects.** If loaded, it subscribes to many events
+  and expects DOM elements that may not exist in the playground. Either don't
+  load it, or create a playground-specific renderer.
+
+- **State assumptions.** `initGame()` expects a network with exploits, macguffins,
+  mission, etc. A bare set-piece may not have lootable nodes. Ensure no crashes
+  when macguffins/mission are absent.

--- a/docs/dev-sessions/2026-03-04-1018-set-piece-playground/spec.md
+++ b/docs/dev-sessions/2026-03-04-1018-set-piece-playground/spec.md
@@ -1,0 +1,212 @@
+# Session Spec: Set-Piece Playground & Playthrough Harness
+
+## Goal
+
+Build a browser-based interactive playground for inspecting, debugging, and
+playtesting node graph circuits in isolation. Think "dev tools for the node graph"
+— layers of visibility you can toggle, a debug console with circuit manipulation
+commands, and enough game context to probe/exploit/reconfigure nodes meaningfully.
+
+Also extend the existing playtest.js harness to work with set-pieces and ad-hoc
+graph definitions, ensuring LLM-legible output.
+
+## Tool 1: Browser Playground (`playground.html`)
+
+### Entry Point
+
+Separate HTML page, independent from the main game UI. Loads via URL parameters:
+
+- `playground.html?piece=idsRelayChain` — load a named set-piece wrapped in a mini-network
+- `playground.html?file=path/to/circuit.json` — load an ad-hoc NodeGraphDef from JSON
+- `playground.html?network=corporate-foothold` — load a full network definition (bonus)
+
+### Graph Input Formats
+
+**Named set-piece** (default): the playground wraps the set-piece in a mini-network
+with a gateway (accessible, entry point) and a WAN node. Set-piece nodes are wrapped
+via `createGameNode()` so full game actions (probe, exploit, read, loot, reconfigure)
+are available. This is the "Option B" wrapper — enough context for meaningful
+interaction without a full game.
+
+**Ad-hoc JSON**: a raw `NodeGraphDef` — `{ nodes, edges, triggers }`. Nodes can use
+traits (resolved at load time) or raw operators/actions. No factory functions needed —
+pure data. Example:
+
+```json
+{
+  "nodes": [
+    { "id": "gw", "type": "gateway", "traits": ["graded", "hackable", "rebootable", "gate"],
+      "attributes": { "visibility": "accessible", "grade": "D" } },
+    { "id": "target", "type": "fileserver",
+      "traits": ["graded", "hackable", "lootable", "rebootable", "gate"],
+      "attributes": { "grade": "C" } }
+  ],
+  "edges": [["gw", "target"]],
+  "triggers": []
+}
+```
+
+**Full network** (bonus): load any registered network definition (corporate-foothold,
+research-station, corporate-exchange) with full dev tools overlay.
+
+### Layout
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ TOOLBAR: [Set-piece ▾] [Load JSON] [Reload] [Tick ▶] [×N]  │
+│          [▶ Auto] [⏸ Pause]  Toggles: [Messages] [State]   │
+├───────────────────────────────────┬──────────────────────────┤
+│                                   │ INSPECTOR PANEL          │
+│         CYTOSCAPE GRAPH           │                          │
+│    (same rendering as game,       │ Selected node:           │
+│     with dev overlays)            │   - attributes           │
+│                                   │   - operators            │
+│                                   │   - traits               │
+│                                   │   - actions              │
+│                                   │   - internal state       │
+│                                   ├──────────────────────────┤
+│                                   │ JSON INSPECTOR           │
+│                                   │ (pretty-printed,         │
+│                                   │  read-only graph state)  │
+├───────────────────────────────────┴──────────────────────────┤
+│ MESSAGE LOG (structured, scrolling text)                     │
+│ > inject ids-1 alert                                         │
+│ [MSG] alert → ids-1 (relay → monitor)                        │
+│ [ATTR] monitor.alerted: false → true                         │
+│ [TRIGGER] alert-reached-monitor: FIRED                       │
+├──────────────────────────────────────────────────────────────┤
+│ > _                                                    DEBUG │
+│ CONSOLE (game commands + debug commands)                     │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Capabilities
+
+**Rendering & navigation:**
+- Cytoscape graph with same node styles as the game
+- Click nodes to select → inspector shows full state
+- Dev overlays toggleable (message propagation, internal state, trigger status)
+
+**Tick controls:**
+- Step 1 tick
+- Step N ticks
+- Auto-play at game speed (100ms/tick)
+- Pause
+
+**Message injection:**
+- Send any message type to any node via console command
+- Visual feedback: highlight receiving nodes, flash edges on propagation
+
+**Node inspection:**
+- Click a node → inspector panel shows all attributes, operators, traits, actions
+- Internal operator state visible (`_clock_ticks`, `_allof_state`, etc.)
+- Toggleable: show/hide attributes hidden from the player in the real game
+
+**Action execution:**
+- Standard game commands work (probe, exploit, read, loot, reconfigure, etc.)
+- Dynamically discovered from graph available actions
+
+**Direct state manipulation:**
+- Set any node attribute via console command
+- Useful for testing trigger conditions without playing through
+
+**Message trace log:**
+- Structured log showing every message delivered: type, origin, path, operators fired
+- Attribute changes logged: which attribute, old value → new value
+- Trigger events logged: which trigger, condition state, fired/armed
+- Defaults to ON (dev tool, not player-facing)
+
+**Trigger inspection:**
+- Console command to list all triggers with current condition state
+- Visual indicator on graph for fired triggers (optional)
+
+**JSON inspector:**
+- Read-only pane showing current graph state as pretty-printed JSON
+- Updates on every state change (or on demand)
+- Foundation for future read/write editor
+
+### Dev Console Commands
+
+Standard game commands (probe, exploit, read, loot, status, etc.) come for free via
+the existing command system + dynamic action discovery.
+
+Additional debug commands:
+
+| Command | Description |
+|---------|-------------|
+| `inject <nodeId> <msgType> [key=val...]` | Send a raw message to a node |
+| `set <nodeId> <attr> <value>` | Directly set a node attribute |
+| `inspect <nodeId>` | Dump full node state (attrs, operators, internal state) |
+| `triggers` | List all triggers with condition state |
+| `messages [on\|off]` | Toggle message trace logging |
+| `qualities` | Dump all quality values |
+| `graph` | Dump full graph state as JSON |
+| `tick [n]` | Step N ticks (already exists) |
+
+Designed for easy extensibility — adding a new debug command is adding an entry
+to a command array, same pattern as the game's command system.
+
+### Toggle Switches (Dev Overlays)
+
+- **Messages**: show/hide message propagation highlights on the graph
+- **Internal state**: show/hide operator internal attributes (_clock_ticks, etc.)
+- **Triggers**: show/hide trigger armed/fired indicators
+- **Hidden attrs**: show/hide attributes normally hidden from the player
+
+These enable assessing what's legible in the real game UI vs what's only visible
+with dev tools — like browser dev tools for the node graph.
+
+## Tool 2: Playtest.js Extensions
+
+### Set-piece mode
+
+Add `--piece <name>` flag to playtest.js. Uses the same mini-network wrapper as the
+playground — shared module, same logic. Wraps the named set-piece with a gateway + WAN,
+initializes the game, and enters the REPL.
+
+### Ad-hoc JSON mode
+
+Add `--graph <path.json>` flag to playtest.js. Loads a NodeGraphDef from JSON, resolves
+traits, wraps if needed, initializes.
+
+### Shared mini-network builder
+
+A module (e.g. `js/core/node-graph/mini-network.js`) that both the playground and
+playtest.js use to wrap a set-piece or raw NodeGraphDef in a playable micro-network:
+
+- Adds a gateway node (accessible, entry point)
+- Adds a WAN node (darknet store access)
+- Connects gateway to set-piece external ports
+- Returns a `{ graphDef, meta }` like full network builders
+
+### LLM-legible output
+
+Ensure playtest.js output from ACTION_FEEDBACK and ACTION_RESOLVED events is
+consistently formatted and complete. The existing output should already be close
+after the composable-traits session — verify and tighten if needed.
+
+## Scope
+
+### In Scope
+
+1. `playground.html` — separate page with Cytoscape + inspector + console + message log
+2. Debug console commands (inject, set, inspect, triggers, messages, qualities, graph)
+3. Dev overlay toggles
+4. JSON inspector pane (read-only)
+5. Mini-network wrapper (shared module)
+6. playtest.js `--piece` and `--graph` flags
+7. URL parameter loading (piece, file, network)
+
+### Out of Scope
+
+- Bot player rebuild
+- Inline JSON editor (future: make inspector read/write)
+- Automated metrics collection / census-style batch runs
+- New set-pieces or traits (this session builds the tool, not the content)
+- Visual effects (probe sweep, exploit brackets) — use game rendering as-is
+
+### Design Aesthetic
+
+Same cyberpunk phosphene look as the game but more utilitarian. Dark background,
+monospace, neon accents. The inspector and message log can be denser/more technical
+than the game's sidebar and log — this is a dev tool, not a player-facing UI.

--- a/js/core/node-graph/mini-network.js
+++ b/js/core/node-graph/mini-network.js
@@ -1,0 +1,107 @@
+// @ts-check
+/**
+ * Mini-network builder — wraps a set-piece or raw NodeGraphDef in a playable
+ * micro-network with a gateway and WAN node. Used by both the browser playground
+ * and playtest.js --piece/--graph modes.
+ */
+
+import { instantiate, SET_PIECES } from "./set-pieces.js";
+import { createGateway, createWAN, createGameNode } from "./game-types.js";
+
+/**
+ * Wrap a raw NodeGraphDef in a mini-network with gateway + WAN.
+ *
+ * @param {{ nodes: any[], edges: [string,string][], triggers?: any[] }} graphDef
+ * @param {{ name?: string, startCash?: number }} [opts]
+ * @returns {{ graphDef: { nodes: any[], edges: [string,string][], triggers: any[] }, meta: object }}
+ */
+export function buildMiniNetwork(graphDef, opts = {}) {
+  const gateway = createGateway("gateway", {
+    attributes: { visibility: "accessible" },
+  });
+  const wan = createWAN("wan");
+
+  // Wrap nodes that don't have traits yet
+  const wrappedNodes = graphDef.nodes.map((n) =>
+    n.traits && n.traits.length > 0 ? n : createGameNode(n)
+  );
+
+  // Connect gateway to the first node if there are any
+  const entryEdges = wrappedNodes.length > 0
+    ? [/** @type {[string,string]} */ (["gateway", wrappedNodes[0].id])]
+    : [];
+
+  return {
+    graphDef: {
+      nodes: [gateway, wan, ...wrappedNodes],
+      edges: [
+        ["gateway", "wan"],
+        ...entryEdges,
+        ...graphDef.edges,
+      ],
+      triggers: graphDef.triggers ?? [],
+    },
+    meta: {
+      name: opts.name ?? "Mini Network",
+      startNode: "gateway",
+      startCash: opts.startCash ?? 500,
+      moneyCost: "F",
+      startHand: ["common", "common", "uncommon", "uncommon"],
+      ice: null,
+    },
+  };
+}
+
+/**
+ * Build a mini-network from a named set-piece.
+ *
+ * @param {string} pieceName — key in SET_PIECES (e.g. "idsRelayChain")
+ * @returns {{ graphDef: { nodes: any[], edges: [string,string][], triggers: any[] }, meta: object }}
+ */
+export function buildSetPieceMiniNetwork(pieceName) {
+  const def = SET_PIECES[pieceName];
+  if (!def) {
+    throw new Error(`Unknown set-piece: "${pieceName}". Available: ${Object.keys(SET_PIECES).join(", ")}`);
+  }
+
+  const instance = instantiate(def, "sp");
+  const wrappedNodes = instance.nodes.map(createGameNode);
+
+  const gateway = createGateway("gateway", {
+    attributes: { visibility: "accessible" },
+  });
+  const wan = createWAN("wan");
+
+  // Connect gateway to all external ports
+  const portEdges = instance.externalPorts.map(
+    (port) => /** @type {[string,string]} */ (["gateway", port])
+  );
+
+  return {
+    graphDef: {
+      nodes: [gateway, wan, ...wrappedNodes],
+      edges: [
+        ["gateway", "wan"],
+        ...portEdges,
+        ...instance.edges,
+      ],
+      triggers: instance.triggers,
+    },
+    meta: {
+      name: `Set-piece: ${pieceName}`,
+      startNode: "gateway",
+      startCash: 500,
+      moneyCost: "F",
+      startHand: ["common", "common", "uncommon", "uncommon", "rare"],
+      ice: null,
+    },
+  };
+}
+
+/**
+ * List available set-piece names.
+ * @returns {string[]}
+ */
+export function listSetPieces() {
+  return Object.keys(SET_PIECES);
+}

--- a/js/core/node-graph/mini-network.test.js
+++ b/js/core/node-graph/mini-network.test.js
@@ -1,0 +1,90 @@
+// @ts-check
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { NodeGraph } from "./runtime.js";
+import { buildMiniNetwork, buildSetPieceMiniNetwork, listSetPieces } from "./mini-network.js";
+
+describe("mini-network builder", () => {
+  it("buildMiniNetwork wraps raw graphDef with gateway + WAN", () => {
+    const raw = {
+      nodes: [
+        { id: "n1", type: "test", attributes: { label: "Node 1" } },
+        { id: "n2", type: "test", attributes: { label: "Node 2" } },
+      ],
+      edges: [["n1", "n2"]],
+    };
+    const result = buildMiniNetwork(raw);
+    assert.ok(result.graphDef);
+    assert.ok(result.meta);
+    assert.equal(result.meta.startNode, "gateway");
+
+    const ids = result.graphDef.nodes.map((n) => n.id);
+    assert.ok(ids.includes("gateway"), "should have gateway");
+    assert.ok(ids.includes("wan"), "should have wan");
+    assert.ok(ids.includes("n1"), "should have original node");
+    assert.ok(ids.includes("n2"), "should have original node");
+
+    // Gateway connected to first node + WAN
+    assert.ok(result.graphDef.edges.some(([a, b]) => a === "gateway" && b === "n1"));
+    assert.ok(result.graphDef.edges.some(([a, b]) => a === "gateway" && b === "wan"));
+  });
+
+  it("buildMiniNetwork produces valid NodeGraph", () => {
+    const raw = {
+      nodes: [
+        { id: "n1", type: "router", attributes: { label: "Node 1", grade: "D" } },
+      ],
+      edges: [],
+    };
+    const result = buildMiniNetwork(raw);
+    const graph = new NodeGraph(result.graphDef);
+    assert.ok(graph.getNodeIds().length >= 2); // gateway + n1 + wan
+  });
+
+  it("buildSetPieceMiniNetwork wraps idsRelayChain", () => {
+    const result = buildSetPieceMiniNetwork("idsRelayChain");
+    assert.ok(result.graphDef);
+    assert.ok(result.meta);
+    assert.equal(result.meta.startNode, "gateway");
+
+    const ids = result.graphDef.nodes.map((n) => n.id);
+    assert.ok(ids.includes("gateway"));
+    assert.ok(ids.includes("wan"));
+    // Set-piece nodes should be prefixed with "sp/"
+    assert.ok(ids.some((id) => id.startsWith("sp/")));
+  });
+
+  it("buildSetPieceMiniNetwork connects gateway to external ports", () => {
+    const result = buildSetPieceMiniNetwork("idsRelayChain");
+    // idsRelayChain has external ports: ["ids", "monitor"] → prefixed as "sp/ids", "sp/monitor"
+    assert.ok(result.graphDef.edges.some(([a, b]) => a === "gateway" && b === "sp/ids"));
+    assert.ok(result.graphDef.edges.some(([a, b]) => a === "gateway" && b === "sp/monitor"));
+  });
+
+  it("buildSetPieceMiniNetwork produces valid NodeGraph", () => {
+    const result = buildSetPieceMiniNetwork("idsRelayChain");
+    const graph = new NodeGraph(result.graphDef);
+    assert.ok(graph.getNodeIds().length >= 3);
+  });
+
+  it("all set-pieces can be wrapped without error", () => {
+    for (const name of listSetPieces()) {
+      const result = buildSetPieceMiniNetwork(name);
+      assert.ok(result.graphDef.nodes.length >= 3, `${name} should have at least gateway + wan + 1 node`);
+      // Verify it constructs a valid graph
+      const graph = new NodeGraph(result.graphDef);
+      assert.ok(graph.getNodeIds().length >= 3, `${name} graph should have nodes`);
+    }
+  });
+
+  it("throws on unknown set-piece name", () => {
+    assert.throws(() => buildSetPieceMiniNetwork("nonexistent"), /Unknown set-piece/);
+  });
+
+  it("listSetPieces returns available names", () => {
+    const pieces = listSetPieces();
+    assert.ok(pieces.includes("idsRelayChain"));
+    assert.ok(pieces.includes("deadmanCircuit"));
+    assert.ok(pieces.length >= 10);
+  });
+});

--- a/js/playground/debug-commands.js
+++ b/js/playground/debug-commands.js
@@ -129,7 +129,7 @@ export function registerDebugCommands() {
   registerCommand({
     verb: "messages",
     execute(args) {
-      const el = document.getElementById("toggle-messages");
+      const el = /** @type {HTMLInputElement} */ (document.getElementById("toggle-messages"));
       if (!el) return;
       if (args[0] === "on") el.checked = true;
       else if (args[0] === "off") el.checked = false;

--- a/js/playground/debug-commands.js
+++ b/js/playground/debug-commands.js
@@ -1,0 +1,211 @@
+// @ts-check
+/**
+ * Playground debug commands — extends the console with circuit debugging tools.
+ * Registered via the standard command registry, works alongside game commands.
+ */
+
+import { getState } from "../core/state.js";
+import { addLogEntry } from "../core/log.js";
+import { registerCommand } from "../core/console-commands/registry.js";
+import { createMessage } from "../core/node-graph/message.js";
+
+/**
+ * Parse a value string into the appropriate JS type.
+ * "true" → true, "false" → false, "null" → null, numeric → number, else string.
+ * @param {string} str
+ * @returns {any}
+ */
+function parseValue(str) {
+  if (str === "true") return true;
+  if (str === "false") return false;
+  if (str === "null") return null;
+  const num = Number(str);
+  if (!isNaN(num) && str.trim() !== "") return num;
+  // Strip quotes if present
+  if ((str.startsWith('"') && str.endsWith('"')) || (str.startsWith("'") && str.endsWith("'"))) {
+    return str.slice(1, -1);
+  }
+  return str;
+}
+
+/**
+ * Register all playground debug commands.
+ */
+export function registerDebugCommands() {
+  registerCommand({
+    verb: "inject",
+    execute(args) {
+      if (args.length < 2) {
+        addLogEntry("Usage: inject <nodeId> <msgType> [key=val ...]", "error");
+        return;
+      }
+      const [nodeId, msgType, ...kvPairs] = args;
+      const s = getState();
+      if (!s.nodeGraph) { addLogEntry("No graph loaded.", "error"); return; }
+
+      // Parse optional key=value payload pairs
+      const payload = {};
+      for (const kv of kvPairs) {
+        const eq = kv.indexOf("=");
+        if (eq > 0) {
+          payload[kv.slice(0, eq)] = parseValue(kv.slice(eq + 1));
+        }
+      }
+
+      try {
+        const msg = createMessage({ type: msgType, origin: nodeId, payload });
+        s.nodeGraph.sendMessage(nodeId, msg);
+        addLogEntry(`[DEBUG] Injected ${msgType} → ${nodeId}`, "meta");
+      } catch (e) {
+        addLogEntry(`[DEBUG] Error: ${e.message}`, "error");
+      }
+    },
+  });
+
+  registerCommand({
+    verb: "set",
+    execute(args) {
+      if (args.length < 3) {
+        addLogEntry("Usage: set <nodeId> <attr> <value>", "error");
+        return;
+      }
+      const [nodeId, attr, ...rest] = args;
+      const value = parseValue(rest.join(" "));
+      const s = getState();
+      if (!s.nodeGraph) { addLogEntry("No graph loaded.", "error"); return; }
+
+      try {
+        s.nodeGraph.setNodeAttr(nodeId, attr, value);
+        addLogEntry(`[DEBUG] ${nodeId}.${attr} = ${JSON.stringify(value)}`, "meta");
+      } catch (e) {
+        addLogEntry(`[DEBUG] Error: ${e.message}`, "error");
+      }
+    },
+  });
+
+  registerCommand({
+    verb: "inspect",
+    execute(args) {
+      if (args.length < 1) {
+        addLogEntry("Usage: inspect <nodeId>", "error");
+        return;
+      }
+      const nodeId = args[0];
+      const s = getState();
+      if (!s.nodeGraph) { addLogEntry("No graph loaded.", "error"); return; }
+
+      try {
+        const attrs = s.nodeGraph.getNodeState(nodeId);
+        addLogEntry(`[INSPECT] ${nodeId}`, "meta");
+        for (const [key, val] of Object.entries(attrs)) {
+          addLogEntry(`  ${key}: ${JSON.stringify(val)}`, "meta");
+        }
+      } catch (e) {
+        addLogEntry(`[DEBUG] Error: ${e.message}`, "error");
+      }
+    },
+  });
+
+  registerCommand({
+    verb: "triggers",
+    execute() {
+      const s = getState();
+      if (!s.nodeGraph) { addLogEntry("No graph loaded.", "error"); return; }
+
+      const snapshot = s.nodeGraph.snapshot();
+      const triggers = snapshot.triggers ?? [];
+      if (triggers.length === 0) {
+        addLogEntry("[TRIGGERS] No triggers defined.", "meta");
+        return;
+      }
+      addLogEntry(`[TRIGGERS] ${triggers.length} trigger(s):`, "meta");
+      for (const t of triggers) {
+        const status = t.fired ? (t.repeating ? "FIRED (repeating)" : "FIRED (one-shot)") : "ARMED";
+        addLogEntry(`  ${t.id}: ${status}`, "meta");
+      }
+    },
+  });
+
+  registerCommand({
+    verb: "messages",
+    execute(args) {
+      const el = document.getElementById("toggle-messages");
+      if (!el) return;
+      if (args[0] === "on") el.checked = true;
+      else if (args[0] === "off") el.checked = false;
+      else el.checked = !el.checked;
+      el.dispatchEvent(new Event("change"));
+      addLogEntry(`[DEBUG] Message trace: ${el.checked ? "ON" : "OFF"}`, "meta");
+    },
+  });
+
+  registerCommand({
+    verb: "qualities",
+    execute() {
+      const s = getState();
+      if (!s.nodeGraph) { addLogEntry("No graph loaded.", "error"); return; }
+
+      const snapshot = s.nodeGraph.snapshot();
+      const qualities = snapshot.qualities ?? {};
+      const entries = Object.entries(qualities);
+      if (entries.length === 0) {
+        addLogEntry("[QUALITIES] No qualities set.", "meta");
+        return;
+      }
+      addLogEntry(`[QUALITIES] ${entries.length} quality(ies):`, "meta");
+      for (const [name, value] of entries) {
+        addLogEntry(`  ${name}: ${value}`, "meta");
+      }
+    },
+  });
+
+  registerCommand({
+    verb: "graph",
+    execute() {
+      const s = getState();
+      if (!s.nodeGraph) { addLogEntry("No graph loaded.", "error"); return; }
+
+      const snapshot = s.nodeGraph.snapshot();
+      const json = JSON.stringify(snapshot, null, 2);
+      addLogEntry("[GRAPH] Full snapshot:", "meta");
+      // Split into lines to avoid one massive log entry
+      for (const line of json.split("\n").slice(0, 100)) {
+        addLogEntry(line, "meta");
+      }
+      if (json.split("\n").length > 100) {
+        addLogEntry("  ... (truncated, use JSON inspector for full view)", "meta");
+      }
+    },
+  });
+
+  registerCommand({
+    verb: "nodes",
+    execute() {
+      const s = getState();
+      if (!s.nodeGraph) { addLogEntry("No graph loaded.", "error"); return; }
+
+      addLogEntry("[NODES]", "meta");
+      for (const nodeId of s.nodeGraph.getNodeIds()) {
+        const attrs = s.nodeGraph.getNodeState(nodeId);
+        const type = attrs.type ?? "unknown";
+        const vis = attrs.visibility ?? "?";
+        const access = attrs.accessLevel ?? "?";
+        addLogEntry(`  ${nodeId} [${type}] vis:${vis} access:${access}`, "meta");
+      }
+    },
+  });
+
+  registerCommand({
+    verb: "edges",
+    execute() {
+      const s = getState();
+      if (!s.nodeGraph) { addLogEntry("No graph loaded.", "error"); return; }
+
+      const edges = s.nodeGraph.getEdges();
+      addLogEntry(`[EDGES] ${edges.length} edge(s):`, "meta");
+      for (const [a, b] of edges) {
+        addLogEntry(`  ${a} ↔ ${b}`, "meta");
+      }
+    },
+  });
+}

--- a/js/playground/main.js
+++ b/js/playground/main.js
@@ -18,6 +18,7 @@ import { buildActionContext, initActionDispatcher, buildNodeClickHandler } from 
 import { initGraphBridge } from "../core/graph-bridge.js";
 import { initDynamicActions } from "../core/console-commands/dynamic-actions.js";
 import { buildSetPieceMiniNetwork, buildMiniNetwork, listSetPieces } from "../core/node-graph/mini-network.js";
+import { registerDebugCommands } from "./debug-commands.js";
 
 import { buildNetwork as buildCorporateFoothold } from "../../data/networks/corporate-foothold.js";
 import { buildNetwork as buildResearchStation } from "../../data/networks/research-station.js";
@@ -324,6 +325,7 @@ async function init() {
   initActionDispatcher(ctx);
 
   // Playground-specific systems
+  registerDebugCommands();
   initMessageLog();
   initInspector();
   initJsonPanel();

--- a/js/playground/main.js
+++ b/js/playground/main.js
@@ -1,0 +1,343 @@
+// @ts-nocheck
+/**
+ * Playground entry point — initializes a set-piece or network in an interactive
+ * debugging environment. Reuses game systems (Cytoscape, console, state) with
+ * added debug tooling.
+ */
+
+import { initGraph, getCy, fitGraph, syncInitialNodes, addIceNode } from "../ui/graph.js";
+import { initGame, getState } from "../core/state.js";
+import { startIce, handleIceTick, handleIceDetect } from "../core/ice.js";
+import { initConsole, runCommand } from "../ui/console.js";
+import { on, emitEvent, E } from "../core/events.js";
+import { tick, TICK_MS, TIMER, getVisibleTimers } from "../core/timers.js";
+import { handleTraceTick } from "../core/alert.js";
+import { initVisualRenderer } from "../ui/visual-renderer.js";
+import { initLogRenderer } from "../ui/log-renderer.js";
+import { buildActionContext, initActionDispatcher, buildNodeClickHandler } from "../core/actions/action-context.js";
+import { initGraphBridge } from "../core/graph-bridge.js";
+import { initDynamicActions } from "../core/console-commands/dynamic-actions.js";
+import { buildSetPieceMiniNetwork, buildMiniNetwork, listSetPieces } from "../core/node-graph/mini-network.js";
+
+import { buildNetwork as buildCorporateFoothold } from "../../data/networks/corporate-foothold.js";
+import { buildNetwork as buildResearchStation } from "../../data/networks/research-station.js";
+import { buildNetwork as buildCorporateExchange } from "../../data/networks/corporate-exchange.js";
+
+// ── Network registry ────────────────────────────────────────
+
+const NETWORKS = {
+  "corporate-foothold": buildCorporateFoothold,
+  "research-station": buildResearchStation,
+  "corporate-exchange": buildCorporateExchange,
+};
+
+// ── URL param parsing ───────────────────────────────────────
+
+function getSourceFromUrl() {
+  const p = new URLSearchParams(location.search);
+  const piece = p.get("piece");
+  const network = p.get("network");
+  const file = p.get("file");
+  return { piece, network, file };
+}
+
+// ── Network builder from source ─────────────────────────────
+
+async function buildNetworkFromSource(source) {
+  if (source.piece) {
+    return buildSetPieceMiniNetwork(source.piece);
+  }
+  if (source.network && NETWORKS[source.network]) {
+    return NETWORKS[source.network]();
+  }
+  if (source.file) {
+    const resp = await fetch(source.file);
+    const graphDef = await resp.json();
+    return buildMiniNetwork(graphDef, { name: `File: ${source.file}` });
+  }
+  // Default: first set-piece
+  return buildSetPieceMiniNetwork("idsRelayChain");
+}
+
+// ── Cytoscape format conversion ─────────────────────────────
+
+function toCytoscapeFormat(result) {
+  const { graphDef, meta } = result;
+  return {
+    nodes: graphDef.nodes.map(n => ({
+      id: n.id,
+      type: n.type,
+      label: n.attributes?.label ?? n.id,
+      grade: n.attributes?.grade ?? "D",
+    })),
+    edges: graphDef.edges.map(([a, b]) => ({ source: a, target: b })),
+    startNode: meta.startNode,
+    startCash: meta.startCash,
+    moneyCost: meta.moneyCost,
+    ice: meta.ice,
+  };
+}
+
+// ── Dropdown population ─────────────────────────────────────
+
+function populateDropdown(source) {
+  const select = document.getElementById("source-select");
+  if (!select) return;
+
+  const pieces = listSetPieces();
+  const networks = Object.keys(NETWORKS);
+
+  // Set-pieces group
+  const pieceGroup = document.createElement("optgroup");
+  pieceGroup.label = "Set-Pieces";
+  for (const name of pieces) {
+    const opt = document.createElement("option");
+    opt.value = `piece:${name}`;
+    opt.textContent = name;
+    if (source.piece === name) opt.selected = true;
+    pieceGroup.appendChild(opt);
+  }
+  select.appendChild(pieceGroup);
+
+  // Networks group
+  const netGroup = document.createElement("optgroup");
+  netGroup.label = "Networks";
+  for (const name of networks) {
+    const opt = document.createElement("option");
+    opt.value = `network:${name}`;
+    opt.textContent = name;
+    if (source.network === name) opt.selected = true;
+    netGroup.appendChild(opt);
+  }
+  select.appendChild(netGroup);
+
+  // Change handler — navigate with URL param
+  select.addEventListener("change", () => {
+    const val = select.value;
+    const [type, name] = val.split(":");
+    location.search = `?${type}=${name}`;
+  });
+}
+
+// ── Message trace log ───────────────────────────────────────
+
+let _messagesEnabled = true;
+
+function initMessageLog() {
+  const el = document.getElementById("message-log-entries");
+  if (!el) return;
+
+  function addMsg(text, cls = "log-msg") {
+    if (!_messagesEnabled) return;
+    const div = document.createElement("div");
+    div.className = `log-entry ${cls}`;
+    div.textContent = text;
+    el.appendChild(div);
+    el.scrollTop = el.scrollHeight;
+    // Cap entries
+    while (el.children.length > 500) el.removeChild(el.firstChild);
+  }
+
+  // Subscribe to graph events via the game event bus
+  on(E.NODE_STATE_CHANGED, ({ nodeId, attr, value, previous }) => {
+    // Skip noisy progress attributes
+    if (attr.startsWith("_ta_") && attr.includes("progress")) return;
+    addMsg(`[ATTR] ${nodeId}.${attr}: ${JSON.stringify(previous)} → ${JSON.stringify(value)}`, "log-attr");
+  });
+
+  on(E.MESSAGE_PROPAGATED, ({ nodeId, message }) => {
+    if (message.type === "tick") return; // too noisy
+    addMsg(`[MSG] ${message.type} → ${nodeId} (origin: ${message.origin})`, "log-msg");
+  });
+
+  // Toggle
+  document.getElementById("toggle-messages")?.addEventListener("change", (e) => {
+    _messagesEnabled = e.target.checked;
+  });
+}
+
+// ── Inspector panel ─────────────────────────────────────────
+
+let _showInternal = true;
+let _showHidden = true;
+
+function initInspector() {
+  const content = document.getElementById("inspector-content");
+  if (!content) return;
+
+  function updateInspector() {
+    const s = getState();
+    if (!s?.selectedNodeId || !s.nodeGraph) {
+      content.textContent = "Select a node to inspect.";
+      return;
+    }
+    const nodeId = s.selectedNodeId;
+    const attrs = s.nodeGraph.getNodeState(nodeId);
+    const lines = [`NODE: ${nodeId}\n`];
+
+    // Attributes
+    lines.push("── ATTRIBUTES ──");
+    for (const [key, val] of Object.entries(attrs)) {
+      if (!_showInternal && key.startsWith("_")) continue;
+      lines.push(`  ${key}: ${JSON.stringify(val)}`);
+    }
+
+    // Node def info (operators, actions, traits)
+    const snapshot = s.nodeGraph.snapshot();
+    const nodeDef = snapshot.nodes.find(n => n.id === nodeId);
+    if (nodeDef) {
+      if (nodeDef.operators?.length) {
+        lines.push("\n── OPERATORS ──");
+        for (const op of nodeDef.operators) {
+          const config = Object.entries(op).filter(([k]) => k !== "name").map(([k, v]) => `${k}=${JSON.stringify(v)}`).join(" ");
+          lines.push(`  ${op.name}${config ? " " + config : ""}`);
+        }
+      }
+      if (nodeDef.actions?.length) {
+        lines.push("\n── ACTIONS ──");
+        const available = s.nodeGraph.getAvailableActions(nodeId);
+        const availIds = new Set(available.map(a => a.id));
+        for (const act of nodeDef.actions) {
+          const avail = availIds.has(act.id) ? "✓" : "·";
+          lines.push(`  ${avail} ${act.id} — ${act.desc ?? act.label}`);
+        }
+      }
+    }
+
+    content.textContent = lines.join("\n");
+  }
+
+  on(E.STATE_CHANGED, updateInspector);
+  on(E.PLAYER_NAVIGATED, () => setTimeout(updateInspector, 10));
+  on(E.NODE_STATE_CHANGED, updateInspector);
+
+  // Toggles
+  document.getElementById("toggle-internal")?.addEventListener("change", (e) => {
+    _showInternal = e.target.checked;
+    updateInspector();
+  });
+  document.getElementById("toggle-hidden")?.addEventListener("change", (e) => {
+    _showHidden = e.target.checked;
+    updateInspector();
+  });
+}
+
+// ── JSON inspector ──────────────────────────────────────────
+
+function initJsonPanel() {
+  const content = document.getElementById("json-content");
+  const refreshBtn = document.getElementById("json-refresh-btn");
+  if (!content || !refreshBtn) return;
+
+  function refresh() {
+    const s = getState();
+    if (!s?.nodeGraph) {
+      content.textContent = "No graph loaded.";
+      return;
+    }
+    const snapshot = s.nodeGraph.snapshot();
+    content.textContent = JSON.stringify(snapshot, null, 2);
+  }
+
+  refreshBtn.addEventListener("click", refresh);
+}
+
+// ── Tick controls ───────────────────────────────────────────
+
+function initTickControls() {
+  let autoInterval = null;
+
+  document.getElementById("tick-1-btn")?.addEventListener("click", () => {
+    tick(1);
+    emitEvent(E.STATE_CHANGED, getState());
+  });
+  document.getElementById("tick-10-btn")?.addEventListener("click", () => {
+    tick(10);
+    emitEvent(E.STATE_CHANGED, getState());
+  });
+  document.getElementById("tick-100-btn")?.addEventListener("click", () => {
+    tick(100);
+    emitEvent(E.STATE_CHANGED, getState());
+  });
+
+  const autoBtn = document.getElementById("auto-btn");
+  const pauseBtn = document.getElementById("pause-btn");
+
+  autoBtn?.addEventListener("click", () => {
+    if (autoInterval) return;
+    autoInterval = setInterval(() => {
+      tick(1);
+      if (getVisibleTimers().length > 0) emitEvent(E.TIMERS_UPDATED, getState());
+    }, TICK_MS);
+    autoBtn.textContent = "[ ▶ RUNNING ]";
+    autoBtn.classList.add("active");
+  });
+
+  pauseBtn?.addEventListener("click", () => {
+    if (autoInterval) {
+      clearInterval(autoInterval);
+      autoInterval = null;
+      autoBtn.textContent = "[ ▶ AUTO ]";
+      autoBtn.classList.remove("active");
+    }
+  });
+}
+
+// ── Init ────────────────────────────────────────────────────
+
+async function init() {
+  const source = getSourceFromUrl();
+  populateDropdown(source);
+
+  const networkResult = await buildNetworkFromSource(source);
+  const cytoscapeNetwork = toCytoscapeFormat(networkResult);
+
+  // Init rendering
+  initLogRenderer();
+  const cy = initGraph(cytoscapeNetwork, buildNodeClickHandler(), () => {
+    emitEvent("starnet:action", { actionId: "deselect" });
+  });
+  initConsole();
+  initVisualRenderer();
+
+  // Init game state + graph
+  initGame(() => networkResult, undefined, {});
+  initGraphBridge();
+  initDynamicActions();
+  syncInitialNodes(getState().nodes);
+  fitGraph(cy);
+
+  // ICE (may not exist in mini-networks)
+  const s = getState();
+  if (s.ice) {
+    addIceNode();
+    startIce();
+  }
+
+  // Timer handlers (non-action timers still use the old system)
+  on(TIMER.ICE_MOVE, () => handleIceTick());
+  on(TIMER.ICE_DETECT, (payload) => handleIceDetect(payload));
+  on(TIMER.TRACE_TICK, () => handleTraceTick());
+
+  // Action dispatcher
+  const ctx = buildActionContext();
+  initActionDispatcher(ctx);
+
+  // Playground-specific systems
+  initMessageLog();
+  initInspector();
+  initJsonPanel();
+  initTickControls();
+
+  // Reload button
+  document.getElementById("reload-btn")?.addEventListener("click", () => {
+    location.reload();
+  });
+
+  // LLM API
+  window.starnet = { cmd: runCommand, state: getState };
+
+  console.log(`Playground loaded: ${networkResult.meta.name}`);
+}
+
+init();

--- a/js/playground/main.js
+++ b/js/playground/main.js
@@ -5,7 +5,7 @@
  * added debug tooling.
  */
 
-import { initGraph, getCy, fitGraph, syncInitialNodes, addIceNode } from "../ui/graph.js";
+import { initGraph, getCy, fitGraph, syncInitialNodes, addIceNode, flashNode } from "../ui/graph.js";
 import { initGame, getState } from "../core/state.js";
 import { startIce, handleIceTick, handleIceDetect } from "../core/ice.js";
 import { initConsole, runCommand } from "../ui/console.js";
@@ -148,7 +148,18 @@ function initMessageLog() {
 
   on(E.MESSAGE_PROPAGATED, ({ nodeId, message }) => {
     if (message.type === "tick") return; // too noisy
-    addMsg(`[MSG] ${message.type} → ${nodeId} (origin: ${message.origin})`, "log-msg");
+    if (message.type === "init") return; // init noise
+    addMsg(`[MSG] ${message.type} → ${nodeId} (origin: ${message.origin}, path: ${message.path?.join("→")})`, "log-msg");
+
+    // Flash the receiving node on the graph
+    if (_messagesEnabled) {
+      try { flashNode(nodeId, "reveal"); } catch (_) { /* node might not be in graph yet */ }
+    }
+  });
+
+  // Trigger fire events — check triggers after each state change
+  on(E.ACTION_RESOLVED, ({ action, nodeId, label }) => {
+    addMsg(`[RESOLVED] ${action} @ ${label ?? nodeId}`, "log-trigger");
   });
 
   // Toggle

--- a/playground.html
+++ b/playground.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>STARNET — Playground</title>
+  <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/playground.css" />
+  <script src="dist/vendor.js"></script>
+</head>
+<body>
+  <div id="app" class="playground-app">
+
+    <!-- Toolbar -->
+    <header id="hud" class="playground-toolbar">
+      <span class="hud-title">★ PLAYGROUND</span>
+
+      <label class="toolbar-label">
+        Source:
+        <select id="source-select"></select>
+      </label>
+
+      <button id="reload-btn" title="Reload current source">[ RELOAD ]</button>
+
+      <span class="toolbar-sep">|</span>
+
+      <button id="tick-1-btn" title="Step 1 tick">[ TICK ]</button>
+      <button id="tick-10-btn" title="Step 10 ticks">[ ×10 ]</button>
+      <button id="tick-100-btn" title="Step 100 ticks">[ ×100 ]</button>
+      <button id="auto-btn" title="Toggle auto-tick">[ ▶ AUTO ]</button>
+      <button id="pause-btn">[ PAUSE ]</button>
+
+      <span class="toolbar-sep">|</span>
+
+      <label class="toggle-label">
+        <input type="checkbox" id="toggle-messages" checked /> Messages
+      </label>
+      <label class="toggle-label">
+        <input type="checkbox" id="toggle-internal" checked /> Internal
+      </label>
+      <label class="toggle-label">
+        <input type="checkbox" id="toggle-hidden" checked /> Hidden
+      </label>
+
+      <span class="toolbar-sep">|</span>
+
+      <div class="hud-alert">
+        <div class="alert-dot" id="alert-dot"></div>
+        <span class="hud-label">ALERT:</span>
+        <span class="hud-value" id="alert-level">GREEN</span>
+      </div>
+      <span class="hud-label">WALLET:</span>
+      <span class="hud-value" id="wallet">¥0</span>
+      <!-- Stubs for visual-renderer compat -->
+      <button id="jack-out-btn" style="display:none"></button>
+    </header>
+
+    <!-- Main area -->
+    <main id="main">
+      <div id="graph-column">
+        <div id="graph-container">
+          <div id="cy"></div>
+          <!-- Minimal SVG overlays for game rendering compat -->
+          <svg id="probe-sweep" style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5;">
+            <path id="probe-sweep-fill" fill="rgba(0,255,255,0.18)" />
+            <circle id="probe-sweep-ring" fill="none" stroke="#00ffff" stroke-width="1" stroke-opacity="0.45" />
+          </svg>
+          <svg id="ice-detect-sweep" style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5;">
+            <path id="ice-detect-arc" fill="none" stroke="#ff00aa" stroke-width="4" stroke-linecap="round"/>
+          </svg>
+          <svg id="loot-rings" style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5;"></svg>
+          <svg id="read-sectors" style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5;">
+            <path id="read-sectors-fill" fill="rgba(0,255,65,0.15)" />
+            <circle id="read-sectors-ring" fill="none" stroke="#00ff41" stroke-width="1" stroke-opacity="0.45" />
+          </svg>
+          <svg id="exploit-brackets" style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5;">
+            <defs>
+              <filter id="zap-bloom" x="-50%" y="-50%" width="200%" height="200%">
+                <feGaussianBlur in="SourceGraphic" stdDeviation="2.5" result="blur"/>
+                <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+              </filter>
+            </defs>
+            <line id="bracket-tl-h" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+            <line id="bracket-tl-v" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+            <line id="bracket-tr-h" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+            <line id="bracket-tr-v" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+            <line id="bracket-br-h" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+            <line id="bracket-br-v" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+            <line id="bracket-bl-h" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+            <line id="bracket-bl-v" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+            <line id="zap-tl" class="exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0" filter="url(#zap-bloom)"/>
+            <line id="zap-tr" class="exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0" filter="url(#zap-bloom)"/>
+            <line id="zap-br" class="exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0" filter="url(#zap-bloom)"/>
+            <line id="zap-bl" class="exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0" filter="url(#zap-bloom)"/>
+          </svg>
+          <svg id="selection-reticle" style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:6;">
+            <g id="reticle-group">
+              <circle id="reticle-ring" cx="30" cy="30" r="28" fill="none" stroke="#cc00cc"
+                      stroke-width="1.5" stroke-dasharray="6 3" stroke-opacity="0.75"/>
+              <line id="reticle-tick-n" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+              <line id="reticle-tick-s" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+              <line id="reticle-tick-e" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+              <line id="reticle-tick-w" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+            </g>
+          </svg>
+          <div id="node-context-menu" style="position:absolute; opacity:0; pointer-events:none; z-index:10;"></div>
+        </div>
+
+        <!-- Message trace log -->
+        <div id="message-log-pane" class="log-pane">
+          <div id="message-log-entries" class="log-entries"></div>
+        </div>
+
+        <!-- Game log + console -->
+        <div id="log-pane" class="log-pane">
+          <div id="log-entries"></div>
+          <div id="console-row">
+            <span class="console-prompt">&gt;</span>
+            <input id="console-input" type="text" autocomplete="off" spellcheck="false" placeholder="enter command..." />
+          </div>
+        </div>
+      </div>
+
+      <!-- Right sidebar: inspector + JSON -->
+      <aside id="sidebar" class="playground-sidebar">
+        <div id="sidebar-mission"></div>
+        <div id="sidebar-node">
+          <div class="sidebar-placeholder">
+            &gt; SELECT A NODE<br />
+            &gt; TO INSPECT
+          </div>
+        </div>
+        <div id="inspector-panel" class="inspector-panel">
+          <div class="inspector-header">// INSPECTOR</div>
+          <div id="inspector-content">Select a node to inspect.</div>
+        </div>
+        <div id="json-panel" class="json-panel">
+          <div class="inspector-header">
+            // GRAPH JSON
+            <button id="json-refresh-btn" class="json-refresh-btn">[ REFRESH ]</button>
+          </div>
+          <pre id="json-content" class="json-content">Click REFRESH to view graph state.</pre>
+        </div>
+        <div id="hand-strip"></div>
+      </aside>
+    </main>
+
+  </div>
+
+  <script type="module" src="js/playground/main.js"></script>
+</body>
+</html>

--- a/scripts/playtest.js
+++ b/scripts/playtest.js
@@ -18,7 +18,7 @@ import { buildNetwork as buildCorporateFoothold } from "../data/networks/corpora
 import { buildNetwork as buildResearchStation } from "../data/networks/research-station.js";
 import { buildNetwork as buildCorporateExchange } from "../data/networks/corporate-exchange.js";
 import { startIce, handleIceTick, handleIceDetect } from "../js/core/ice.js";
-import { on, E } from "../js/core/events.js";
+import { on, emitEvent, E } from "../js/core/events.js";
 import { tick, TIMER } from "../js/core/timers.js";
 import { handleTraceTick } from "../js/core/alert.js";
 import { initLog, addLogEntry } from "../js/core/log.js";
@@ -27,6 +27,7 @@ import { handleCheatCommand } from "../js/core/cheats.js";
 import { buildActionContext, initActionDispatcher } from "../js/core/actions/action-context.js";
 import { initGraphBridge } from "../js/core/graph-bridge.js";
 import { initDynamicActions } from "../js/core/console-commands/dynamic-actions.js";
+import { buildSetPieceMiniNetwork, buildMiniNetwork, listSetPieces } from "../js/core/node-graph/mini-network.js";
 
 // alert.js registers NODE_ALERT_RAISED / NODE_RECONFIGURED listeners at module load
 // (importing handleTraceTick above already loaded the module — no separate import needed)
@@ -37,6 +38,8 @@ let stateFile = "scripts/playtest-state.json";
 let cmdStr = null;
 let seedArg = null;
 let networkArg = null;
+let pieceArg = null;
+let graphFileArg = null;
 
 {
   const argv = process.argv.slice(2);
@@ -47,6 +50,10 @@ let networkArg = null;
       seedArg = argv[++i];
     } else if (argv[i] === "--network" && argv[i + 1]) {
       networkArg = argv[++i];
+    } else if (argv[i] === "--piece" && argv[i + 1]) {
+      pieceArg = argv[++i];
+    } else if (argv[i] === "--graph" && argv[i + 1]) {
+      graphFileArg = argv[++i];
     } else if (cmdStr === null) {
       cmdStr = argv[i];
     }
@@ -60,11 +67,27 @@ const GRAPH_NETWORKS = {
   "corporate-exchange": buildCorporateExchange,
 };
 
-const selectedNetwork = networkArg ?? "corporate-foothold";
-const buildNetworkFn = GRAPH_NETWORKS[selectedNetwork];
-if (!buildNetworkFn) {
-  console.error(`Unknown network: ${selectedNetwork}. Available: ${Object.keys(GRAPH_NETWORKS).join(", ")}`);
-  process.exit(1);
+let buildNetworkFn;
+if (pieceArg) {
+  // Set-piece mode: wrap in mini-network
+  const available = listSetPieces();
+  if (!available.includes(pieceArg)) {
+    console.error(`Unknown set-piece: ${pieceArg}. Available: ${available.join(", ")}`);
+    process.exit(1);
+  }
+  buildNetworkFn = () => buildSetPieceMiniNetwork(pieceArg);
+} else if (graphFileArg) {
+  // Ad-hoc JSON mode: load file and wrap
+  const graphJson = JSON.parse(readFileSync(graphFileArg, "utf-8"));
+  buildNetworkFn = () => buildMiniNetwork(graphJson, { name: `File: ${graphFileArg}` });
+} else {
+  // Standard network mode
+  const selectedNetwork = networkArg ?? "corporate-foothold";
+  buildNetworkFn = GRAPH_NETWORKS[selectedNetwork];
+  if (!buildNetworkFn) {
+    console.error(`Unknown network: ${selectedNetwork}. Available: ${Object.keys(GRAPH_NETWORKS).join(", ")}`);
+    process.exit(1);
+  }
 }
 
 if (!cmdStr) {
@@ -166,7 +189,8 @@ function runCmd(raw) {
     startIce();
     const s = getState();
     const nodeCount = Object.keys(s.nodes).length;
-    out(`[SYS] Initialized. Seed: "${s.seed}". Network: ${nodeCount} nodes (${selectedNetwork}).`);
+    const networkName = pieceArg ? `piece:${pieceArg}` : graphFileArg ? `file:${graphFileArg}` : (networkArg ?? "corporate-foothold");
+    out(`[SYS] Initialized. Seed: "${s.seed}". Network: ${nodeCount} nodes (${networkName}).`);
     return;
   }
   if (verb === "tick") {
@@ -193,6 +217,9 @@ if (!isReset) {
   if (existsSync(stateFile)) {
     try {
       deserializeState(JSON.parse(readFileSync(stateFile, "utf8")));
+      initDynamicActions();
+      // Emit STATE_CHANGED so dynamic actions sync for the restored state
+      emitEvent(E.STATE_CHANGED, getState());
     } catch (e) {
       out(`[SYS] Failed to load ${stateFile}: ${e.message}. Initializing fresh.`);
       initGame(() => buildNetworkFn(), seedArg ?? undefined);


### PR DESCRIPTION
## Summary

- **Browser playground** (`playground.html`): interactive node graph dev tools for inspecting, debugging, and playtesting set-piece circuits in isolation
- **Mini-network builder**: shared module that wraps set-pieces or raw JSON in playable micro-networks with gateway + WAN
- **playtest.js extensions**: `--piece` and `--graph` flags for headless set-piece testing

## Key features

**Playground page:**
- Source dropdown: all 15 set-pieces + 3 full networks
- Full game actions (probe, exploit, read, loot, reconfigure) via console
- 9 debug commands: inject, set, inspect, triggers, messages, qualities, graph, nodes, edges
- Node inspector panel showing attributes, operators, actions
- Read-only JSON inspector for graph state
- Message trace log (attribute changes, message propagation)
- Tick controls (×1, ×10, ×100, auto, pause)
- Dev overlay toggles (messages, internal state, hidden attrs)

**Headless harness:**
- `node scripts/playtest.js --piece idsRelayChain reset`
- `node scripts/playtest.js --graph circuit.json reset`
- Fixed dynamic action discovery after state restore

## Test plan

- [x] `make check` passes (505 tests)
- [x] Mini-network builder: 8 tests, all 15 set-pieces wrap successfully
- [x] Browser: playground loads, console works, debug commands functional
- [x] Headless: `--piece idsRelayChain` probe/exploit cycle works
- [ ] Manual: test switching set-pieces via dropdown, try different circuits

🤖 Generated with [Claude Code](https://claude.com/claude-code)