### PR TITLE
Bot player rebuild: modular perception→scoring→execute architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: serve lint test check bundle-vendor census bot-census ng-playtest
+.PHONY: serve lint test check bundle-vendor census bot-census bot-run ng-playtest
 
 # Start local dev server (open http://localhost:3000)
 serve:
@@ -28,9 +28,8 @@ bundle-vendor:
 census:
 	node scripts/network-census.js
 
-# Run bot simulation at B/B (override with: make bot-census TC=S MC=S SEEDS=50)
-TC ?= B
-MC ?= B
-SEEDS ?= 100
-bot-census:
-	node scripts/bot-census.js --time $(TC) --money $(MC) --seeds $(SEEDS)
+# Run bot player against a network (override with: make bot-run NET=research-station SEED=test-1)
+NET ?= corporate-foothold
+SEED ?= ""
+bot-run:
+	node scripts/bot/cli.js --network $(NET) $(if $(filter-out "",$(SEED)),--seed $(SEED))

--- a/docs/BOT-PLAYER.md
+++ b/docs/BOT-PLAYER.md
@@ -1,143 +1,180 @@
 # Bot Player
 
-The bot player (`scripts/bot-player.js`) is an automated game-playing agent that
-runs a complete Starnet LAN dungeon from initialization to jackout. It uses a
-fixed greedy strategy — deliberately simple so that difficulty differences show up
-in results rather than strategy variance. The bot establishes a pessimistic lower
-bound on completion rates: a skilled human player should beat it at every
-difficulty level.
-
-The bot census CLI (`scripts/bot-census.js`) runs the bot many times across
-parameterized difficulties and produces LLM-readable reports.
+The bot player (`scripts/bot/`) is an automated game-playing agent that runs a
+complete Starnet LAN dungeon from initialization to jackout. It uses a modular
+**perception → scoring → execute** architecture with pluggable strategy
+heuristics — deliberately greedy (no lookahead) so that difficulty differences
+show up in results rather than strategy variance. The bot establishes a
+pessimistic lower bound on completion rates: a skilled human player should beat
+it at every difficulty level.
 
 ---
 
 ## Quick Start
 
 ```bash
-# Run 100 simulated games at B/B difficulty
-node scripts/bot-census.js --time B --money B
+# Run a single bot game
+node scripts/bot/cli.js --network corporate-foothold --seed test-1
 
-# Run with evasion strategy (recommended — much better at C+ ICE)
-node scripts/bot-census.js --time B --money B --evasion
+# Verbose mode — shows scoring proposals and decisions
+node scripts/bot/cli.js --network research-station --seed test-1 --verbose
 
-# Quick test with fewer seeds
-node scripts/bot-census.js --time C --money C --seeds 20 --evasion
-
-# Makefile shortcut (defaults: B/B, 100 seeds)
-make bot-census
-make bot-census TC=S MC=S SEEDS=50
+# Available networks: corporate-foothold, research-station, corporate-exchange
 ```
 
