### PR TITLE
feat: scattered set-pieces — companion piece system

### DIFF
--- a/data/biomes/corporate-pieces.js
+++ b/data/biomes/corporate-pieces.js
@@ -1625,6 +1625,186 @@ export const scatteredLock3 = makeScatteredLock(3, "B");
 export const scatteredLock5 = makeScatteredLock(5, "A");
 
 /**
+ * Build a scattered multi-key vault with N key-servers.
+ * Key-servers are scatter:true, communicate with core via "keys-collected" quality.
+ * @param {number} n - number of key-servers
+ * @param {string} cost - grade
+ * @returns {SetPieceDef}
+ */
+function makeScatteredKeyVault(n, cost) {
+  /** @type {import('../../js/core/node-graph/types.js').NodeDef[]} */
+  const keys = [];
+  for (let i = 0; i < n; i++) {
+    keys.push({
+      id: `key-server-${i + 1}`,
+      scatter: true,
+      type: "key-server",
+      traits: ["graded", "hackable", "rebootable"],
+      attributes: { accessLevel: "locked", tokenExtracted: false },
+      operators: [],
+      actions: [
+        {
+          id: "extract-token",
+          label: "Extract Token",
+          requires: [
+            /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
+            /** @type {const} */ ({ type: "node-attr", attr: "tokenExtracted", eq: false }),
+          ],
+          effects: [
+            /** @type {const} */ ({ effect: "set-attr", attr: "tokenExtracted", value: true }),
+            /** @type {const} */ ({ effect: "quality-delta", name: "keys-collected", delta: 1 }),
+            /** @type {const} */ ({ effect: "ctx-call", method: "log", args: ["Auth token extracted"] }),
+          ],
+        },
+      ],
+    });
+  }
+
+  return {
+    id: `scattered-key-vault-${n}`,
+    description: `${n} scattered key-servers must be owned to unlock a central vault.`,
+    nodes: [
+      ...keys,
+      {
+        id: "vault-node",
+        type: "cryptovault",
+        traits: ["graded", "hackable", "rebootable"],
+        attributes: { accessLevel: "locked" },
+        operators: [],
+        actions: [
+          {
+            id: "scan-vault",
+            label: "Scan Vault",
+            requires: [
+              /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
+            ],
+            effects: [
+              /** @type {const} */ ({ effect: "log-template", template: `Key vault: \${quality:keys-collected}/${n} tokens collected` }),
+            ],
+          },
+          {
+            id: "unlock-vault",
+            label: "Unlock Vault",
+            requires: [
+              /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
+              /** @type {const} */ ({ type: "quality-gte", name: "keys-collected", value: n }),
+            ],
+            effects: [
+              /** @type {const} */ ({ effect: "quality-set", name: "keys-collected", value: 0 }),
+              /** @type {const} */ ({ effect: "ctx-call", method: "giveReward", args: [5000] }),
+              /** @type {const} */ ({ effect: "ctx-call", method: "log", args: ["Vault unlocked — ¥5,000 extracted"] }),
+            ],
+          },
+        ],
+      },
+    ],
+    internalEdges: [],
+    triggers: [],
+    externalPorts: ["vault-node"],
+    tags: ["puzzle", "treasure"],
+    cost,
+    ports: [
+      { nodeId: "vault-node", direction: "inbound", wantsTags: [], required: true },
+    ],
+  };
+}
+
+/** @type {SetPieceDef} */
+export const scatteredKeyVault2 = makeScatteredKeyVault(2, "C");
+/** @type {SetPieceDef} */
+export const scatteredKeyVault3 = makeScatteredKeyVault(3, "B");
+
+/**
+ * Build a scattered encrypted vault with N key-gen nodes.
+ * Key-gens are scatter:true, communicate with core via "decryption-keys" quality.
+ * @param {number} n - number of key-gens
+ * @param {string} cost - grade
+ * @returns {SetPieceDef}
+ */
+function makeScatteredEncryptedVault(n, cost) {
+  /** @type {import('../../js/core/node-graph/types.js').NodeDef[]} */
+  const keyGens = [];
+  for (let i = 0; i < n; i++) {
+    keyGens.push({
+      id: `key-gen-${i + 1}`,
+      scatter: true,
+      type: "key-gen",
+      traits: ["graded", "hackable", "rebootable"],
+      attributes: { accessLevel: "locked", keyExtracted: false },
+      operators: [],
+      actions: [
+        {
+          id: "extract-key",
+          label: "Extract Key",
+          requires: [
+            /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
+            /** @type {const} */ ({ type: "node-attr", attr: "keyExtracted", eq: false }),
+          ],
+          effects: [
+            /** @type {const} */ ({ effect: "set-attr", attr: "keyExtracted", value: true }),
+            /** @type {const} */ ({ effect: "quality-delta", name: "decryption-keys", delta: 1 }),
+            /** @type {const} */ ({ effect: "ctx-call", method: "log", args: ["Decryption key extracted"] }),
+          ],
+        },
+      ],
+    });
+  }
+
+  return {
+    id: `scattered-encrypted-vault-${n}`,
+    description: `${n} scattered key-gen nodes must be owned to decrypt a central vault.`,
+    nodes: [
+      ...keyGens,
+      {
+        id: "vault",
+        type: "cryptovault",
+        traits: ["graded", "hackable", "rebootable", "lootable"],
+        attributes: { accessLevel: "locked" },
+        operators: [],
+        actions: [
+          {
+            id: "scan-vault",
+            label: "Scan Vault",
+            requires: [
+              /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
+            ],
+            effects: [
+              /** @type {const} */ ({ effect: "log-template", template: `Encrypted vault: \${quality:decryption-keys}/${n} keys collected` }),
+            ],
+          },
+          {
+            id: "decrypt-loot",
+            label: "Decrypt & Loot",
+            requires: [
+              /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
+              /** @type {const} */ ({ type: "quality-gte", name: "decryption-keys", value: n }),
+            ],
+            effects: [
+              /** @type {const} */ ({ effect: "quality-set", name: "decryption-keys", value: 0 }),
+              /** @type {const} */ ({ effect: "ctx-call", method: "giveReward", args: [3000] }),
+              /** @type {const} */ ({ effect: "ctx-call", method: "log", args: ["Encrypted vault decrypted — ¥3,000 extracted"] }),
+            ],
+          },
+        ],
+      },
+    ],
+    internalEdges: [],
+    triggers: [],
+    externalPorts: ["vault"],
+    tags: ["puzzle", "treasure"],
+    cost,
+    ports: [
+      { nodeId: "vault", direction: "inbound", wantsTags: [], required: true },
+    ],
+  };
+}
+
+/** @type {SetPieceDef} */
+export const scatteredEncryptedVault2 = makeScatteredEncryptedVault(2, "C");
+/** @type {SetPieceDef} */
+export const scatteredEncryptedVault3 = makeScatteredEncryptedVault(3, "B");
+
+/**
  * Convenience catalog of all set-pieces.
  */
 export const SET_PIECES = {
@@ -1653,6 +1833,10 @@ export const SET_PIECES = {
   scatteredLock1,
   scatteredLock3,
   scatteredLock5,
+  scatteredKeyVault2,
+  scatteredKeyVault3,
+  scatteredEncryptedVault2,
+  scatteredEncryptedVault3,
 };
 
 // ---------------------------------------------------------------------------

--- a/data/biomes/corporate-pieces.js
+++ b/data/biomes/corporate-pieces.js
@@ -1507,6 +1507,123 @@ export const dataCenter = {
   ],
 };
 
+// ---------------------------------------------------------------------------
+// Scattered set-pieces — nodes with scatter:true are placed independently
+// by the generator elsewhere in the network. Quality-based communication.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a scattered combination lock with N switches.
+ * Switches are scatter:true, communicate with core via "locks-opened" quality.
+ * @param {number} n - number of switches
+ * @param {string} cost - grade
+ * @returns {SetPieceDef}
+ */
+function makeScatteredLock(n, cost) {
+  /** @type {import('../../js/core/node-graph/types.js').NodeDef[]} */
+  const switches = [];
+  for (let i = 0; i < n; i++) {
+    const letter = String.fromCharCode(97 + i); // a, b, c, ...
+    switches.push({
+      id: `switch-${letter}`,
+      scatter: true,
+      type: "routing-switch",
+      traits: ["graded", "hackable", "rebootable"],
+      attributes: { accessLevel: "locked", activated: false },
+      operators: [],
+      actions: [
+        {
+          id: "activate",
+          label: "Activate",
+          requires: [
+            /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
+            /** @type {const} */ ({ type: "node-attr", attr: "activated", eq: false }),
+          ],
+          effects: [
+            /** @type {const} */ ({ effect: "set-attr", attr: "activated", value: true }),
+            /** @type {const} */ ({ effect: "quality-delta", name: "locks-opened", delta: 1 }),
+            /** @type {const} */ ({ effect: "ctx-call", method: "log", args: ["Switch activated — routing signal sent"] }),
+          ],
+        },
+      ],
+    });
+  }
+
+  return {
+    id: `scattered-lock-${n}`,
+    description: `${n} scattered switches must be activated to reveal a hidden vault.`,
+    nodes: [
+      ...switches,
+      {
+        id: "gate",
+        type: "logic-gate",
+        traits: ["graded", "hackable", "rebootable"],
+        attributes: {},
+        operators: [],
+        actions: [
+          {
+            id: "scan-lock",
+            label: "Scan Lock",
+            requires: [
+              /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
+            ],
+            effects: [
+              /** @type {const} */ ({ effect: "log-template", template: `Combination lock: \${quality:locks-opened}/${n} switches activated` }),
+            ],
+          },
+        ],
+      },
+      {
+        id: "vault",
+        type: "cryptovault",
+        traits: ["graded", "hackable", "rebootable"],
+        attributes: { accessLevel: "locked", concealed: true },
+        operators: [],
+        actions: [
+          {
+            id: "crack-vault",
+            label: "Crack Vault",
+            requires: [
+              /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
+              /** @type {const} */ ({ type: "quality-gte", name: "locks-opened", value: n }),
+            ],
+            effects: [
+              /** @type {const} */ ({ effect: "ctx-call", method: "giveReward", args: [1500] }),
+              /** @type {const} */ ({ effect: "ctx-call", method: "log", args: ["Vault cracked — ¥1,500 extracted"] }),
+            ],
+          },
+        ],
+      },
+    ],
+    internalEdges: [["gate", "vault"]],
+    triggers: [
+      {
+        id: "vault-reveal",
+        when: /** @type {const} */ ({ type: "quality-gte", name: "locks-opened", value: n }),
+        then: [
+          /** @type {const} */ ({ effect: "set-node-attr", nodeId: "vault", attr: "concealed", value: false }),
+          /** @type {const} */ ({ effect: "reveal-node", nodeId: "vault" }),
+          /** @type {const} */ ({ effect: "ctx-call", method: "log", args: ["Combination lock disengaged — vault accessible"] }),
+        ],
+      },
+    ],
+    externalPorts: ["gate"],
+    tags: ["puzzle", "treasure", "gate"],
+    cost,
+    ports: [
+      { nodeId: "gate", direction: "inbound", wantsTags: [], required: true },
+      { nodeId: "vault", direction: "outbound", wantsTags: ["treasure", "filler"], required: false },
+    ],
+  };
+}
+
+/** @type {SetPieceDef} */
+export const scatteredLock1 = makeScatteredLock(1, "D");
+/** @type {SetPieceDef} */
+export const scatteredLock3 = makeScatteredLock(3, "B");
+/** @type {SetPieceDef} */
+export const scatteredLock5 = makeScatteredLock(5, "A");
+
 /**
  * Convenience catalog of all set-pieces.
  */
@@ -1532,6 +1649,10 @@ export const SET_PIECES = {
   defensePlex,
   fortifiedGate,
   dataCenter,
+  // Scattered variants
+  scatteredLock1,
+  scatteredLock3,
+  scatteredLock5,
 };
 
 // ---------------------------------------------------------------------------

--- a/data/biomes/corporate.js
+++ b/data/biomes/corporate.js
@@ -16,6 +16,8 @@ import {
   tamperDetect, serverBank, officeCluster,
   largeServerBank, vaultCluster, defensePlex, fortifiedGate, dataCenter,
   scatteredLock1, scatteredLock3, scatteredLock5,
+  scatteredKeyVault2, scatteredKeyVault3,
+  scatteredEncryptedVault2, scatteredEncryptedVault3,
   entryPoint, singleRouter, singleFirewall,
   singleWorkstation, singleFileserver,
 } from "./corporate-pieces.js";
