### PR TITLE
Grade-scaled timing for set-piece operators (#56, #58)

### DIFF
--- a/data/biomes/corporate-pieces.js
+++ b/data/biomes/corporate-pieces.js
@@ -312,8 +312,8 @@ export const deadmanCircuit = {
       type: "heartbeat-source",
       traits: ["graded", "hackable", "rebootable"],
       attributes: {},
-      // Clock sends heartbeat every 30 ticks (3s) — must be faster than watchdog period
-      operators: [{ name: "clock", period: 30 }],
+      // Clock sends heartbeat — must be faster than watchdog period
+      operators: [{ name: "clock", period: 30, periodTable: { S: 15, A: 20, B: 25, C: 30, D: 40, F: 50 } }],
       actions: [],
     },
     {
@@ -339,10 +339,9 @@ export const deadmanCircuit = {
       type: "watchdog-daemon",
       traits: ["graded", "hackable", "rebootable"],
       attributes: {},
-      // Watchdog resets on any non-tick message. If no message arrives in
-      // 50 ticks (5s), it fires a "set" message to the alarm latch.
-      // Player has ~5s after subverting the relay before the alarm fires.
-      operators: [{ name: "watchdog", period: 50 }],
+      // Watchdog resets on any non-tick message. If no message arrives within
+      // the period, it fires a "set" message to the alarm latch.
+      operators: [{ name: "watchdog", period: 50, periodTable: { S: 25, A: 30, B: 40, C: 50, D: 60, F: 80 } }],
       actions: [],
     },
     {
@@ -673,7 +672,7 @@ export const encryptedVault = {
       type: "key-gen",
       traits: ["graded", "hackable", "rebootable"],
       attributes: { accessLevel: "locked", keyReady: false },
-      operators: [{ name: "clock", period: 100 }],  // 10s cycle at 100ms/tick
+      operators: [{ name: "clock", period: 100, periodTable: { S: 50, A: 60, B: 80, C: 100, D: 120, F: 150 } }],
       actions: [
         {
           id: "extract-key",
@@ -826,7 +825,7 @@ export const cascadeShutdown = {
       type: "watchdog-daemon",
       traits: ["graded", "hackable", "rebootable"],
       attributes: {},
-      operators: [{ name: "watchdog", period: 4 }],
+      operators: [{ name: "watchdog", period: 4, periodTable: { S: 2, A: 3, B: 3, C: 4, D: 5, F: 6 } }],
       actions: [],
     },
     {
@@ -901,7 +900,7 @@ export const tripwireGauntlet = {
       attributes: { accessLevel: "locked", triggered: false, sensorEnabled: true },
       operators: [
         { name: "flag", on: "probe-noise", attr: "triggered", enabledAttr: "sensorEnabled" },
-        { name: "delay", ticks: 6, enabledAttr: "sensorEnabled" },
+        { name: "delay", ticks: 6, ticksTable: { S: 3, A: 4, B: 5, C: 6, D: 8, F: 10 }, enabledAttr: "sensorEnabled" },
       ],
       actions: [
         {
@@ -1020,7 +1019,7 @@ export const noisySensor = {
       type: "traffic-sensor",
       traits: ["graded", "hackable", "rebootable"],
       attributes: { accessLevel: "locked", debounceEnabled: true },
-      operators: [{ name: "debounce", on: "probe-noise", ticks: 4, enabledAttr: "debounceEnabled" }],
+      operators: [{ name: "debounce", on: "probe-noise", ticks: 4, ticksTable: { S: 2, A: 3, B: 3, C: 4, D: 5, F: 7 }, enabledAttr: "debounceEnabled" }],
       actions: [
         {
           id: "muffle",

--- a/js/core/network/set-pieces.test.js
+++ b/js/core/network/set-pieces.test.js
@@ -459,7 +459,7 @@ describe("encrypted-vault: key expiry forces timing pressure", () => {
     const graph = new NodeGraph(inst, ctx);
 
     graph._nodes.get("ev1/key-gen").attributes.accessLevel = "owned";
-    graph.tick(100); // clock period is 5
+    graph.tick(120); // clock period is 120 at grade D
     const actions = graph.getAvailableActions("ev1/key-gen").map((a) => a.id);
     assert.ok(actions.includes("extract-key"), "key ready after clock fires");
   });
@@ -476,7 +476,7 @@ describe("encrypted-vault: key expiry forces timing pressure", () => {
     assert.ok(!graph.getAvailableActions("ev1/vault").map((a) => a.id).includes("fetch"));
 
     // Fire clock, extract key, then fetch
-    graph.tick(100);
+    graph.tick(120);
     graph.executeAction("ev1/key-gen", "extract-key");
     assert.equal(graph.getQuality("ev1/decryption-key"), 1);
 
@@ -498,12 +498,12 @@ describe("encrypted-vault: key expiry forces timing pressure", () => {
     graph._nodes.get("ev1/vault").attributes.accessLevel = "owned";
 
     // First clock cycle: extract the key
-    graph.tick(100);
+    graph.tick(120);
     graph.executeAction("ev1/key-gen", "extract-key");
     assert.equal(graph.getQuality("ev1/decryption-key"), 1);
 
     // Don't loot — let next clock cycle fire and expire the key
-    graph.tick(100);
+    graph.tick(120);
     assert.equal(graph.getQuality("ev1/decryption-key"), 0);
     assert.equal(graph.getNodeState("ev1/key-gen").keyReady, true); // new key ready
     assert.ok(!graph.getAvailableActions("ev1/vault").map((a) => a.id).includes("loot"));
@@ -552,15 +552,15 @@ describe("cascade-shutdown: subvert all relays before watchdog expires", () => {
     graph._nodes.get("cs1/relay-a").attributes.accessLevel = "owned";
     // Subvert only relay-a — the subvert action uses emit-message to send
     // subvert-ping directly to watchdog (bypassing relay-a's own operators),
-    // which resets the watchdog timer. Need 4 more ticks for it to expire.
+    // which resets the watchdog timer. Need 5 more ticks for it to expire (grade D).
     graph.executeAction("cs1/relay-a", "subvert");
-    graph.tick(4); // watchdog period elapses without further messages
+    graph.tick(5); // watchdog period elapses without further messages (grade D)
 
     assert.equal(ctx.calls.startTrace?.length, 1);
   });
 });
 
-describe("tripwire-gauntlet: 6-tick delay from probe to alarm", () => {
+describe("tripwire-gauntlet: 8-tick delay from probe to alarm (grade D)", () => {
   it("sensor flags triggered immediately on probe-noise", () => {
     const ctx = mockCtx();
     const inst = instantiate(tripwireGauntlet, "tg1");
@@ -572,24 +572,24 @@ describe("tripwire-gauntlet: 6-tick delay from probe to alarm", () => {
     assert.equal(ctx.calls.startTrace, undefined);
   });
 
-  it("alarm does not fire before 6 ticks", () => {
+  it("alarm does not fire before 8 ticks (grade D)", () => {
     const ctx = mockCtx();
     const inst = instantiate(tripwireGauntlet, "tg1");
     const graph = new NodeGraph(inst, ctx);
 
     graph.sendMessage("tg1/sensor", createMessage({ type: "probe-noise", origin: "player", payload: {} }));
-    graph.tick(5); // one tick short of the full 6-tick delay
+    graph.tick(7); // one tick short of the full 8-tick delay
     assert.equal(graph.getNodeState("tg1/alarm").triggered, false);
     assert.equal(ctx.calls.startTrace, undefined);
   });
 
-  it("alarm fires and trace starts on tick 6", () => {
+  it("alarm fires and trace starts on tick 8 (grade D)", () => {
     const ctx = mockCtx();
     const inst = instantiate(tripwireGauntlet, "tg1");
     const graph = new NodeGraph(inst, ctx);
 
     graph.sendMessage("tg1/sensor", createMessage({ type: "probe-noise", origin: "player", payload: {} }));
-    graph.tick(6);
+    graph.tick(8);
     assert.equal(graph.getNodeState("tg1/alarm").triggered, true);
     assert.equal(ctx.calls.startTrace?.length, 1);
   });
@@ -681,7 +681,7 @@ describe("noisy-sensor: first probe per window raises alert, subsequent suppress
     assert.equal(ctx.calls.setGlobalAlert?.length, 1);
   });
 
-  it("raises alert again after cooldown expires (4 ticks)", () => {
+  it("raises alert again after cooldown expires (5 ticks, grade D)", () => {
     const ctx = mockCtx();
     const inst = instantiate(noisySensor, "ns1");
     const graph = new NodeGraph(inst, ctx);
@@ -689,7 +689,7 @@ describe("noisy-sensor: first probe per window raises alert, subsequent suppress
     graph.sendMessage("ns1/sensor", createMessage({ type: "probe-noise", origin: "player", payload: {} }));
     assert.equal(ctx.calls.setGlobalAlert?.length, 1);
 
-    graph.tick(4); // expire the 4-tick cooldown
+    graph.tick(5); // expire the 5-tick cooldown (grade D)
     graph.sendMessage("ns1/sensor", createMessage({ type: "probe-noise", origin: "player", payload: {} }));
     assert.equal(ctx.calls.setGlobalAlert?.length, 2); // second window, second alert
   });

--- a/js/core/node-graph/operators.js
+++ b/js/core/node-graph/operators.js
@@ -17,6 +17,24 @@
  * @typedef {(config: OperatorConfig, nodeAttributes: Record<string, any>, message: Message | null, ctx: CtxInterface) => OperatorResult} OperatorFn
  */
 
+/**
+ * Resolve a timing value from a grade table or fall back to a fixed value.
+ * Operators can declare e.g. `periodTable: { S: 20, A: 25, B: 30, C: 40, D: 50, F: 60 }`
+ * alongside `period: 30`. If the table exists, the node's grade selects the value.
+ * @param {Record<string, any>} config - operator config
+ * @param {Record<string, any>} attrs - node attributes (must include `grade`)
+ * @param {string} field - base field name (e.g. "period", "ticks")
+ * @returns {number}
+ */
+function resolveGradedTiming(config, attrs, field) {
+  const table = config[field + "Table"];
+  if (table) {
+    const grade = attrs.grade ?? "D";
+    return table[grade] ?? table["D"] ?? config[field] ?? 1;
+  }
+  return config[field] ?? 1;
+}
+
 /** @type {Map<string, OperatorFn>} */
 const _registry = new Map();
 
@@ -172,7 +190,7 @@ registerOperator("latch", (_config, _attrs, message, _ctx) => {
  */
 registerOperator("clock", (config, attrs, message, _ctx) => {
   if (!message || message.type !== "tick") return {};
-  const period = config.period ?? 1;
+  const period = resolveGradedTiming(config, attrs, "period");
   const ticks = (attrs._clock_ticks ?? 0) + 1;
   if (ticks >= period) {
     return {
@@ -193,7 +211,7 @@ registerOperator("clock", (config, attrs, message, _ctx) => {
 registerOperator("delay", (config, attrs, message, _ctx) => {
   if (!message) return {};
 
-  const delayTicks = config.ticks ?? 1;
+  const delayTicks = resolveGradedTiming(config, attrs, "ticks");
   /** @type {Array<{type: string, payload: Record<string,any>, destinations: string[]|null, remaining: number}>} */
   const queue = (attrs._delay_queue ?? []).map((/** @type {any} */ e) => ({ ...e }));
 
@@ -273,7 +291,7 @@ registerOperator("flag", (config, _attrs, message, _ctx) => {
  */
 registerOperator("watchdog", (config, attrs, message, _ctx) => {
   if (!message) return {};
-  const period = config.period ?? 5;
+  const period = resolveGradedTiming(config, attrs, "period");
   if (message.type === "tick") {
     const ticks = (attrs._watchdog_ticks ?? 0) + 1;
     if (ticks >= period) {
@@ -439,7 +457,7 @@ registerOperator("timed-action", (config, attrs, message, _ctx) => {
 
 registerOperator("debounce", (config, attrs, message, _ctx) => {
   if (!message) return {};
-  const ticks = config.ticks ?? 1;
+  const ticks = resolveGradedTiming(config, attrs, "ticks");
 
   if (message.type === "tick") {
     const cooldown = attrs._debounce_cooldown ?? 0;

--- a/js/core/node-graph/types.js
+++ b/js/core/node-graph/types.js
@@ -28,7 +28,9 @@
  * @property {string[]} [inputs]      - any-of / all-of: list of origin nodeIds to track
  * @property {string[] | null} [destinations] - relay/debounce: override outgoing destinations (null = broadcast)
  * @property {number} [period]        - clock / watchdog: emit / timeout every N ticks
+ * @property {Record<string, number>} [periodTable] - clock / watchdog: grade → period ticks
  * @property {number} [ticks]         - delay / debounce: re-emit after / suppress for N ticks
+ * @property {Record<string, number>} [ticksTable]  - delay / debounce: grade → ticks
  * @property {number} [n]             - counter: emit after N triggers
  * @property {MessageDescriptor} [emits] - counter: message to emit when threshold reached
  * @property {string} [on]            - flag / tally / debounce: message type to react to


### PR DESCRIPTION
## Summary

- Add `periodTable` / `ticksTable` support to clock, watchdog, delay, and debounce operators
- Generic `resolveGradedTiming()` helper reads node grade attribute, falls back to fixed value
- All 6 fixed timing values in set-pieces now scale with difficulty:

| Set-Piece | Operator | S | A | B | C | D | F |
|-----------|----------|---|---|---|---|---|---|
| Deadman Circuit | clock | 15 | 20 | 25 | 30 | 40 | 50 |
| Deadman Circuit | watchdog | 25 | 30 | 40 | 50 | 60 | 80 |
| Encrypted Vault | clock | 50 | 60 | 80 | 100 | 120 | 150 |
| Cascade Shutdown | watchdog | 2 | 3 | 3 | 4 | 5 | 6 |
| Tripwire Gauntlet | delay | 3 | 4 | 5 | 6 | 8 | 10 |
| Noisy Sensor | debounce | 2 | 3 | 3 | 4 | 5 | 7 |

Backward compatible — operators without a table use the existing fixed value.

## Test plan

- [x] `make check` — 600 tests pass, lint clean
- [x] Tests updated to D-grade default values
- [ ] Playtest at S/A grades to verify timing feels appropriately tight

Closes #56, closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)