----
-
-## Bot Strategy
-
-### Node Selection Priority
-
-Each iteration of the main loop, the bot picks the next node to work on:
-
-1. **Current node** — if the bot's current position (gateway at start) is
-   unowned, work on it first.
-2. **IDS reconfiguration** (evasion mode only) — if a visible IDS node is not
-   yet reconfigured, prioritize owning and reconfiguring it. This severs the
-   ICE detection → alert chain, which is the key counterplay to ICE pressure.
-3. **Nearest lootable target** — BFS through owned nodes to find the closest
-   fileserver or cryptovault that isn't yet owned.
-4. **Nearest unowned node** — any visible, non-security, non-wan node.
-5. **Null** — nothing reachable; the bot jacks out.
-
-The BFS only traverses through owned nodes (the bot can't see past nodes it
-doesn't control). Hidden nodes behind firewalls are invisible until the gate
-is owned.
-
-### Per-Node Action Sequence
-
-For each target node:
-
-1. **Select** — navigate to the node (makes it accessible if revealed).
-2. **Probe** — if not already probed, scan for vulnerabilities. Ticks forward
-   until `NODE_PROBED` fires. In evasion mode, cancels and hides if ICE arrives
-   mid-probe.
-3. **Exploit** — pick the best card and attack:
-   - **Card selection**: prefer cards matching a known vulnerability, then
-     highest quality, then most uses remaining.
-   - **Proactive store** (evasion mode): if no card matches any known vuln, buy
-     a matching card from the darknet store before exploiting.
-   - Ticks forward until `EXPLOIT_SUCCESS` or `EXPLOIT_FAILURE` fires.
-   - Repeats until the node is owned or no usable cards remain.
-4. **Read** — if owned and not yet read, extract data. Ticks until `NODE_READ`.
-5. **Loot** — if read and has uncollected macguffins, extract loot. Ticks until
-   `NODE_LOOTED`.
-6. **Reconfigure** (evasion, IDS nodes) — if the owned node is an IDS, disable
-   event forwarding to sever the alert chain.
-
-### When Stuck
-
-If the bot has no usable cards for the current node:
-
-1. Look for a known vulnerability and buy a matching card from the darknet store.
-2. If the store purchase fails (can't afford), try a different node.
-3. If no nodes are reachable, jack out with failure reason `"no-cards"`.
+Output is a JSON `BotRunStats` object (see Stats Collected below).
 
 ---
 
-## Evasion Mode
+## Architecture
 
-Enabled with the `--evasion` flag (or `{ evasion: true }` option). Adds ICE
-avoidance behaviors that significantly improve success rates at C+ difficulty.
+```
+scripts/bot/
+  cli.js            — CLI entry point (parse args, select network, print stats)
+  run.js            — init engine, assemble strategies, run loop
+  loop.js           — main cycle: perceive → score → execute → track
+  perception.js     — reads game state, builds WorldModel snapshot
+  scoring.js        — runs all strategies, picks highest-scored proposal
+  execute.js        — dispatches actions, ticks timed actions to resolution
+  stats.js          — stat creation, recording, finalization
+  types.js          — JSDoc typedefs (WorldModel, ScoredAction, etc.)
+  heuristics/
+    explore.js      — probe unprobed nodes, exploit probed ones
+    loot.js         — read and loot owned nodes
+    security.js     — subvert IDS, cancel trace
+    traps.js        — disarm set-piece traps on owned nodes
+    evasion.js      — avoid ICE, jack out under trace
+    cards.js        — buy cards from darknet store, jack out when stuck
 
-### Deselect Between Actions
+scripts/lib/
+  headless-engine.js — shared init for bot + playtest harness
+```
 
-After each timed action completes (probe, exploit, read, loot), the bot
-immediately deselects. ICE can only detect the player when co-located on the
-same node — deselecting removes the player's presence.
+### Pipeline
 
-### Cancel-on-ICE-Arrival
+Each main-loop iteration:
 
-During exploit and probe execution, the bot monitors for `ICE_MOVED` events.
-If ICE arrives at the player's current node mid-action:
+1. **Perceive** — snapshot game state into a `WorldModel`: categorized nodes,
+   card-to-vuln matching, ICE position, available actions, mission status.
+2. **Score** — every strategy heuristic returns `ScoredAction[]` proposals. The
+   scoring engine picks the highest by score magnitude.
+3. **Execute** — dispatch the winning action. Instant actions return immediately.
+   Timed actions (probe, exploit, read, loot) tick forward until resolution,
+   ICE interruption, or tick budget.
+4. **Track** — record stats, update failed-exploit memory, ICE cooldowns, and
+   completed-action sets.
 
-1. Cancel the current action (`cancel-exploit` or `cancel-probe`).
-2. Deselect to hide.
-3. **Patience**: wait for 3 ICE move events. This gives ICE time to arrive at
-   the disturbance source, investigate, clear the signal, and wander away.
-4. Set the current node as `avoidNodeId` — the next iteration will prefer a
-   different target.
+### Shared Headless Engine
 
-### Node Avoidance
+`scripts/lib/headless-engine.js` extracts the timer wiring, action context, and
+game init sequence shared by the bot and playtest harness. Both entry points
+import `initHeadlessEngine()` and `resetGame()` from here.
 
-After an ICE encounter, the bot avoids the node where ICE was last seen and
-picks a different target if one is available. This prevents the bot from
-immediately re-triggering disturbance at the same location. The avoidance
-clears once any node is successfully owned.
+---
 
-### IDS Reconfiguration
+## Strategy Heuristics
 
-In evasion mode, the bot prioritizes owning and reconfiguring IDS nodes before
-pursuing the mission target. Reconfiguring an IDS severs the ICE detection →
-security monitor → global alert chain, preventing detections from escalating
-to trace.
+Each heuristic is a function `(world: WorldModel) => ScoredAction[]`. Score
+ranges establish natural priority:
+
+| Score Range | Category |
+|-------------|----------|
+| 800–900 | Emergency (ICE on node, cancel-trace) |
+| 100 | Trace jackout |
+| 55–70 | Security subversion, buy cards, disarm traps |
+| 42–58 | Normal exploration (select, probe, exploit) |
+| 15 | Deselect (reduce exposure) |
+| 10 | Stuck jackout |
+
+### explore
+
+Probes unprobed nodes (base 50), exploits probed ones (base 45). Card
+selection: prefer vuln match, then highest quality/uses. Bonuses for mission
+path (+10) and current selection (+8). Distance penalty (-5/hop). Hail-mary
+penalty (-5) for non-matching cards. Dangerous-type penalty (-10) for IDS and
+security-monitor nodes.
+
+### loot
+
+Read owned unread nodes (base 60), loot read nodes (base 62). Only proposes
+if the `read`/`loot` action is actually available (checks `availableActions`).
+Mission target bonus (+20).
+
+### security
+
+Reconfigure owned IDS (70). Probe/exploit IDS for subversion (72/71). Cancel
+active trace (900 — emergency). Green-alert penalty (-35) delays security
+work until alert pressure exists.
+
+### traps
+
+Disarm actions on owned nodes (65). Tracks completed disarms to prevent
+infinite retry (set-piece disarm actions lack post-conditions).
+
+### evasion
+
+ICE on selected node → deselect (800). Trace active → jackout (100).
+Idle selection → deselect (15).
+
+### cards
+
+Buy matching card from darknet store (55) when no cards match exploitable
+nodes. Uses `buyFromStore()` directly (headless — no browser store UI).
+Jack out (10) when no usable cards remain and can't afford store.
+
+---
+
+## ICE Handling
+
+### Interrupt During Timed Actions
+
+If ICE arrives at the player's node mid-action, `execute.js` cancels the
+action and deselects. The main loop adds the node to `iceCooldown` — a
+one-cycle score penalty (-20) that encourages the bot to try a different
+node before retrying.
+
+### Cooldown Lifecycle
+
+- ICE interrupts → node added to cooldown set
+- Next non-interrupted cycle → cooldown cleared
+- Cooled-down nodes get penalty, not hard skip (avoids "no proposals" when
+  there's only one path forward)
+
+---
+
+## Card Economy
+
+### Matching vs Hail-Mary
+
+Cards have `targetVulnTypes` matched against node `vulnerabilities[].id`.
+Matching cards get full score; non-matching get a -5 penalty (explore) or
+-30 penalty (security).
+
+### Failed Exploit Memory
+
+The loop tracks `failedExploits` as `"nodeId:cardId"` pairs. Cards that
+failed on a node are skipped by `pickBestCard()`. Successful exploits
+(access level changed) clear all failures for that node.
+
+### Store Purchases
+
+The `buy-card` action calls `buyFromStore()` from `js/core/store-logic.js`
+directly. `pickVulnToBuy()` collects vulnerability IDs from `needsExploit`
+nodes and finds the cheapest affordable catalog match.
 
 ---
 
 ## Tick Advancement
 
-The bot drives the game clock directly via `tick()`. After dispatching any timed
-action, it ticks in small increments (default: 1 tick = 100ms virtual time)
-until the completion event fires. This gives realistic tick counts and lets ICE
-pressure manifest naturally.
+The bot drives the game clock via `tick()`. After dispatching a timed action,
+`tickUntilResolved()` advances in 1-tick increments until:
 
-Two tick-loop variants:
+- `ACTION_RESOLVED` fires for the target node/action
+- `ICE_MOVED` to the selected node (interrupted)
+- `RUN_ENDED` fires
+- Per-action tick budget (500) exhausted
 
-- **`tickUntilEvent`** — ticks until a specific event fires or budget is
-  exceeded. Used for non-evasion mode and for read/loot actions.
-- **`tickUntilEventOrIce`** — same, but also breaks if ICE arrives at the
-  player's node (`ICE_MOVED` to selected node). Used in evasion mode for
-  probe and exploit.
-
-A per-run tick cap (default: 5000 ticks) prevents infinite loops. If the bot
-hasn't completed within the cap, the run ends with failure reason `"tick-cap"`.
+A per-run tick cap (default: 5000) prevents infinite loops.
 
 ---
 
@@ -148,14 +185,13 @@ Each `runBot()` call returns a `BotRunStats` object:
 ### Outcome
 | Field | Type | Description |
 |-------|------|-------------|
-| `missionSuccess` | boolean | Target macguffin looted and jacked out |
-| `fullClear` | boolean | All non-security, non-wan nodes owned |
-| `failReason` | string/null | `"trace"`, `"no-cards"`, `"stuck"`, `"tick-cap"`, or null |
+| `success` | boolean | Mission complete and jacked out |
+| `failReason` | string/null | `"trace"`, `"stuck"`, `"tick-cap"`, or null |
 
 ### Resources
 | Field | Type | Description |
 |-------|------|-------------|
-| `cardUsesConsumed` | number | Total exploit attempts (success + failure) |
+| `cardsUsed` | number | Total exploit attempts |
 | `cardsBurned` | number | Cards fully depleted or disclosed |
 | `storeVisits` | number | Darknet store purchases |
 | `cashSpent` | number | Total darknet expenditure |
@@ -164,77 +200,19 @@ Each `runBot()` call returns a `BotRunStats` object:
 ### Time / Pressure
 | Field | Type | Description |
 |-------|------|-------------|
-| `totalTicks` | number | Virtual ticks elapsed at jackout |
-| `peakAlert` | string | Highest global alert reached (`"green"`, `"yellow"`, `"red"`) |
+| `ticksElapsed` | number | Virtual ticks at jackout |
+| `peakAlert` | string | Highest alert reached |
 | `traceFired` | boolean | Whether trace countdown started |
-| `iceDetections` | number | Times ICE detection event fired |
+| `iceDetections` | number | ICE detection events |
+| `iceEvasions` | number | Actions cancelled due to ICE |
 
 ### Exploration
 | Field | Type | Description |
 |-------|------|-------------|
-| `nodesOwned` | number | Nodes at "owned" access (excluding wan) |
-| `nodesTotal` | number | Total nodes (excluding wan) |
-
-### Timeline Breakpoints
-| Field | Type | Description |
-|-------|------|-------------|
-| `tickFirstNodeOwned` | number | Tick when first non-gateway node reached "owned" (-1 = never) |
-| `tickFirstDetection` | number | Tick when first ICE detection fired (-1 = never) |
-| `tickTraceStarted` | number | Tick when trace countdown began (-1 = never) |
-| `tickMissionComplete` | number | Tick when mission target was looted (-1 = never) |
-
----
-
-## Census CLI
-
-`scripts/bot-census.js` runs the bot across many seeds and aggregates stats.
-
-### Arguments
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--time <grade>` | required | timeCost grade (F through S) |
-| `--money <grade>` | required | moneyCost grade (F through S) |
-| `--seeds <N>` | 100 | Number of simulation runs |
-| `--seed-prefix <str>` | `"bot"` | Seed prefix (seeds are `{prefix}-0` through `{prefix}-{N-1}`) |
-| `--evasion` | off | Enable evasion mode |
-
-### Report Format
-
-The report is text-based and designed for LLM readability:
-
-```
-=== BOT SIMULATION: B/B [EVASION] ===
-Seeds: bot-0 through bot-99 (100 runs)
-
---- MISSION COMPLETION ---
-Success rate:     N/100 (pct%)
-Avg ticks:        X (succeeded) / Y (failed)
-Failure reasons:  trace=N  no-cards=N  stuck=N  tick-cap=N
-
---- FULL EXPLORATION ---
-Full clear rate:  N/100 (pct%)
-Avg nodes owned:  X / Y total (pct%)
-
---- RESOURCE USAGE (succeeded runs) ---
-              Min    Avg    Max
-Card uses:    X      X      X
-Cards burned: X      X      X
-Store visits: X      X      X
-Cash spent:   X      X      X
-Cash left:    X      X      X
-
---- PRESSURE ---
-Peak alert:   GREEN=N  YELLOW=N  RED=N
-Trace fired:  N/100
-ICE detects:  avg X  max X
-
---- TIMELINE (avg tick when event first occurs) ---
-First node owned:    X (N/100 runs)
-First ICE detection: X (N/100 runs)
-Trace started:       X (N/100 runs)
-Mission complete:    X (N/100 runs)
-```
+| `nodesOwned` | number | Nodes at "owned" access (excluding WAN) |
+| `nodesTotal` | number | Total nodes (excluding WAN) |
+| `disarmActionsUsed` | number | Disarm actions executed |
+| `strategyCounts` | Record | Per-strategy win counts |
 
 ---
 
@@ -244,32 +222,15 @@ These omissions are intentional — they make the bot a pessimistic baseline:
 
 - **Eject ICE** — never pushes ICE to an adjacent node
 - **Reboot nodes** — never forces ICE back to its resident node
-- **Cancel trace** — never owns the security monitor to cancel an active trace
-- **Strategic node ordering** — beyond the greedy BFS priority, no planning
-- **Anticipate ICE movement** — doesn't track ICE position or time actions
-  around patrol cycles (only reacts when ICE arrives)
+- **Strategic patience** — doesn't wait for ICE to move away before re-engaging
 - **Manage card decay** — doesn't preserve high-value cards for hard nodes
-- **Multi-attempt strategies** — if an exploit fails, retries with the same
-  approach; doesn't switch tactics based on failure history
+- **Plan ahead** — no lookahead; greedy scoring of current moment only
+- **Anticipate ICE movement** — only reacts when ICE arrives, doesn't track
+  patrol patterns
 
 ---
 
-## Architecture Notes
+## Determinism
 
-### Event Handler Lifecycle
-
-The game engine registers event handlers at module import time (ice.js,
-exploit-exec.js, alert.js, etc.). The bot does **not** call `clearHandlers()`
-between runs — doing so would destroy these module-level handlers.
-
-Instead:
-- **One-time init** (first `runBot` call): registers timer handlers and action
-  dispatcher. These persist across runs.
-- **Per-run handlers**: stat tracking listeners are registered at the start of
-  each run and explicitly removed via `off()` at the end.
-- `initState()` resets all game state between runs.
-
-### Determinism
-
-Same seed + same difficulty + same options = identical stats. The bot uses the
-game's seeded PRNG and drives the clock deterministically via `tick()`.
+Same seed + same network = identical stats. The bot uses the game's seeded PRNG
+and drives the clock deterministically via `tick()`.

--- a/docs/dev-sessions/2026-03-05-2008-bot-player-rebuild/notes.md
+++ b/docs/dev-sessions/2026-03-05-2008-bot-player-rebuild/notes.md
@@ -1,0 +1,1 @@
+# Session Notes: Bot Player Rebuild

--- a/docs/dev-sessions/2026-03-05-2008-bot-player-rebuild/notes.md
+++ b/docs/dev-sessions/2026-03-05-2008-bot-player-rebuild/notes.md
@@ -90,3 +90,92 @@ Ran the new modular bot against all 3 networks and found 5 bugs + 3 strategy iss
 - **Set-piece design: disarm post-conditions** — The alarm-latch disarm action should
   require `latchEnabled === true` so it self-gates after execution. Currently worked around
   in the bot, but this is a game-side fix that would benefit all consumers.
+
+---
+
+## Session Retro
+
+### What Was Delivered (vs Spec)
+
+All 8 phases from the plan were completed:
+
+1. Shared headless engine — done, `scripts/lib/headless-engine.js`
+2. Bot types and stats — done, `scripts/bot/types.js` + `stats.js`
+3. Perception layer — done, `scripts/bot/perception.js`
+4. Scoring engine — done, `scripts/bot/scoring.js`
+5. Execute layer — done, `scripts/bot/execute.js`
+6. Strategy heuristics (6) — done, `scripts/bot/heuristics/*.js`
+7. Main loop + run + CLI — done, `scripts/bot/{loop,run,cli}.js`
+8. Playtest harness refactor — done, `scripts/playtest.js` uses shared engine
+
+Spec items explicitly deferred and still deferred:
+- Census CLI rebuild (separate session)
+- LLM-driven bot (future)
+- Strategy tuning/weight optimization
+
+### What Worked Well
+
+- **The perception→scoring→execute pipeline is solid.** Cleanly separates
+  concerns. Heuristics are easy to reason about and tune independently. The
+  verbose scoring output was invaluable for debugging.
+
+- **Pluggable strategies.** The spec's vision of composable "personalities"
+  works — different strategy mixes would produce meaningfully different play.
+
+- **Shared headless engine.** The extraction from playtest.js was clean and
+  the two entry points share code without friction.
+
+- **Iterative smoke-testing caught 9 bugs.** Running the bot and reading the
+  verbose output was more effective than unit tests would have been at this
+  stage, because the bugs were integration-level (wrong field names, missing
+  state transitions, action availability mismatches).
+
+### What Didn't Work Well
+
+- **Field name mismatches dominated the bugs.** 3 of 9 bugs were the bot
+  reading the wrong property name from game state objects (`uses` vs
+  `usesRemaining`, `vulnType` vs `targetVulnTypes`, `v.type` vs `v.id`).
+  The JSDoc types in `scripts/bot/types.js` defined a `WorldCard.vulnType`
+  that didn't match the actual `ExploitCard.targetVulnTypes`. These should
+  have been caught by the type checker if the bot files were in the lint
+  scope, or by a simple integration test that verifies card matching.
+
+- **The original implementation (Phase 1-8) shipped with zero working card
+  matching.** Every exploit was a hail-mary. The bot appeared to work (it
+  ran, it produced stats) but was fundamentally broken. This went unnoticed
+  because there was no smoke-test step in the plan.
+
+- **Headless store was a no-op.** The spec mentioned store visits but the
+  headless engine passed `() => {}` for `openDarknetsStore`. The bot needs
+  to call `buyFromStore()` directly — this wasn't in the plan.
+
+- **ICE interrupt re-scoring was spec'd but caused an infinite loop.** The
+  spec described the interrupt as "re-enter the scoring loop" but in practice
+  the re-scored choice was always the same node, causing a tight loop. The
+  fix was to remove the re-score and let the main loop handle it with a
+  cooldown penalty.
+
+### Lessons
+
+- **Add a smoke-test phase to bot/agent plans.** "Run it against each network
+  with verbose output and check the first 20 decisions" would have caught
+  all the field-name bugs immediately.
+
+- **Bot perception should validate against source types.** Either include bot
+  files in `make lint`, or write a small test that asserts `buildHand()`
+  output shape matches `ExploitCard` field names.
+
+- **Test card matching specifically.** A test like "given a hand with
+  `targetVulnTypes: ['weak-auth']` and a node with `vulnerabilities: [{id:
+  'weak-auth'}]`, assert the card appears in `cardMatchesByNode`" would have
+  prevented 2 of the 3 field-name bugs.
+
+### Follow-Up Work
+
+- **Census CLI rebuild** — batch runner for balance analysis across seeds.
+  Separate session.
+- **Bot unit tests** — perception, card matching, heuristic proposals. Would
+  prevent regression on field-name bugs.
+- **corporate-foothold balance** — starting hand generation should consider
+  network vulnerabilities, or the network should provide starting cash.
+- **Disarm post-conditions** — game-side fix to alarm-latch set-piece.

--- a/docs/dev-sessions/2026-03-05-2008-bot-player-rebuild/notes.md
+++ b/docs/dev-sessions/2026-03-05-2008-bot-player-rebuild/notes.md
@@ -1,1 +1,68 @@
 # Session Notes: Bot Player Rebuild
+
+## Smoke-test Bug Fixes (2026-03-10)
+
+Ran the new modular bot against all 3 networks and found 5 bugs + 3 strategy issues.
+
+### Bugs Fixed
+
+1. **Card field name mismatch (critical)** — `perception.js:buildHand()` read `c.uses` and
+   `c.vulnType` but the actual `ExploitCard` type uses `c.usesRemaining`,
+   `c.targetVulnTypes` (array), and `c.decayState`. The bot was never filtering
+   disclosed/spent cards and never matching vulns correctly. Every exploit was a
+   hail-mary because card matching was silently broken.
+
+2. **`read`/`looted` strict equality vs undefined** — Perception checked `n.read === false`
+   but only nodes with the "lootable" trait get `read: false` initialized. Gateway, router,
+   IDS, key-server etc. have `read: undefined`. The bot was trying to read every owned node
+   (including unreadable ones like gateway/WAN), then getting stuck when the timed action
+   never resolved.
+
+3. **WAN node in owned/lootable lists** — WAN is `accessLevel: "owned"` at game start but
+   doesn't support read/loot actions. The `!isWan` exclusion was only on the `else if`
+   branches, so WAN leaked into `owned` and `lootable`. Bot would infinitely try to read WAN.
+
+4. **Disarm action infinite loop** — The alarm-latch set-piece's disarm action only requires
+   `accessLevel === "owned"` with no post-condition (like `latchEnabled === true`). After
+   disarming, the action is still "available". Additionally, `disarm` wasn't in the
+   `INSTANT_ACTIONS` set, so each attempt burned 500 ticks in `tickUntilResolved`. Fixed
+   with: (a) `isInstant()` helper that recognizes dynamic action IDs, (b) `completedActions`
+   tracking in the loop, (c) traps heuristic skips already-completed disarms.
+
+5. **Cards heuristic didn't account for `failedExploits`** — `hasUsableMatch` checked
+   `cardMatchesByNode` but not the `failedExploits` set. A card that matched a vuln but had
+   already failed on the target was still counted as "usable", preventing the store-visit and
+   jackout proposals from firing. Bot got stuck with "matching" cards that couldn't succeed.
+
+### Strategy Improvements
+
+- **Hail-mary exploit penalty** (explore + security heuristics) — non-matching cards get a
+  score penalty (-5 in explore, -30 in security) so the bot prefers matching cards and
+  doesn't tunnel-vision on nodes where it has no good cards.
+
+- **Security node deprioritization at green alert** — IDS probe/exploit gets a -35 penalty
+  when alert is green. Probing an IDS can trigger immediate alert escalation via the
+  detection→monitor chain, so the bot should explore data nodes first.
+
+- **Dangerous type penalty in explore** — IDS and security-monitor nodes get -10 when
+  selecting revealed nodes, so the bot prefers data-bearing nodes.
+
+- **Trace-active jackout** — Evasion heuristic proposes jackout at score 100 when trace is
+  active, so the bot saves progress instead of dying to trace.
+
+### Remaining Issues (not yet fixed)
+
+- **Bot runs out of cards before reaching lootable nodes** on corporate-foothold. The
+  lootable nodes (vault-node, fileserver, workstations) are 3-4 hops deep and the starting
+  hand doesn't match their vulns. Strategy needs better card economy: visit darknet store
+  with initial cash, or focus exploits on the path to lootable nodes.
+
+- **research-station tick-cap** — Bot earns cash (5000-9000¥) but hits 5000-tick budget.
+  Likely another infinite loop in a heuristic — needs investigation.
+
+- **corporate-exchange stuck at 1 node** — 0 cards used, 200 cash. Network may start with
+  empty hand or different initial state. Bot doesn't know to visit store first.
+
+- **Set-piece design: disarm post-conditions** — The alarm-latch disarm action should
+  require `latchEnabled === true` so it self-gates after execution. Currently worked around
+  in the bot, but this is a game-side fix that would benefit all consumers.

--- a/docs/dev-sessions/2026-03-05-2008-bot-player-rebuild/notes.md
+++ b/docs/dev-sessions/2026-03-05-2008-bot-player-rebuild/notes.md
@@ -1,6 +1,6 @@
 # Session Notes: Bot Player Rebuild
 
-## Smoke-test Bug Fixes (2026-03-10)
+## Smoke-test Bug Fixes — Round 1 (2026-03-10)
 
 Ran the new modular bot against all 3 networks and found 5 bugs + 3 strategy issues.
 
@@ -50,18 +50,42 @@ Ran the new modular bot against all 3 networks and found 5 bugs + 3 strategy iss
 - **Trace-active jackout** — Evasion heuristic proposes jackout at score 100 when trace is
   active, so the bot saves progress instead of dying to trace.
 
-### Remaining Issues (not yet fixed)
+## Smoke-test Bug Fixes — Round 2 (2026-03-11)
 
-- **Bot runs out of cards before reaching lootable nodes** on corporate-foothold. The
-  lootable nodes (vault-node, fileserver, workstations) are 3-4 hops deep and the starting
-  hand doesn't match their vulns. Strategy needs better card economy: visit darknet store
-  with initial cash, or focus exploits on the path to lootable nodes.
+### Bugs Fixed
 
-- **research-station tick-cap** — Bot earns cash (5000-9000¥) but hits 5000-tick budget.
-  Likely another infinite loop in a heuristic — needs investigation.
+6. **Vulnerability field name mismatch** — `perception.js` card matching used `v.type` but
+   the Vulnerability type uses `v.id`. Card-to-node matching was completely broken — every
+   card appeared as non-matching. This was the root cause of all hail-mary exploits.
 
-- **corporate-exchange stuck at 1 node** — 0 cards used, 200 cash. Network may start with
-  empty hand or different initial state. Bot doesn't know to visit store first.
+7. **`access-darknet` infinite loop** — The darknet store is a no-op in headless mode
+   (browser UI only). Bot would repeatedly dispatch `access-darknet` thousands of times.
+   Fixed by replacing with `buy-card` — a bot-only action that calls `buyFromStore()` from
+   `store-logic.js` directly, picking the cheapest card matching a needed vulnerability.
+
+8. **`needsExploit` included non-exploitable nodes** — Set-piece internal nodes (latches,
+   relays, key-gens) are probed and not owned, but have no vulnerabilities and can't be
+   exploited. The perception layer now requires `vulnerabilities.length > 0` for needsExploit.
+
+9. **ICE interrupt re-score loop** — After ICE interruption, the interrupt handler immediately
+   re-scored and picked the same exploit, which got interrupted again → infinite loop (81+
+   evasions per run). Removed the interrupt re-score; the main loop now handles it naturally.
+   Added ICE cooldown penalty (-20) to deprioritize recently-interrupted nodes for one cycle.
+
+### Results After Round 2
+
+| Network             | Win Rate | Notes |
+|---------------------|----------|-------|
+| corporate-foothold  | 0/10     | 0 cash, 0 store visits — starting hand never matches vulns |
+| research-station    | 3/10     | 16/20 nodes owned, store working (5-16 visits), 9k-60k cash |
+| corporate-exchange  | 3/10     | Up to 14/14 nodes, high ICE evasion counts on failing seeds |
+
+### Remaining Issues
+
+- **corporate-foothold card economy** — Starting hand has no vulnerability matches for any
+  node. All exploits are hail-marys. Bot runs out of cards before reaching lootable nodes
+  (3-4 hops deep). Needs either: starting cash to buy from store, better starting hand
+  generation, or a network with shallower paths to loot.
 
 - **Set-piece design: disarm post-conditions** — The alarm-latch disarm action should
   require `latchEnabled === true` so it self-gates after execution. Currently worked around

--- a/docs/dev-sessions/2026-03-05-2008-bot-player-rebuild/plan.md
+++ b/docs/dev-sessions/2026-03-05-2008-bot-player-rebuild/plan.md
@@ -1,0 +1,311 @@
+# Plan: Bot Player Rebuild
+
+## Overview
+
+8 phases, each building on the previous. The shared headless engine comes
+first (prerequisite for everything), then the bot modules bottom-up
+(types → perception → scoring → execute → strategies → loop → run), and
+finally integration testing and playtest harness refactor.
+
+---
+
+## Phase 1: Shared Headless Engine Module
+
+**Goal:** Extract common init plumbing from `scripts/playtest.js` into a
+reusable module that any headless tool can import.
+
+**Create `scripts/lib/headless-engine.js`:**
+- Export `initHeadlessEngine(buildNetworkFn, opts)` that:
+  - Wires timer handlers (ICE_MOVE, ICE_DETECT, TRACE_TICK)
+  - Builds ActionContext via `buildActionContext()`
+  - Calls `initActionDispatcher(ctx)`
+  - Returns `{ ctx }` for the caller to extend
+- Export `resetGame(buildNetworkFn, seed)` that:
+  - Calls `initGame(buildNetworkFn, seed)`
+  - Calls `initGraphBridge()`
+  - Calls `initDynamicActions()`
+  - Calls `startIce()`
+  - Returns `getState()`
+- Import all the modules that `playtest.js` currently imports for wiring
+  (ice.js handlers, alert.js handlers, timers, graph-bridge, dynamic-actions)
+
+**Do NOT refactor playtest.js yet** — just extract. Playtest refactor is
+Phase 8 after the bot is working, so we have a known-good reference during
+development.
+
+**Test:** Import the module in a throwaway script, call `initHeadlessEngine`
++ `resetGame`, verify a game initializes and `tick()` advances state.
+
+---
+
+## Phase 2: Bot Types and Stats
+
+**Goal:** Define the data shapes the bot modules pass around.
+
+**Create `scripts/bot/types.js`:**
+- `WorldModel` typedef — the perception snapshot:
+  - `nodes`: categorized node lists (accessible, owned, needsProbe,
+    needsExploit, lootable, security, hasDisarmActions)
+  - `adjacency`: graph edges for BFS
+  - `ice`: `{ nodeId, lastSeenNodeId, isOnSelectedNode, isActive }`
+  - `player`: `{ selectedNodeId, cash, alertLevel, traceActive,
+    traceCountdown }`
+  - `hand`: cards with `{ id, name, vulnType, quality, usesLeft,
+    matchesForNode: Map<nodeId, boolean> }`
+  - `availableActions`: `Map<nodeId, ActionDef[]>`
+  - `mission`: `{ targetNodeId, targetName, found, looted }`
+  - `gamePhase`: "playing" | "ended"
+  - `ticks`: current tick count
+- `ScoredAction` typedef:
+  - `action`: string (action ID)
+  - `nodeId`: string | null
+  - `score`: number
+  - `reason`: string
+  - `payload`: object (optional, e.g. `{ exploitId }`)
+- `Strategy` typedef: `(world: WorldModel) => ScoredAction[]`
+- `BotRunStats` typedef — outcome + metrics:
+  - `success`: boolean
+  - `failReason`: string | null
+  - `ticksElapsed`: number
+  - `nodesOwned`: number
+  - `nodesTotal`: number
+  - `cardsUsed`: number
+  - `cardsBurned`: number
+  - `storeVisits`: number
+  - `cashSpent`: number
+  - `cashRemaining`: number
+  - `peakAlert`: string
+  - `traceFired`: boolean
+  - `iceDetections`: number
+  - `iceEvasions`: number
+  - `disarmActionsUsed`: number
+  - `strategyCounts`: `Record<string, number>` (strategy name → times chosen)
+
+**Create `scripts/bot/stats.js`:**
+- Export `createStats()` — returns a fresh stats object with zeroed counters
+- Export `recordAction(stats, scoredAction)` — increments relevant counters
+- Export `finalizeStats(stats, state)` — fills in end-of-run values
+  (nodesOwned, cashRemaining, etc.)
+
+**Test:** Unit tests for stats creation and recording.
+
+---
+
+## Phase 3: Perception Layer
+
+**Goal:** Build the world model from game state.
+
+**Create `scripts/bot/perception.js`:**
+- Export `perceive(getState, getAvailableActions) → WorldModel`
+- Reads `state.nodes`, `state.adjacency`, `state.ice`, `state.player`,
+  `state.mission`, `state.globalAlert`, `state.traceSecondsRemaining`
+- Categorizes nodes by walking `state.nodes`:
+  - `accessible`: visible, not owned, not WAN
+  - `owned`: accessLevel === "owned"
+  - `needsProbe`: accessible + not probed
+  - `needsExploit`: accessible + probed + not owned
+  - `lootable`: owned + (not read, or has uncollected macguffins)
+  - `security`: type is "ids" or "security-monitor"
+  - `hasDisarmActions`: owned nodes where `getAvailableActions()` returns
+    actions with IDs matching `/^disarm/`
+- Builds card-to-node match map: for each card in hand, for each node with
+  vulns, does the card's vulnType match any vuln?
+- Exposes BFS helper: `shortestPath(fromNodeId, toNodeId)` using adjacency
+  through owned/accessible nodes
+
+**Test:** Build a minimal game state fixture, run `perceive()`, verify
+node categorization and card matching.
+
+---
+
+## Phase 4: Scoring Engine
+
+**Goal:** Collect proposals from strategies, pick the winner.
+
+**Create `scripts/bot/scoring.js`:**
+- Export `score(world, strategies) → ScoredAction | null`
+- Runs each strategy function, collects all returned `ScoredAction[]` into
+  a flat array
+- Sorts by `score` descending
+- Returns the top result, or null if no proposals
+- For debugging: optionally log all proposals (controlled by a `verbose` flag)
+
+This module is tiny — it's the glue between perception and strategies.
+
+**Test:** Mock strategies that return fixed proposals, verify winner selection
+and null handling.
+
+---
+
+## Phase 5: Execute Layer
+
+**Goal:** Dispatch actions and tick the game forward.
+
+**Create `scripts/bot/execute.js`:**
+- Export `execute(choice, world, opts) → { completed, interrupted }`
+- Handles two action categories:
+  1. **Instant actions** (select, deselect, reconfigure, disarm-*, eject,
+     jackout, cancel-*, buy): dispatch via `emitEvent("starnet:action", ...)`
+     and return immediately
+  2. **Timed actions** (probe, exploit, read, loot, reboot): dispatch the
+     start event, then tick forward incrementally until an `ACTION_RESOLVED`
+     or `ACTION_FEEDBACK` cancel event fires for this node+action
+- Timed action tick loop:
+  - Register temporary event listeners for ACTION_RESOLVED, ACTION_FEEDBACK
+    (cancel), ICE_MOVED, RUN_ENDED
+  - Tick 1 at a time
+  - Between ticks, check:
+    - Did the action resolve? → return `{ completed: true }`
+    - Did ICE arrive at player's node? → return `{ interrupted: true }`
+      (the main loop will re-score)
+    - Did the run end (trace caught)? → return `{ completed: true }`
+  - Tick budget cap (e.g. 500 per action) to prevent infinite loops
+  - Clean up temporary listeners on exit
+- The execute layer also needs to handle navigation: if the target node
+  isn't currently selected, dispatch a `select` action first
+
+**Test:** Init a game, dispatch probe via execute, verify it ticks to
+completion. Test ICE interruption with a mock ICE_MOVED event.
+
+---
+
+## Phase 6: Strategy Heuristics
+
+**Goal:** Implement the 6 strategy functions. Each in its own file.
+
+### `scripts/bot/heuristics/explore.js`
+- Proposes `select` + `probe` for unprobed accessible nodes
+- Proposes `exploit` for probed unowned nodes (with best matching card)
+- Card selection: prefer exact vuln match, then highest quality, then most
+  uses remaining. Include `exploitId` in payload.
+- Score: base 50, +10 for mission-relevant path, -5 per BFS hop distance
+- If no cards match any visible vuln, propose nothing (cards.js handles store)
+
+### `scripts/bot/heuristics/loot.js`
+- Proposes `read` for owned unread nodes
+- Proposes `loot` for owned read nodes with macguffins
+- Score: base 60, +20 if node contains mission target macguffin
+- Prefer closer nodes (BFS distance penalty)
+
+### `scripts/bot/heuristics/security.js`
+- Proposes `exploit` (then `reconfigure`) for IDS nodes not yet subverted
+- Proposes `cancel-trace` for owned security monitors when trace is active
+- Score: reconfigure = 70, cancel-trace = 900 (emergency)
+
+### `scripts/bot/heuristics/traps.js`
+- Scans owned nodes for available disarm actions (action ID matches `/^disarm/`)
+- Proposes the disarm action
+- Score: 65 (higher than explore, lower than security — disarm before
+  pushing deeper)
+
+### `scripts/bot/heuristics/evasion.js`
+- When ICE is on the player's selected node:
+  - Proposes `cancel-probe` / `cancel-exploit` + `deselect` with score 800
+- When ICE is on an adjacent node (one hop away):
+  - Lowers scores of actions at the player's current node (return negative
+    score modifier? or just propose `deselect` at score 40)
+- After any timed action completes: proposes `deselect` at low score (15)
+  to clear presence
+- Note: evasion's mid-action cancel is handled by the execute layer's
+  interrupt mechanism, not by this heuristic. This heuristic handles the
+  decision at the top of the loop.
+
+### `scripts/bot/heuristics/cards.js`
+- When hand has no cards matching any visible node's vulns:
+  - Proposes navigating to WAN node + `access-darknet` (store visit)
+  - Score: 55
+- When hand is completely empty:
+  - If can't afford store: triggers jackout proposal (score 10)
+
+**Test:** For each heuristic, build a targeted world model fixture and
+verify the proposals (action IDs, scores, reasons). These are pure
+functions — easy to test in isolation.
+
+---
+
+## Phase 7: Main Loop and Run Entry Point
+
+**Goal:** Wire everything together into a runnable bot.
+
+### `scripts/bot/loop.js`
+- Export `runLoop(engine, strategies, opts) → BotRunStats`
+- The core loop:
+  ```
+  while (state.phase === "playing") {
+    world = perceive(...)
+    choice = score(world, strategies)
+    if (!choice) { jackout; break }
+    recordAction(stats, choice)
+    result = execute(choice, world)
+    if (result.interrupted) {
+      // ICE arrived mid-action — re-score immediately
+      world = perceive(...)
+      choice = score(world, strategies)
+      if (choice) execute(choice, world)
+    }
+    if (tickBudget exceeded) break
+  }
+  ```
+- Tick budget: 5000 ticks total per run
+- On exit: finalize stats, return them
+
+### `scripts/bot/run.js`
+- Export `runBot(buildNetworkFn, opts) → BotRunStats`
+- `opts`: `{ seed, strategies, tickBudget, verbose }`
+- Calls `initHeadlessEngine()` + `resetGame()`
+- Assembles default strategy set (all 6 heuristics)
+- Calls `runLoop()`
+- Returns stats
+
+### CLI entry point: `scripts/bot/cli.js`
+- Parses args: `--network`, `--seed`, `--verbose`
+- Imports network builder, calls `runBot()`, prints stats as JSON
+- Usage: `node scripts/bot/cli.js --network corporate-foothold --seed test-1`
+
+**Test:** Run the bot against corporate-foothold with a fixed seed. Verify:
+- Bot completes (doesn't hang or infinite loop)
+- Stats are populated
+- Deterministic: same seed → same stats
+
+---
+
+## Phase 8: Playtest Harness Refactor + Cleanup
+
+**Goal:** Refactor `scripts/playtest.js` to use the shared headless engine.
+Update Makefile. Clean up.
+
+**Refactor `scripts/playtest.js`:**
+- Replace inline init code with `initHeadlessEngine()` + `resetGame()`
+- Keep all playtest-specific logic (command dispatch, state file persistence,
+  event→output formatting, --piece/--graph flags)
+- The external CLI interface stays identical
+
+**Update Makefile:**
+- Update `bot-census` target (or remove it, since census is a future session)
+- Add `bot-run` target: `node scripts/bot/cli.js --network corporate-foothold`
+- Verify `make test` still excludes bot tests if needed, or includes them
+
+**Verify:**
+- `node scripts/playtest.js reset` still works
+- `node scripts/playtest.js "status"` still works
+- `node scripts/bot/cli.js --network corporate-foothold --seed test-1` works
+- `make check` passes
+
+---
+
+## Execution Order Summary
+
+| Phase | Module | Depends On | Key Output |
+|-------|--------|-----------|------------|
+| 1 | headless-engine.js | — | Shared init plumbing |
+| 2 | types.js, stats.js | — | Data shapes |
+| 3 | perception.js | types | World model builder |
+| 4 | scoring.js | types | Strategy aggregator |
+| 5 | execute.js | headless-engine | Action dispatch + tick loop |
+| 6 | heuristics/*.js | types, perception | 6 strategy functions |
+| 7 | loop.js, run.js, cli.js | all above | Working bot |
+| 8 | playtest.js refactor | headless-engine | Cleanup |
+
+Phases 2-4 can be developed in parallel (no dependencies between them).
+Phase 5 depends on Phase 1. Phase 6 depends on Phases 2-3. Phase 7 wires
+everything. Phase 8 is cleanup.

--- a/docs/dev-sessions/2026-03-05-2008-bot-player-rebuild/spec.md
+++ b/docs/dev-sessions/2026-03-05-2008-bot-player-rebuild/spec.md
@@ -1,0 +1,212 @@
+# Spec: Bot Player Rebuild
+
+## Goal
+
+Rebuild the bot player as a modular, extensible automated game-playing agent.
+The old bot was a monolithic file with hardcoded strategy. The new bot uses a
+perception→scoring→execute architecture with pluggable strategy functions.
+
+The bot establishes a "slightly above novice" baseline for balance testing:
+it makes reasonable decisions but doesn't plan ahead or optimize deeply.
+
+## Architecture
+
+### Core Loop
+
+```
+while (!done) {
+  const world = perceive(state);
+  const choice = score(world, strategies);
+  if (!choice) { jackOut(); break; }
+  done = execute(choice, world);
+}
+```
+
+The loop runs synchronously, driving the game clock via `tick()`.
+
+### File Structure
+
+```
+scripts/bot/
+  run.js          — entry point: accept network, run loop, return stats
+  loop.js         — the decide→act→tick cycle
+  perception.js   — reads game state, builds structured world model
+  scoring.js      — collects proposals from all strategies, picks highest
+  heuristics/     — one file per concern, each exports a scoring function
+    security.js   — IDS/monitor subversion priority
+    loot.js       — mission target + lootable node scoring
+    traps.js      — discover and use disarm actions on owned nodes
+    evasion.js    — ICE proximity, deselect, cancel-on-arrival
+    cards.js      — hand quality, store visits when stuck
+    explore.js    — general node expansion (probe/exploit unowned nodes)
+  execute.js      — fires starnet:action, ticks until resolution
+  stats.js        — stat collection
+```
+
+### Shared Headless Engine
+
+Extract common game engine init plumbing into a shared module that the
+playtest harness, bot, and future headless tools all import:
+
+- Game init (initGame, buildActionContext, initActionDispatcher)
+- Timer wiring (ICE_MOVE, ICE_DETECT, TRACE_TICK)
+- Graph bridge + dynamic actions
+- Tick driving
+
+This means refactoring `scripts/playtest.js` to use the shared module.
+
+## Strategies
+
+### Interface
+
+Each strategy is a function:
+
+```js
+/** @param {WorldModel} world */
+function strategyName(world) → ScoredAction[]
+```
+
+Where `ScoredAction` is:
+
+```js
+{
+  action: string,      // action ID (e.g. "probe", "exploit", "disarm-counter")
+  nodeId: string,      // target node
+  score: number,       // higher wins
+  reason: string,      // human-readable explanation for debugging
+  payload?: object,    // extra data (e.g. { exploitId } for exploit actions)
+}
+```
+
+### Scoring
+
+`scoring.js` runs all strategies, collects all proposals into a flat list,
+sorts by score descending, returns the winner. No priority tiers — score
+magnitude conveys urgency (emergencies use high scores like 1000, normal
+actions use 0-100).
+
+### Composability
+
+The strategy array is the bot's "personality." Different compositions produce
+different play styles:
+
+- **Default** — all heuristics active, balanced weights
+- **Aggressive** — no evasion, pure speed
+- **Cautious** — evasion weighted high, IDS subversion first
+- **Completionist** — explore/own everything, not just mission target
+
+### Card Selection
+
+Card selection is part of strategy proposals. The explore/loot heuristics
+propose complete `exploit` actions with a specific `exploitId` in the payload.
+Different strategies could propose different card choices for the same node
+(e.g. "best match" vs "conserve good cards"), and scoring resolves the
+tradeoff.
+
+## World Model (Perception)
+
+The perception layer reads game state and produces a structured snapshot:
+
+- **Nodes by category** — visible nodes grouped by state:
+  - unowned but accessible (can navigate to)
+  - owned (bot controls)
+  - needs-probe (accessible, not yet probed)
+  - needs-exploit (probed, not yet owned)
+  - lootable (owned, readable or has uncollected loot)
+  - security (IDS/monitor nodes, reconfigure status)
+  - has-disarm-actions (owned nodes with available disarm-type actions)
+- **Graph topology** — adjacency for BFS pathfinding
+- **ICE state** — position (if known from events), last seen node, whether
+  it's on the currently selected node
+- **Player state** — selected node, cash, alert level, trace active/countdown
+- **Hand** — cards with uses remaining; for each visible node's vulns, which
+  cards match
+- **Available actions** — per accessible node, from `getAvailableActions()`
+- **Mission** — target node ID, whether found, whether looted
+
+The world model is recomputed each iteration (cheap — it's just reading state
+and categorizing).
+
+## ICE Handling
+
+During timed action execution (probe, exploit, read, loot), the execute layer
+ticks forward incrementally. Between ticks, it checks for ICE-relevant events.
+If ICE arrives at the player's node mid-action, the execute step re-enters the
+scoring loop with updated perception. The evasion heuristic can then propose
+"cancel current action and deselect" with a high score, or other strategies
+might propose "ride it out" if the action is nearly complete.
+
+This makes evasion emergent from scoring rather than a hardcoded interrupt.
+The recursion is bounded to one level: mid-action re-score → either continue
+or cancel+act.
+
+## Trait Awareness
+
+The bot has no hardcoded knowledge of specific traits (hardened, trapped,
+encrypted, volatile, etc.). Instead, it discovers what it can do via
+`getAvailableActions()` on each node. After owning a node, if disarm actions
+appear (e.g. "disarm-counter", "disarm-sensor"), the traps heuristic proposes
+using them.
+
+This means the bot automatically adapts to new traits that add disarm actions
+without code changes.
+
+## Network Input
+
+The bot accepts any network as a `buildNetwork` function returning a
+NodeGraphDef. It is network-agnostic — no assumptions about specific node IDs,
+topology, or set-piece composition. The existing hand-crafted networks
+(corporate-foothold, research-station, corporate-exchange) and any future
+networks or JSON-defined graphs all work.
+
+## Outcomes and Stats
+
+### Outcome
+
+Simple success/failure:
+- **Success** — mission target looted and jacked out
+- **Failure** — run ended without completing mission (trace caught, no cards,
+  stuck, tick cap exceeded)
+
+Track a `failReason` string for diagnostics but keep the categories minimal.
+
+### Stats
+
+Design the stats shape around what the new bot actually does. Include at
+minimum:
+
+- Ticks elapsed
+- Nodes owned / total
+- Cards used / burned
+- Store visits / cash spent
+- Peak alert level
+- Trace fired (boolean)
+- ICE detections count
+- ICE evasions count (cancel-on-arrival events)
+- Disarm actions used
+- Actions proposed per strategy (for tuning — which heuristics are driving
+  decisions)
+
+The exact shape will be refined during implementation. The stats object is
+returned from each bot run for census aggregation.
+
+## Census
+
+The census system will be rebuilt as a separate follow-up session. For now,
+the bot's `run()` function returns a stats object that the census can consume.
+The bot itself has no census logic.
+
+## Playtest Harness Refactor
+
+As part of extracting the shared headless engine, `scripts/playtest.js` will
+be refactored to import from the shared module. Its external interface (CLI
+args, state file persistence, command dispatch) stays the same — only the
+internal init plumbing changes.
+
+## Out of Scope
+
+- Census CLI rebuild (separate session)
+- LLM-driven bot (future project)
+- Procgen network generation (deleted, not being restored here)
+- Strategy tuning / weight optimization (iterate after basic bot works)
+- Bot-vs-bot or multi-bot scenarios

--- a/scripts/bot/cli.js
+++ b/scripts/bot/cli.js
@@ -1,0 +1,39 @@
+// @ts-check
+// Bot CLI — run a single bot game and print stats.
+//
+// Usage:
+//   node scripts/bot/cli.js --network corporate-foothold --seed test-1
+//   node scripts/bot/cli.js --network research-station --verbose
+
+import { runBot } from "./run.js";
+import { buildNetwork as buildCorporateFoothold } from "../../data/networks/corporate-foothold.js";
+import { buildNetwork as buildResearchStation } from "../../data/networks/research-station.js";
+import { buildNetwork as buildCorporateExchange } from "../../data/networks/corporate-exchange.js";
+
+const NETWORKS = {
+  "corporate-foothold": buildCorporateFoothold,
+  "research-station": buildResearchStation,
+  "corporate-exchange": buildCorporateExchange,
+};
+
+// Parse args
+let networkName = "corporate-foothold";
+let seed = undefined;
+let verbose = false;
+
+const argv = process.argv.slice(2);
+for (let i = 0; i < argv.length; i++) {
+  if (argv[i] === "--network" && argv[i + 1]) networkName = argv[++i];
+  else if (argv[i] === "--seed" && argv[i + 1]) seed = argv[++i];
+  else if (argv[i] === "--verbose" || argv[i] === "-v") verbose = true;
+}
+
+const buildNetwork = NETWORKS[networkName];
+if (!buildNetwork) {
+  console.error(`Unknown network: ${networkName}. Available: ${Object.keys(NETWORKS).join(", ")}`);
+  process.exit(1);
+}
+
+const stats = runBot(() => buildNetwork(), { seed, verbose });
+
+console.log(JSON.stringify(stats, null, 2));

--- a/scripts/bot/execute.js
+++ b/scripts/bot/execute.js
@@ -1,0 +1,116 @@
+// @ts-check
+// Execute layer — dispatches actions and ticks the game forward.
+
+/** @typedef {import('./types.js').ScoredAction} ScoredAction */
+/** @typedef {import('./types.js').WorldModel} WorldModel */
+
+import { emitEvent, on, off, E, tick, getState } from "../lib/headless-engine.js";
+
+/** Actions that start a timed process and need tick-forward */
+const TIMED_ACTIONS = new Set(["probe", "exploit", "read", "loot", "reboot"]);
+
+/** Actions that are instant (no ticking needed) */
+const INSTANT_ACTIONS = new Set([
+  "select", "deselect", "jackout", "reconfigure", "cancel-trace",
+  "cancel-probe", "cancel-exploit", "cancel-read", "cancel-loot",
+  "eject", "access-darknet",
+]);
+
+/**
+ * Execute a scored action: dispatch it and tick forward if needed.
+ *
+ * @param {ScoredAction} choice
+ * @param {WorldModel} world
+ * @param {{ tickBudgetPerAction?: number }} [opts]
+ * @returns {{ completed: boolean, interrupted: boolean, ticksUsed: number }}
+ */
+export function execute(choice, world, opts = {}) {
+  const tickBudget = opts.tickBudgetPerAction ?? 500;
+  const state = getState();
+
+  // If we need to select a different node first
+  if (choice.nodeId && choice.nodeId !== state.selectedNodeId && choice.action !== "select") {
+    emitEvent("starnet:action", { actionId: "select", nodeId: choice.nodeId });
+  }
+
+  // Build the action payload
+  const payload = {
+    actionId: choice.action,
+    ...(choice.nodeId ? { nodeId: choice.nodeId } : {}),
+    ...(choice.payload ?? {}),
+  };
+
+  // Dispatch the action
+  emitEvent("starnet:action", payload);
+
+  // Instant actions are done immediately
+  if (!TIMED_ACTIONS.has(choice.action)) {
+    return { completed: true, interrupted: false, ticksUsed: 0 };
+  }
+
+  // Timed action: tick forward until resolution or interruption
+  return tickUntilResolved(choice, tickBudget);
+}
+
+/**
+ * Tick forward until the timed action resolves, ICE interrupts, or budget expires.
+ * @param {ScoredAction} choice
+ * @param {number} budget
+ * @returns {{ completed: boolean, interrupted: boolean, ticksUsed: number }}
+ */
+function tickUntilResolved(choice, budget) {
+  let resolved = false;
+  let interrupted = false;
+  let runEnded = false;
+  let ticksUsed = 0;
+
+  const targetNodeId = choice.nodeId;
+
+  // Temporary event listeners
+  const onResolved = ({ action, nodeId }) => {
+    if (nodeId === targetNodeId && action === choice.action) {
+      resolved = true;
+    }
+  };
+
+  const onFeedback = ({ action, nodeId, phase }) => {
+    if (nodeId === targetNodeId && action === choice.action && phase === "cancel") {
+      resolved = true; // Externally cancelled (e.g. navigate away)
+    }
+  };
+
+  const onIceMoved = ({ toId }) => {
+    const s = getState();
+    if (s.selectedNodeId && toId === s.selectedNodeId) {
+      interrupted = true;
+    }
+  };
+
+  const onRunEnded = () => { runEnded = true; };
+
+  on(E.ACTION_RESOLVED, onResolved);
+  on(E.ACTION_FEEDBACK, onFeedback);
+  on(E.ICE_MOVED, onIceMoved);
+  on(E.RUN_ENDED, onRunEnded);
+
+  try {
+    for (let i = 0; i < budget && !resolved && !interrupted && !runEnded; i++) {
+      tick(1);
+      ticksUsed++;
+    }
+  } finally {
+    off(E.ACTION_RESOLVED, onResolved);
+    off(E.ACTION_FEEDBACK, onFeedback);
+    off(E.ICE_MOVED, onIceMoved);
+    off(E.RUN_ENDED, onRunEnded);
+  }
+
+  // If interrupted by ICE, cancel the current action and deselect
+  if (interrupted && !resolved && !runEnded) {
+    const cancelAction = `cancel-${choice.action}`;
+    emitEvent("starnet:action", { actionId: cancelAction, nodeId: targetNodeId });
+    emitEvent("starnet:action", { actionId: "deselect" });
+  }
+
+  return { completed: resolved || runEnded, interrupted, ticksUsed };
+}

--- a/scripts/bot/execute.js
+++ b/scripts/bot/execute.js
@@ -17,6 +17,19 @@ const INSTANT_ACTIONS = new Set([
 ]);
 
 /**
+ * Check if an action is instant. Handles dynamic action IDs (disarm-*) that
+ * aren't in the static sets.
+ * @param {string} actionId
+ * @returns {boolean}
+ */
+function isInstant(actionId) {
+  if (INSTANT_ACTIONS.has(actionId)) return true;
+  if (actionId.startsWith("disarm")) return true;
+  if (!TIMED_ACTIONS.has(actionId)) return true; // unknown actions default to instant
+  return false;
+}
+
+/**
  * Execute a scored action: dispatch it and tick forward if needed.
  *
  * @param {ScoredAction} choice
@@ -44,7 +57,7 @@ export function execute(choice, world, opts = {}) {
   emitEvent("starnet:action", payload);
 
   // Instant actions are done immediately
-  if (!TIMED_ACTIONS.has(choice.action)) {
+  if (isInstant(choice.action)) {
     return { completed: true, interrupted: false, ticksUsed: 0 };
   }
 

--- a/scripts/bot/execute.js
+++ b/scripts/bot/execute.js
@@ -5,6 +5,7 @@
 /** @typedef {import('./types.js').WorldModel} WorldModel */
 
 import { emitEvent, on, off, E, tick, getState } from "../lib/headless-engine.js";
+import { buyFromStore } from "../../js/core/store-logic.js";
 
 /** Actions that start a timed process and need tick-forward */
 const TIMED_ACTIONS = new Set(["probe", "exploit", "read", "loot", "reboot"]);
@@ -44,6 +45,18 @@ export function execute(choice, world, opts = {}) {
   // If we need to select a different node first
   if (choice.nodeId && choice.nodeId !== state.selectedNodeId && choice.action !== "select") {
     emitEvent("starnet:action", { actionId: "select", nodeId: choice.nodeId });
+  }
+
+  // Bot-only action: buy a card directly from the store (headless)
+  if (choice.action === "buy-card") {
+    const vulnId = choice.payload?.vulnId;
+    if (vulnId) {
+      const result = buyFromStore(vulnId);
+      if (result) {
+        emitEvent(E.STATE_CHANGED, getState());
+      }
+    }
+    return { completed: true, interrupted: false, ticksUsed: 0 };
   }
 
   // Build the action payload

--- a/scripts/bot/heuristics/cards.js
+++ b/scripts/bot/heuristics/cards.js
@@ -1,0 +1,66 @@
+// @ts-check
+// Cards heuristic — manage hand, visit store when needed.
+
+/** @typedef {import('../types.js').WorldModel} WorldModel */
+/** @typedef {import('../types.js').ScoredAction} ScoredAction */
+
+const STRATEGY = "cards";
+const STORE_VISIT_SCORE = 55;
+const NO_CARDS_JACKOUT = 10;
+
+/**
+ * @param {WorldModel} world
+ * @returns {ScoredAction[]}
+ */
+export function cardsStrategy(world) {
+  /** @type {ScoredAction[]} */
+  const proposals = [];
+
+  // Check if we have any cards that match visible nodes' vulns
+  const hasUsableMatch = world.needsExploit.some(nodeId =>
+    (world.cardMatchesByNode.get(nodeId)?.length ?? 0) > 0
+  );
+
+  // If no cards match any exploitable node, visit the store
+  if (!hasUsableMatch && world.needsExploit.length > 0 && world.hand.length > 0) {
+    // Find the WAN node for store access
+    const wanNodeId = findWanNode(world);
+    if (wanNodeId && world.player.cash > 0) {
+      proposals.push({
+        action: "access-darknet",
+        nodeId: wanNodeId,
+        score: STORE_VISIT_SCORE,
+        reason: "no matching cards — visit darknet store",
+        strategy: STRATEGY,
+      });
+    }
+  }
+
+  // Hand is completely empty and can't buy
+  if (world.hand.length === 0 && world.needsExploit.length > 0) {
+    const wanNodeId = findWanNode(world);
+    if (!wanNodeId || world.player.cash <= 0) {
+      proposals.push({
+        action: "jackout",
+        nodeId: null,
+        score: NO_CARDS_JACKOUT,
+        reason: "no cards, can't buy — jack out",
+        strategy: STRATEGY,
+      });
+    }
+  }
+
+  return proposals;
+}
+
+/**
+ * Find the WAN node.
+ * @param {WorldModel} world
+ * @returns {string|null}
+ */
+function findWanNode(world) {
+  for (const [id, node] of world.nodes) {
+    if (node.type === "wan") return id;
+  }
+  return null;
+}

--- a/scripts/bot/heuristics/cards.js
+++ b/scripts/bot/heuristics/cards.js
@@ -16,14 +16,26 @@ export function cardsStrategy(world) {
   /** @type {ScoredAction[]} */
   const proposals = [];
 
-  // Check if we have any cards that match visible nodes' vulns
-  const hasUsableMatch = world.needsExploit.some(nodeId =>
-    (world.cardMatchesByNode.get(nodeId)?.length ?? 0) > 0
+  if (world.needsExploit.length === 0) return proposals;
+
+  // Check if we have any non-failed cards that match exploitable nodes' vulns
+  const hasUsableMatch = world.needsExploit.some(nodeId => {
+    const matchingIds = world.cardMatchesByNode.get(nodeId) ?? [];
+    // Filter out cards that already failed on this node
+    return matchingIds.some(cardId =>
+      !world.failedExploits.has(`${nodeId}:${cardId}`)
+    );
+  });
+
+  // Check if any card in hand hasn't failed on at least one exploitable node
+  const hasAnyUsableCard = world.hand.some(card =>
+    world.needsExploit.some(nodeId =>
+      !world.failedExploits.has(`${nodeId}:${card.id}`)
+    )
   );
 
-  // If no cards match any exploitable node, visit the store
-  if (!hasUsableMatch && world.needsExploit.length > 0 && world.hand.length > 0) {
-    // Find the WAN node for store access
+  // Visit store if no matching cards (or all matches exhausted)
+  if (!hasUsableMatch && world.hand.length > 0) {
     const wanNodeId = findWanNode(world);
     if (wanNodeId && world.player.cash > 0) {
       proposals.push({
@@ -36,15 +48,16 @@ export function cardsStrategy(world) {
     }
   }
 
-  // Hand is completely empty and can't buy
-  if (world.hand.length === 0 && world.needsExploit.length > 0) {
+  // Jack out if we're truly stuck: no usable cards left and can't buy more
+  if (!hasAnyUsableCard) {
     const wanNodeId = findWanNode(world);
-    if (!wanNodeId || world.player.cash <= 0) {
+    const canBuy = wanNodeId && world.player.cash > 0;
+    if (!canBuy) {
       proposals.push({
         action: "jackout",
         nodeId: null,
         score: NO_CARDS_JACKOUT,
-        reason: "no cards, can't buy — jack out",
+        reason: "no usable cards, can't buy — jack out",
         strategy: STRATEGY,
       });
     }

--- a/scripts/bot/heuristics/cards.js
+++ b/scripts/bot/heuristics/cards.js
@@ -4,8 +4,10 @@
 /** @typedef {import('../types.js').WorldModel} WorldModel */
 /** @typedef {import('../types.js').ScoredAction} ScoredAction */
 
+import { getStoreCatalog } from "../../../js/core/exploits.js";
+
 const STRATEGY = "cards";
-const STORE_VISIT_SCORE = 55;
+const BUY_CARD_SCORE = 55;
 const NO_CARDS_JACKOUT = 10;
 
 /**
@@ -21,7 +23,6 @@ export function cardsStrategy(world) {
   // Check if we have any non-failed cards that match exploitable nodes' vulns
   const hasUsableMatch = world.needsExploit.some(nodeId => {
     const matchingIds = world.cardMatchesByNode.get(nodeId) ?? [];
-    // Filter out cards that already failed on this node
     return matchingIds.some(cardId =>
       !world.failedExploits.has(`${nodeId}:${cardId}`)
     );
@@ -34,46 +35,60 @@ export function cardsStrategy(world) {
     )
   );
 
-  // Visit store if no matching cards (or all matches exhausted)
-  if (!hasUsableMatch && world.hand.length > 0) {
-    const wanNodeId = findWanNode(world);
-    if (wanNodeId && world.player.cash > 0) {
+  // Buy a matching card if we have cash and no matching cards
+  if (!hasUsableMatch && world.player.cash > 0) {
+    const vulnToBuy = pickVulnToBuy(world);
+    if (vulnToBuy) {
       proposals.push({
-        action: "access-darknet",
-        nodeId: wanNodeId,
-        score: STORE_VISIT_SCORE,
-        reason: "no matching cards — visit darknet store",
+        action: "buy-card",
+        nodeId: null,
+        score: BUY_CARD_SCORE,
+        reason: `buy ${vulnToBuy.vulnId} card (¥${vulnToBuy.price})`,
         strategy: STRATEGY,
+        payload: { vulnId: vulnToBuy.vulnId },
       });
     }
   }
 
   // Jack out if we're truly stuck: no usable cards left and can't buy more
-  if (!hasAnyUsableCard) {
-    const wanNodeId = findWanNode(world);
-    const canBuy = wanNodeId && world.player.cash > 0;
-    if (!canBuy) {
-      proposals.push({
-        action: "jackout",
-        nodeId: null,
-        score: NO_CARDS_JACKOUT,
-        reason: "no usable cards, can't buy — jack out",
-        strategy: STRATEGY,
-      });
-    }
+  if (!hasAnyUsableCard && !pickVulnToBuy(world)) {
+    proposals.push({
+      action: "jackout",
+      nodeId: null,
+      score: NO_CARDS_JACKOUT,
+      reason: "no usable cards, can't buy — jack out",
+      strategy: STRATEGY,
+    });
   }
 
   return proposals;
 }
 
 /**
- * Find the WAN node.
+ * Pick the best vulnerability type to buy from the store.
+ * Finds vulns on needsExploit nodes and picks the cheapest affordable match.
  * @param {WorldModel} world
- * @returns {string|null}
+ * @returns {{ vulnId: string, price: number } | null}
  */
-function findWanNode(world) {
-  for (const [id, node] of world.nodes) {
-    if (node.type === "wan") return id;
+function pickVulnToBuy(world) {
+  // Collect all vuln types needed across exploitable nodes
+  /** @type {Set<string>} */
+  const neededVulns = new Set();
+  for (const nodeId of world.needsExploit) {
+    const node = world.nodes.get(nodeId);
+    if (!node?.vulnerabilities) continue;
+    for (const v of node.vulnerabilities) {
+      neededVulns.add(v.id);
+    }
   }
-  return null;
+
+  if (neededVulns.size === 0) return null;
+
+  // Find affordable catalog entries matching needed vulns
+  const catalog = getStoreCatalog();
+  const affordable = catalog
+    .filter(item => neededVulns.has(item.vulnId) && item.price <= world.player.cash)
+    .sort((a, b) => a.price - b.price); // cheapest first
+
+  return affordable[0] ?? null;
 }

--- a/scripts/bot/heuristics/evasion.js
+++ b/scripts/bot/heuristics/evasion.js
@@ -1,0 +1,47 @@
+// @ts-check
+// Evasion heuristic — avoid ICE, deselect to hide.
+
+/** @typedef {import('../types.js').WorldModel} WorldModel */
+/** @typedef {import('../types.js').ScoredAction} ScoredAction */
+
+const STRATEGY = "evasion";
+const ICE_ON_NODE_CANCEL = 800;
+const POST_ACTION_DESELECT = 15;
+
+/**
+ * @param {WorldModel} world
+ * @returns {ScoredAction[]}
+ */
+export function evasionStrategy(world) {
+  /** @type {ScoredAction[]} */
+  const proposals = [];
+
+  // If ICE is on the currently selected node, propose deselecting
+  if (world.ice.isOnSelectedNode && world.player.selectedNodeId) {
+    proposals.push({
+      action: "deselect",
+      nodeId: null,
+      score: ICE_ON_NODE_CANCEL,
+      reason: "ICE on current node — hide",
+      strategy: STRATEGY,
+    });
+  }
+
+  // If player is selected on a node but not doing anything, propose deselect
+  // (reduces exposure time between actions)
+  if (world.player.selectedNodeId) {
+    const nodeId = world.player.selectedNodeId;
+    const node = world.nodes.get(nodeId);
+    if (node && !node.probing && !node.exploiting && !node.reading && !node.looting) {
+      proposals.push({
+        action: "deselect",
+        nodeId: null,
+        score: POST_ACTION_DESELECT,
+        reason: "deselect to reduce ICE exposure",
+        strategy: STRATEGY,
+      });
+    }
+  }
+
+  return proposals;
+}

--- a/scripts/bot/heuristics/evasion.js
+++ b/scripts/bot/heuristics/evasion.js
@@ -6,6 +6,7 @@
 
 const STRATEGY = "evasion";
 const ICE_ON_NODE_CANCEL = 800;
+const TRACE_JACKOUT = 100;
 const POST_ACTION_DESELECT = 15;
 
 /**
@@ -23,6 +24,18 @@ export function evasionStrategy(world) {
       nodeId: null,
       score: ICE_ON_NODE_CANCEL,
       reason: "ICE on current node — hide",
+      strategy: STRATEGY,
+    });
+  }
+
+  // If trace is active, propose jacking out (security heuristic may override
+  // with cancel-trace if the bot owns a security monitor)
+  if (world.player.traceActive) {
+    proposals.push({
+      action: "jackout",
+      nodeId: null,
+      score: TRACE_JACKOUT,
+      reason: "trace active — jack out to save progress",
       strategy: STRATEGY,
     });
   }

--- a/scripts/bot/heuristics/explore.js
+++ b/scripts/bot/heuristics/explore.js
@@ -1,0 +1,123 @@
+// @ts-check
+// Explore heuristic — probe unprobed nodes, exploit probed ones.
+
+/** @typedef {import('../types.js').WorldModel} WorldModel */
+/** @typedef {import('../types.js').ScoredAction} ScoredAction */
+
+const STRATEGY = "explore";
+const BASE_SELECT_REVEALED = 42;
+const BASE_PROBE = 50;
+const BASE_EXPLOIT = 45;
+const SELECTED_BONUS = 8;
+const MISSION_BONUS = 10;
+const DISTANCE_PENALTY = 5;
+
+/**
+ * @param {WorldModel} world
+ * @returns {ScoredAction[]}
+ */
+export function exploreStrategy(world) {
+  /** @type {ScoredAction[]} */
+  const proposals = [];
+
+  // Propose selecting revealed (but not yet accessible) nodes to traverse deeper
+  for (const nodeId of world.revealed) {
+    proposals.push({
+      action: "select",
+      nodeId,
+      score: BASE_SELECT_REVEALED,
+      reason: "select revealed node to make accessible",
+      strategy: STRATEGY,
+      payload: { nodeId },
+    });
+  }
+
+  // Propose probing unprobed nodes
+  for (const nodeId of world.needsProbe) {
+    const distance = pathDistance(world, nodeId);
+    const missionBonus = isMissionRelevant(world, nodeId) ? MISSION_BONUS : 0;
+    const selectedBonus = (nodeId === world.player.selectedNodeId) ? SELECTED_BONUS : 0;
+    proposals.push({
+      action: "probe",
+      nodeId,
+      score: BASE_PROBE + missionBonus + selectedBonus - (distance * DISTANCE_PENALTY),
+      reason: `probe unprobed node${missionBonus ? " (mission path)" : ""}`,
+      strategy: STRATEGY,
+    });
+  }
+
+  // Propose exploiting probed, unowned nodes
+  for (const nodeId of world.needsExploit) {
+    const card = pickBestCard(world, nodeId);
+    if (!card) continue;
+
+    const distance = pathDistance(world, nodeId);
+    const missionBonus = isMissionRelevant(world, nodeId) ? MISSION_BONUS : 0;
+    const selectedBonus = (nodeId === world.player.selectedNodeId) ? SELECTED_BONUS : 0;
+    proposals.push({
+      action: "exploit",
+      nodeId,
+      score: BASE_EXPLOIT + missionBonus + selectedBonus - (distance * DISTANCE_PENALTY),
+      reason: `exploit with ${card.name}${missionBonus ? " (mission path)" : ""}`,
+      strategy: STRATEGY,
+      payload: { exploitId: card.id },
+    });
+  }
+
+  return proposals;
+}
+
+/**
+ * Pick the best card for a node: prefer vuln match, skip failed combos.
+ * @param {WorldModel} world
+ * @param {string} nodeId
+ * @returns {import('../types.js').WorldCard|null}
+ */
+function pickBestCard(world, nodeId) {
+  // Filter out cards that already failed on this node
+  const available = world.hand.filter(c =>
+    !world.failedExploits.has(`${nodeId}:${c.id}`)
+  );
+  if (available.length === 0) return null;
+
+  const matchingIds = world.cardMatchesByNode.get(nodeId);
+  const matching = matchingIds
+    ? available.filter(c => matchingIds.includes(c.id))
+    : [];
+
+  if (matching.length > 0) {
+    matching.sort((a, b) => b.quality - a.quality || b.usesLeft - a.usesLeft);
+    return matching[0];
+  }
+
+  // No vuln match — pick highest quality card as a hail mary
+  const sorted = [...available].sort((a, b) => b.quality - a.quality || b.usesLeft - a.usesLeft);
+  return sorted[0];
+}
+
+/**
+ * BFS hop distance from currently selected node (or gateway) to target.
+ * @param {WorldModel} world
+ * @param {string} nodeId
+ * @returns {number}
+ */
+function pathDistance(world, nodeId) {
+  const from = world.player.selectedNodeId;
+  if (!from) return 0;
+  const path = world.shortestPath(from, nodeId);
+  return path ? path.length - 1 : 99;
+}
+
+/**
+ * Is this node on the path to the mission target?
+ * @param {WorldModel} world
+ * @param {string} nodeId
+ * @returns {boolean}
+ */
+function isMissionRelevant(world, nodeId) {
+  if (!world.mission.targetNodeId) return false;
+  if (nodeId === world.mission.targetNodeId) return true;
+  // Check if owning this node opens a path toward the mission target
+  const path = world.shortestPath(nodeId, world.mission.targetNodeId);
+  return path !== null && path.length <= 4;
+}

--- a/scripts/bot/heuristics/explore.js
+++ b/scripts/bot/heuristics/explore.js
@@ -15,6 +15,7 @@ const DISTANCE_PENALTY = 5;
 // Node types that are dangerous to probe (trigger alert escalation)
 const DANGEROUS_TYPES = new Set(["ids", "security-monitor"]);
 const DANGEROUS_PENALTY = 10;
+const ICE_COOLDOWN_PENALTY = 20;
 
 /**
  * @param {WorldModel} world
@@ -38,21 +39,22 @@ export function exploreStrategy(world) {
     });
   }
 
-  // Propose probing unprobed nodes
+  // Propose probing unprobed nodes (penalize ICE-cooled nodes)
   for (const nodeId of world.needsProbe) {
     const distance = pathDistance(world, nodeId);
     const missionBonus = isMissionRelevant(world, nodeId) ? MISSION_BONUS : 0;
     const selectedBonus = (nodeId === world.player.selectedNodeId) ? SELECTED_BONUS : 0;
+    const cooldownPenalty = world.iceCooldown.has(nodeId) ? ICE_COOLDOWN_PENALTY : 0;
     proposals.push({
       action: "probe",
       nodeId,
-      score: BASE_PROBE + missionBonus + selectedBonus - (distance * DISTANCE_PENALTY),
+      score: BASE_PROBE + missionBonus + selectedBonus - (distance * DISTANCE_PENALTY) - cooldownPenalty,
       reason: `probe unprobed node${missionBonus ? " (mission path)" : ""}`,
       strategy: STRATEGY,
     });
   }
 
-  // Propose exploiting probed, unowned nodes
+  // Propose exploiting probed, unowned nodes (penalize ICE-cooled nodes)
   for (const nodeId of world.needsExploit) {
     const card = pickBestCard(world, nodeId);
     if (!card) continue;
@@ -60,6 +62,7 @@ export function exploreStrategy(world) {
     const distance = pathDistance(world, nodeId);
     const missionBonus = isMissionRelevant(world, nodeId) ? MISSION_BONUS : 0;
     const selectedBonus = (nodeId === world.player.selectedNodeId) ? SELECTED_BONUS : 0;
+    const cooldownPenalty = world.iceCooldown.has(nodeId) ? ICE_COOLDOWN_PENALTY : 0;
 
     // Slight penalty for hail-mary (non-matching) exploits — prefer matches
     // but still willing to try non-matching cards over just exploring
@@ -69,7 +72,7 @@ export function exploreStrategy(world) {
     proposals.push({
       action: "exploit",
       nodeId,
-      score: BASE_EXPLOIT + missionBonus + selectedBonus - (distance * DISTANCE_PENALTY) - matchPenalty,
+      score: BASE_EXPLOIT + missionBonus + selectedBonus - (distance * DISTANCE_PENALTY) - matchPenalty - cooldownPenalty,
       reason: `exploit with ${card.name}${missionBonus ? " (mission path)" : ""}${matchPenalty ? " (hail-mary)" : ""}`,
       strategy: STRATEGY,
       payload: { exploitId: card.id },

--- a/scripts/bot/heuristics/explore.js
+++ b/scripts/bot/heuristics/explore.js
@@ -12,6 +12,10 @@ const SELECTED_BONUS = 8;
 const MISSION_BONUS = 10;
 const DISTANCE_PENALTY = 5;
 
+// Node types that are dangerous to probe (trigger alert escalation)
+const DANGEROUS_TYPES = new Set(["ids", "security-monitor"]);
+const DANGEROUS_PENALTY = 10;
+
 /**
  * @param {WorldModel} world
  * @returns {ScoredAction[]}
@@ -22,10 +26,12 @@ export function exploreStrategy(world) {
 
   // Propose selecting revealed (but not yet accessible) nodes to traverse deeper
   for (const nodeId of world.revealed) {
+    const node = world.nodes.get(nodeId);
+    const dangerPenalty = (node && DANGEROUS_TYPES.has(node.type)) ? DANGEROUS_PENALTY : 0;
     proposals.push({
       action: "select",
       nodeId,
-      score: BASE_SELECT_REVEALED,
+      score: BASE_SELECT_REVEALED - dangerPenalty,
       reason: "select revealed node to make accessible",
       strategy: STRATEGY,
       payload: { nodeId },
@@ -54,11 +60,17 @@ export function exploreStrategy(world) {
     const distance = pathDistance(world, nodeId);
     const missionBonus = isMissionRelevant(world, nodeId) ? MISSION_BONUS : 0;
     const selectedBonus = (nodeId === world.player.selectedNodeId) ? SELECTED_BONUS : 0;
+
+    // Slight penalty for hail-mary (non-matching) exploits — prefer matches
+    // but still willing to try non-matching cards over just exploring
+    const matchingIds = world.cardMatchesByNode.get(nodeId) ?? [];
+    const matchPenalty = matchingIds.includes(card.id) ? 0 : 5;
+
     proposals.push({
       action: "exploit",
       nodeId,
-      score: BASE_EXPLOIT + missionBonus + selectedBonus - (distance * DISTANCE_PENALTY),
-      reason: `exploit with ${card.name}${missionBonus ? " (mission path)" : ""}`,
+      score: BASE_EXPLOIT + missionBonus + selectedBonus - (distance * DISTANCE_PENALTY) - matchPenalty,
+      reason: `exploit with ${card.name}${missionBonus ? " (mission path)" : ""}${matchPenalty ? " (hail-mary)" : ""}`,
       strategy: STRATEGY,
       payload: { exploitId: card.id },
     });

--- a/scripts/bot/heuristics/loot.js
+++ b/scripts/bot/heuristics/loot.js
@@ -1,0 +1,63 @@
+// @ts-check
+// Loot heuristic — read and loot owned nodes, prioritize mission target.
+
+/** @typedef {import('../types.js').WorldModel} WorldModel */
+/** @typedef {import('../types.js').ScoredAction} ScoredAction */
+
+const STRATEGY = "loot";
+const BASE_READ = 60;
+const BASE_LOOT = 62;
+const MISSION_BONUS = 20;
+const DISTANCE_PENALTY = 3;
+
+/**
+ * @param {WorldModel} world
+ * @returns {ScoredAction[]}
+ */
+export function lootStrategy(world) {
+  /** @type {ScoredAction[]} */
+  const proposals = [];
+
+  for (const nodeId of world.lootable) {
+    const node = world.nodes.get(nodeId);
+    if (!node) continue;
+
+    const distance = pathDistance(world, nodeId);
+    const hasMissionTarget = world.mission.targetNodeId === nodeId;
+    const missionBonus = hasMissionTarget ? MISSION_BONUS : 0;
+
+    if (node.read === false) {
+      // Needs reading first
+      proposals.push({
+        action: "read",
+        nodeId,
+        score: BASE_READ + missionBonus - (distance * DISTANCE_PENALTY),
+        reason: `read owned node${hasMissionTarget ? " (MISSION TARGET)" : ""}`,
+        strategy: STRATEGY,
+      });
+    } else if (node.looted === false && node.macguffins?.length > 0) {
+      // Read but not looted
+      proposals.push({
+        action: "loot",
+        nodeId,
+        score: BASE_LOOT + missionBonus - (distance * DISTANCE_PENALTY),
+        reason: `loot ${node.macguffins.length} item(s)${hasMissionTarget ? " (MISSION TARGET)" : ""}`,
+        strategy: STRATEGY,
+      });
+    }
+  }
+
+  return proposals;
+}
+
+/**
+ * @param {WorldModel} world
+ * @param {string} nodeId
+ * @returns {number}
+ */
+function pathDistance(world, nodeId) {
+  const from = world.player.selectedNodeId;
+  if (!from) return 0;
+  const path = world.shortestPath(from, nodeId);
+  return path ? path.length - 1 : 99;
+}

--- a/scripts/bot/heuristics/loot.js
+++ b/scripts/bot/heuristics/loot.js
@@ -22,11 +22,16 @@ export function lootStrategy(world) {
     const node = world.nodes.get(nodeId);
     if (!node) continue;
 
+    // Only propose read/loot if the action is actually available on this node type
+    const actions = world.availableActions.get(nodeId) ?? [];
+    const canRead = actions.some(a => a.id === "read");
+    const canLoot = actions.some(a => a.id === "loot");
+
     const distance = pathDistance(world, nodeId);
     const hasMissionTarget = world.mission.targetNodeId === nodeId;
     const missionBonus = hasMissionTarget ? MISSION_BONUS : 0;
 
-    if (node.read === false) {
+    if (!node.read && canRead) {
       // Needs reading first
       proposals.push({
         action: "read",
@@ -35,7 +40,7 @@ export function lootStrategy(world) {
         reason: `read owned node${hasMissionTarget ? " (MISSION TARGET)" : ""}`,
         strategy: STRATEGY,
       });
-    } else if (node.looted === false && node.macguffins?.length > 0) {
+    } else if (!node.looted && node.macguffins?.length > 0 && canLoot) {
       // Read but not looted
       proposals.push({
         action: "loot",

--- a/scripts/bot/heuristics/security.js
+++ b/scripts/bot/heuristics/security.js
@@ -1,0 +1,111 @@
+// @ts-check
+// Security heuristic — subvert IDS nodes, cancel trace when possible.
+
+/** @typedef {import('../types.js').WorldModel} WorldModel */
+/** @typedef {import('../types.js').ScoredAction} ScoredAction */
+
+const STRATEGY = "security";
+const BASE_RECONFIGURE = 70;
+const CANCEL_TRACE_SCORE = 900;
+
+/**
+ * @param {WorldModel} world
+ * @returns {ScoredAction[]}
+ */
+export function securityStrategy(world) {
+  /** @type {ScoredAction[]} */
+  const proposals = [];
+
+  // Emergency: cancel trace if we own a security monitor
+  if (world.player.traceActive) {
+    for (const nodeId of world.security) {
+      const node = world.nodes.get(nodeId);
+      if (!node) continue;
+      if (node.type === "security-monitor" && node.accessLevel === "owned") {
+        const actions = world.availableActions.get(nodeId) ?? [];
+        if (actions.some(a => a.id === "cancel-trace")) {
+          proposals.push({
+            action: "cancel-trace",
+            nodeId,
+            score: CANCEL_TRACE_SCORE,
+            reason: "EMERGENCY: cancel active trace",
+            strategy: STRATEGY,
+          });
+        }
+      }
+    }
+  }
+
+  // Prioritize subverting IDS nodes
+  for (const nodeId of world.security) {
+    const node = world.nodes.get(nodeId);
+    if (!node || node.type !== "ids") continue;
+    if (node.visibility !== "accessible") continue;
+
+    // Already reconfigured?
+    if (node.forwardingEnabled === false) continue;
+
+    if (node.accessLevel === "owned") {
+      // Own it — reconfigure
+      const actions = world.availableActions.get(nodeId) ?? [];
+      if (actions.some(a => a.id === "reconfigure")) {
+        proposals.push({
+          action: "reconfigure",
+          nodeId,
+          score: BASE_RECONFIGURE,
+          reason: "reconfigure IDS to sever alert chain",
+          strategy: STRATEGY,
+        });
+      }
+    } else if (!node.probed) {
+      // Need to probe first
+      proposals.push({
+        action: "probe",
+        nodeId,
+        score: BASE_RECONFIGURE + 2,
+        reason: "probe IDS for subversion",
+        strategy: STRATEGY,
+      });
+    } else {
+      // Probed but not owned — exploit
+      const card = pickBestCard(world, nodeId);
+      if (card) {
+        proposals.push({
+          action: "exploit",
+          nodeId,
+          score: BASE_RECONFIGURE + 1,
+          reason: "exploit IDS for subversion",
+          strategy: STRATEGY,
+          payload: { exploitId: card.id },
+        });
+      }
+    }
+  }
+
+  return proposals;
+}
+
+/**
+ * @param {WorldModel} world
+ * @param {string} nodeId
+ * @returns {import('../types.js').WorldCard|null}
+ */
+function pickBestCard(world, nodeId) {
+  const available = world.hand.filter(c =>
+    !world.failedExploits.has(`${nodeId}:${c.id}`)
+  );
+  if (available.length === 0) return null;
+
+  const matchingIds = world.cardMatchesByNode.get(nodeId);
+  const matching = matchingIds
+    ? available.filter(c => matchingIds.includes(c.id))
+    : [];
+
+  if (matching.length > 0) {
+    matching.sort((a, b) => b.quality - a.quality || b.usesLeft - a.usesLeft);
+    return matching[0];
+  }
+
+  const sorted = [...available].sort((a, b) => b.quality - a.quality);
+  return sorted[0];
+}

--- a/scripts/bot/heuristics/security.js
+++ b/scripts/bot/heuristics/security.js
@@ -7,6 +7,8 @@
 const STRATEGY = "security";
 const BASE_RECONFIGURE = 70;
 const CANCEL_TRACE_SCORE = 900;
+// When alert is green, deprioritize security work — explore data nodes first
+const GREEN_ALERT_PENALTY = 35;
 
 /**
  * @param {WorldModel} world
@@ -36,7 +38,10 @@ export function securityStrategy(world) {
     }
   }
 
-  // Prioritize subverting IDS nodes
+  // Prioritize subverting IDS nodes (but not when alert is still green —
+  // probing IDS can trigger alert escalation, so explore data nodes first)
+  const alertPenalty = world.player.alertLevel === "green" ? GREEN_ALERT_PENALTY : 0;
+
   for (const nodeId of world.security) {
     const node = world.nodes.get(nodeId);
     if (!node || node.type !== "ids") continue;
@@ -62,19 +67,22 @@ export function securityStrategy(world) {
       proposals.push({
         action: "probe",
         nodeId,
-        score: BASE_RECONFIGURE + 2,
+        score: BASE_RECONFIGURE + 2 - alertPenalty,
         reason: "probe IDS for subversion",
         strategy: STRATEGY,
       });
     } else {
-      // Probed but not owned — exploit
+      // Probed but not owned — exploit (only if we have a matching card)
       const card = pickBestCard(world, nodeId);
       if (card) {
+        // Only propose at high priority if card actually matches a vuln
+        const matchingIds = world.cardMatchesByNode.get(nodeId) ?? [];
+        const isMatch = matchingIds.includes(card.id);
         proposals.push({
           action: "exploit",
           nodeId,
-          score: BASE_RECONFIGURE + 1,
-          reason: "exploit IDS for subversion",
+          score: (isMatch ? BASE_RECONFIGURE + 1 : BASE_RECONFIGURE - 30) - alertPenalty,
+          reason: isMatch ? "exploit IDS for subversion" : "hail-mary exploit on IDS",
           strategy: STRATEGY,
           payload: { exploitId: card.id },
         });

--- a/scripts/bot/heuristics/traps.js
+++ b/scripts/bot/heuristics/traps.js
@@ -1,0 +1,33 @@
+// @ts-check
+// Traps heuristic — discover and use disarm actions on owned nodes.
+
+/** @typedef {import('../types.js').WorldModel} WorldModel */
+/** @typedef {import('../types.js').ScoredAction} ScoredAction */
+
+const STRATEGY = "traps";
+const BASE_DISARM = 65;
+
+/**
+ * @param {WorldModel} world
+ * @returns {ScoredAction[]}
+ */
+export function trapsStrategy(world) {
+  /** @type {ScoredAction[]} */
+  const proposals = [];
+
+  for (const nodeId of world.hasDisarmActions) {
+    const actions = world.availableActions.get(nodeId) ?? [];
+    for (const action of actions) {
+      if (!action.id.startsWith("disarm")) continue;
+      proposals.push({
+        action: action.id,
+        nodeId,
+        score: BASE_DISARM,
+        reason: `disarm trap: ${action.label ?? action.id}`,
+        strategy: STRATEGY,
+      });
+    }
+  }
+
+  return proposals;
+}

--- a/scripts/bot/heuristics/traps.js
+++ b/scripts/bot/heuristics/traps.js
@@ -19,6 +19,9 @@ export function trapsStrategy(world) {
     const actions = world.availableActions.get(nodeId) ?? [];
     for (const action of actions) {
       if (!action.id.startsWith("disarm")) continue;
+      // Skip actions we already completed (they may still appear "available"
+      // due to missing post-conditions on the set-piece definition)
+      if (world.completedActions.has(`${nodeId}:${action.id}`)) continue;
       proposals.push({
         action: action.id,
         nodeId,

--- a/scripts/bot/loop.js
+++ b/scripts/bot/loop.js
@@ -1,0 +1,123 @@
+// @ts-check
+// Bot main loop — perceive → score → execute cycle.
+
+/** @typedef {import('./types.js').Strategy} Strategy */
+/** @typedef {import('./types.js').BotRunStats} BotRunStats */
+
+import { getState, emitEvent, on, off, E, tick } from "../lib/headless-engine.js";
+import { perceive } from "./perception.js";
+import { score } from "./scoring.js";
+import { execute } from "./execute.js";
+import { createStats, recordAction, recordEvasion, updatePeakAlert, finalizeStats } from "./stats.js";
+
+/**
+ * Run the bot loop until the game ends or budget is exhausted.
+ *
+ * @param {Strategy[]} strategies
+ * @param {{ tickBudget?: number, verbose?: boolean }} [opts]
+ * @returns {BotRunStats}
+ */
+export function runLoop(strategies, opts = {}) {
+  const tickBudget = opts.tickBudget ?? 5000;
+  const verbose = opts.verbose ?? false;
+  const stats = createStats();
+  let totalTicks = 0;
+  /** @type {Set<string>} */
+  const failedExploits = new Set();
+
+  // Track events for stats
+  const onDetected = () => { stats.iceDetections++; };
+  const onTraceStarted = () => { stats.traceFired = true; };
+  const onAlertRaised = ({ next }) => { updatePeakAlert(stats, next); };
+  const onRunEnded = ({ outcome }) => {
+    if (outcome === "caught") stats.failReason = "trace";
+  };
+
+  on(E.ICE_DETECTED, onDetected);
+  on(E.ALERT_TRACE_STARTED, onTraceStarted);
+  on(E.ALERT_GLOBAL_RAISED, onAlertRaised);
+  on(E.RUN_ENDED, onRunEnded);
+
+  try {
+    while (totalTicks < tickBudget) {
+      const state = getState();
+      if (state.phase !== "playing") break;
+
+      const world = perceive(state, { failedExploits });
+
+      // If mission is complete, jack out
+      if (world.mission.complete) {
+        emitEvent("starnet:action", { actionId: "jackout" });
+        break;
+      }
+
+      const choice = score(world, strategies, { verbose });
+
+      if (!choice) {
+        // Nothing to do — jack out
+        if (verbose) console.log("[BOT] No proposals — jacking out.");
+        stats.failReason = "stuck";
+        emitEvent("starnet:action", { actionId: "jackout" });
+        break;
+      }
+
+      if (verbose) {
+        console.log(`[BOT] → ${choice.action} ${choice.nodeId ?? ""} (${choice.score}) — ${choice.reason}`);
+      }
+
+      // Snapshot access level before execute for exploit tracking
+      const accessBefore = choice.action === "exploit" && choice.nodeId
+        ? getState().nodes[choice.nodeId]?.accessLevel
+        : null;
+
+      recordAction(stats, choice);
+      const result = execute(choice, world);
+      totalTicks += result.ticksUsed || 1;
+
+      // Track failed exploits: if access level didn't change, mark this card+node as failed
+      if (choice.action === "exploit" && result.completed && choice.nodeId) {
+        const accessAfter = getState().nodes[choice.nodeId]?.accessLevel;
+        const cardId = choice.payload?.exploitId;
+        if (cardId && accessAfter === accessBefore) {
+          failedExploits.add(`${choice.nodeId}:${cardId}`);
+        } else if (accessAfter !== accessBefore) {
+          // Progress was made — clear failures for this node so cards can be retried
+          for (const key of [...failedExploits]) {
+            if (key.startsWith(`${choice.nodeId}:`)) failedExploits.delete(key);
+          }
+        }
+      }
+
+      if (result.interrupted) {
+        // ICE arrived mid-action — re-score
+        recordEvasion(stats);
+        if (verbose) console.log("[BOT] ICE interrupted — re-scoring.");
+
+        const interruptWorld = perceive(getState());
+        const interruptChoice = score(interruptWorld, strategies, { verbose });
+
+        if (interruptChoice) {
+          if (verbose) {
+            console.log(`[BOT] interrupt → ${interruptChoice.action} ${interruptChoice.nodeId ?? ""} (${interruptChoice.score})`);
+          }
+          recordAction(stats, interruptChoice);
+          execute(interruptChoice, interruptWorld);
+        }
+      }
+    }
+
+    if (totalTicks >= tickBudget && getState().phase === "playing") {
+      stats.failReason = "tick-cap";
+      emitEvent("starnet:action", { actionId: "jackout" });
+    }
+  } finally {
+    off(E.ICE_DETECTED, onDetected);
+    off(E.ALERT_TRACE_STARTED, onTraceStarted);
+    off(E.ALERT_GLOBAL_RAISED, onAlertRaised);
+    off(E.RUN_ENDED, onRunEnded);
+  }
+
+  stats.ticksElapsed = totalTicks;
+  finalizeStats(stats, getState());
+  return stats;
+}

--- a/scripts/bot/loop.js
+++ b/scripts/bot/loop.js
@@ -24,6 +24,8 @@ export function runLoop(strategies, opts = {}) {
   let totalTicks = 0;
   /** @type {Set<string>} */
   const failedExploits = new Set();
+  /** @type {Set<string>} Track disarmed node:action pairs to avoid retrying */
+  const completedActions = new Set();
 
   // Track events for stats
   const onDetected = () => { stats.iceDetections++; };
@@ -43,7 +45,7 @@ export function runLoop(strategies, opts = {}) {
       const state = getState();
       if (state.phase !== "playing") break;
 
-      const world = perceive(state, { failedExploits });
+      const world = perceive(state, { failedExploits, completedActions });
 
       // If mission is complete, jack out
       if (world.mission.complete) {
@@ -73,6 +75,11 @@ export function runLoop(strategies, opts = {}) {
       recordAction(stats, choice);
       const result = execute(choice, world);
       totalTicks += result.ticksUsed || 1;
+
+      // Track instant actions that shouldn't repeat (disarm, reconfigure, etc.)
+      if (choice.action.startsWith("disarm") && choice.nodeId) {
+        completedActions.add(`${choice.nodeId}:${choice.action}`);
+      }
 
       // Track failed exploits: if access level didn't change, mark this card+node as failed
       if (choice.action === "exploit" && result.completed && choice.nodeId) {

--- a/scripts/bot/loop.js
+++ b/scripts/bot/loop.js
@@ -26,6 +26,8 @@ export function runLoop(strategies, opts = {}) {
   const failedExploits = new Set();
   /** @type {Set<string>} Track disarmed node:action pairs to avoid retrying */
   const completedActions = new Set();
+  /** @type {Set<string>} Nodes where ICE recently interrupted — avoid for a cycle */
+  const iceCooldown = new Set();
 
   // Track events for stats
   const onDetected = () => { stats.iceDetections++; };
@@ -45,7 +47,7 @@ export function runLoop(strategies, opts = {}) {
       const state = getState();
       if (state.phase !== "playing") break;
 
-      const world = perceive(state, { failedExploits, completedActions });
+      const world = perceive(state, { failedExploits, completedActions, iceCooldown });
 
       // If mission is complete, jack out
       if (world.mission.complete) {
@@ -72,9 +74,17 @@ export function runLoop(strategies, opts = {}) {
         ? getState().nodes[choice.nodeId]?.accessLevel
         : null;
 
+      // Snapshot cash before buy-card for tracking spend
+      const cashBefore = choice.action === "buy-card" ? getState().player.cash : 0;
+
       recordAction(stats, choice);
       const result = execute(choice, world);
       totalTicks += result.ticksUsed || 1;
+
+      // Track buy-card cash spent
+      if (choice.action === "buy-card") {
+        stats.cashSpent += cashBefore - getState().player.cash;
+      }
 
       // Track instant actions that shouldn't repeat (disarm, reconfigure, etc.)
       if (choice.action.startsWith("disarm") && choice.nodeId) {
@@ -96,20 +106,14 @@ export function runLoop(strategies, opts = {}) {
       }
 
       if (result.interrupted) {
-        // ICE arrived mid-action — re-score
+        // ICE arrived mid-action — already cancelled + deselected in execute.
+        // Cool down this node for ONE cycle so the bot tries something else first.
         recordEvasion(stats);
-        if (verbose) console.log("[BOT] ICE interrupted — re-scoring.");
-
-        const interruptWorld = perceive(getState());
-        const interruptChoice = score(interruptWorld, strategies, { verbose });
-
-        if (interruptChoice) {
-          if (verbose) {
-            console.log(`[BOT] interrupt → ${interruptChoice.action} ${interruptChoice.nodeId ?? ""} (${interruptChoice.score})`);
-          }
-          recordAction(stats, interruptChoice);
-          execute(interruptChoice, interruptWorld);
-        }
+        if (choice.nodeId) iceCooldown.add(choice.nodeId);
+        if (verbose) console.log("[BOT] ICE interrupted — will re-score next cycle.");
+      } else {
+        // Non-interrupted cycle clears all cooldowns (one-cycle penalty served)
+        iceCooldown.clear();
       }
     }
 

--- a/scripts/bot/perception.js
+++ b/scripts/bot/perception.js
@@ -1,0 +1,228 @@
+// @ts-check
+// Perception layer — reads game state and builds a structured WorldModel
+// for strategy functions to score against.
+
+/** @typedef {import('./types.js').WorldModel} WorldModel */
+/** @typedef {import('./types.js').WorldNode} WorldNode */
+/** @typedef {import('./types.js').WorldCard} WorldCard */
+
+import { getAvailableActions } from "../../js/core/actions/node-actions.js";
+
+/**
+ * Build a WorldModel snapshot from current game state.
+ * @param {import('../../js/core/types.js').GameState} state
+ * @param {{ failedExploits?: Set<string> }} [context]
+ * @returns {WorldModel}
+ */
+export function perceive(state, context = {}) {
+  const nodes = /** @type {Map<string, WorldNode>} */ (new Map());
+  const accessible = [];
+  const owned = [];
+  const needsProbe = [];
+  const needsExploit = [];
+  const lootable = [];
+  const security = [];
+  const hasDisarmActions = [];
+
+  /** @type {Map<string, import('../../js/core/types.js').ActionDef[]>} */
+  const availableActions = new Map();
+
+  /** @type {string[]} */
+  const revealed = [];
+
+  // Categorize all visible nodes
+  for (const [id, n] of Object.entries(state.nodes)) {
+    if (n.visibility === "hidden") continue;
+
+    nodes.set(id, /** @type {WorldNode} */ (n));
+
+    // Get available actions for accessible nodes
+    if (n.visibility === "accessible") {
+      const actions = getAvailableActions(n, state);
+      availableActions.set(id, actions);
+    }
+
+    const isWan = n.type === "wan";
+    const isAccessible = n.visibility === "accessible";
+    const isOwned = n.accessLevel === "owned";
+
+    if (isOwned) {
+      owned.push(id);
+
+      // Check for disarm actions
+      const actions = availableActions.get(id) ?? getAvailableActions(n, state);
+      if (!availableActions.has(id)) availableActions.set(id, actions);
+      const disarms = actions.filter(a => a.id.startsWith("disarm"));
+      if (disarms.length > 0) hasDisarmActions.push(id);
+
+      // Lootable: not read, or read but not looted with macguffins
+      if (n.read === false) {
+        lootable.push(id);
+      } else if (n.looted === false && n.macguffins?.length > 0) {
+        lootable.push(id);
+      }
+    } else if (isAccessible && !isWan) {
+      accessible.push(id);
+
+      if (!n.probed) {
+        needsProbe.push(id);
+      } else if (n.accessLevel !== "owned") {
+        needsExploit.push(id);
+      }
+    } else if (n.visibility === "revealed" && !isWan) {
+      // Revealed but not yet accessible — selecting it will make it accessible
+      revealed.push(id);
+    }
+
+    // Security nodes (any access level)
+    if (n.type === "ids" || n.type === "security-monitor") {
+      security.push(id);
+    }
+  }
+
+  // Build card-to-node match map
+  /** @type {Map<string, string[]>} */
+  const cardMatchesByNode = new Map();
+  const hand = buildHand(state);
+
+  for (const [nodeId, node] of nodes) {
+    if (!node.vulnerabilities?.length) continue;
+    const vulnTypes = new Set(node.vulnerabilities.map(v => v.type));
+    const matching = hand.filter(c => vulnTypes.has(c.vulnType)).map(c => c.id);
+    if (matching.length > 0) cardMatchesByNode.set(nodeId, matching);
+  }
+
+  // ICE state
+  const ice = {
+    nodeId: state.ice?.attentionNodeId ?? null,
+    isOnSelectedNode: !!(state.ice?.active && state.ice.attentionNodeId === state.selectedNodeId),
+    isActive: state.ice?.active ?? false,
+  };
+
+  // Player state
+  const player = {
+    selectedNodeId: state.selectedNodeId,
+    cash: state.player.cash,
+    alertLevel: state.globalAlert,
+    traceActive: state.traceSecondsRemaining !== null,
+    traceCountdown: state.traceSecondsRemaining,
+  };
+
+  // Mission state
+  const mission = buildMission(state);
+
+  // BFS shortest path through owned/accessible nodes
+  const shortestPath = (fromId, toId) =>
+    bfsPath(fromId, toId, state.adjacency, state.nodes);
+
+  return {
+    nodes,
+    adjacency: state.adjacency,
+    revealed,
+    accessible,
+    owned,
+    needsProbe,
+    needsExploit,
+    lootable,
+    security,
+    hasDisarmActions,
+    ice,
+    player,
+    hand,
+    cardMatchesByNode,
+    availableActions,
+    mission,
+    gamePhase: state.phase,
+    failedExploits: context.failedExploits ?? new Set(),
+    shortestPath,
+  };
+}
+
+/**
+ * Build hand summary from state.
+ * @param {import('../../js/core/types.js').GameState} state
+ * @returns {WorldCard[]}
+ */
+function buildHand(state) {
+  return (state.player.hand ?? [])
+    .filter(c => (c.uses ?? 1) > 0)
+    .map(c => ({
+      id: c.id,
+      name: c.name,
+      vulnType: c.vulnType,
+      quality: c.quality ?? 50,
+      usesLeft: c.uses ?? 1,
+    }));
+}
+
+/**
+ * Build mission summary, finding which node has the target macguffin.
+ * @param {import('../../js/core/types.js').GameState} state
+ * @returns {import('./types.js').WorldMission}
+ */
+function buildMission(state) {
+  const m = state.mission;
+  if (!m) return { targetMacguffinId: null, targetName: null, complete: false, targetNodeId: null };
+
+  let targetNodeId = null;
+  if (!m.complete) {
+    for (const [nodeId, node] of Object.entries(state.nodes)) {
+      if (node.macguffins?.some(mg => mg.id === m.targetMacguffinId)) {
+        targetNodeId = nodeId;
+        break;
+      }
+    }
+  }
+
+  return {
+    targetMacguffinId: m.targetMacguffinId,
+    targetName: m.targetName,
+    complete: m.complete,
+    targetNodeId,
+  };
+}
+
+/**
+ * BFS through accessible/owned nodes to find shortest path.
+ * Returns array of node IDs from start to end (inclusive), or null if unreachable.
+ * @param {string} fromId
+ * @param {string} toId
+ * @param {Object<string, string[]>} adjacency
+ * @param {Object<string, any>} nodes
+ * @returns {string[]|null}
+ */
+function bfsPath(fromId, toId, adjacency, nodes) {
+  if (fromId === toId) return [fromId];
+
+  const visited = new Set([fromId]);
+  /** @type {Map<string, string>} */
+  const parent = new Map();
+  const queue = [fromId];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    for (const neighbor of (adjacency[current] ?? [])) {
+      if (visited.has(neighbor)) continue;
+      const n = nodes[neighbor];
+      if (!n || n.visibility === "hidden") continue;
+      // Can traverse through accessible or owned nodes
+      if (n.visibility !== "accessible") continue;
+
+      visited.add(neighbor);
+      parent.set(neighbor, current);
+
+      if (neighbor === toId) {
+        // Reconstruct path
+        const path = [toId];
+        let step = toId;
+        while (parent.has(step)) {
+          step = parent.get(step);
+          path.unshift(step);
+        }
+        return path;
+      }
+      queue.push(neighbor);
+    }
+  }
+  return null;
+}

--- a/scripts/bot/perception.js
+++ b/scripts/bot/perception.js
@@ -11,7 +11,7 @@ import { getAvailableActions } from "../../js/core/actions/node-actions.js";
 /**
  * Build a WorldModel snapshot from current game state.
  * @param {import('../../js/core/types.js').GameState} state
- * @param {{ failedExploits?: Set<string>, completedActions?: Set<string> }} [context]
+ * @param {{ failedExploits?: Set<string>, completedActions?: Set<string>, iceCooldown?: Set<string> }} [context]
  * @returns {WorldModel}
  */
 export function perceive(state, context = {}) {
@@ -68,7 +68,8 @@ export function perceive(state, context = {}) {
 
       if (!n.probed) {
         needsProbe.push(id);
-      } else if (n.accessLevel !== "owned") {
+      } else if (n.accessLevel !== "owned" && n.vulnerabilities?.length > 0) {
+        // Only exploitable if the node has vulnerabilities to target
         needsExploit.push(id);
       }
     } else if (n.visibility === "revealed" && !isWan) {
@@ -89,7 +90,7 @@ export function perceive(state, context = {}) {
 
   for (const [nodeId, node] of nodes) {
     if (!node.vulnerabilities?.length) continue;
-    const vulnTypes = new Set(node.vulnerabilities.map(v => v.type));
+    const vulnTypes = new Set(node.vulnerabilities.map(v => v.id));
     const matching = hand.filter(c =>
       c.targetVulnTypes.some(t => vulnTypes.has(t))
     ).map(c => c.id);
@@ -139,6 +140,7 @@ export function perceive(state, context = {}) {
     gamePhase: state.phase,
     failedExploits: context.failedExploits ?? new Set(),
     completedActions: context.completedActions ?? new Set(),
+    iceCooldown: context.iceCooldown ?? new Set(),
     shortestPath,
   };
 }

--- a/scripts/bot/perception.js
+++ b/scripts/bot/perception.js
@@ -11,7 +11,7 @@ import { getAvailableActions } from "../../js/core/actions/node-actions.js";
 /**
  * Build a WorldModel snapshot from current game state.
  * @param {import('../../js/core/types.js').GameState} state
- * @param {{ failedExploits?: Set<string> }} [context]
+ * @param {{ failedExploits?: Set<string>, completedActions?: Set<string> }} [context]
  * @returns {WorldModel}
  */
 export function perceive(state, context = {}) {
@@ -46,7 +46,7 @@ export function perceive(state, context = {}) {
     const isAccessible = n.visibility === "accessible";
     const isOwned = n.accessLevel === "owned";
 
-    if (isOwned) {
+    if (isOwned && !isWan) {
       owned.push(id);
 
       // Check for disarm actions
@@ -55,10 +55,12 @@ export function perceive(state, context = {}) {
       const disarms = actions.filter(a => a.id.startsWith("disarm"));
       if (disarms.length > 0) hasDisarmActions.push(id);
 
-      // Lootable: not read, or read but not looted with macguffins
+      // Lootable: nodes with read/looted attributes (from "lootable" trait)
+      // that haven't been fully looted yet. read/looted are undefined on
+      // node types that don't support these actions (gateway, router, etc.)
       if (n.read === false) {
         lootable.push(id);
-      } else if (n.looted === false && n.macguffins?.length > 0) {
+      } else if (n.read === true && n.looted === false && n.macguffins?.length > 0) {
         lootable.push(id);
       }
     } else if (isAccessible && !isWan) {
@@ -88,7 +90,9 @@ export function perceive(state, context = {}) {
   for (const [nodeId, node] of nodes) {
     if (!node.vulnerabilities?.length) continue;
     const vulnTypes = new Set(node.vulnerabilities.map(v => v.type));
-    const matching = hand.filter(c => vulnTypes.has(c.vulnType)).map(c => c.id);
+    const matching = hand.filter(c =>
+      c.targetVulnTypes.some(t => vulnTypes.has(t))
+    ).map(c => c.id);
     if (matching.length > 0) cardMatchesByNode.set(nodeId, matching);
   }
 
@@ -134,6 +138,7 @@ export function perceive(state, context = {}) {
     mission,
     gamePhase: state.phase,
     failedExploits: context.failedExploits ?? new Set(),
+    completedActions: context.completedActions ?? new Set(),
     shortestPath,
   };
 }
@@ -145,13 +150,13 @@ export function perceive(state, context = {}) {
  */
 function buildHand(state) {
   return (state.player.hand ?? [])
-    .filter(c => (c.uses ?? 1) > 0)
+    .filter(c => c.usesRemaining > 0 && c.decayState !== "disclosed")
     .map(c => ({
       id: c.id,
       name: c.name,
-      vulnType: c.vulnType,
+      targetVulnTypes: c.targetVulnTypes,
       quality: c.quality ?? 50,
-      usesLeft: c.uses ?? 1,
+      usesLeft: c.usesRemaining,
     }));
 }
 

--- a/scripts/bot/run.js
+++ b/scripts/bot/run.js
@@ -1,0 +1,50 @@
+// @ts-check
+// Bot entry point — initialize game, assemble strategies, run loop, return stats.
+
+/** @typedef {import('./types.js').BotRunStats} BotRunStats */
+/** @typedef {import('./types.js').Strategy} Strategy */
+
+import { initHeadlessEngine, resetGame } from "../lib/headless-engine.js";
+import { runLoop } from "./loop.js";
+
+// Default strategies
+import { exploreStrategy } from "./heuristics/explore.js";
+import { lootStrategy } from "./heuristics/loot.js";
+import { securityStrategy } from "./heuristics/security.js";
+import { trapsStrategy } from "./heuristics/traps.js";
+import { evasionStrategy } from "./heuristics/evasion.js";
+import { cardsStrategy } from "./heuristics/cards.js";
+
+/** @type {Strategy[]} */
+const DEFAULT_STRATEGIES = [
+  exploreStrategy,
+  lootStrategy,
+  securityStrategy,
+  trapsStrategy,
+  evasionStrategy,
+  cardsStrategy,
+];
+
+let engineInitialized = false;
+
+/**
+ * Run the bot against a network.
+ *
+ * @param {() => { graphDef: any, meta: any }} buildNetworkFn
+ * @param {{ seed?: string, strategies?: Strategy[], tickBudget?: number, verbose?: boolean }} [opts]
+ * @returns {BotRunStats}
+ */
+export function runBot(buildNetworkFn, opts = {}) {
+  if (!engineInitialized) {
+    initHeadlessEngine();
+    engineInitialized = true;
+  }
+
+  resetGame(buildNetworkFn, opts.seed);
+
+  const strategies = opts.strategies ?? DEFAULT_STRATEGIES;
+  return runLoop(strategies, {
+    tickBudget: opts.tickBudget,
+    verbose: opts.verbose,
+  });
+}

--- a/scripts/bot/scoring.js
+++ b/scripts/bot/scoring.js
@@ -1,0 +1,36 @@
+// @ts-check
+// Scoring engine — collects proposals from all strategies, picks the winner.
+
+/** @typedef {import('./types.js').WorldModel} WorldModel */
+/** @typedef {import('./types.js').ScoredAction} ScoredAction */
+/** @typedef {import('./types.js').Strategy} Strategy */
+
+/**
+ * Run all strategies against the world model and return the highest-scored action.
+ * @param {WorldModel} world
+ * @param {Strategy[]} strategies
+ * @param {{ verbose?: boolean }} [opts]
+ * @returns {ScoredAction|null}
+ */
+export function score(world, strategies, opts = {}) {
+  /** @type {ScoredAction[]} */
+  const proposals = [];
+
+  for (const strategy of strategies) {
+    const results = strategy(world);
+    proposals.push(...results);
+  }
+
+  if (proposals.length === 0) return null;
+
+  proposals.sort((a, b) => b.score - a.score);
+
+  if (opts.verbose) {
+    console.log(`[SCORING] ${proposals.length} proposals:`);
+    for (const p of proposals.slice(0, 10)) {
+      console.log(`  ${p.score.toFixed(0).padStart(5)} | ${p.action} ${p.nodeId ?? ""} | ${p.reason} [${p.strategy}]`);
+    }
+  }
+
+  return proposals[0];
+}

--- a/scripts/bot/stats.js
+++ b/scripts/bot/stats.js
@@ -1,0 +1,83 @@
+// @ts-check
+// Bot stats — creation, recording, and finalization.
+
+/** @typedef {import('./types.js').BotRunStats} BotRunStats */
+/** @typedef {import('./types.js').ScoredAction} ScoredAction */
+
+const ALERT_RANK = { green: 0, yellow: 1, red: 2 };
+
+/**
+ * Create a fresh stats object with zeroed counters.
+ * @returns {BotRunStats}
+ */
+export function createStats() {
+  return {
+    success: false,
+    failReason: null,
+    ticksElapsed: 0,
+    nodesOwned: 0,
+    nodesTotal: 0,
+    cardsUsed: 0,
+    cardsBurned: 0,
+    storeVisits: 0,
+    cashSpent: 0,
+    cashRemaining: 0,
+    peakAlert: "green",
+    traceFired: false,
+    iceDetections: 0,
+    iceEvasions: 0,
+    disarmActionsUsed: 0,
+    strategyCounts: {},
+  };
+}
+
+/**
+ * Record a chosen action into stats.
+ * @param {BotRunStats} stats
+ * @param {ScoredAction} action
+ */
+export function recordAction(stats, action) {
+  // Track which strategy produced the winning action
+  const name = action.strategy ?? "unknown";
+  stats.strategyCounts[name] = (stats.strategyCounts[name] ?? 0) + 1;
+
+  if (action.action === "exploit") stats.cardsUsed++;
+  if (action.action === "access-darknet") stats.storeVisits++;
+  if (action.action?.startsWith("disarm")) stats.disarmActionsUsed++;
+}
+
+/**
+ * Record an ICE evasion (cancel + deselect due to ICE arrival).
+ * @param {BotRunStats} stats
+ */
+export function recordEvasion(stats) {
+  stats.iceEvasions++;
+}
+
+/**
+ * Update peak alert level.
+ * @param {BotRunStats} stats
+ * @param {string} alertLevel
+ */
+export function updatePeakAlert(stats, alertLevel) {
+  if ((ALERT_RANK[alertLevel] ?? 0) > (ALERT_RANK[stats.peakAlert] ?? 0)) {
+    stats.peakAlert = alertLevel;
+  }
+}
+
+/**
+ * Fill in end-of-run values from final game state.
+ * @param {BotRunStats} stats
+ * @param {import('../../js/core/types.js').GameState} state
+ */
+export function finalizeStats(stats, state) {
+  const nodeEntries = Object.values(state.nodes);
+  stats.nodesOwned = nodeEntries.filter(n => n.accessLevel === "owned" && n.type !== "wan").length;
+  stats.nodesTotal = nodeEntries.filter(n => n.type !== "wan").length;
+  stats.cashRemaining = state.player.cash;
+  stats.ticksElapsed = stats.ticksElapsed; // set by loop
+  stats.success = state.mission?.complete ?? false;
+  if (!stats.success && !stats.failReason) {
+    stats.failReason = "stuck";
+  }
+}

--- a/scripts/bot/stats.js
+++ b/scripts/bot/stats.js
@@ -42,7 +42,7 @@ export function recordAction(stats, action) {
   stats.strategyCounts[name] = (stats.strategyCounts[name] ?? 0) + 1;
 
   if (action.action === "exploit") stats.cardsUsed++;
-  if (action.action === "access-darknet") stats.storeVisits++;
+  if (action.action === "buy-card") stats.storeVisits++;
   if (action.action?.startsWith("disarm")) stats.disarmActionsUsed++;
 }
 

--- a/scripts/bot/types.js
+++ b/scripts/bot/types.js
@@ -1,0 +1,111 @@
+// @ts-check
+// Bot player type definitions — JSDoc typedefs only, no runtime code.
+
+/**
+ * @typedef {Object} WorldNode
+ * @property {string} id
+ * @property {string} label
+ * @property {string} type
+ * @property {string} accessLevel
+ * @property {string} visibility
+ * @property {string} grade
+ * @property {boolean} probed
+ * @property {boolean} [read]
+ * @property {boolean} [looted]
+ * @property {boolean} [rebooting]
+ * @property {boolean} [forwardingEnabled]
+ * @property {any[]} [vulnerabilities]
+ * @property {any[]} [macguffins]
+ */
+
+/**
+ * @typedef {Object} WorldIce
+ * @property {string|null} nodeId — current ICE attention node
+ * @property {boolean} isOnSelectedNode
+ * @property {boolean} isActive
+ */
+
+/**
+ * @typedef {Object} WorldPlayer
+ * @property {string|null} selectedNodeId
+ * @property {number} cash
+ * @property {string} alertLevel — "green", "yellow", "red"
+ * @property {boolean} traceActive
+ * @property {number|null} traceCountdown — seconds remaining, or null
+ */
+
+/**
+ * @typedef {Object} WorldCard
+ * @property {string} id
+ * @property {string} name
+ * @property {string} vulnType
+ * @property {number} quality
+ * @property {number} usesLeft
+ */
+
+/**
+ * @typedef {Object} WorldMission
+ * @property {string|null} targetMacguffinId
+ * @property {string|null} targetName
+ * @property {boolean} complete
+ * @property {string|null} targetNodeId — node containing the mission macguffin, if known
+ */
+
+/**
+ * @typedef {Object} WorldModel
+ * @property {Map<string, WorldNode>} nodes — all visible nodes by ID
+ * @property {Object<string, string[]>} adjacency
+ * @property {string[]} revealed — revealed but not yet accessible (select to traverse)
+ * @property {string[]} accessible — visible, not owned, not WAN
+ * @property {string[]} owned
+ * @property {string[]} needsProbe — accessible + not probed
+ * @property {string[]} needsExploit — accessible + probed + not owned
+ * @property {string[]} lootable — owned + (not read or has uncollected macguffins)
+ * @property {string[]} security — IDS / security-monitor nodes
+ * @property {string[]} hasDisarmActions — owned nodes with disarm-* actions
+ * @property {WorldIce} ice
+ * @property {WorldPlayer} player
+ * @property {WorldCard[]} hand
+ * @property {Map<string, string[]>} cardMatchesByNode — nodeId → matching card IDs
+ * @property {Map<string, import('../../js/core/types.js').ActionDef[]>} availableActions
+ * @property {WorldMission} mission
+ * @property {string} gamePhase
+ * @property {Set<string>} failedExploits — "nodeId:cardId" pairs that already failed
+ * @property {(fromId: string, toId: string) => string[]|null} shortestPath
+ */
+
+/**
+ * @typedef {Object} ScoredAction
+ * @property {string} action — action ID
+ * @property {string|null} nodeId — target node (null for global actions)
+ * @property {number} score
+ * @property {string} reason — human-readable explanation
+ * @property {string} [strategy] — which heuristic produced this
+ * @property {Object} [payload] — extra data (e.g. { exploitId })
+ */
+
+/**
+ * @callback Strategy
+ * @param {WorldModel} world
+ * @returns {ScoredAction[]}
+ */
+
+/**
+ * @typedef {Object} BotRunStats
+ * @property {boolean} success
+ * @property {string|null} failReason
+ * @property {number} ticksElapsed
+ * @property {number} nodesOwned
+ * @property {number} nodesTotal
+ * @property {number} cardsUsed
+ * @property {number} cardsBurned
+ * @property {number} storeVisits
+ * @property {number} cashSpent
+ * @property {number} cashRemaining
+ * @property {string} peakAlert
+ * @property {boolean} traceFired
+ * @property {number} iceDetections
+ * @property {number} iceEvasions
+ * @property {number} disarmActionsUsed
+ * @property {Record<string, number>} strategyCounts
+ */

--- a/scripts/bot/types.js
+++ b/scripts/bot/types.js
@@ -72,6 +72,7 @@
  * @property {string} gamePhase
  * @property {Set<string>} failedExploits — "nodeId:cardId" pairs that already failed
  * @property {Set<string>} completedActions — "nodeId:actionId" pairs already completed
+ * @property {Set<string>} iceCooldown — node IDs recently interrupted by ICE
  * @property {(fromId: string, toId: string) => string[]|null} shortestPath
  */
 

--- a/scripts/bot/types.js
+++ b/scripts/bot/types.js
@@ -38,7 +38,7 @@
  * @typedef {Object} WorldCard
  * @property {string} id
  * @property {string} name
- * @property {string} vulnType
+ * @property {string[]} targetVulnTypes
  * @property {number} quality
  * @property {number} usesLeft
  */
@@ -71,6 +71,7 @@
  * @property {WorldMission} mission
  * @property {string} gamePhase
  * @property {Set<string>} failedExploits — "nodeId:cardId" pairs that already failed
+ * @property {Set<string>} completedActions — "nodeId:actionId" pairs already completed
  * @property {(fromId: string, toId: string) => string[]|null} shortestPath
  */
 

--- a/scripts/lib/headless-engine.js
+++ b/scripts/lib/headless-engine.js
@@ -1,0 +1,62 @@
+// @ts-check
+// Shared headless game engine — common init plumbing for bot, playtest
+// harness, and any future headless tools.
+//
+// Extracts the timer wiring, action context, and game init sequence that
+// was previously duplicated across entry points.
+
+import { initGame, getState, serializeState, deserializeState } from "../../js/core/state.js";
+import { buildActionContext, initActionDispatcher } from "../../js/core/actions/action-context.js";
+import { startIce, handleIceTick, handleIceDetect } from "../../js/core/ice.js";
+import { on, off, emitEvent, E } from "../../js/core/events.js";
+import { tick, TIMER } from "../../js/core/timers.js";
+import { handleTraceTick } from "../../js/core/alert.js";
+import { initLog } from "../../js/core/log.js";
+import { initGraphBridge } from "../../js/core/graph-bridge.js";
+import { initDynamicActions } from "../../js/core/console-commands/dynamic-actions.js";
+
+// Importing alert.js registers NODE_ALERT_RAISED listeners at module load.
+// Importing ice.js registers PLAYER_NAVIGATED / ACTION_FEEDBACK listeners.
+// These side effects are needed for correct game behavior.
+
+/**
+ * Wire timer handlers and action dispatcher. Call once per process.
+ * Returns the action context for callers that need to extend it.
+ *
+ * @param {{ openDarknetsStore?: (state: any) => void }} [opts]
+ * @returns {{ ctx: import('../../js/core/types.js').ActionContext }}
+ */
+export function initHeadlessEngine(opts = {}) {
+  // Timer → handler wiring
+  on(TIMER.ICE_MOVE,   () => handleIceTick());
+  on(TIMER.ICE_DETECT, (payload) => handleIceDetect(payload));
+  on(TIMER.TRACE_TICK, () => handleTraceTick());
+
+  // Action dispatcher
+  const ctx = buildActionContext(opts.openDarknetsStore);
+  initActionDispatcher(ctx);
+
+  // Log buffer (needed for getRecentLog / log command)
+  initLog();
+
+  return { ctx };
+}
+
+/**
+ * Initialize a fresh game from a network builder function.
+ * Sets up graph bridge, dynamic actions, and ICE.
+ *
+ * @param {() => { graphDef: any, meta: any }} buildNetworkFn
+ * @param {string} [seed]
+ * @returns {import('../../js/core/types.js').GameState}
+ */
+export function resetGame(buildNetworkFn, seed) {
+  const state = initGame(buildNetworkFn, seed);
+  initGraphBridge();
+  initDynamicActions();
+  startIce();
+  return state;
+}
+
+// Re-export commonly needed functions so callers don't need extra imports
+export { getState, serializeState, deserializeState, tick, on, off, emitEvent, E, TIMER };

--- a/scripts/playtest.js
+++ b/scripts/playtest.js
@@ -13,24 +13,19 @@
 //   node scripts/playtest.js --state scenario.json "status"
 
 import { readFileSync, writeFileSync, existsSync } from "fs";
-import { initGame, getState, serializeState, deserializeState } from "../js/core/state.js";
+import {
+  initHeadlessEngine, resetGame,
+  getState, serializeState, deserializeState,
+  tick, on, emitEvent, E,
+} from "./lib/headless-engine.js";
 import { buildNetwork as buildCorporateFoothold } from "../data/networks/corporate-foothold.js";
 import { buildNetwork as buildResearchStation } from "../data/networks/research-station.js";
 import { buildNetwork as buildCorporateExchange } from "../data/networks/corporate-exchange.js";
-import { startIce, handleIceTick, handleIceDetect } from "../js/core/ice.js";
-import { on, emitEvent, E } from "../js/core/events.js";
-import { tick, TIMER } from "../js/core/timers.js";
-import { handleTraceTick } from "../js/core/alert.js";
-import { initLog, addLogEntry } from "../js/core/log.js";
+import { addLogEntry } from "../js/core/log.js";
 import { runCommand } from "../js/ui/console.js";
 import { handleCheatCommand } from "../js/core/cheats.js";
-import { buildActionContext, initActionDispatcher } from "../js/core/actions/action-context.js";
-import { initGraphBridge } from "../js/core/graph-bridge.js";
 import { initDynamicActions } from "../js/core/console-commands/dynamic-actions.js";
 import { buildSetPieceMiniNetwork, buildMiniNetwork, listSetPieces } from "../js/core/node-graph/mini-network.js";
-
-// alert.js registers NODE_ALERT_RAISED / NODE_RECONFIGURED listeners at module load
-// (importing handleTraceTick above already loaded the module — no separate import needed)
 
 // ── Arg parsing ────────────────────────────────────────────
 
@@ -101,29 +96,16 @@ if (!cmdStr) {
   process.exit(1);
 }
 
-// ── Timer wiring ───────────────────────────────────────────
+// ── Engine init ─────────────────────────────────────────────
 
-on(TIMER.ICE_MOVE,        ()        => handleIceTick());
-on(TIMER.ICE_DETECT,      (payload) => handleIceDetect(payload));
-on(TIMER.TRACE_TICK,      ()        => handleTraceTick());
-// Probe, exploit, read, loot, reboot timers removed — timed-action operator drives these
-
-// ── Action dispatcher ──────────────────────────────────────
-// Same path as the browser: starnet:action → getAvailableActions guard → ActionDef.execute()
-
-const ctx = {
-  ...buildActionContext(),
+initHeadlessEngine({
   openDarknetsStore: () => addLogEntry("[DARKNET] Use 'store' and 'buy' commands in the harness.", "meta"),
-};
-initActionDispatcher(ctx);
+});
 
 // ── Event → output ─────────────────────────────────────────
 
 const lines = [];
 function out(msg) { lines.push(String(msg)); }
-
-// Start the log buffer so getRecentLog() works (used by the 'log' command).
-initLog();
 
 // All LOG_ENTRY events → output (covers console.js command output + direct emits)
 on(E.LOG_ENTRY, ({ text }) => out(text));
@@ -183,10 +165,7 @@ function runCmd(raw) {
 
   // Harness-only commands
   if (verb === "reset") {
-    initGame(() => buildNetworkFn(), seedArg ?? undefined);
-    initGraphBridge();
-    initDynamicActions();
-    startIce();
+    resetGame(() => buildNetworkFn(), seedArg ?? undefined);
     const s = getState();
     const nodeCount = Object.keys(s.nodes).length;
     const networkName = pieceArg ? `piece:${pieceArg}` : graphFileArg ? `file:${graphFileArg}` : (networkArg ?? "corporate-foothold");
@@ -222,14 +201,11 @@ if (!isReset) {
       emitEvent(E.STATE_CHANGED, getState());
     } catch (e) {
       out(`[SYS] Failed to load ${stateFile}: ${e.message}. Initializing fresh.`);
-      initGame(() => buildNetworkFn(), seedArg ?? undefined);
-      initGraphBridge();
-      startIce();
+      resetGame(() => buildNetworkFn(), seedArg ?? undefined);
     }
   } else {
     out(`[SYS] No state file at ${stateFile}. Initializing fresh.`);
-    initState(NETWORK, seedArg ?? undefined);
-    startIce();
+    resetGame(() => buildNetworkFn(), seedArg ?? undefined);
   }
 }
 


### PR DESCRIPTION
## Summary

- **Shared headless engine** (`scripts/lib/headless-engine.js`) — extracted common init plumbing from playtest.js for reuse by bot, playtest harness, and future headless tools
- **Modular bot player** (`scripts/bot/`) — perception→scoring→execute architecture with 6 pluggable strategy heuristics (explore, loot, security, traps, evasion, cards)
- **Playtest harness refactored** to use shared engine — same external interface, less duplication
- Deterministic runs (same seed = same stats), failed exploit tracking, ICE interrupt handling

### Bot strategies
Each heuristic is an independent scoring function — composable "personalities" by mixing different strategy sets. The bot discovers available actions via `getAvailableActions()` rather than hardcoding trait knowledge, so it auto-adapts to new node types.

### Current state
The bot runs and completes games, but win rates are low against the existing hand-crafted networks (0-10%). This is expected — the networks have 0 starting cash (can't use the store), no ICE (alert set-pieces are the sole threat), and limited card pools. Network balance tuning is a separate concern.

## Test plan
- [x] `make check` — 523 tests passing, no regressions
- [x] `node scripts/bot/cli.js --network corporate-foothold --seed test-1` — runs to completion
- [x] Deterministic: same seed produces identical stats
- [x] `node scripts/playtest.js reset` + `status` — playtest harness works with shared engine
- [ ] Strategy tuning against balanced networks (future session)
- [ ] Census rebuild to consume new stats shape (future session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)