@@ -52,6 +54,10 @@ const catalog = [
   scatteredLock1,
   scatteredLock3,
   scatteredLock5,
+  scatteredKeyVault2,
+  scatteredKeyVault3,
+  scatteredEncryptedVault2,
+  scatteredEncryptedVault3,
   // Scaled variants (higher cost tiers)
   largeServerBank,
   vaultCluster,

--- a/data/biomes/corporate.js
+++ b/data/biomes/corporate.js
@@ -15,6 +15,7 @@ import {
   cascadeShutdown, tripwireGauntlet, probeBurstAlarm, noisySensor,
   tamperDetect, serverBank, officeCluster,
   largeServerBank, vaultCluster, defensePlex, fortifiedGate, dataCenter,
+  scatteredLock1, scatteredLock3, scatteredLock5,
   entryPoint, singleRouter, singleFirewall,
   singleWorkstation, singleFileserver,
 } from "./corporate-pieces.js";
@@ -47,6 +48,10 @@ const catalog = [
   encryptedVault,
   // Defense + puzzle
   tamperDetect,
+  // Scattered variants (nodes distributed across network)
+  scatteredLock1,
+  scatteredLock3,
+  scatteredLock5,
   // Scaled variants (higher cost tiers)
   largeServerBank,
   vaultCluster,

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -36,6 +36,29 @@ tier. A full overhaul will be needed to support:
   dispatch system. This is a significant architectural change — defer until the single-ICE
   prototype is fully playtested and the design is stable.
 
+### Network Branching and Topology Variety
+Generated networks tend toward long, unbranching linear paths — each piece has one
+inbound and one outbound port, creating corridors rather than trees. This is
+especially noticeable when hunting for scattered nodes across the network.
+
+Approaches to improve branching:
+- **More outbound ports on existing pieces** — add optional second/third outbound
+  ports to puzzle, defense, and treasure pieces (IDS chains, tamper detect,
+  scattered lock cores). The generator already handles multi-port pieces via the
+  opportunistic filler path.
+- **Dedicated branching piece** — a cheap "switch hub" (1 inbound, 3 outbound)
+  the skeleton can place to fork paths, ensuring more tree-like topology.
+- **Lateral ports** — cross-connections between sibling branches, creating loops
+  and alternate routes. The port system already supports `direction: "lateral"`
+  but no piece uses it yet.
+- **Skeleton branching factor tuning** — the skeleton generator's branching
+  heuristic (1-3 branches per depth) may be too conservative. Increasing the
+  minimum branching factor or adding a "topology: branching" spec parameter
+  could produce wider networks.
+
+_Identified during scattered set-pieces session (2026-03-12): long unbranching
+paths noticed while playtesting scattered switch hunting._
+
 ### Large Network Generation
 Current networks are 9-16 nodes. Larger networks (40-60+ nodes) would support
 longer runs, multiple security domains, and multiple ICE instances. Design

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -560,6 +560,30 @@ via style selectors keyed on `data.type`); the work is designing the shape inven
 and wiring it through `graph.js` node styles. Shapes should be meaningful: security
 nodes look different from loot nodes, gate nodes look different from filler.
 
+### Scattered Sub-Set-Pieces (Compound Scatter Groups)
+The current scatter system distributes single atomic nodes. A natural extension:
+scatter entire mini set-pieces (multi-node subgraphs with internal edges and
+structure) rather than lone nodes. Examples:
+
+- **Guarded key-server** — a key-server + IDS guard scattered as a unit. The
+  player must subvert the guard before extracting the token.
+- **Trapped switch** — a routing-switch + tripwire. Activating the switch
+  without disarming the trap triggers an alert.
+- **Encrypted relay** — a key-gen + signal-latch pair that must be cracked
+  in sequence before the quality counter increments.
+
+Implementation: replace `scatter: true` (boolean) with `scatter: "group-name"`
+(string). Nodes sharing the same scatter group are placed together as a mini
+set-piece — their internal edges preserved, placed as a unit with one synthetic
+inbound port. Different groups scatter independently.
+
+This composes with the existing system: quality communication still links
+scattered groups to the core. The generator treats each group like the current
+atomic scattered nodes, but instantiates a subgraph instead of a single node.
+
+_Extension of the scattered set-pieces system (2026-03-12). Noted in spec
+future directions as "scatter groups."_
+
 ### Companion Pieces (Long-Range Set-Piece Dependencies)
 The `requires` field exists in the set-piece schema but no piece uses it yet. The
 design: a set-piece can declare companion pieces that must be placed elsewhere in the

--- a/docs/dev-sessions/2026-03-12-2128-scattered-set-pieces/notes.md
+++ b/docs/dev-sessions/2026-03-12-2128-scattered-set-pieces/notes.md
@@ -1,1 +1,122 @@
 # Notes: Scattered Set-Pieces (Companion Piece System)
+
+## Session Retro
+
+### What Was Delivered
+
+Full implementation of the scattered set-piece system:
+
+1. **`scatter: true` attribute on NodeDef** — generator-only flag, runtime ignores it
+2. **`log-template` effect** — `${quality:name}` substitution in log messages,
+   with proper prefix rewriting during instantiation
+3. **7 scattered piece variants** — scatteredLock (1/3/5), scatteredKeyVault (2/3),
+   scatteredEncryptedVault (2/3)
+4. **Two-pass generator** — pass 1 separates core/scattered nodes, pass 2 places
+   scattered nodes in gate-free slots via free ports or leaf replacement
+5. **Bot puzzle heuristic** — generic "execute available actions on owned nodes"
+   with dedup tracking to prevent action spam
+6. **Card flicker fix** — hand pane caches state key, skips redundant innerHTML
+7. **Legacy cleanup** — removed Dependency typedef, added scatter to NodeDef
+
+10 commits on branch, 542 tests passing, lint clean.
+
+### What Diverged from Plan
+
+- **Leaf node replacement** (Phase 7 bug-driven). The original plan only placed
+  scattered nodes on unused outbound ports. Testing revealed that most ports are
+  consumed during pass 1, leaving nowhere for scattered nodes. Les suggested
+  replacing leaf filler nodes (workstation/fileserver) with scattered nodes —
+  this dramatically improved success rates (86% → 100% default, 48% → 98% F/B/B/C).
+
+- **Gate-free computation redesign** (Phase 4). The original spec said "don't
+  place behind gate-tagged pieces." In practice, nearly every piece below the
+  spine has the `gate` tag (routers, firewalls) — making almost no slots
+  available. Changed to only block on *puzzle* gates (pieces with `concealed`
+  or `scatter` nodes), not regular hackable gates.
+
+- **Orphan scatter obligation cleanup** (Phase 7). When a core piece couldn't
+  wire to its parent (no outbound port), it was removed from `pieces` but the
+  scatter obligation survived, causing orphan scattered nodes. Fixed by removing
+  the obligation alongside the core.
+
+- **Filler exclusion** (Phase 7). The opportunistic filler path lacked scatter
+  separation logic, so scattered pieces placed as fillers had all nodes
+  co-located with no edges. Fixed by excluding scattered pieces from filler.
+
+- **Card flicker fix** — unplanned, found during manual playtesting. Not caused
+  by this session's changes — pre-existing issue with innerHTML replacement on
+  every STATE_CHANGED event.
+
+- **Network branching observation** — noted as a general procgen issue, deferred.
+
+### Key Insights
+
+- **Leaf replacement is the key enabler.** Without it, scattered pieces only
+  work in networks with spare outbound ports, which is rare after the main fill.
+  Replacing cheap leaf nodes is a simple, budget-neutral strategy that makes
+  scatter placement reliable.
+
+- **"Gate-free" needs a narrow definition.** The `gate` tag is overloaded —
+  routers and firewalls are `gate`-tagged (player must hack to pass) but they're
+  not deadlock risks. Only puzzle gates (concealed vaults, scattered cores)
+  create actual deadlocks. The scatter placement rule needs to distinguish these.
+
+- **Builder functions with JSDoc type casts are verbose.** The `makeScatteredLock`
+  function needed `/** @type {const} */` casts on every condition/effect object
+  to satisfy tsc. This is a pain point of JSDoc @ts-check — TypeScript infers
+  `{ type: string }` instead of `{ type: "node-attr" }` from computed builder
+  output. Might be worth a shared helper or loosening the type union.
+
+- **Spec review iterations paid off.** Three review passes caught: gate-ness is
+  piece-level not slot-level (ordering problem), NodeDef typedef needed updating,
+  bot player didn't know about puzzle actions, cost accounting needed specifying,
+  orphan obligation edge case. All of these would have been bugs during
+  implementation.
+
+- **The bot's puzzle heuristic needs dedup.** Without tracking completed actions,
+  the bot spams repeatable actions (scan-lock, recalibrate) every turn. The
+  `completed` set in puzzles.js fixes this but it's module-level state that
+  needs explicit reset between runs.
+
+### Efficiency Notes
+
+- Quick session — brainstorm through execution in one sitting
+- ~45 conversation turns
+- 10 commits, 7 plan phases executed
+- Heavy use of generation stress testing (50-100 seed runs) to validate
+  success rates — essential for catching scatter placement failures
+- The spec brainstorm (8 questions) and 3 review passes front-loaded the
+  design work, making execution mostly mechanical
+
+### Process Improvements
+
+- **Add a `make gen-stress` target** that runs 100 seeds across several specs
+  and reports success/failure rates. Would have caught the 86% regression faster.
+
+- **Network topology visualization** — hard to tell from text output whether
+  switches are actually scattered. A simple ASCII tree dump would help during
+  development. The `--summary` flag on `generate-network.js` could show the
+  edge graph.
+
+- **More outbound ports on set-pieces** — the branching observation is a real
+  issue. Long linear paths make networks feel like corridors. Adding optional
+  outbound ports to existing pieces would create more branching without new
+  piece types. Track as a follow-up.
+
+### Follow-Up Items
+
+- **Network branching** — add more outbound ports to existing pieces, or create
+  dedicated branching pieces. Long unbranching paths noticed while playtesting
+  scattered networks.
+
+- **Scatter groups** — pairs of nodes scattered as a unit (from spec future
+  directions).
+
+- **Placement preferences** — author-controlled hints for scatter placement
+  depth/distance.
+
+- **Dynamic scatter count** — generator picks N switches based on network size
+  instead of fixed variants.
+
+- **JSDoc builder type ergonomics** — the `/** @type {const} */` pattern in
+  builder functions is noisy. Consider a helper or type relaxation.

--- a/docs/dev-sessions/2026-03-12-2128-scattered-set-pieces/notes.md
+++ b/docs/dev-sessions/2026-03-12-2128-scattered-set-pieces/notes.md
@@ -1,0 +1,1 @@
+# Notes: Scattered Set-Pieces (Companion Piece System)

--- a/docs/dev-sessions/2026-03-12-2128-scattered-set-pieces/plan.md
+++ b/docs/dev-sessions/2026-03-12-2128-scattered-set-pieces/plan.md
@@ -1,0 +1,499 @@
+# Plan: Scattered Set-Pieces (Companion Piece System)
+
+## Overview
+
+7 phases, building bottom-up: type changes + cleanup → log-template effect →
+first scattered piece → generator scatter support → remaining pieces + biome
+catalog → bot player → playtest + polish.
+
+Each phase is testable independently and builds on the previous one.
+
+---
+
+## Phase 1: Type Changes + Legacy Cleanup
+
+**Goal:** Add the `scatter` field to `NodeDef`, remove the unused `Dependency`
+typedef, and establish the foundation all later phases build on.
+
+**Why first:** Every subsequent phase reads or writes the `scatter` field.
+Cleaning up `Dependency` now avoids confusion during implementation.
+
+### Prompt 1.1: Add `scatter` to NodeDef typedef
+
+In `js/core/node-graph/types.js`, add an optional `scatter` boolean field to
+the `NodeDef` typedef:
+
+```
+@property {boolean} [scatter] - node is placed independently by the generator
+```
+
+This field is read by the generator during core/scatter separation. The
+NodeGraph runtime ignores it.
+
+**Verify:** `make lint` passes.
+
+### Prompt 1.2: Remove legacy Dependency typedef
+
+In `js/core/network/set-pieces.js`:
+
+1. Remove the `Dependency` typedef (the `@typedef {Object} Dependency` block).
+2. Remove the `@property {Dependency[]} [requires]` line from the `SetPieceDef`
+   typedef.
+3. Search for any imports or references to `Dependency` across the codebase and
+   remove them.
+
+**Verify:** `make check` passes. `grep -r "Dependency\|requires.*Dependency"` in
+`js/` and `data/` returns no results.
+
+---
+
+## Phase 2: `log-template` Effect
+
+**Goal:** Implement the new `log-template` effect type end-to-end: instantiation
+rewriting, runtime execution, and tests. This is independent of the generator
+changes and can be used by any set-piece.
+
+### Prompt 2.1: Add `log-template` to rewriteEffect
+
+In `js/core/network/set-pieces.js`, add a new case to `rewriteEffect()` for
+`"log-template"`. The handler must parse the template string, find all
+`${quality:name}` tokens, prefix each quality name with the instance prefix,
+and return the rewritten effect:
+
+```js
+case "log-template": {
+  const rewritten = effect.template.replace(
+    /\$\{quality:([^}]+)\}/g,
+    (_, name) => `\${quality:${pfx(name, prefix)}}`
+  );
+  return { ...effect, template: rewritten };
+}
+```
+
+**Verify:** `make lint` passes.
+
+### Prompt 2.2: Add `log-template` to applyEffect
+
+In `js/core/node-graph/effects.js`, add a new case to `applyEffect()` for
+`"log-template"`. The handler:
+
+1. Takes `effect.template` string.
+2. Replaces all `${quality:name}` tokens by calling `mutators.getQuality(name)`.
+   Use `?? 0` for missing qualities (default to 0).
+3. Logs the result via `mutators.ctx.log(resolved)`.
+
+```js
+case "log-template": {
+  const resolved = effect.template.replace(
+    /\$\{quality:([^}]+)\}/g,
+    (_, name) => String(getQuality(name) ?? 0)
+  );
+  ctx.log(resolved);
+  break;
+}
+```
+
+Note: `getQuality` is already available in the `mutators` destructuring at the
+top of `applyEffect`.
+
+**Verify:** `make lint` passes.
+
+### Prompt 2.3: Test log-template effect
+
+Write tests in `js/core/node-graph/effects.test.js` (or a new co-located
+test file if one doesn't exist):
+
+1. **Rewriting test:** Call `rewriteEffect` on a `log-template` effect with
+   quality references. Verify the quality names are prefixed correctly.
+   Test with multiple quality references in one template.
+
+2. **Runtime test:** Create a minimal NodeGraph with a node that has an action
+   using `log-template`. Set up qualities, execute the action, verify `ctx.log`
+   was called with the correct substituted string.
+
+3. **Edge case:** Template with no quality references — should pass through
+   unchanged. Quality that doesn't exist — should substitute `0`.
+
+**Verify:** `make check` passes with new tests.
+
+---
+
+## Phase 3: First Scattered Piece — `scatteredLock3`
+
+**Goal:** Author the first scattered set-piece (`scatteredLock3`) and write
+unit tests proving the quality-based communication works in isolation (no
+generator changes yet). This validates the authoring model before touching the
+generator.
+
+### Prompt 3.1: Author scatteredLock3 piece definition
+
+In `data/biomes/corporate-pieces.js`, add a new `scatteredLock3` set-piece
+definition. This is a quality-based version of `combinationLock` with 3
+scattered switches:
+
+**Scattered nodes** (3 switches, each `scatter: true`):
+- Type: `routing-switch`
+- Traits: `["graded", "hackable", "rebootable"]`
+- Attributes: `{ accessLevel: "locked", activated: false }`
+- Action: `activate` — requires `owned` + `activated: false`, effects:
+  `set-attr activated true`, `quality-delta "locks-opened" 1`,
+  `ctx-call log "Switch activated — routing signal sent"`
+
+**Core nodes:**
+- `gate` — type `logic-gate`, traits `["graded", "hackable", "rebootable"]`.
+  Action: `scan-lock` — requires `owned`, effect:
+  `log-template "Combination lock: ${quality:locks-opened}/3 switches activated"`
+- `vault` — type `cryptovault`, traits `["graded", "hackable", "rebootable"]`,
+  attributes `{ accessLevel: "locked", concealed: true }`.
+  Action: `crack-vault` — requires `owned` + `quality-gte "locks-opened" 3`,
+  effects: `giveReward 1500`, `set-attr opened false`,
+  `ctx-call log "Vault cracked — ¥1,500 extracted"`
+
+**Internal edges:** `["gate", "vault"]` only (switches have no edges).
+
+**Trigger:** `vault-reveal` — when `quality-gte "locks-opened" 3`:
+  `set-node-attr vault concealed false`, `reveal-node vault`,
+  `log "Combination lock disengaged — vault accessible"`.
+
+**Metadata:**
+- `tags: ["puzzle", "treasure", "gate"]`
+- `cost: "B"`
+- `ports:` gate as inbound, vault as outbound (wantsTags treasure/filler)
+- No entries for scattered nodes in ports (generator synthesizes them)
+
+**Verify:** `make lint` passes.
+
+### Prompt 3.2: Test scatteredLock3 quality communication
+
+In `js/core/network/set-pieces.test.js`, add tests for `scatteredLock3`:
+
+1. **Instantiate and verify prefixing.** Call `instantiate(scatteredLock3, "sl")`.
+   Verify all node IDs are prefixed. Verify the trigger's quality reference is
+   `sl/locks-opened`. Verify the switch actions reference `sl/locks-opened`.
+
+2. **Quality communication in NodeGraph.** Create a NodeGraph with all 5
+   instantiated nodes (core + scattered, all in the same graph — simulating
+   what the generator would produce). Own all switches, activate all 3. Verify:
+   - After 2 activations: `ctx.calls.revealNode` is undefined
+   - After 3rd activation: vault is revealed, `concealed` cleared
+
+3. **Scan-lock action.** Own the gate, execute `scan-lock`. Verify ctx.log
+   was called with `"Combination lock: 0/3 switches activated"`. Activate
+   one switch, scan again, verify `"1/3"`.
+
+4. **Crack-vault action.** Activate all 3 switches, own the vault, execute
+   `crack-vault`. Verify `giveReward` called with `[1500]`.
+
+**Verify:** `make check` passes with new tests.
+
+### Prompt 3.3: Author scatteredLock1 and scatteredLock5 variants
+
+Add `scatteredLock1` (1 switch, cost D) and `scatteredLock5` (5 switches,
+cost A) as variants. Same pattern as `scatteredLock3` but with different
+switch counts and trigger thresholds. Add a quick sanity test for each
+(instantiate + verify trigger threshold matches switch count).
+
+**Verify:** `make check` passes.
+
+---
+
+## Phase 4: Generator Scatter Support
+
+**Goal:** Teach the slot filler to handle scattered pieces: separate core from
+scattered nodes during pass 1, compute gate-free attachment points, and place
+scattered nodes in pass 2.
+
+This is the core engineering work of the session.
+
+### Prompt 4.1: Core/scatter separation in fillSlot
+
+In `js/core/network/slot-filler.js`, modify the `fillSlot` function:
+
+After `instantiate()` is called and the instance is created, check if the
+chosen piece has any nodes with `scatter: true` (check the original piece
+definition, since `scatter` is on the authored node, not the instantiated one).
+
+If scattered nodes exist:
+1. Separate `instance.nodes` into `coreNodes` (no scatter) and
+   `scatteredNodes` (scatter: true). Use the original piece definition's node
+   list to determine which IDs are scattered, then match by prefixed ID.
+2. Filter `instance.edges` to only include edges where both endpoints are
+   core node IDs.
+3. Build the `PlacedPiece` using only core nodes and filtered edges.
+   Triggers stay with the core (they're piece-level, not node-level).
+4. Record a "scatter obligation" — store the scattered nodes and the piece's
+   prefix for later placement.
+
+Add a `scatterObligations` array to the state tracked by `fillSkeleton`.
+Each obligation: `{ prefix, scatteredNodes: NodeDef[], pieceDef }`.
+
+For non-scattered pieces, behavior is unchanged.
+
+**Verify:** `make check` passes (no scattered pieces in the catalog yet, so
+this code path isn't exercised — but existing behavior is preserved).
+
+### Prompt 4.2: Conservative scatter eligibility check
+
+In `findCandidates` (or as a filter after it), add a check: if a candidate
+piece has scattered nodes, count the number of scattered nodes. Estimate
+available attachment points by counting all placed pieces' unused outbound
+ports in the current network. If fewer attachment points than scattered nodes,
+exclude the candidate.
+
+This is a conservative estimate — it doesn't check gate-free reachability yet
+(that happens in pass 2). The goal is to avoid obviously impossible placements.
+
+**Verify:** `make check` passes.
+
+### Prompt 4.3: Gate-free reachability computation
+
+Add a new function `computeGateFreeSlots(pieces, skeleton)` to
+`slot-filler.js`:
+
+1. Build a map from slot ID → placed piece (using `piece.slot.id`).
+2. Walk the skeleton tree from the root (entry slot).
+3. For each slot, check if the placed piece's `pieceDef.tags` includes `"gate"`.
+4. If yes, mark this slot and all its descendants as NOT gate-free.
+5. If no, mark this slot as gate-free and continue to children.
+6. Return a `Set<string>` of gate-free slot IDs.
+
+**Verify:** Unit test: build a small skeleton with 5 slots, place pieces (some
+with gate tag, some without), call `computeGateFreeSlots`, verify the correct
+slots are marked gate-free.
+
+### Prompt 4.4: Scatter placement pass (pass 2)
+
+Add a new function `placeScatteredNodes(scatterObligations, pieces, skeleton, crossEdges)`:
+
+For each obligation:
+1. Get the set of gate-free slot IDs from `computeGateFreeSlots`.
+2. For each scattered node in the obligation:
+   a. Find a placed piece in a gate-free slot that has an unused outbound port
+      (iterate `pieces`, check `piece.outboundNodeIds.length > 0`,
+      check slot is gate-free).
+   b. If found: consume the outbound port, add the scattered node to
+      `piece.nodes`, add the edge `[outboundPort, scatteredNodeId]` to
+      `crossEdges`.
+   c. If not found: return `{ ok: false }`.
+3. If all scattered nodes placed: return `{ ok: true }`.
+
+Call this function at the end of `fillSkeleton`, after the main recursive fill.
+If scatter placement fails, set `ok: false` on the return value (triggers
+retry in `generateNetwork`).
+
+**Verify:** `make check` passes.
+
+### Prompt 4.5: Integration test — generate with scatteredLock3
+
+1. Add `scatteredLock3` to `CORPORATE_BIOME.catalog` in
+   `data/biomes/corporate.js`.
+
+2. Write an integration test that generates a network with a seed known to
+   produce a `scatteredLock3` placement. Verify:
+   - The 3 switch nodes exist in the generated `graphDef.nodes`
+   - The switch nodes share the same prefix as the gate/vault core nodes
+   - Each switch node has at least one edge connecting it to the network
+   - No switch is behind a gate-tagged piece (verify by BFS from gateway
+     through non-gate paths)
+   - The vault is concealed
+   - The existing validator passes (`validate(graphDef, spec)`)
+
+3. If finding a deterministic seed is difficult, use `--verbose` mode to
+   inspect which pieces were placed and manually verify.
+
+**Verify:** `make check` passes with new tests. `node scripts/generate-network.js --seed <test-seed> --summary` shows scattered switches in the output.
+
+---
+
+## Phase 5: Remaining Scattered Pieces + Biome Catalog
+
+**Goal:** Author the remaining scattered piece variants, add all to the biome
+catalog, and verify generation works across a range of seeds.
+
+### Prompt 5.1: Scattered multi-key vault variants
+
+In `data/biomes/corporate-pieces.js`, add `scatteredKeyVault2` and
+`scatteredKeyVault3`:
+
+- Scattered key-server nodes: `scatter: true`, type `key-server`,
+  traits `["graded", "hackable", "rebootable"]`.
+  Action: `extract-token` — requires `owned` + `tokenExtracted: false`,
+  effects: `set-attr tokenExtracted true`,
+  `quality-delta "keys-collected" 1`,
+  `ctx-call log "Auth token extracted"`
+- Core vault node: type `cryptovault`,
+  traits `["graded", "hackable", "rebootable", "lootable"]`.
+  Action: `unlock-vault` — requires `owned` + `quality-gte "keys-collected" N`,
+  effects: `quality-set "keys-collected" 0`, `giveReward 5000`,
+  `ctx-call log "Vault unlocked — ¥5,000 extracted"`.
+  Scan action: `log-template "Key vault: ${quality:keys-collected}/N tokens collected"`.
+
+Metadata: tags `["puzzle", "treasure"]`, cost C (2 keys) or B (3 keys).
+
+Write basic tests: instantiate, verify quality prefixing, verify unlock
+requires correct quality threshold.
+
+**Verify:** `make check` passes.
+
+### Prompt 5.2: Scattered encrypted vault variants
+
+In `data/biomes/corporate-pieces.js`, add `scatteredEncryptedVault2` and
+`scatteredEncryptedVault3`:
+
+- Scattered key-gen nodes: `scatter: true`, type `key-gen`,
+  traits `["graded", "hackable", "rebootable"]`.
+  Action: `extract-key` — requires `owned`,
+  effects: `quality-delta "decryption-keys" 1`,
+  `ctx-call log "Decryption key extracted"`.
+- Core vault node: type `cryptovault`,
+  traits `["graded", "hackable", "rebootable", "lootable"]`.
+  Action: `loot` — requires `owned` + `quality-gte "decryption-keys" N`,
+  effects: `quality-set "decryption-keys" 0`, `giveReward 3000`,
+  `ctx-call log "Encrypted vault decrypted — ¥3,000 extracted"`.
+  Scan action for progress.
+
+Metadata: tags `["puzzle", "treasure"]`, cost C (2 keys) or B (3 keys).
+
+Write basic tests.
+
+**Verify:** `make check` passes.
+
+### Prompt 5.3: Update biome catalog
+
+In `data/biomes/corporate.js`:
+
+1. Import all new scattered pieces from `corporate-pieces.js`.
+2. Add them to `CORPORATE_BIOME.catalog`.
+3. The existing co-located versions remain in the catalog.
+
+Run generation across 10+ seeds to verify:
+```bash
+for seed in test-{1..10}; do
+  node scripts/generate-network.js --seed $seed --summary 2>&1 | head -5
+done
+```
+
+Check that some networks include scattered pieces and generation succeeds.
+
+**Verify:** `make check` passes. Generation succeeds across seeds.
+
+---
+
+## Phase 6: Bot Player Heuristic
+
+**Goal:** Teach the bot to execute puzzle actions on owned nodes so it can
+interact with scattered pieces during automated play.
+
+### Prompt 6.1: Add puzzle action heuristic
+
+Create a new heuristic file `scripts/bot/heuristics/puzzles.js`:
+
+1. Iterate all owned nodes in `world.nodes`.
+2. For each owned node, check `world.availableActions.get(nodeId)`.
+3. For each available action that is NOT in the bot's known set
+   (`probe`, `exploit`, `read`, `loot`, `reconfigure`, `cancel-trace`,
+   `eject`, `reboot`, `access-darknet`, and `disarm-*`), propose it as
+   a `ScoredAction` with score ~60 (between loot at 62 and explore at 50).
+4. Use reason string: `"puzzle: ${action.label} on ${nodeId}"`.
+
+Register this heuristic in the bot's strategy list (in `scripts/bot-player.js`
+or wherever strategies are composed).
+
+Add `"activate"`, `"scan-lock"`, `"crack-vault"`, `"unlock-vault"`,
+`"extract-token"`, `"extract-key"` to the `INSTANT_ACTIONS` set in
+`scripts/bot/execute.js`.
+
+### Prompt 6.2: Test bot with scattered pieces
+
+Run the bot against generated networks with scattered pieces:
+
+```bash
+node scripts/bot-player.js --generated --seed test-1 --threat C --wealth B --verbose
+```
+
+Verify in the verbose output:
+- Bot encounters and activates scattered switches
+- Bot scans locks on gate nodes
+- Bot cracks vaults when available
+- Bot completes runs (or at least makes meaningful progress)
+
+Run a quick census:
+```bash
+node scripts/bot-census.js --seeds 10 --time F --money F
+```
+
+**Verify:** Bot doesn't crash. Win rate is reasonable (not zero).
+
+---
+
+## Phase 7: Playtest + Polish
+
+**Goal:** Manually playtest generated networks with scattered pieces. Fix any
+issues found. Commit session docs.
+
+### Prompt 7.1: Headless playtest
+
+Use the playtest harness to play through a network with scattered pieces:
+
+```bash
+node scripts/playtest.js --generated --seed <seed> --threat C --wealth B reset
+node scripts/playtest.js --generated ... "status full"
+```
+
+Navigate to switches, activate them, check scan-lock output, crack the vault.
+Verify:
+- Switch activation logs appear
+- Scan-lock shows correct progress (0/3, 1/3, 2/3, 3/3)
+- Vault reveals after all switches activated
+- Crack-vault gives reward
+- Switches have the same prefix as the vault (diegetic breadcrumb)
+
+### Prompt 7.2: Fix any issues
+
+Address bugs found during playtesting. Run `make check` after each fix.
+
+### Prompt 7.3: Session docs + commit
+
+Update `notes.md` with session retro. Commit all changes. Open PR.
+
+---
+
+## Phase Summary
+
+| Phase | Scope | Depends On | Key Output |
+|-------|-------|-----------|------------|
+| 1 | Type changes + cleanup | — | `scatter` on NodeDef, Dependency removed |
+| 2 | `log-template` effect | — | New effect in effects.js + set-pieces.js |
+| 3 | First scattered piece | Phase 2 | `scatteredLock3` + variants, unit tests |
+| 4 | Generator scatter support | Phases 1, 3 | Two-pass slot filler, gate-free computation |
+| 5 | Remaining pieces + catalog | Phases 3, 4 | All variants in biome, generation verified |
+| 6 | Bot player | Phases 4, 5 | Puzzle heuristic, bot plays scattered networks |
+| 7 | Playtest + polish | Phase 6 | Manual verification, bug fixes, session retro |
+
+Phases 1 and 2 are independent and can be done in either order.
+Phase 3 depends on Phase 2 (log-template used by scan-lock action).
+Phase 4 is the core engineering work.
+Phases 5-7 are incremental content + integration.
+
+---
+
+## Risk Notes
+
+- **Attachment point exhaustion.** If the network has few unused outbound ports
+  in gate-free slots, scatter placement fails. Mitigation: the conservative
+  eligibility check in Phase 4.2 prevents obviously impossible placements.
+  The retry mechanism in `generateNetwork` handles marginal cases.
+
+- **Quality namespace collisions.** Two instances of the same scattered piece
+  could collide if they share a prefix. This can't happen — each instantiation
+  gets a unique prefix from the slot filler. But verify with a test that
+  places two `scatteredLock3` instances in one network.
+
+- **Gate-free computation complexity.** Walking the skeleton tree is O(n) where
+  n is the number of slots — trivial for current network sizes (10-30 nodes).
+  No performance concern.
+
+- **Bot regression.** The new puzzle heuristic might interfere with the bot's
+  existing priorities. The score of 60 is deliberately between loot (62) and
+  explore (50) — puzzle actions are taken when convenient, not at the expense
+  of core gameplay. Monitor bot census metrics after Phase 6.

--- a/docs/dev-sessions/2026-03-12-2128-scattered-set-pieces/spec.md
+++ b/docs/dev-sessions/2026-03-12-2128-scattered-set-pieces/spec.md
@@ -1,0 +1,435 @@
+# Spec: Scattered Set-Pieces (Companion Piece System)
+
+## Goal
+
+Enable set-pieces whose nodes are distributed across the network rather than
+co-located. A single authored puzzle (e.g., vault + 3 switches) gets "exploded"
+by the generator: the core stays in one slot, while scattered nodes are placed
+independently elsewhere in the LAN. Communication between scattered nodes and
+the core happens via prefixed quality counters — no direct edges.
+
+This creates a new class of puzzles: "hunt through the network to find all the
+switches before you can crack the vault."
+
+---
+
+## Core Concepts
+
+### Scatter Attribute
+
+Nodes in a set-piece definition can be marked `scatter: true`:
+
+```js
+nodes: [
+  { id: "switch-a", scatter: true, type: "routing-switch", ... },
+  { id: "switch-b", scatter: true, type: "routing-switch", ... },
+  { id: "switch-c", scatter: true, type: "routing-switch", ... },
+  { id: "gate", type: "logic-gate", ... },     // core
+  { id: "vault", type: "cryptovault", ... },    // core
+]
+```
+
+**Core nodes** — no `scatter` flag. Connected via `internalEdges`, placed together
+as a unit. Normal set-piece behavior.
+
+**Scattered nodes** — `scatter: true`. No `internalEdges` to/from them. Communicate
+with the core exclusively via qualities. Placed independently by the generator as
+mini atomic pieces.
+
+**The `scatter` attribute is generator-only.** It is only meaningful during
+procedural network generation. In non-generated contexts (hand-crafted networks,
+the mini-network test harness, `--piece` mode in the playtest harness),
+`instantiate()` processes all nodes identically — scattered nodes will be
+instantiated but have no edges, leaving them orphaned. Authors should use
+co-located variants (e.g., the original `combinationLock`) for hand-crafted
+networks and tests.
+
+**Authoring invariants:**
+- Every scattered piece **must have at least one core node**. Triggers and
+  qualities need a host NodeGraph instantiation; a piece with zero core nodes
+  has nowhere to anchor its triggers.
+- `internalEdges` **must not reference scattered nodes**. The generator enforces
+  this by filtering edges during core/scatter separation — any edge referencing
+  a scattered node ID is dropped. This is a safety net; authors should simply
+  not include such edges.
+
+### Quality-Based Communication
+
+Scattered nodes and core nodes share a quality namespace. The author writes
+quality names without prefixes:
+
+```js
+// Scattered switch action
+{ effect: "quality-delta", name: "locks-opened", delta: 1 }
+
+// Core trigger
+{ when: { type: "quality-gte", name: "locks-opened", value: 3 } }
+```
+
+During instantiation, `instantiate()` prefixes all quality names with the
+instance prefix (e.g., `d3-0/locks-opened`). This already works — the existing
+`instantiate()` rewrites `quality-delta`, `quality-set`, `quality-gte`,
+`quality-eq`, and `tally` operator quality references.
+
+The critical detail: **scattered nodes are instantiated with the same prefix as
+the core piece**, not with a prefix derived from their placement slot. This is
+what ties the qualities together.
+
+### Instance Prefix as Player Clue
+
+Scattered nodes keep their parent piece's prefix in their node ID. A switch
+placed at depth 1 that belongs to a vault at depth 3 might be `d3-0/switch-a`.
+The shared prefix is a diegetic breadcrumb — the player can reason about which
+nodes belong to the same puzzle by reading the IDs.
+
+### Placement Constraints
+
+**Primary rule: scattered nodes must be reachable from the gateway without
+traversing any gate-tagged piece.**
+
+This prevents:
+- Switches placed behind their own gate (impossible puzzle)
+- Cross-deadlocks between two scattered pieces (gate A's switches behind gate B
+  and vice versa)
+
+**Important: gate-ness is a property of pieces, not skeleton slots.** The
+skeleton assigns abstract tags to slots (e.g., `["puzzle", "treasure"]`), but
+whether a slot contains a gate is only known after the slot filler places a
+concrete piece there. A slot tagged `["puzzle"]` might get filled with a
+`combinationLock` (which has `tags: ["puzzle", "treasure", "gate"]`) or a
+`switchArrangement` (which has `tags: ["filler", "puzzle"]`, no gate).
+
+This means valid scatter slot computation **cannot happen at skeleton time**.
+It must happen during or after the slot-filling pass, when we know which pieces
+actually occupy which slots.
+
+**Two-pass filling approach:** The slot filler runs in two passes:
+1. **Main pass** — fill all skeleton slots with concrete pieces as today. Track
+   which placed pieces have the `gate` tag.
+2. **Scatter pass** — for each placed piece that has scattered nodes, compute
+   gate-free reachable slots and place the scattered nodes.
+
+This avoids the ordering problem where we'd need to know gate positions before
+they're placed. After the main pass, the full gate map is known.
+
+**Eligibility during main pass:** When evaluating a candidate piece with
+scattered nodes during the main pass, the filler must conservatively estimate
+whether scatter placement will succeed. A simple heuristic: count unfilled
+slots that aren't on paths through slots tagged with gate-compatible tags
+(e.g., `["gate"]`, `["puzzle", "gate"]`). If the count is less than the
+number of scattered nodes, skip the piece. This is an estimate — the actual
+scatter pass may still fail if the slots get consumed by other pieces, in
+which case the generation attempt retries.
+
+**Eligibility rule: if all scattered nodes cannot be placed in valid slots,
+the piece is not eligible for that network.** The generator picks a different
+piece for the slot. This is the same behavior as when a piece's tags don't
+match — no partial placement, no degraded puzzles.
+
+### Piece Variants
+
+Authors should create multiple variants of scattered puzzles with different
+node counts to fit different network sizes:
+
+- Small network (few open slots) → 1-switch vault variant
+- Medium network → 3-switch vault variant
+- Large network → 5-switch vault variant
+
+Each variant is a separate `SetPieceDef` with its own `cost` grade. The
+generator picks the variant that fits the available slot budget.
+
+---
+
+## New Effect: `log-template`
+
+A new effect type for logging messages with dynamic value substitution:
+
+```js
+{ effect: "log-template", template: "Combination lock: ${quality:locks-opened}/3 switches activated" }
+```
+
+### Effect Handler (`effects.js`)
+
+The handler in `applyEffect()`:
+1. Parses `${quality:name}` tokens in the template string
+2. Looks up the current quality value via `mutators.getQuality(name)` (already
+   available in the mutators interface)
+3. Substitutes the value into the string
+4. Logs the result via `ctx.log()`
+
+### Instantiation Rewriting (`set-pieces.js`)
+
+`rewriteEffect()` needs a new case for `"log-template"`. It must parse the
+template string, find all `${quality:name}` tokens, prefix each quality name,
+and return the rewritten template. This is string manipulation inside a rewrite
+pass — more involved than the simple field-copy pattern used by other effects:
+
+```js
+case "log-template": {
+  const rewritten = effect.template.replace(
+    /\$\{quality:([^}]+)\}/g,
+    (_, name) => `\${quality:${pfx(name, prefix)}}`
+  );
+  return { ...effect, template: rewritten };
+}
+```
+
+### Extensibility
+
+This is useful beyond scattered pieces — any set-piece can use templated
+logging for dynamic status messages. Future substitution types (e.g.,
+`${node-attr:nodeId:attr}`) can be added by extending the regex and lookup
+in `applyEffect()`.
+
+---
+
+## Scan Action on Core Gate
+
+The core gate/vault node gets a "scan" action that reports puzzle progress:
+
+```js
+{
+  id: "scan-lock",
+  label: "Scan Lock",
+  requires: [{ type: "node-attr", attr: "accessLevel", eq: "owned" }],
+  effects: [
+    { effect: "log-template", template: "Combination lock: ${quality:locks-opened}/3 switches activated" },
+  ],
+}
+```
+
+This gives the player a concrete objective without revealing switch locations.
+Available when the gate is owned — you know the puzzle exists and how much
+progress you've made, but you still have to explore to find the remaining
+switches.
+
+---
+
+## Generator Changes
+
+### Slot Filler — Two-Pass Approach
+
+The slot filler (`js/core/network/slot-filler.js`) changes from a single
+depth-first pass to two passes:
+
+**Pass 1 (main fill):** Fill all skeleton slots with concrete pieces, same as
+today. Additionally:
+
+1. **Detect scattered pieces.** When evaluating a candidate piece, check if it
+   has any `scatter: true` nodes.
+
+2. **Estimate scatter eligibility.** Count the scattered nodes. Estimate
+   available scatter slots using the heuristic (unfilled slots not on
+   gate-tagged paths). If insufficient, the piece is ineligible — skip it.
+
+3. **Place core nodes only.** When a scattered piece is chosen, separate its
+   nodes into core (no `scatter` flag) and scattered (`scatter: true`). Place
+   core nodes, their internal edges, and triggers into the primary slot as
+   today. Filter `internalEdges` to exclude any edge referencing a scattered
+   node ID (safety net for authoring errors).
+
+4. **Record scatter obligations.** Track which placed pieces have pending
+   scattered nodes, along with their prefix and the scattered node definitions.
+
+**Pass 2 (scatter fill):** After all skeleton slots are filled:
+
+1. **Compute gate-free slots.** Walk the filled skeleton. Mark each slot as
+   "gate-free reachable" if the path from the entry slot to that slot does not
+   pass through any placed piece with the `gate` tag. This uses the **actual
+   placed pieces**, not skeleton tags.
+
+2. **Identify available attachment points.** Within gate-free slots, find placed
+   pieces with unused outbound ports (or any accessible node the scattered node
+   can wire to as a neighbor).
+
+3. **Place scattered nodes.** For each scatter obligation:
+   - The scattered node was already instantiated with the parent piece's prefix
+     during pass 1 (sharing the same `instantiate()` call).
+   - The generator synthesizes an implicit inbound port for the scattered node:
+     `{ nodeId: "<prefix>/<nodeId>", direction: "inbound", required: true }`.
+     This is not authored in the piece definition — scattered nodes have no
+     ports since they have no edges in the authored piece. The generator
+     creates the port to match the mini-atomic-piece placement pattern.
+   - Wire the scattered node to an available attachment point in a gate-free slot.
+   - Add the node and its edge to the output.
+
+4. **Validate scatter success.** If any scatter obligation couldn't be fully
+   placed (not enough gate-free attachment points), the generation attempt
+   fails and retries with a different seed.
+
+### Instantiation
+
+`instantiate()` itself doesn't change — it already prefixes everything
+correctly. The change is in **how the generator uses the result**: after
+calling `instantiate()`, the generator separates core nodes from scattered
+nodes. Both share the same prefix. Core nodes go into the primary slot
+immediately; scattered nodes are held for pass 2.
+
+### Cost Accounting
+
+The **entire piece's `cost` grade is charged during pass 1** when the core
+is placed. Scattered nodes do not incur additional budget cost — their
+complexity is included in the piece's overall cost. A `scatteredLock3`
+with cost `"B"` charges B-points once, regardless of how many scattered
+nodes it has.
+
+This is the right behavior: the piece cost reflects total puzzle complexity
+(3 switches + gate + vault = B), not the physical node count. Do not charge
+per-scattered-node during pass 2.
+
+### Type Changes
+
+The `NodeDef` typedef in `js/core/node-graph/types.js` needs a new optional
+field:
+
+```js
+@property {boolean} [scatter] - node is placed independently by the generator
+```
+
+This is read by the generator during core/scatter separation. The NodeGraph
+runtime ignores it — it's purely a generator hint.
+
+### Biome Catalog Update
+
+New scattered piece variants must be added to `CORPORATE_BIOME.catalog` in
+`data/biomes/corporate.js`. The existing co-located versions (combinationLock,
+multiKeyVault, encryptedVault) remain in the catalog for networks where
+scattering isn't possible or appropriate.
+
+### Legacy `Dependency` Typedef
+
+The existing `Dependency` typedef and `requires` field on `SetPieceDef` in
+`js/core/network/set-pieces.js` were designed for an earlier approach where
+pieces referenced external companion pieces by tag/role. The `scatter`
+attribute replaces this — the piece is self-contained, with scattered nodes
+defined inline rather than referencing external pieces.
+
+The `Dependency` typedef and `requires` field should be removed from
+`SetPieceDef` to avoid confusion between the two systems. No existing piece
+uses `requires`.
+
+---
+
+## Bot Player
+
+The bot player (`scripts/bot/`) doesn't currently know about set-piece puzzle
+actions (`activate`, `align`, `crack-vault`, `scan-lock`, etc.). These actions
+default to instant execution (the `isInstant()` fallback in `execute.js`
+returns `true` for unknown action IDs), so the bot won't crash — but it also
+won't use them.
+
+### In Scope
+
+- **Add `activate` and `scan-lock` to the bot's action vocabulary.** The bot
+  should activate switches when it owns them and scan locks when it owns a
+  gate. These are instant, zero-risk actions — the bot should always take them
+  when available.
+
+- **Add `crack-vault` to the bot's loot heuristic.** When the bot owns a vault
+  node and `crack-vault` is available, it should execute it (same priority as
+  the existing `loot` action).
+
+### Implementation
+
+The simplest approach: in the bot's action scoring loop, check
+`getAvailableActions()` for each owned node. If any action isn't in the bot's
+known set (probe/exploit/read/loot/reconfigure/etc.), execute it as an instant
+action with moderate priority. This covers `activate`, `align`, `crack-vault`,
+`scan-lock`, and any future set-piece actions without hardcoding each one.
+
+This is a generic "do available things on owned nodes" heuristic — the bot
+doesn't need to understand the puzzle, just that there's a button to press.
+
+---
+
+## Set-Pieces to Build / Convert
+
+### Scattered Combination Lock (from `combinationLock`)
+
+Replace message-based `all-of` gate with quality-based communication:
+- Each switch: `activate` action does `quality-delta: "locks-opened", 1`
+- Core trigger: `quality-gte: "locks-opened", N` → reveal vault
+- Gate node: `scan-lock` action reports `${quality:locks-opened}/N`
+
+Variants:
+- `scatteredLock1` — 1 switch, cost D
+- `scatteredLock3` — 3 switches, cost B
+- `scatteredLock5` — 5 switches, cost A
+
+### Scattered Multi-Key Vault (from `multiKeyVault`)
+
+Replace co-located key-servers with scattered key nodes:
+- Each key-server: loot/own action does `quality-delta: "keys-collected", 1`
+- Core trigger: `quality-gte: "keys-collected", N` → unlock vault action
+- Gate node: scan action reports key progress
+
+Variants:
+- `scatteredKeyVault2` — 2 keys, cost C
+- `scatteredKeyVault3` — 3 keys, cost B
+
+### Scattered Encrypted Vault (from `encryptedVault`)
+
+Scatter the key-gen nodes:
+- Each key-gen: own action does `quality-delta: "decryption-keys", 1`
+- Core trigger: `quality-gte: "decryption-keys", N` → enable timed loot
+- Gate node: scan action reports key progress
+
+Variants:
+- `scatteredEncryptedVault2` — 2 key-gens, cost C
+- `scatteredEncryptedVault3` — 3 key-gens, cost B
+
+---
+
+## Scope
+
+### In Scope
+
+- `scatter: true` attribute on set-piece nodes
+- `NodeDef` typedef update: add optional `scatter` boolean field
+- Generator support: two-pass filling, scatter eligibility, gate-free slot
+  computation, scatter placement, synthetic inbound ports for scattered nodes
+- Cost accounting: whole piece cost charged at pass 1, no per-node charge at pass 2
+- Quality prefixing (already works via `instantiate()`)
+- `log-template` effect with `${quality:name}` substitution
+  - New case in `rewriteEffect()` for template string quality prefixing
+  - New case in `applyEffect()` for quality lookup and substitution
+- Scan action pattern for core gate nodes
+- 3 scattered piece families (combination lock, multi-key vault, encrypted vault)
+  with size variants
+- Biome catalog update (`data/biomes/corporate.js`)
+- Remove legacy `Dependency` typedef and `requires` field from `SetPieceDef`
+- Bot player: generic "execute available actions on owned nodes" heuristic
+- Edge filtering: drop `internalEdges` referencing scattered node IDs
+- Authoring invariant: at least one core node per scattered piece
+- Document that `scatter` is generator-only (ignored in hand-crafted networks)
+- Playtest generated networks with scattered pieces
+- Tests for the generator scatter placement logic
+- Tests for `log-template` effect (rewriting + runtime)
+
+### Out of Scope
+
+- Scatter groups (pairs of nodes scattered as a unit) — future direction
+- Placement preferences beyond "reachable without gates" (deeper/shallower/
+  near-core) — future direction
+- Visual indicators for scattered node relationships (beyond ID prefix)
+- New puzzle types designed from scratch for scattering
+
+---
+
+## Future Directions
+
+- **Scatter groups**: mark multiple nodes as a scatter unit that stays together
+  (e.g., key-server + guard node placed as a pair). Requires a `scatterGroup`
+  field instead of a boolean `scatter`.
+
+- **Placement preferences**: author-specified hints like `placement: "shallow"`
+  or `placement: "far-from-core"` for fine-grained control over where scattered
+  nodes land.
+
+- **Gate-behind-gate**: allowing scattered nodes behind *other* gates (not their
+  own) for more complex puzzle layering. Requires dependency graph analysis to
+  prevent deadlocks.
+
+- **Dynamic scatter count**: the generator picks how many scattered nodes to
+  place based on network size, rather than fixed variants. The trigger threshold
+  adjusts automatically.

--- a/js/core/network/set-pieces.js
+++ b/js/core/network/set-pieces.js
@@ -153,6 +153,13 @@ function rewriteEffect(effect, prefix) {
     case "quality-delta":
     case "quality-set":
       return { ...effect, name: pfx(effect.name, prefix) };
+    case "log-template": {
+      const rewritten = effect.template.replace(
+        /\$\{quality:([^}]+)\}/g,
+        (_, name) => `\${quality:${pfx(name, prefix)}}`
+      );
+      return { ...effect, template: rewritten };
+    }
     default:
       return effect;
   }

--- a/js/core/network/set-pieces.js
+++ b/js/core/network/set-pieces.js
@@ -48,15 +48,6 @@
  */
 
 /**
- * A long-range dependency — companion pieces that must be placed elsewhere.
- * @typedef {Object} Dependency
- * @property {string} role                -identifier for linking (e.g. quality counter name)
- * @property {string[]} tags              -what tags the companion piece should have
- * @property {number} count               -how many companions needed
- * @property {"deeper"|"shallower"|"any"} placement
- */
-
-/**
  * A set-piece definition — a self-contained, reusable subgraph.
  * @typedef {Object} SetPieceDef
  * @property {string} id
@@ -68,7 +59,6 @@
  * @property {string[]} [tags]            -role tags (entry, spine, filler, treasure, etc.)
  * @property {string} [cost]              -grade F through S
  * @property {Port[]} [ports]             -typed connection points (replaces externalPorts for procgen)
- * @property {Dependency[]} [requires]    - long-range companion requirements
  * @property {number} [minDepth]          - minimum depth for placement (pieces with auto-start timers)
  */
 

--- a/js/core/network/set-pieces.test.js
+++ b/js/core/network/set-pieces.test.js
@@ -75,6 +75,61 @@ describe("instantiate: external ports are prefixed", () => {
   });
 });
 
