### PR TITLE
feat: new node traits + enabledAttr disarm system

### DIFF
--- a/js/core/node-graph/operators.js
+++ b/js/core/node-graph/operators.js
@@ -61,6 +61,7 @@ export function applyOperators(operatorConfigs, nodeAttributes, message, ctx) {
   const events = [];
 
   for (const config of operatorConfigs) {
+    if (config.enabledAttr && attrs[config.enabledAttr] === false) continue;
     const fn = getOperator(config.name);
     const result = fn(config, attrs, message, ctx);
     if (result.attributes) {

--- a/js/core/node-graph/operators.test.js
+++ b/js/core/node-graph/operators.test.js
@@ -400,6 +400,40 @@ describe("applyOperators", () => {
     assert.equal(result.outgoing.length, 2);
   });
 
+  it("skips operator when enabledAttr is false", () => {
+    const msg = createMessage({ type: "set", origin: "A" });
+    const result = applyOperators(
+      [{ name: "latch", enabledAttr: "latchEnabled" }],
+      { latchEnabled: false },
+      msg,
+      nullCtx,
+    );
+    // Latch should NOT have fired — latched should be undefined
+    assert.equal(result.attributes.latched, undefined);
+  });
+
+  it("runs operator when enabledAttr is true", () => {
+    const msg = createMessage({ type: "set", origin: "A" });
+    const result = applyOperators(
+      [{ name: "latch", enabledAttr: "latchEnabled" }],
+      { latchEnabled: true },
+      msg,
+      nullCtx,
+    );
+    assert.equal(result.attributes.latched, true);
+  });
+
+  it("runs operator when enabledAttr is absent from config", () => {
+    const msg = createMessage({ type: "set", origin: "A" });
+    const result = applyOperators(
+      [{ name: "latch" }],
+      {},
+      msg,
+      nullCtx,
+    );
+    assert.equal(result.attributes.latched, true);
+  });
+
   it("collects qualityDeltas from tally operators", () => {
     const msg = createMessage({ type: "probe-noise", origin: "A" });
     const result = applyOperators(

--- a/js/core/node-graph/runtime.js
+++ b/js/core/node-graph/runtime.js
@@ -68,6 +68,7 @@ export class NodeGraph {
           allTriggers.push({
             ...t,
             id: `${n.id}/${t.id}`,
+            _nodeId: n.id,
             when: _fillNodeId(t.when, n.id),
             then: t.then.map(eff => _fillEffectNodeId(eff, n.id)),
           });

--- a/js/core/node-graph/set-pieces.js
+++ b/js/core/node-graph/set-pieces.js
@@ -253,26 +253,45 @@ export const nthAlarm = {
     {
       id: "sensor",
       type: "tripwire-sensor",
-      attributes: { accessLevel: "locked", threshold: 3 },
+      attributes: { accessLevel: "locked", threshold: 3, counterEnabled: true },
       operators: [
         {
           name: "counter",
           n: 3,
           filter: "probe-noise",
           emits: { type: "set", payload: {} },
+          enabledAttr: "counterEnabled",
         },
       ],
-      actions: [],
+      actions: [
+        {
+          id: "recalibrate",
+          label: "Recalibrate Sensor",
+          requires: [{ type: "node-attr", attr: "accessLevel", eq: "owned" }],
+          effects: [{ effect: "set-attr", attr: "counterEnabled", value: false }],
+        },
+      ],
     },
     {
       id: "alarm-latch",
       type: "alarm-latch",
-      attributes: { latched: false },
-      operators: [{ name: "latch" }],
-      actions: [],
+      attributes: { latched: false, latchEnabled: true },
+      operators: [{ name: "latch", enabledAttr: "latchEnabled" }],
+      actions: [
+        {
+          id: "disarm",
+          label: "Disarm Latch",
+          requires: [{ type: "node-attr", attr: "accessLevel", eq: "owned" }],
+          effects: [
+            { effect: "set-attr", attr: "latchEnabled", value: false },
+            { effect: "set-attr", attr: "latched", value: false },
+          ],
+        },
+      ],
       triggers: [{
         id: "alarm-fire",
         when: { type: "node-attr", attr: "latched", eq: true },
+        enabledAttr: "latchEnabled",
         then: [
           { effect: "ctx-call", method: "startTrace", args: [] },
           { effect: "ctx-call", method: "log", args: ["ALERT: Access threshold exceeded — trace initiated"] },
@@ -938,17 +957,24 @@ export const tripwireGauntlet = {
     {
       id: "sensor",
       type: "tripwire-sensor",
-      attributes: { triggered: false },
+      attributes: { accessLevel: "locked", triggered: false, sensorEnabled: true },
       operators: [
-        { name: "flag", on: "probe-noise", attr: "triggered" },
-        { name: "delay", ticks: 6 },
+        { name: "flag", on: "probe-noise", attr: "triggered", enabledAttr: "sensorEnabled" },
+        { name: "delay", ticks: 6, enabledAttr: "sensorEnabled" },
       ],
-      actions: [],
+      actions: [
+        {
+          id: "bypass",
+          label: "Bypass Tripwire",
+          requires: [{ type: "node-attr", attr: "accessLevel", eq: "owned" }],
+          effects: [{ effect: "set-attr", attr: "sensorEnabled", value: false }],
+        },
+      ],
     },
     {
       id: "alarm",
       type: "alarm",
-      attributes: { triggered: false },
+      attributes: { accessLevel: "locked", triggered: false },
       operators: [{ name: "flag", on: "probe-noise", attr: "triggered" }],
       actions: [],
     },
@@ -990,9 +1016,16 @@ export const probeBurstAlarm = {
     {
       id: "scanner",
       type: "traffic-scanner",
-      attributes: { accessLevel: "locked" },
-      operators: [{ name: "tally", on: "probe-noise", quality: "probe-bursts", delta: 1 }],
-      actions: [],
+      attributes: { accessLevel: "locked", tallyEnabled: true },
+      operators: [{ name: "tally", on: "probe-noise", quality: "probe-bursts", delta: 1, enabledAttr: "tallyEnabled" }],
+      actions: [
+        {
+          id: "blind",
+          label: "Blind Scanner",
+          requires: [{ type: "node-attr", attr: "accessLevel", eq: "owned" }],
+          effects: [{ effect: "set-attr", attr: "tallyEnabled", value: false }],
+        },
+      ],
     },
   ],
   internalEdges: [],
@@ -1031,9 +1064,16 @@ export const noisySensor = {
     {
       id: "sensor",
       type: "traffic-sensor",
-      attributes: { accessLevel: "locked" },
-      operators: [{ name: "debounce", on: "probe-noise", ticks: 4 }],
-      actions: [],
+      attributes: { accessLevel: "locked", debounceEnabled: true },
+      operators: [{ name: "debounce", on: "probe-noise", ticks: 4, enabledAttr: "debounceEnabled" }],
+      actions: [
+        {
+          id: "muffle",
+          label: "Muffle Sensor",
+          requires: [{ type: "node-attr", attr: "accessLevel", eq: "owned" }],
+          effects: [{ effect: "set-attr", attr: "debounceEnabled", value: false }],
+        },
+      ],
     },
     {
       id: "alarm-flag",

--- a/js/core/node-graph/triggers.js
+++ b/js/core/node-graph/triggers.js
@@ -45,6 +45,8 @@ export class TriggerStore {
   evaluate(stateAccessors, mutators) {
     for (const def of this._defs) {
       if (this._fired.has(def.id)) continue;
+      if (def.enabledAttr && def._nodeId &&
+          stateAccessors.getNodeAttr(def._nodeId, def.enabledAttr) === false) continue;
       if (evaluateCondition(def.when, stateAccessors)) {
         if (!def.repeating) {
           this._fired.add(def.id);

--- a/js/core/node-graph/triggers.test.js
+++ b/js/core/node-graph/triggers.test.js
@@ -167,6 +167,56 @@ describe("TriggerStore", () => {
     assert.equal(ts.getFired().has("repeater"), false);
   });
 
+  it("skips trigger when enabledAttr on owning node is false", () => {
+    const { ctx, calls } = makeCtx();
+    const store = makeStore({ "sensor": { latched: true, latchEnabled: false } });
+    const ts = new TriggerStore([{
+      id: "sensor/alarm",
+      _nodeId: "sensor",
+      enabledAttr: "latchEnabled",
+      when: { type: "node-attr", nodeId: "sensor", attr: "latched", eq: true },
+      then: [{ effect: "ctx-call", method: "startTrace", args: [] }],
+    }]);
+
+    const accessors = { getNodeAttr: store.getNodeAttr, getQuality: store.getQuality };
+    const mutators = { ...store, targetNodeId: null, ctx };
+    ts.evaluate(accessors, mutators);
+    assert.equal(calls.startTrace, undefined);
+  });
+
+  it("fires trigger when enabledAttr on owning node is true", () => {
+    const { ctx, calls } = makeCtx();
+    const store = makeStore({ "sensor": { latched: true, latchEnabled: true } });
+    const ts = new TriggerStore([{
+      id: "sensor/alarm",
+      _nodeId: "sensor",
+      enabledAttr: "latchEnabled",
+      when: { type: "node-attr", nodeId: "sensor", attr: "latched", eq: true },
+      then: [{ effect: "ctx-call", method: "startTrace", args: [] }],
+    }]);
+
+    const accessors = { getNodeAttr: store.getNodeAttr, getQuality: store.getQuality };
+    const mutators = { ...store, targetNodeId: null, ctx };
+    ts.evaluate(accessors, mutators);
+    assert.equal(calls.startTrace?.length, 1);
+  });
+
+  it("fires trigger when enabledAttr is absent (default enabled)", () => {
+    const { ctx, calls } = makeCtx();
+    const store = makeStore({ "sensor": { latched: true } });
+    const ts = new TriggerStore([{
+      id: "sensor/alarm",
+      _nodeId: "sensor",
+      when: { type: "node-attr", nodeId: "sensor", attr: "latched", eq: true },
+      then: [{ effect: "ctx-call", method: "startTrace", args: [] }],
+    }]);
+
+    const accessors = { getNodeAttr: store.getNodeAttr, getQuality: store.getQuality };
+    const mutators = { ...store, targetNodeId: null, ctx };
+    ts.evaluate(accessors, mutators);
+    assert.equal(calls.startTrace?.length, 1);
+  });
+
   it("one-shot trigger still fires only once even when condition stays true", () => {
     const { ctx, calls } = makeCtx();
     const store = makeStore({ "A": { active: true } });

--- a/js/core/node-graph/types.js
+++ b/js/core/node-graph/types.js
@@ -45,6 +45,7 @@
  * @property {Effect[]} [onComplete]  - timed-action: effects to fire on completion
  * @property {number} [onProgressInterval] - timed-action: fraction at which to fire progress effects
  * @property {any[]} [onProgressEffects] - timed-action: effects at progress milestones
+ * @property {string} [enabledAttr]     - if set, operator is skipped when this node attribute is false
  */
 
 /**
@@ -74,6 +75,8 @@
  * @property {Effect[]} then
  * @property {boolean} [fired]
  * @property {boolean} [repeating]    - if true, fires every evaluation cycle the condition is true (not just once)
+ * @property {string} [enabledAttr]  - if set, trigger is skipped when owning node's attribute is false
+ * @property {string} [_nodeId]      - owning node ID (filled in by runtime for per-node triggers)
  */
 
 /**


### PR DESCRIPTION
## Summary

- **New traits system** with 5 traits: hardened, audited, trapped, encrypted, volatile — applied via `traits` array on NodeDefs, resolved at construction time
- **Per-node triggers** on NodeDefs, with nodeId auto-filled by runtime
- **`quality-from-attr` condition type** for traits that derive quality names from node attributes
- **`enabledAttr` on operators and triggers** — optional field naming a node attribute; when false, the operator/trigger is skipped. Enables player disarm actions on defensive set-pieces
- **Disarm actions** added to 4 set-pieces that previously had no counterplay: nthAlarm, tripwireGauntlet, probeBurstAlarm, noisySensor
- **`timed-action` operator enhancements**: `durationMultiplier`, `noiseInterval`, `durationAttrSource`
- Refactored set-piece triggers to per-node triggers where appropriate
- Session docs (spec, plan, retro notes)

## Test plan

- [x] All 523 tests pass (`make check`)
- [ ] Manual playtest with set-pieces containing new traits
- [ ] Verify disarm actions appear in sidebar when node is owned
- [ ] Verify disarmed operators/triggers no longer fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)