### PR TITLE
Add workstation-array, lucky-break, security-theater set pieces (#54)

### DIFF
--- a/data/biomes/corporate-pieces.js
+++ b/data/biomes/corporate-pieces.js
@@ -1994,6 +1994,177 @@ export const singleFileserver = {
 };
 
 // ---------------------------------------------------------------------------
+// Scenario set-pieces — narrative-flavored configurations that create
+// interesting tactical situations through grade asymmetry or topology.
+// ---------------------------------------------------------------------------
+
+/**
+ * Workstation Array — a router hub connected to 4 workstations.
+ * Methodical looting: many small targets behind a single gate.
+ * Each workstation has small loot; the volume adds up.
+ *
+ * @type {SetPieceDef}
+ */
+export const workstationArray = {
+  id: "workstation-array",
+  description: "Array of four workstations behind a hub router. Methodical looting territory.",
+  nodes: [
+    {
+      id: "hub",
+      type: "router",
+      traits: ["graded", "hackable", "rebootable", "gate"],
+      attributes: { accessLevel: "locked", gateAccess: "compromised" },
+      operators: [{ name: "relay" }],
+      actions: [],
+    },
+    {
+      id: "ws-1",
+      type: "workstation",
+      traits: ["graded", "hackable", "rebootable", "lootable", "gate"],
+      attributes: { accessLevel: "locked" },
+      operators: [],
+      actions: [],
+    },
+    {
+      id: "ws-2",
+      type: "workstation",
+      traits: ["graded", "hackable", "rebootable", "lootable", "gate"],
+      attributes: { accessLevel: "locked" },
+      operators: [],
+      actions: [],
+    },
+    {
+      id: "ws-3",
+      type: "workstation",
+      traits: ["graded", "hackable", "rebootable", "lootable", "gate"],
+      attributes: { accessLevel: "locked" },
+      operators: [],
+      actions: [],
+    },
+    {
+      id: "ws-4",
+      type: "workstation",
+      traits: ["graded", "hackable", "rebootable", "lootable", "gate"],
+      attributes: { accessLevel: "locked" },
+      operators: [],
+      actions: [],
+    },
+  ],
+  internalEdges: [
+    ["hub", "ws-1"],
+    ["hub", "ws-2"],
+    ["hub", "ws-3"],
+    ["hub", "ws-4"],
+  ],
+  triggers: [],
+  externalPorts: ["hub", "ws-1", "ws-2", "ws-3", "ws-4"],
+  tags: ["filler", "treasure"],
+  cost: "D",
+  ports: [
+    { nodeId: "hub", direction: "inbound", wantsTags: [], required: true },
+    { nodeId: "ws-1", direction: "outbound", wantsTags: [], required: false },
+    { nodeId: "ws-2", direction: "outbound", wantsTags: [], required: false },
+    { nodeId: "ws-3", direction: "outbound", wantsTags: [], required: false },
+    { nodeId: "ws-4", direction: "outbound", wantsTags: [], required: false },
+  ],
+};
+
+/**
+ * Lucky Break — a low-grade firewall guarding a cryptovault.
+ * The corp cut corners on perimeter hardening but the vault itself is standard.
+ * Easy entry, normal prize. The player who spots this saves time.
+ *
+ * Grade asymmetry: firewall is 2 grades below default, vault is at default.
+ * After network-level grade shift, the relative gap is preserved.
+ *
+ * @type {SetPieceDef}
+ */
+export const luckyBreak = {
+  id: "lucky-break",
+  description: "Weak firewall guarding a cryptovault. Someone cut corners on hardening.",
+  nodes: [
+    {
+      id: "weak-gate",
+      type: "firewall",
+      traits: ["graded", "hackable", "rebootable", "gate"],
+      attributes: { accessLevel: "locked", gateAccess: "owned", grade: "F" },
+      operators: [],
+      actions: [],
+    },
+    {
+      id: "vault",
+      type: "cryptovault",
+      traits: ["graded", "hackable", "rebootable", "lootable", "gate"],
+      attributes: { accessLevel: "locked", grade: "C" },
+      operators: [],
+      actions: [],
+    },
+  ],
+  internalEdges: [["weak-gate", "vault"]],
+  triggers: [],
+  externalPorts: ["weak-gate", "vault"],
+  tags: ["treasure"],
+  cost: "C",
+  ports: [
+    { nodeId: "weak-gate", direction: "inbound", wantsTags: [], required: true },
+    { nodeId: "vault", direction: "outbound", wantsTags: [], required: false },
+  ],
+};
+
+/**
+ * Security Theater — a high-grade firewall protecting low-grade fileservers.
+ * The corp invested in a flashy perimeter but the interior is soft.
+ * Hard entry, easy loot. Rewards the player who commits to cracking the gate.
+ *
+ * Grade asymmetry: firewall is 2 grades above default, fileservers are 2 below.
+ *
+ * @type {SetPieceDef}
+ */
+export const securityTheater = {
+  id: "security-theater",
+  description: "Imposing firewall, unprotected fileservers behind it. All bark, no bite inside.",
+  nodes: [
+    {
+      id: "hard-gate",
+      type: "firewall",
+      traits: ["graded", "hackable", "rebootable", "gate"],
+      attributes: { accessLevel: "locked", gateAccess: "owned", grade: "B" },
+      operators: [],
+      actions: [],
+    },
+    {
+      id: "soft-server-1",
+      type: "fileserver",
+      traits: ["graded", "hackable", "rebootable", "lootable", "gate"],
+      attributes: { accessLevel: "locked", grade: "F" },
+      operators: [],
+      actions: [],
+    },
+    {
+      id: "soft-server-2",
+      type: "fileserver",
+      traits: ["graded", "hackable", "rebootable", "lootable", "gate"],
+      attributes: { accessLevel: "locked", grade: "F" },
+      operators: [],
+      actions: [],
+    },
+  ],
+  internalEdges: [
+    ["hard-gate", "soft-server-1"],
+    ["hard-gate", "soft-server-2"],
+  ],
+  triggers: [],
+  externalPorts: ["hard-gate", "soft-server-1", "soft-server-2"],
+  tags: ["gate", "treasure"],
+  cost: "C",
+  ports: [
+    { nodeId: "hard-gate", direction: "inbound", wantsTags: [], required: true },
+    { nodeId: "soft-server-1", direction: "outbound", wantsTags: [], required: false },
+    { nodeId: "soft-server-2", direction: "outbound", wantsTags: [], required: false },
+  ],
+};
+
+// ---------------------------------------------------------------------------
 // Backbone set-pieces — spine nodes connecting wings in hierarchical networks.
 // All backbone pieces include relay operators for alert message propagation.
 // ---------------------------------------------------------------------------

--- a/data/biomes/corporate.js
+++ b/data/biomes/corporate.js
@@ -23,6 +23,7 @@ import {
   scatteredEncryptedVault2, scatteredEncryptedVault3,
   entryPoint, singleRouter, singleFirewall,
   singleWorkstation, singleFileserver,
+  workstationArray, luckyBreak, securityTheater,
   backboneRouter, backboneFirewall, backboneHub,
 } from "./corporate-pieces.js";
 
@@ -38,6 +39,10 @@ const catalog = [
   serverBank,
   officeCluster,
   switchArrangement,
+  workstationArray,
+  // Scenario (grade asymmetry)
+  luckyBreak,
+  securityTheater,
   // Defense
   idsRelayChain,
   noisySensor,
@@ -103,6 +108,7 @@ export const serverRoom = {
     "server-bank", "large-server-bank", "data-center", "vault-cluster",
     "single-fileserver", "single-router",
     "encrypted-vault", "multi-key-vault",
+    "lucky-break", "security-theater",
   ],
   requiredPieceIds: [],
   baseGrades: { threat: "F", wealth: "B", complexity: "D", depth: "C" },
@@ -116,6 +122,7 @@ export const officeFloor = {
   pieceIds: [
     "office-cluster", "single-workstation", "single-fileserver",
     "single-router", "switch-arrangement",
+    "workstation-array", "security-theater",
   ],
   requiredPieceIds: [],
   baseGrades: { threat: "F", wealth: "D", complexity: "F", depth: "D" },
@@ -129,6 +136,7 @@ export const executiveSuite = {
   pieceIds: [
     "fortified-gate", "combination-lock", "encrypted-vault", "vault-cluster",
     "single-firewall", "single-router", "single-workstation", "multi-key-vault",
+    "lucky-break",
   ],
   requiredPieceIds: [],
   baseGrades: { threat: "C", wealth: "A", complexity: "B", depth: "C" },
@@ -157,7 +165,7 @@ export const dataCenterWing = {
   pieceIds: [
     "server-bank", "large-server-bank", "data-center",
     "single-fileserver", "single-router", "single-workstation",
-    "office-cluster",
+    "office-cluster", "workstation-array",
   ],
   requiredPieceIds: [],
   baseGrades: { threat: "F", wealth: "A", complexity: "F", depth: "D" },


### PR DESCRIPTION
## Summary

- **workstation-array** — 4 workstations behind a hub router. Methodical looting territory.
- **lucky-break** — weak firewall (grade F) guarding a cryptovault (grade C). The corp cut corners on perimeter hardening. Easy entry, normal prize.
- **security-theater** — strong firewall (grade B) protecting soft fileservers (grade F). All bark, no bite inside. Rewards committing to the hard gate.

Grade asymmetry is preserved through network-level grade shifts — the relative difference between nodes stays constant regardless of network difficulty.

Added to sub-biome palettes: office-floor, server-room, executive-suite, data-center-wing.

## Test plan

- [x] `make check` — 600 tests pass, lint clean
- [x] Smoke test: all three pieces appear in flat (F-grade) networks
- [x] Smoke test: all three pieces appear in hierarchical (B-grade) networks
- [ ] Playtest: verify grade asymmetry feels right in-game (easy gate / hard prize and vice versa)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)