+describe("instantiate: log-template quality names are prefixed", () => {
+  it("rewrites ${quality:name} tokens in log-template effects", () => {
+    /** @type {import('./set-pieces.js').SetPieceDef} */
+    const piece = {
+      id: "test-log-tmpl",
+      description: "test",
+      nodes: [{
+        id: "node-a",
+        type: "test",
+        attributes: {},
+        actions: [{
+          id: "scan",
+          label: "Scan",
+          requires: [],
+          effects: [
+            { effect: "log-template", template: "Progress: ${quality:counter}/3 done" },
+          ],
+        }],
+      }],
+      internalEdges: [],
+      externalPorts: ["node-a"],
+    };
+    const inst = instantiate(piece, "t1");
+    const action = inst.nodes[0].actions[0];
+    const tmplEffect = action.effects[0];
+    assert.equal(tmplEffect.template, "Progress: ${quality:t1/counter}/3 done");
+  });
+
+  it("rewrites multiple quality refs in one template", () => {
+    /** @type {import('./set-pieces.js').SetPieceDef} */
+    const piece = {
+      id: "test-multi-tmpl",
+      description: "test",
+      nodes: [{
+        id: "node-a",
+        type: "test",
+        attributes: {},
+        actions: [{
+          id: "scan",
+          label: "Scan",
+          requires: [],
+          effects: [
+            { effect: "log-template", template: "A=${quality:alpha} B=${quality:beta}" },
+          ],
+        }],
+      }],
+      internalEdges: [],
+      externalPorts: ["node-a"],
+    };
+    const inst = instantiate(piece, "p1");
+    const tmplEffect = inst.nodes[0].actions[0].effects[0];
+    assert.equal(tmplEffect.template, "A=${quality:p1/alpha} B=${quality:p1/beta}");
+  });
+});
+
 describe("instantiate: two instances have independent IDs", () => {
   it("inst1 and inst2 have no overlapping node IDs", () => {
     const inst1 = instantiate(combinationLock, "v1");

--- a/js/core/network/set-pieces.test.js
+++ b/js/core/network/set-pieces.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { instantiate } from "./set-pieces.js";
-import { SET_PIECES, combinationLock, deadmanCircuit, idsRelayChain, honeyPot, encryptedVault, cascadeShutdown, tripwireGauntlet, probeBurstAlarm, noisySensor, tamperDetect } from "../../../data/biomes/corporate-pieces.js";
+import { SET_PIECES, combinationLock, deadmanCircuit, idsRelayChain, honeyPot, encryptedVault, cascadeShutdown, tripwireGauntlet, probeBurstAlarm, noisySensor, tamperDetect, scatteredLock1, scatteredLock3, scatteredLock5 } from "../../../data/biomes/corporate-pieces.js";
 import { NodeGraph } from "../node-graph/runtime.js";
 import { mockCtx } from "../node-graph/ctx.js";
 import { createMessage } from "../node-graph/message.js";
@@ -748,5 +748,121 @@ describe("tamper-detect: reconfiguring IDS without neutralizing relay triggers t
     graph.sendMessage("td1/ids", createMessage({ type: "alert", origin: "probe-node", payload: {} }));
     assert.equal(graph.getNodeState("td1/security-monitor").alerted, true);
     assert.equal(ctx.calls.setGlobalAlert?.length, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scattered combination lock — quality-based communication
+// ---------------------------------------------------------------------------
+
+describe("scatteredLock3: instantiation prefixes quality names", () => {
+  it("prefixes quality refs in switch actions and core trigger", () => {
+    const inst = instantiate(scatteredLock3, "sl");
+    // Check switch action quality-delta
+    const sw = inst.nodes.find(n => n.id === "sl/switch-a");
+    const activateAction = sw.actions.find(a => a.id === "activate");
+    const qualityEffect = activateAction.effects.find(e => e.effect === "quality-delta");
+    assert.equal(qualityEffect.name, "sl/locks-opened");
+
+    // Check trigger quality-gte
+    const trigger = inst.triggers.find(t => t.id === "sl/vault-reveal");
+    assert.equal(trigger.when.name, "sl/locks-opened");
+
+    // Check scan-lock log-template
+    const gate = inst.nodes.find(n => n.id === "sl/gate");
+    const scanAction = gate.actions.find(a => a.id === "scan-lock");
+    const tmplEffect = scanAction.effects.find(e => e.effect === "log-template");
+    assert.ok(tmplEffect.template.includes("${quality:sl/locks-opened}"));
+  });
+
+  it("scattered nodes have scatter:true attribute", () => {
+    const switches = scatteredLock3.nodes.filter(n => n.scatter);
+    assert.equal(switches.length, 3);
+    const core = scatteredLock3.nodes.filter(n => !n.scatter);
+    assert.equal(core.length, 2); // gate + vault
+  });
+});
+
+describe("scatteredLock3: quality communication in NodeGraph", () => {
+  it("vault not revealed until all 3 switches activated", () => {
+    const ctx = mockCtx();
+    const inst = instantiate(scatteredLock3, "sl");
+    const graph = new NodeGraph(inst, ctx);
+
+    // Own all switches
+    for (const sw of ["sl/switch-a", "sl/switch-b", "sl/switch-c"]) {
+      graph._nodes.get(sw).attributes.accessLevel = "owned";
+    }
+
+    // Activate 2 — vault should NOT reveal
+    graph.executeAction("sl/switch-a", "activate");
+    graph.executeAction("sl/switch-b", "activate");
+    assert.equal(ctx.calls.revealNode, undefined);
+
+    // Activate 3rd — vault reveals
+    graph.executeAction("sl/switch-c", "activate");
+    assert.ok(ctx.calls.revealNode?.length > 0);
+    assert.deepEqual(ctx.calls.revealNode[0], ["sl/vault"]);
+    assert.equal(graph.getNodeState("sl/vault").concealed, false);
+  });
+});
+
+describe("scatteredLock3: scan-lock action reports progress", () => {
+  it("reports 0/3 initially, then 1/3 after one activation", () => {
+    const ctx = mockCtx();
+    const inst = instantiate(scatteredLock3, "sl");
+    const graph = new NodeGraph(inst, ctx);
+
+    graph._nodes.get("sl/gate").attributes.accessLevel = "owned";
+    graph.executeAction("sl/gate", "scan-lock");
+    assert.ok(ctx.calls.log?.some(args => args[0] === "Combination lock: 0/3 switches activated"));
+
+    // Activate one switch
+    graph._nodes.get("sl/switch-a").attributes.accessLevel = "owned";
+    graph.executeAction("sl/switch-a", "activate");
+    graph.executeAction("sl/gate", "scan-lock");
+    assert.ok(ctx.calls.log?.some(args => args[0] === "Combination lock: 1/3 switches activated"));
+  });
+});
+
+describe("scatteredLock3: crack-vault requires all switches + owned", () => {
+  it("gives reward when all switches activated and vault owned", () => {
+    const ctx = mockCtx();
+    const inst = instantiate(scatteredLock3, "sl");
+    const graph = new NodeGraph(inst, ctx);
+
+    for (const sw of ["sl/switch-a", "sl/switch-b", "sl/switch-c"]) {
+      graph._nodes.get(sw).attributes.accessLevel = "owned";
+    }
+    graph.executeAction("sl/switch-a", "activate");
+    graph.executeAction("sl/switch-b", "activate");
+    graph.executeAction("sl/switch-c", "activate");
+
+    // Vault not owned — crack-vault unavailable
+    let available = graph.getAvailableActions("sl/vault").map(a => a.id);
+    assert.ok(!available.includes("crack-vault"));
+
+    // Own vault
+    graph._nodes.get("sl/vault").attributes.accessLevel = "owned";
+    available = graph.getAvailableActions("sl/vault").map(a => a.id);
+    assert.ok(available.includes("crack-vault"));
+
+    graph.executeAction("sl/vault", "crack-vault");
+    assert.equal(ctx.calls.giveReward?.length, 1);
+    assert.deepEqual(ctx.calls.giveReward[0], [1500]);
+  });
+});
+
+describe("scatteredLock variants: correct switch counts and thresholds", () => {
+  it("scatteredLock1 has 1 switch", () => {
+    assert.equal(scatteredLock1.nodes.filter(n => n.scatter).length, 1);
+    const trigger = scatteredLock1.triggers[0];
+    assert.equal(trigger.when.value, 1);
+  });
+
+  it("scatteredLock5 has 5 switches", () => {
+    assert.equal(scatteredLock5.nodes.filter(n => n.scatter).length, 5);
+    const trigger = scatteredLock5.triggers[0];
+    assert.equal(trigger.when.value, 5);
   });
 });

--- a/js/core/network/set-pieces.test.js
+++ b/js/core/network/set-pieces.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { instantiate } from "./set-pieces.js";
-import { SET_PIECES, combinationLock, deadmanCircuit, idsRelayChain, honeyPot, encryptedVault, cascadeShutdown, tripwireGauntlet, probeBurstAlarm, noisySensor, tamperDetect, scatteredLock1, scatteredLock3, scatteredLock5 } from "../../../data/biomes/corporate-pieces.js";
+import { SET_PIECES, combinationLock, deadmanCircuit, idsRelayChain, honeyPot, encryptedVault, cascadeShutdown, tripwireGauntlet, probeBurstAlarm, noisySensor, tamperDetect, scatteredLock1, scatteredLock3, scatteredLock5, scatteredKeyVault2, scatteredKeyVault3, scatteredEncryptedVault2, scatteredEncryptedVault3 } from "../../../data/biomes/corporate-pieces.js";
 import { NodeGraph } from "../node-graph/runtime.js";
 import { mockCtx } from "../node-graph/ctx.js";
 import { createMessage } from "../node-graph/message.js";
@@ -864,5 +864,86 @@ describe("scatteredLock variants: correct switch counts and thresholds", () => {
     assert.equal(scatteredLock5.nodes.filter(n => n.scatter).length, 5);
     const trigger = scatteredLock5.triggers[0];
     assert.equal(trigger.when.value, 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scattered multi-key vault — quality-based communication
+// ---------------------------------------------------------------------------
+
+describe("scatteredKeyVault: quality communication", () => {
+  it("scatteredKeyVault2 has 2 scattered key-servers", () => {
+    assert.equal(scatteredKeyVault2.nodes.filter(n => n.scatter).length, 2);
+    assert.equal(scatteredKeyVault2.nodes.filter(n => !n.scatter).length, 1);
+  });
+
+  it("unlock-vault requires all tokens collected", () => {
+    const ctx = mockCtx();
+    const inst = instantiate(scatteredKeyVault2, "kv");
+    const graph = new NodeGraph(inst, ctx);
+
+    // Own and extract from both keys
+    for (const ks of ["kv/key-server-1", "kv/key-server-2"]) {
+      graph._nodes.get(ks).attributes.accessLevel = "owned";
+      graph.executeAction(ks, "extract-token");
+    }
+
+    // Own vault and unlock
+    graph._nodes.get("kv/vault-node").attributes.accessLevel = "owned";
+    const available = graph.getAvailableActions("kv/vault-node").map(a => a.id);
+    assert.ok(available.includes("unlock-vault"));
+
+    graph.executeAction("kv/vault-node", "unlock-vault");
+    assert.equal(ctx.calls.giveReward?.length, 1);
+    assert.deepEqual(ctx.calls.giveReward[0], [5000]);
+  });
+
+  it("scan-vault reports progress", () => {
+    const ctx = mockCtx();
+    const inst = instantiate(scatteredKeyVault3, "kv");
+    const graph = new NodeGraph(inst, ctx);
+
+    graph._nodes.get("kv/vault-node").attributes.accessLevel = "owned";
+    graph.executeAction("kv/vault-node", "scan-vault");
+    assert.ok(ctx.calls.log?.some(args => args[0] === "Key vault: 0/3 tokens collected"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scattered encrypted vault — quality-based communication
+// ---------------------------------------------------------------------------
+
+describe("scatteredEncryptedVault: quality communication", () => {
+  it("scatteredEncryptedVault2 has 2 scattered key-gens", () => {
+    assert.equal(scatteredEncryptedVault2.nodes.filter(n => n.scatter).length, 2);
+    assert.equal(scatteredEncryptedVault2.nodes.filter(n => !n.scatter).length, 1);
+  });
+
+  it("decrypt-loot requires all keys", () => {
+    const ctx = mockCtx();
+    const inst = instantiate(scatteredEncryptedVault2, "ev");
+    const graph = new NodeGraph(inst, ctx);
+
+    // Own and extract from both key-gens
+    for (const kg of ["ev/key-gen-1", "ev/key-gen-2"]) {
+      graph._nodes.get(kg).attributes.accessLevel = "owned";
+      graph.executeAction(kg, "extract-key");
+    }
+
+    // Own vault and decrypt
+    graph._nodes.get("ev/vault").attributes.accessLevel = "owned";
+    graph.executeAction("ev/vault", "decrypt-loot");
+    assert.equal(ctx.calls.giveReward?.length, 1);
+    assert.deepEqual(ctx.calls.giveReward[0], [3000]);
+  });
+
+  it("scan-vault reports progress", () => {
+    const ctx = mockCtx();
+    const inst = instantiate(scatteredEncryptedVault3, "ev");
+    const graph = new NodeGraph(inst, ctx);
+
+    graph._nodes.get("ev/vault").attributes.accessLevel = "owned";
+    graph.executeAction("ev/vault", "scan-vault");
+    assert.ok(ctx.calls.log?.some(args => args[0] === "Encrypted vault: 0/3 keys collected"));
   });
 });

--- a/js/core/network/slot-filler.js
+++ b/js/core/network/slot-filler.js
@@ -37,6 +37,14 @@ import { gradeToNumber, costBudget } from "./budget.js";
  * @property {string[]} outboundNodeIds - prefixed outbound port node IDs (unconsumed)
  */
 
+/**
+ * A deferred scatter placement — scattered nodes waiting for pass 2.
+ * @typedef {Object} ScatterObligation
+ * @property {string} prefix - parent piece prefix (shared with core)
+ * @property {NodeDef[]} scatteredNodes - instantiated scattered nodes
+ * @property {SetPieceDef} pieceDef - original piece definition
+ */
+
 // ---------------------------------------------------------------------------
 // Slot filler
 // ---------------------------------------------------------------------------
@@ -60,8 +68,18 @@ export function fillSkeleton(skeleton, biome, spec, rng) {
   const placed = new Map();
   /** @type {Set<string>} Track which piece IDs have been used for diversity */
   const usedPieceIds = new Set();
+  /** @type {ScatterObligation[]} Deferred scattered nodes for pass 2 */
+  const scatterObligations = [];
 
-  const ok = fillSlot(skeleton, null, biome, spec, rng, pieces, crossEdges, placed, { budget: budgetRemaining }, usedPieceIds);
+  // Pass 1: fill all skeleton slots
+  const ok = fillSlot(skeleton, null, biome, spec, rng, pieces, crossEdges, placed, { budget: budgetRemaining }, usedPieceIds, scatterObligations);
+  if (!ok) return { pieces, crossEdges, ok: false };
+
+  // Pass 2: place scattered nodes in gate-free slots
+  if (scatterObligations.length > 0) {
+    const scatterOk = placeScatteredNodes(scatterObligations, pieces, skeleton, crossEdges, placed);
+    if (!scatterOk) return { pieces, crossEdges, ok: false };
+  }
 
   return { pieces, crossEdges, ok };
 }
@@ -78,9 +96,10 @@ export function fillSkeleton(skeleton, biome, spec, rng) {
  * @param {Map<string, PlacedPiece>} placed
  * @param {{ budget: number }} state
  * @param {Set<string>} usedPieceIds
+ * @param {ScatterObligation[]} scatterObligations
  * @returns {boolean}
  */
-function fillSlot(slot, parentPiece, biome, spec, rng, pieces, crossEdges, placed, state, usedPieceIds) {
+function fillSlot(slot, parentPiece, biome, spec, rng, pieces, crossEdges, placed, state, usedPieceIds, scatterObligations) {
   // 1. Filter catalog candidates
   let candidates = findCandidates(slot, parentPiece, biome, state.budget);
 
@@ -102,7 +121,21 @@ function fillSlot(slot, parentPiece, biome, spec, rng, pieces, crossEdges, place
   const prefix = slot.id.replace(/^slot-\d+-/, ""); // clean prefix
   const instance = instantiate(chosen, prefix);
 
-  const gameNodes = instance.nodes;
+  // 4. Separate core nodes from scattered nodes
+  const scatteredIds = new Set(
+    chosen.nodes.filter(n => n.scatter).map(n => `${prefix}/${n.id}`)
+  );
+  let gameNodes = instance.nodes;
+  let gameEdges = instance.edges;
+
+  if (scatteredIds.size > 0) {
+    const scatteredNodes = gameNodes.filter(n => scatteredIds.has(n.id));
+    gameNodes = gameNodes.filter(n => !scatteredIds.has(n.id));
+    // Filter edges — drop any edge referencing a scattered node
+    gameEdges = gameEdges.filter(([a, b]) => !scatteredIds.has(a) && !scatteredIds.has(b));
+    // Record scatter obligation for pass 2
+    scatterObligations.push({ prefix, scatteredNodes, pieceDef: chosen });
+  }
 
   // 5. Build prefixed ports
   const prefixedPorts = (chosen.ports ?? []).map(p => ({
@@ -118,7 +151,7 @@ function fillSlot(slot, parentPiece, biome, spec, rng, pieces, crossEdges, place
     pieceDef: chosen,
     prefix,
     nodes: gameNodes,
-    edges: instance.edges,
+    edges: gameEdges,
     triggers: instance.triggers,
     ports: prefixedPorts,
     inboundNodeId: inboundPort?.nodeId ?? null,
@@ -148,7 +181,7 @@ function fillSlot(slot, parentPiece, biome, spec, rng, pieces, crossEdges, place
   // 8. Fill children
   let outPortIdx = 0;
   for (const child of slot.children) {
-    if (!fillSlot(child, piece, biome, spec, rng, pieces, crossEdges, placed, state, usedPieceIds)) {
+    if (!fillSlot(child, piece, biome, spec, rng, pieces, crossEdges, placed, state, usedPieceIds, scatterObligations)) {
       return false;
     }
   }
@@ -298,6 +331,92 @@ function pickCandidate(candidates, rng, usedPieceIds) {
 function consumeOutboundPort(piece) {
   if (piece.outboundNodeIds.length === 0) return null;
   return piece.outboundNodeIds.shift() ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Scatter placement (pass 2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute which skeleton slots are reachable from the entry without passing
+ * through any placed piece that contains a puzzle gate (concealed nodes or
+ * scattered nodes that create unsolvable dependencies).
+ *
+ * Regular gate-tagged pieces (routers, firewalls) are NOT blocking — the
+ * player can always hack through them. Only puzzle gates that require solving
+ * a distributed puzzle (concealed vaults, scattered lock cores) block scatter
+ * placement.
+ *
+ * @param {Map<string, PlacedPiece>} placed - slotId → piece
+ * @param {SkeletonSlot} skeleton - root of skeleton tree
+ * @returns {Set<string>} gate-free slot IDs
+ */
+export function computeGateFreeSlots(placed, skeleton) {
+  /** @type {Set<string>} */
+  const gateFree = new Set();
+
+  /**
+   * @param {SkeletonSlot} slot
+   * @param {boolean} blocked - whether an ancestor was a puzzle gate
+   */
+  function walk(slot, blocked) {
+    const piece = placed.get(slot.id);
+    // A piece is a puzzle gate if it has concealed nodes (vault behind a lock)
+    // or if it has scattered nodes (it IS a distributed puzzle core)
+    const isPuzzleGate = piece?.pieceDef?.nodes?.some(
+      n => n.attributes?.concealed || n.scatter
+    ) ?? false;
+    const nowBlocked = blocked || isPuzzleGate;
+
+    if (!nowBlocked) {
+      gateFree.add(slot.id);
+    }
+
+    for (const child of slot.children) {
+      walk(child, nowBlocked);
+    }
+  }
+
+  walk(skeleton, false);
+  return gateFree;
+}
+
+/**
+ * Place all deferred scattered nodes into gate-free slots.
+ *
+ * @param {ScatterObligation[]} obligations
+ * @param {PlacedPiece[]} pieces
+ * @param {SkeletonSlot} skeleton
+ * @param {[string, string][]} crossEdges
+ * @param {Map<string, PlacedPiece>} placed
+ * @returns {boolean} true if all scattered nodes were placed
+ */
+function placeScatteredNodes(obligations, pieces, skeleton, crossEdges, placed) {
+  const gateFreeSlots = computeGateFreeSlots(placed, skeleton);
+
+  for (const obligation of obligations) {
+    for (const scatteredNode of obligation.scatteredNodes) {
+      // Find a piece in a gate-free slot with an unused outbound port
+      let attached = false;
+      for (const piece of pieces) {
+        if (piece.outboundNodeIds.length === 0) continue;
+        if (!gateFreeSlots.has(piece.slot.id)) continue;
+
+        const outPort = consumeOutboundPort(piece);
+        if (!outPort) continue;
+
+        // Add scattered node to the piece's node list and wire it
+        piece.nodes.push(scatteredNode);
+        crossEdges.push([outPort, scatteredNode.id]);
+        attached = true;
+        break;
+      }
+
+      if (!attached) return false; // couldn't place — generation should retry
+    }
+  }
+
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/js/core/network/slot-filler.js
+++ b/js/core/network/slot-filler.js
@@ -174,6 +174,9 @@ function fillSlot(slot, parentPiece, biome, spec, rng, pieces, crossEdges, place
       // Can't wire — remove piece to prevent orphan. Refund budget.
       pieces.pop();
       state.budget += gradeToNumber(chosen.cost ?? "F");
+      // Also remove any scatter obligation for this piece
+      const oblIdx = scatterObligations.findIndex(o => o.prefix === prefix);
+      if (oblIdx !== -1) scatterObligations.splice(oblIdx, 1);
       return true; // continue with siblings (they might not need this parent's ports)
     }
   }
@@ -401,6 +404,7 @@ export function computeGateFreeSlots(placed, skeleton) {
  */
 function placeScatteredNodes(obligations, pieces, skeleton, crossEdges, placed) {
   const gateFreeSlots = computeGateFreeSlots(placed, skeleton);
+  scatterPlaced.clear();
 
   for (const obligation of obligations) {
     for (const scatteredNode of obligation.scatteredNodes) {
@@ -424,6 +428,7 @@ function attachToFreePort(scatteredNode, pieces, gateFreeSlots, crossEdges) {
 
     piece.nodes.push(scatteredNode);
     crossEdges.push([outPort, scatteredNode.id]);
+    scatterPlaced.add(scatteredNode.id);
     return true;
   }
   return false;
@@ -431,6 +436,9 @@ function attachToFreePort(scatteredNode, pieces, gateFreeSlots, crossEdges) {
 
 /** Replaceable leaf types — cheap filler nodes that can be swapped for scattered nodes. */
 const REPLACEABLE_TYPES = new Set(["workstation", "fileserver"]);
+
+/** Track node IDs that were placed via scatter — can't replace these. */
+const scatterPlaced = new Set();
 
 /**
  * Replace a leaf filler node with a scattered node. The filler node is removed
@@ -443,6 +451,8 @@ function replaceLeafNode(scatteredNode, pieces, gateFreeSlots, crossEdges) {
     if (piece.nodes.length !== 1) continue;
     const candidate = piece.nodes[0];
     if (!REPLACEABLE_TYPES.has(candidate.type)) continue;
+    // Don't replace a node that was already placed via scatter
+    if (scatterPlaced.has(candidate.id)) continue;
     // Don't replace pieces that are the scatter node's own parent
     if (piece.prefix === scatteredNode.id.split("/")[0]) continue;
 
@@ -456,6 +466,7 @@ function replaceLeafNode(scatteredNode, pieces, gateFreeSlots, crossEdges) {
     // Replace: swap the filler node for the scattered node, rewire edge
     piece.nodes[0] = scatteredNode;
     crossEdges[edgeIdx] = [parentPort, scatteredNode.id];
+    scatterPlaced.add(scatteredNode.id);
     return true;
   }
   return false;

--- a/js/core/network/slot-filler.js
+++ b/js/core/network/slot-filler.js
@@ -199,7 +199,10 @@ function fillSlot(slot, parentPiece, biome, spec, rng, pieces, crossEdges, place
       isLeaf: true,
       dependency: null,
     };
-    const fillerCandidates = findCandidates(fillerSlot, piece, biome, state.budget);
+    let fillerCandidates = findCandidates(fillerSlot, piece, biome, state.budget);
+    // Exclude scattered pieces from opportunistic filler — they need the
+    // main fill path's scatter separation logic
+    fillerCandidates = fillerCandidates.filter(p => !p.nodes.some(n => n.scatter));
     if (fillerCandidates.length === 0) break;
 
     const fillerChosen = pickCandidate(fillerCandidates, rng, usedPieceIds);
@@ -384,6 +387,11 @@ export function computeGateFreeSlots(placed, skeleton) {
 /**
  * Place all deferred scattered nodes into gate-free slots.
  *
+ * Strategy: first try unused outbound ports, then replace leaf filler nodes
+ * (single workstation/fileserver pieces) with scattered nodes. Replacement
+ * is safe because the scattered node's cost is already included in its parent
+ * piece's budget.
+ *
  * @param {ScatterObligation[]} obligations
  * @param {PlacedPiece[]} pieces
  * @param {SkeletonSlot} skeleton
@@ -396,27 +404,61 @@ function placeScatteredNodes(obligations, pieces, skeleton, crossEdges, placed) 
 
   for (const obligation of obligations) {
     for (const scatteredNode of obligation.scatteredNodes) {
-      // Find a piece in a gate-free slot with an unused outbound port
-      let attached = false;
-      for (const piece of pieces) {
-        if (piece.outboundNodeIds.length === 0) continue;
-        if (!gateFreeSlots.has(piece.slot.id)) continue;
-
-        const outPort = consumeOutboundPort(piece);
-        if (!outPort) continue;
-
-        // Add scattered node to the piece's node list and wire it
-        piece.nodes.push(scatteredNode);
-        crossEdges.push([outPort, scatteredNode.id]);
-        attached = true;
-        break;
-      }
-
-      if (!attached) return false; // couldn't place — generation should retry
+      if (attachToFreePort(scatteredNode, pieces, gateFreeSlots, crossEdges)) continue;
+      if (replaceLeafNode(scatteredNode, pieces, gateFreeSlots, crossEdges)) continue;
+      return false; // couldn't place — generation should retry
     }
   }
 
   return true;
+}
+
+/** Try to attach a scattered node to an unused outbound port in a gate-free slot. */
+function attachToFreePort(scatteredNode, pieces, gateFreeSlots, crossEdges) {
+  for (const piece of pieces) {
+    if (piece.outboundNodeIds.length === 0) continue;
+    if (!gateFreeSlots.has(piece.slot.id)) continue;
+
+    const outPort = consumeOutboundPort(piece);
+    if (!outPort) continue;
+
+    piece.nodes.push(scatteredNode);
+    crossEdges.push([outPort, scatteredNode.id]);
+    return true;
+  }
+  return false;
+}
+
+/** Replaceable leaf types — cheap filler nodes that can be swapped for scattered nodes. */
+const REPLACEABLE_TYPES = new Set(["workstation", "fileserver"]);
+
+/**
+ * Replace a leaf filler node with a scattered node. The filler node is removed
+ * and the scattered node takes its place in the edge graph.
+ */
+function replaceLeafNode(scatteredNode, pieces, gateFreeSlots, crossEdges) {
+  for (const piece of pieces) {
+    if (!gateFreeSlots.has(piece.slot.id)) continue;
+    // Only replace single-node leaf pieces (atomics)
+    if (piece.nodes.length !== 1) continue;
+    const candidate = piece.nodes[0];
+    if (!REPLACEABLE_TYPES.has(candidate.type)) continue;
+    // Don't replace pieces that are the scatter node's own parent
+    if (piece.prefix === scatteredNode.id.split("/")[0]) continue;
+
+    // Find the cross-edge that wires this piece into the network
+    const inboundId = piece.inboundNodeId;
+    const edgeIdx = crossEdges.findIndex(([, dst]) => dst === inboundId);
+    if (edgeIdx === -1) continue;
+
+    const [parentPort] = crossEdges[edgeIdx];
+
+    // Replace: swap the filler node for the scattered node, rewire edge
+    piece.nodes[0] = scatteredNode;
+    crossEdges[edgeIdx] = [parentPort, scatteredNode.id];
+    return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/js/core/node-graph/effects.js
+++ b/js/core/node-graph/effects.js
@@ -23,7 +23,7 @@
  * @param {EffectMutators} mutators
  */
 export function applyEffect(effect, mutators) {
-  const { setNodeAttr, targetNodeId, getNodeAttr, setQuality, deltaQuality, emitFrom, ctx } = mutators;
+  const { setNodeAttr, targetNodeId, getNodeAttr, getQuality, setQuality, deltaQuality, emitFrom, ctx } = mutators;
 
   switch (effect.effect) {
     case "set-attr":
@@ -64,6 +64,15 @@ export function applyEffect(effect, mutators) {
     case "log":
       ctx.log(effect.message);
       break;
+
+    case "log-template": {
+      const resolved = effect.template.replace(
+        /\$\{quality:([^}]+)\}/g,
+        (_, name) => String(getQuality(name) ?? 0)
+      );
+      ctx.log(resolved);
+      break;
+    }
 
     case "reveal-node":
       ctx.revealNode(effect.nodeId);

--- a/js/core/node-graph/effects.test.js
+++ b/js/core/node-graph/effects.test.js
@@ -143,6 +143,51 @@ describe("applyEffect: enable-node", () => {
   });
 });
 
+describe("applyEffect: log-template", () => {
+  it("substitutes quality values into the template", () => {
+    const store = makeStore();
+    store.qualities["locks-opened"] = 2;
+    const { ctx, calls } = makeCtx();
+    applyEffect(
+      { effect: "log-template", template: "Lock: ${quality:locks-opened}/3 activated" },
+      { ...store, targetNodeId: null, ctx }
+    );
+    assert.deepEqual(calls.log?.[0], ["Lock: 2/3 activated"]);
+  });
+
+  it("substitutes 0 for missing qualities", () => {
+    const store = makeStore();
+    const { ctx, calls } = makeCtx();
+    applyEffect(
+      { effect: "log-template", template: "Keys: ${quality:missing-quality}/5" },
+      { ...store, targetNodeId: null, ctx }
+    );
+    assert.deepEqual(calls.log?.[0], ["Keys: 0/5"]);
+  });
+
+  it("handles multiple quality references in one template", () => {
+    const store = makeStore();
+    store.qualities["a"] = 1;
+    store.qualities["b"] = 4;
+    const { ctx, calls } = makeCtx();
+    applyEffect(
+      { effect: "log-template", template: "A=${quality:a} B=${quality:b}" },
+      { ...store, targetNodeId: null, ctx }
+    );
+    assert.deepEqual(calls.log?.[0], ["A=1 B=4"]);
+  });
+
+  it("passes through template with no quality refs unchanged", () => {
+    const store = makeStore();
+    const { ctx, calls } = makeCtx();
+    applyEffect(
+      { effect: "log-template", template: "No qualities here" },
+      { ...store, targetNodeId: null, ctx }
+    );
+    assert.deepEqual(calls.log?.[0], ["No qualities here"]);
+  });
+});
+
 describe("applyEffect: unknown type", () => {
   it("throws for unknown effect type", () => {
     const store = makeStore();

--- a/js/core/node-graph/types.js
+++ b/js/core/node-graph/types.js
@@ -16,6 +16,7 @@
  * @property {OperatorConfig[]} [operators]
  * @property {ActionDef[]} [actions]
  * @property {TriggerDef[]} [triggers]   - per-node triggers (nodeId filled in at construction)
+ * @property {boolean} [scatter]        - node is placed independently by the generator
  */
 
 /**

--- a/js/core/node-graph/types.js
+++ b/js/core/node-graph/types.js
@@ -143,7 +143,7 @@
  * Effect — union of supported effect shapes.
  * @typedef {SetAttrEffect | SetNodeAttrEffect | ToggleAttrEffect | EmitMessageEffect |
  *           QualitySetEffect | QualityDeltaEffect | CtxCallEffect | LogEffect |
- *           RevealNodeEffect | EnableNodeEffect} Effect
+ *           LogTemplateEffect | RevealNodeEffect | EnableNodeEffect} Effect
  */
 
 /**
@@ -198,6 +198,12 @@
  * @typedef {Object} LogEffect
  * @property {'log'} effect
  * @property {string} message
+ */
+
+/**
+ * @typedef {Object} LogTemplateEffect - log with ${quality:name} substitution
+ * @property {'log-template'} effect
+ * @property {string} template
  */
 
 /**

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -510,6 +510,8 @@ function updateExploitProgress(progress = null) {
   if (label) label.textContent = `▶ EXECUTING — ${pct}%`;
 }
 
+let _lastHandKey = "";
+
 function syncHandPane(state) {
   const el = document.getElementById("hand-strip");
   if (!el) return;
@@ -522,6 +524,13 @@ function syncHandPane(state) {
   const sortedHand = selectedNode
     ? [...state.player.hand].sort((a, b) => exploitSortKey(a, selectedNode) - exploitSortKey(b, selectedNode))
     : state.player.hand;
+
+  // Skip re-render if hand state hasn't changed (prevents flicker from
+  // frequent STATE_CHANGED events destroying and recreating card DOM)
+  const handKey = sortedHand.map(c => `${c.id}:${c.uses}:${c.decayState}`).join("|")
+    + `|sel:${state.selectedNodeId ?? ""}|exec:${exploitingId ?? ""}`;
+  if (handKey === _lastHandKey) return;
+  _lastHandKey = handKey;
 
   const handClass = ["nd-hand", isSelecting ? "selectable" : "", executing ? "exploit-hand-executing" : ""]
     .filter(Boolean).join(" ");

--- a/scripts/bot/execute.js
+++ b/scripts/bot/execute.js
@@ -15,6 +15,9 @@ const INSTANT_ACTIONS = new Set([
   "select", "deselect", "jackout", "reconfigure", "cancel-trace",
   "cancel-probe", "cancel-exploit", "cancel-read", "cancel-loot",
   "eject", "access-darknet",
+  // Set-piece puzzle actions
+  "activate", "scan-lock", "scan-vault", "crack-vault",
+  "unlock-vault", "extract-token", "extract-key", "decrypt-loot",
 ]);
 
 /**

--- a/scripts/bot/heuristics/puzzles.js
+++ b/scripts/bot/heuristics/puzzles.js
@@ -1,0 +1,57 @@
+// @ts-check
+// Puzzle heuristic — execute set-piece actions on owned nodes.
+// Generic: proposes any available action that isn't in the bot's known set.
+// Covers activate, scan-lock, crack-vault, unlock-vault, extract-token, etc.
+// Each action is proposed at most once per node per run.
+
+/** @typedef {import('../types.js').WorldModel} WorldModel */
+/** @typedef {import('../types.js').ScoredAction} ScoredAction */
+
+const STRATEGY = "puzzle";
+const BASE_PUZZLE = 60;
+
+/** Actions the bot already handles via other heuristics */
+const KNOWN_ACTIONS = new Set([
+  "probe", "exploit", "read", "loot", "reboot",
+  "select", "deselect", "jackout", "reconfigure", "cancel-trace",
+  "cancel-probe", "cancel-exploit", "cancel-read", "cancel-loot",
+  "eject", "access-darknet",
+]);
+
+/** Track "nodeId:actionId" pairs we've already proposed to avoid loops */
+const completed = new Set();
+
+/** Reset tracking between runs */
+export function resetPuzzleTracking() { completed.clear(); }
+
+/**
+ * @param {WorldModel} world
+ * @returns {ScoredAction[]}
+ */
+export function puzzleStrategy(world) {
+  /** @type {ScoredAction[]} */
+  const proposals = [];
+
+  for (const nodeId of world.owned) {
+    const actions = world.availableActions.get(nodeId) ?? [];
+    for (const action of actions) {
+      if (KNOWN_ACTIONS.has(action.id)) continue;
+      if (action.id.startsWith("disarm")) continue; // handled by traps heuristic
+      if (action.id.startsWith("cancel")) continue;
+
+      const key = `${nodeId}:${action.id}`;
+      if (completed.has(key)) continue;
+      completed.add(key);
+
+      proposals.push({
+        action: action.id,
+        nodeId,
+        score: BASE_PUZZLE,
+        reason: `puzzle: ${action.label} on ${nodeId}`,
+        strategy: STRATEGY,
+      });
+    }
+  }
+
+  return proposals;
+}

--- a/scripts/bot/run.js
+++ b/scripts/bot/run.js
@@ -14,6 +14,7 @@ import { securityStrategy } from "./heuristics/security.js";
 import { trapsStrategy } from "./heuristics/traps.js";
 import { evasionStrategy } from "./heuristics/evasion.js";
 import { cardsStrategy } from "./heuristics/cards.js";
+import { puzzleStrategy, resetPuzzleTracking } from "./heuristics/puzzles.js";
 
 /** @type {Strategy[]} */
 const DEFAULT_STRATEGIES = [
@@ -23,6 +24,7 @@ const DEFAULT_STRATEGIES = [
   trapsStrategy,
   evasionStrategy,
   cardsStrategy,
+  puzzleStrategy,
 ];
 
 let engineInitialized = false;
@@ -41,6 +43,7 @@ export function runBot(buildNetworkFn, opts = {}) {
   }
 
   resetGame(buildNetworkFn, opts.seed);
+  resetPuzzleTracking();
 
   const strategies = opts.strategies ?? DEFAULT_STRATEGIES;
   return runLoop(strategies, {


### PR DESCRIPTION
## Summary

- **Scatter attribute**: set-piece nodes marked `scatter: true` are placed independently by the generator elsewhere in the network. Communication with the core happens via prefixed quality counters — no direct edges.
- **Two-pass generator**: pass 1 fills skeleton slots normally (separating core from scattered nodes), pass 2 places scattered nodes in gate-free slots via unused outbound ports or leaf node replacement.
- **`log-template` effect**: new effect type with `${quality:name}` substitution for dynamic status messages. Quality names rewritten during instantiation.
- **7 scattered piece variants**: scatteredLock (1/3/5 switches), scatteredKeyVault (2/3 keys), scatteredEncryptedVault (2/3 key-gens)
- **Bot puzzle heuristic**: generic "execute available actions on owned nodes" strategy covers activate, scan-lock, crack-vault, etc.
- **Scan actions**: core gate/vault nodes report puzzle progress (e.g., "2/3 switches activated")

## Key design decisions

- Scattered nodes keep the parent piece's prefix as a player-legible clue (e.g., `d3-0/switch-a` hints at connection to `d3-0/gate`)
- Gate-free placement prevents deadlocks: scattered nodes only go in slots reachable without traversing puzzle gates
- Leaf replacement: when no outbound ports are available, scattered nodes replace single-node filler pieces (workstation/fileserver)
- Whole piece cost charged at pass 1 — no per-scattered-node budget charge

## Test plan

- [x] `make check` passes (542 tests, lint clean)
- [x] Generation success: 100% default spec, 98% F/B/B/C across 50 seeds
- [x] Bot plays scattered networks without crashes
- [x] Unit tests for log-template (rewriting + runtime), scattered lock quality communication, scan progress, crack-vault reward
- [ ] Manual browser playtest with scattered switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)