### PR TITLE
Alert tuning + gate-access tests (#35, #59)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ Rules:
 6. **Fetch** from an owned node → collects macguffins, adds cash to wallet
 7. **Corrupt** an IDS node → disables alert event forwarding to security monitor
 8. Global alert rises as detection nodes fire events to security monitors
-9. At TRACE: 60-second countdown begins — jack out or lose your score
+9. At TRACE: countdown begins (30–90s by threat grade) — jack out or lose your score
 
 ## Alert System (Two-Layer)
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -293,8 +293,8 @@ upstream to its security monitor. The security monitor raises the global alert.
 
 ### The TRACE Countdown
 
-When global alert hits red and security monitors confirm active intrusion, a **60-second
-TRACE countdown** begins. The countdown shows in the HUD and sidebar. If it reaches zero,
+When global alert hits red and security monitors confirm active intrusion, a **TRACE
+countdown** begins (30–90 seconds depending on network threat grade). The countdown shows in the HUD and sidebar. If it reaches zero,
 your tether is traced back to your home node — run over, score lost.
 
 To stop it: **jack out** before zero, or **own the security monitor** and use the

--- a/js/core/alert.js
+++ b/js/core/alert.js
@@ -130,9 +130,15 @@ export function raiseGlobalAlert() {
 
 // ── Trace countdown ───────────────────────────────────────
 
+/** Trace countdown duration scales with network threat grade. */
+const TRACE_SECONDS = { S: 30, A: 40, B: 45, C: 60, D: 75, F: 90 };
+
 export function startTraceCountdown() {
-  setTraceCountdown(60);
-  emitEvent(E.ALERT_TRACE_STARTED, { seconds: 60 });
+  const s = getState();
+  const threat = s.spec?.threat ?? "C";
+  const seconds = TRACE_SECONDS[threat] ?? 60;
+  setTraceCountdown(seconds);
+  emitEvent(E.ALERT_TRACE_STARTED, { seconds });
   const timerId = scheduleRepeating(TIMER.TRACE_TICK, 1000);
   setTraceTimerId(timerId);
 }

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -16,8 +16,9 @@ import assert from "node:assert/strict";
 
 import {
   createGateway, createRouter, createIDS, createSecurityMonitor,
-  createFileserver, createWAN,
+  createFileserver, createFirewall, createWAN,
 } from "../js/core/node-graph/game-types.js";
+import { buildSetPieceMiniNetwork } from "../js/core/node-graph/mini-network.js";
 import { initGame, getState, isIceVisible, buyExploit } from "../js/core/state.js";
 import { navigateTo, navigateAway } from "../js/core/navigation.js";
 import { startIce, handleIceTick, handleIceDetect, teleportIce, ejectIce } from "../js/core/ice.js";
@@ -742,5 +743,172 @@ describe("Exploit success: neighbor visibility", () => {
       assert.equal(s.nodes[nid].visibility, "revealed",
         `${nid} should be revealed (???) after exploit, not immediately accessible`);
     }
+  });
+});
+
+// ── gate-access: nodes behind gates are inaccessible until conditions met ────
+
+/**
+ * LAN with a firewall (gateAccess: "owned") between gateway and a fileserver.
+ * gateway → firewall → fileserver
+ */
+function buildFirewallGateLAN({ startCash = 0 } = {}) {
+  return {
+    graphDef: {
+      nodes: [
+        createGateway("gateway", { attributes: { visibility: "accessible" } }),
+        createFirewall("firewall-1", { attributes: { grade: "D" } }),
+        createFileserver("hidden-fs"),
+      ],
+      edges: [["gateway", "firewall-1"], ["firewall-1", "hidden-fs"]],
+      triggers: [],
+    },
+    meta: { startNode: "gateway", startCash, moneyCost: "C", ice: null },
+  };
+}
+
+/**
+ * LAN with a router (gateAccess: "compromised") between gateway and a fileserver.
+ * gateway → router → fileserver
+ */
+function buildRouterGateLAN({ startCash = 0 } = {}) {
+  return {
+    graphDef: {
+      nodes: [
+        createGateway("gateway", { attributes: { visibility: "accessible" } }),
+        createRouter("router-gate"),
+        createFileserver("behind-router"),
+      ],
+      edges: [["gateway", "router-gate"], ["router-gate", "behind-router"]],
+      triggers: [],
+    },
+    meta: { startNode: "gateway", startCash, moneyCost: "C", ice: null },
+  };
+}
+
+describe("gate-access: nodes behind gates are inaccessible until conditions met", () => {
+
+  describe("firewall gate (gateAccess: 'owned')", () => {
+    beforeEach(() => {
+      clearAll();
+      initGame(() => buildFirewallGateLAN());
+    });
+
+    it("node behind firewall is hidden before any exploit", () => {
+      const s = getState();
+      assert.equal(s.nodes["hidden-fs"].visibility, "hidden",
+        "fileserver behind firewall should start hidden");
+    });
+
+    it("compromising the firewall does NOT reveal nodes behind it", () => {
+      const s = getState();
+      // Force exploit to succeed (roll=0 always succeeds)
+      _forceNext(RNG.COMBAT, 0);
+      _forceNext(RNG.COMBAT, 0);
+      launchExploit("firewall-1", s.player.hand[0].id);
+
+      assert.equal(s.nodes["firewall-1"].accessLevel, "compromised",
+        "firewall should be compromised after first successful exploit");
+      assert.equal(s.nodes["hidden-fs"].visibility, "hidden",
+        "fileserver behind owned-gated firewall must remain hidden when firewall is only compromised");
+    });
+
+    it("owning the firewall DOES reveal nodes behind it", () => {
+      const s = getState();
+
+      // First exploit: locked → compromised
+      _forceNext(RNG.COMBAT, 0);
+      _forceNext(RNG.COMBAT, 0);
+      launchExploit("firewall-1", s.player.hand[0].id);
+      assert.equal(s.nodes["firewall-1"].accessLevel, "compromised");
+      assert.equal(s.nodes["hidden-fs"].visibility, "hidden",
+        "precondition: still hidden after compromised");
+
+      // Second exploit: compromised → owned
+      _forceNext(RNG.COMBAT, 0);
+      _forceNext(RNG.COMBAT, 0);
+      launchExploit("firewall-1", s.player.hand[1].id);
+      assert.equal(s.nodes["firewall-1"].accessLevel, "owned",
+        "firewall should be owned after second exploit");
+      assert.equal(s.nodes["hidden-fs"].visibility, "revealed",
+        "fileserver behind firewall must be revealed once firewall is owned");
+    });
+  });
+
+  describe("router gate (gateAccess: 'compromised')", () => {
+    beforeEach(() => {
+      clearAll();
+      initGame(() => buildRouterGateLAN());
+    });
+
+    it("node behind router is hidden before exploit", () => {
+      const s = getState();
+      assert.equal(s.nodes["behind-router"].visibility, "hidden",
+        "fileserver behind router should start hidden");
+    });
+
+    it("compromising the router reveals nodes behind it", () => {
+      const s = getState();
+
+      // Force exploit success
+      _forceNext(RNG.COMBAT, 0);
+      _forceNext(RNG.COMBAT, 0);
+      launchExploit("router-gate", s.player.hand[0].id);
+
+      assert.equal(s.nodes["router-gate"].accessLevel, "compromised",
+        "router should be compromised after first successful exploit");
+      assert.equal(s.nodes["behind-router"].visibility, "revealed",
+        "fileserver behind compromised-gated router should be revealed on compromise");
+    });
+  });
+
+  describe("concealed node (quality-based gate via combination lock)", () => {
+    beforeEach(() => {
+      clearAll();
+      initGame(() => buildSetPieceMiniNetwork("combinationLock"));
+    });
+
+    it("vault starts concealed and hidden", () => {
+      const s = getState();
+      const vault = s.nodes["sp/vault"];
+      assert.ok(vault, "vault node should exist in state");
+      assert.equal(vault.concealed, true, "vault should start concealed");
+      assert.equal(vault.visibility, "hidden", "vault should start hidden");
+    });
+
+    it("vault remains hidden even when gateway neighbors are revealed", () => {
+      const s = getState();
+
+      // Probe the gateway to reveal its neighbors (the switches and gate)
+      // The vault is connected to the gate, not directly to gateway,
+      // but even if we reveal everything around it, concealed blocks it.
+      // First, exploit gateway to reveal neighbors
+      _forceNext(RNG.COMBAT, 0);
+      _forceNext(RNG.COMBAT, 0);
+      launchExploit("gateway", s.player.hand[0].id);
+
+      // Vault should still be hidden because it's concealed
+      const vault = s.nodes["sp/vault"];
+      assert.equal(vault.concealed, true, "vault must remain concealed");
+      assert.equal(vault.visibility, "hidden", "concealed vault must stay hidden");
+    });
+
+    it("vault becomes visible after all combination lock switches are activated", () => {
+      const s = getState();
+      const graph = s.nodeGraph;
+
+      // Activate all 3 switches via the node graph (same pattern as set-pieces.test.js)
+      for (const sw of ["sp/switch-a", "sp/switch-b", "sp/switch-c"]) {
+        graph.setNodeAttr(sw, "accessLevel", "owned");
+        graph.executeAction(sw, "activate");
+      }
+
+      const vault = s.nodes["sp/vault"];
+      assert.equal(vault.concealed, false,
+        "vault should no longer be concealed after all switches activated");
+      // The revealNode ctx call sets visibility to "revealed"
+      assert.notEqual(vault.visibility, "hidden",
+        "vault should be visible (revealed or accessible) after trigger fires");
+    });
   });
 });


### PR DESCRIPTION
## Summary

**#35 — Trace countdown scales by threat grade:**

| Grade | S | A | B | C | D | F |
|-------|---|---|---|---|---|---|
| Seconds | 30 | 40 | 45 | 60 | 75 | 90 |

Reads `spec.threat` from game state. Falls back to 60s if no spec.

**#59 — Gate-access integration tests (8 new tests):**

- Firewall gate (`gateAccess: "owned"`): nodes behind are hidden until firewall is owned, NOT revealed on compromise alone
- Router gate (`gateAccess: "compromised"`): nodes revealed on compromise
- Concealed node (quality-based): vault hidden until all combination lock switches activated

## Test plan

- [x] `make check` — 608 tests pass, lint clean
- [x] Tests run stable across multiple iterations
- [ ] Playtest at S-grade to verify 30s trace feels appropriately intense

Closes #35, closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)