### PR TITLE
Bot census script + playtest --json mode (#65)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ make lint          — run tsc type checker (JSDoc annotations, no emit)
 make test          — run unit + integration tests
 make check         — lint + test (run both)
 make bundle-vendor — build dist/vendor.js (Cytoscape + layout extensions)
+make census        — run bot census (50 seeds, default grades; override with SEEDS=100 THREAT=B)
 ```
 
 **`dist/vendor.js` must be built before opening the game in a browser.** It is
@@ -198,6 +199,10 @@ node scripts/playtest.js "jackout"                     # end run
 # Named state files — start from a checkpoint, run parallel scenarios
 node scripts/playtest.js --state /tmp/scenario.json reset
 node scripts/playtest.js --state /tmp/scenario.json "probe gateway"
+
+# JSON mode — structured output for scripts and LLMs
+node scripts/playtest.js --json "status"              # { events, state, log }
+node scripts/playtest.js --json "tick 50"             # captures all events during ticks
 ```
 
 ### How it works

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,16 @@ check: lint test
 bundle-vendor:
 	npx esbuild js/vendor.js --bundle --outfile=dist/vendor.js --format=iife --platform=browser --minify
 
-# Run network census report across all difficulty combos
+# Shared grade defaults for bot/census/generate targets
+THREAT ?= C
+WEALTH ?= B
+COMPLEXITY ?= C
+DEPTH ?= C
+SEEDS ?= 50
+
+# Run bot census — aggregate stats across many seeds (override: make census SEEDS=100 THREAT=B)
 census:
-	node scripts/network-census.js
+	@node scripts/bot/census.js --seeds $(SEEDS) --threat $(THREAT) --wealth $(WEALTH) --complexity $(COMPLEXITY) --depth $(DEPTH)
 
 # Run bot player against a network (override with: make bot-run NET=research-station SEED=test-1)
 NET ?= corporate-foothold
@@ -44,10 +51,6 @@ bot-run:
 	node scripts/bot/cli.js --network $(NET) $(if $(filter-out "",$(SEED)),--seed $(SEED))
 
 # Generate a network and play it with the bot
-THREAT ?= C
-WEALTH ?= B
-COMPLEXITY ?= C
-DEPTH ?= C
 gen-bot:
 	node scripts/bot/cli.js --generated --threat $(THREAT) --wealth $(WEALTH) --complexity $(COMPLEXITY) --depth $(DEPTH) $(if $(filter-out "",$(SEED)),--seed $(SEED))
 

--- a/docs/BOT-PLAYER.md
+++ b/docs/BOT-PLAYER.md
@@ -24,6 +24,27 @@ node scripts/bot/cli.js --network research-station --seed test-1 --verbose
 
 Output is a JSON `BotRunStats` object (see Stats Collected below).
 
+### Census (Aggregate Stats)
+
+```bash
+# Run 50 seeds at default grades (C/B/C/C), output JSON summary
+node scripts/bot/census.js --seeds 50
+
+# Override grades
+node scripts/bot/census.js --seeds 100 --threat B --wealth A
+
+# Include per-seed raw stats in output
+node scripts/bot/census.js --seeds 20 --threat S --wealth S --full
+
+# Via Makefile (uses shared THREAT/WEALTH/etc vars)
+make census SEEDS=100 THREAT=B
+```
+
+Output is JSON with `config`, `summary` (aggregates), and optionally `runs` (per-seed
+stats). Summary includes success rate, fail reason distribution, averages for cash/nodes/
+cards/ICE encounters, and peak alert distribution. Use for balance testing across
+difficulty grades.
+
 ---
 
 ## Architecture

--- a/docs/dev-sessions/2026-03-19-1221-playtest-harness-tooling/notes.md
+++ b/docs/dev-sessions/2026-03-19-1221-playtest-harness-tooling/notes.md
@@ -2,4 +2,33 @@
 
 _Session: 2026-03-19-1221 | Issue: #65_
 
-<!-- Running notes, decisions, and session summary -->
+## Execution Log
+
+### Phase 1+2: Bot census script ✓
+- Created `scripts/bot/census.js` — loops `runBot()` over N seeds, aggregates stats
+- JSON output with config, summary, optional per-seed runs array
+- Progress output to stderr (doesn't pollute JSON stdout)
+- Error handling: caught exceptions recorded as `failReason: "error"`
+- Repurposed `make census` target (old one pointed at missing network-census.js)
+- Added `@` prefix to suppress Make command echo for clean JSON piping
+- Smoke tested at F/F and C/B grades, --full flag, make target
+
+### Phase 3+4: Playtest --json mode ✓
+- Added `--json` global flag to playtest.js arg parsing
+- JSON mode captures structured events via listeners on all E.* event types
+- Events cloned via JSON.parse(JSON.stringify()) to avoid circular ref issues
+- LOG_ENTRY events captured separately into `log` array
+- Text event handlers (NODE_ALERT_RAISED, ACTION_FEEDBACK, etc.) skipped in JSON mode
+- `out()` routes to `capturedLog` in JSON mode, `lines` in text mode
+- Output envelope: `{ events, state, log }` — same shape for every command
+- State file persistence still works silently in JSON mode
+- Smoke tested: reset, target, probe, tick, status, actions all produce valid JSON
+
+### Phase 5: Docs ✓
+- Added `make census` to CLAUDE.md Makefile section
+- Added `--json` examples to CLAUDE.md playtest harness section
+- Added Census section to BOT-PLAYER.md
+
+## Spin-offs created
+- #86 — LLM gameplay agent (deferred)
+- #87 — Playtest harness ActionContext wiring (deferred)

--- a/docs/dev-sessions/2026-03-19-1221-playtest-harness-tooling/notes.md
+++ b/docs/dev-sessions/2026-03-19-1221-playtest-harness-tooling/notes.md
@@ -1,0 +1,5 @@
+# Playtest Harness Tooling — Notes
+
+_Session: 2026-03-19-1221 | Issue: #65_
+
+<!-- Running notes, decisions, and session summary -->

--- a/docs/dev-sessions/2026-03-19-1221-playtest-harness-tooling/plan.md
+++ b/docs/dev-sessions/2026-03-19-1221-playtest-harness-tooling/plan.md
@@ -1,0 +1,204 @@
+# Playtest Harness Tooling — Plan
+
+_Session: 2026-03-19-1221 | Issue: #65_
+
+## Strategy
+
+Two independent deliverables: **bot census script** and **playtest `--json` mode**. The census script is self-contained (new file, imports existing bot runner). The JSON mode modifies playtest.js. No dependencies between them — can be built in either order.
+
+Start with census (simpler, higher immediate value for tuning), then JSON mode.
+
+---
+
+## Phase 1: Bot census script
+
+Create `scripts/bot/census.js` that runs the bot across N seeds and aggregates stats.
+
+### Prompt
+
+Create a new file `scripts/bot/census.js` in the Starnet codebase at `/Users/lorchard/devel/starnet-game-2026`.
+
+This CLI tool runs the bot player across many seeds and produces aggregate statistics as JSON.
+
+**Pattern to follow:** Look at `scripts/bot/cli.js` for the arg parsing and network setup pattern. The census script uses the same `runBot()` function but loops over seeds.
+
+**Arg parsing:**
+- `--seeds N` (default: 50)
+- `--threat`, `--wealth`, `--complexity`, `--depth` (default: C/B/C/C)
+- `--network <name>` — use static network instead of generated
+- `--full` — include per-seed BotRunStats in output
+
+**Core logic:**
+```
+for i in 0..seeds:
+  seed = `census-${i}`
+  try:
+    stats = runBot(() => buildNetwork(seed, spec), { seed })
+    runs.push(stats)
+  catch:
+    runs.push({ success: false, failReason: "error", error: e.message })
+```
+
+**Aggregation:** Compute from the runs array:
+- `successRate` — fraction of runs with `success: true`
+- `failReasons` — count by failReason (caught, stuck, error)
+- `avgTicksElapsed`, `avgNodesOwned`, `avgCash` (cashRemaining), `avgCardsUsed`, `avgStoreVisits`, `avgIceDetections`, `avgIceEvasions` — mean of numeric fields
+- `peakAlertDistribution` — count by peakAlert value
+- `traceFiredRate` — fraction with `traceFired: true`
+
+**Output:** JSON to stdout:
+```json
+{
+  "config": { "seeds": N, "spec": { ... }, "network": "generated" | "<name>" },
+  "summary": { ... aggregates ... },
+  "runs": [ ... ]  // only with --full
+}
+```
+
+Import `runBot` from `./run.js`. Import network builders the same way `cli.js` does. Import `buildNetwork as buildGenerated` from `../../data/networks/generated.js`.
+
+For generated networks, each seed produces a different network: `buildGenerated({ seed, spec })`.
+
+After creating the file, update the Makefile: change the existing `census` target from `node scripts/network-census.js` to `node scripts/bot/census.js --seeds 50`. Add a comment.
+
+Run `make check` after changes.
+
+---
+
+## Phase 2: Census smoke test
+
+### Prompt
+
+Verify the census script works by running it with a small seed count:
+
+```bash
+node scripts/bot/census.js --seeds 5 --threat F --wealth F
+node scripts/bot/census.js --seeds 3 --threat C --wealth B --full
+```
+
+Check that:
+- Output is valid JSON
+- Summary fields are present and reasonable
+- `--full` includes the runs array
+- No crashes on generated networks
+
+Also run `make census` to verify the Makefile target works.
+
+Fix any issues found.
+
+---
+
+## Phase 3: Playtest JSON mode — event capture infrastructure
+
+Add the `--json` flag to playtest.js and wire up event capture. This phase sets up the infrastructure without changing existing text output.
+
+### Prompt
+
+Modify `scripts/playtest.js` in the Starnet codebase to add a `--json` global flag.
+
+**Arg parsing:** Add `--json` flag detection in the existing arg parsing block (around line 44-75). Set a `let jsonMode = false` variable.
+
+**Event capture:** When `jsonMode` is true, install listeners for ALL game events that capture them into a `capturedEvents` array. The events to capture (from `js/core/events.js` `E.*` constants):
+
+```javascript
+const CAPTURE_EVENTS = [
+  E.NODE_REVEALED, E.NODE_ACCESSED, E.NODE_ALERT_RAISED,
+  E.EXPLOIT_DISCLOSED, E.EXPLOIT_PARTIAL_BURN, E.EXPLOIT_SURFACE,
+  E.ALERT_GLOBAL_RAISED, E.ALERT_TRACE_STARTED, E.ALERT_TRACE_CANCELLED, E.ALERT_PROPAGATED,
+  E.PLAYER_NAVIGATED,
+  E.ICE_MOVED, E.ICE_DETECT_PENDING, E.ICE_DETECTED, E.ICE_EJECTED, E.ICE_REBOOTED, E.ICE_DISABLED,
+  E.MISSION_STARTED, E.MISSION_COMPLETE,
+  E.ACTION_FEEDBACK, E.ACTION_RESOLVED,
+  E.RUN_STARTED, E.RUN_ENDED,
+];
+```
+
+For each, register: `on(eventType, (payload) => capturedEvents.push({ type: eventType, payload }))`.
+
+Also capture LOG_ENTRY events into a separate `capturedLog` array: `on(E.LOG_ENTRY, ({ text, type }) => capturedLog.push({ text, type }))`.
+
+**Output:** After `runCmd()` and state save, instead of printing `lines` to stdout, print the JSON envelope:
+
+```javascript
+if (jsonMode) {
+  const envelope = {
+    events: capturedEvents,
+    state: serializeState(),
+    log: capturedLog,
+  };
+  console.log(JSON.stringify(envelope, null, 2));
+} else {
+  lines.forEach((line) => console.log(line));
+}
+```
+
+**Suppress text output in JSON mode:** When `jsonMode` is true, the `out()` function should still collect lines (they feed into `capturedLog` via LOG_ENTRY), but the existing event→text handlers should NOT write to `lines` since the structured events replace them. The simplest approach: when `jsonMode` is true, redefine `out` to be a no-op. The LOG_ENTRY capture handles log collection separately.
+
+Wait — actually the text handlers (lines 141-184) call `out()` which pushes to `lines`. In JSON mode we don't want those text strings, we want the raw events. But LOG_ENTRY events from console commands (status, actions, help) ARE the useful text output and should be captured.
+
+Better approach:
+- Keep `out()` as-is (writes to `lines`)
+- In JSON mode, the event→text handlers (NODE_ALERT_RAISED, ACTION_FEEDBACK, etc.) should be skipped — the raw events are captured instead
+- LOG_ENTRY should still be captured (these come from console commands)
+- At the end: JSON mode prints the envelope, text mode prints lines
+
+To skip the text handlers in JSON mode: wrap each handler registration in `if (!jsonMode)`. The event capture listeners (installed when jsonMode is true) replace them.
+
+**Special case — `reset` and `tick`:** These commands use `out()` directly (e.g. `out("[SYS] Initialized...")`). In JSON mode, these messages should go to `capturedLog` instead. Handle by making `out()` push to `capturedLog` when `jsonMode` is true, and to `lines` otherwise.
+
+**Special case — error paths:** State load failures and other error messages use `out()`. These should appear in `capturedLog` in JSON mode.
+
+Run `make check` after changes.
+
+---
+
+## Phase 4: JSON mode smoke test and fixes
+
+### Prompt
+
+Verify the JSON mode works with several commands:
+
+```bash
+node scripts/playtest.js --json reset
+node scripts/playtest.js --json "target gateway"
+node scripts/playtest.js --json "probe"
+node scripts/playtest.js --json "status"
+node scripts/playtest.js --json "tick 10"
+node scripts/playtest.js --json "actions"
+```
+
+Check that:
+- Each outputs valid JSON with `events`, `state`, and `log` fields
+- `reset` includes a populated state
+- `target gateway` shows a PLAYER_NAVIGATED event
+- `probe` shows ACTION_FEEDBACK events (start at minimum)
+- `status` shows log entries with the status text
+- `tick 10` captures any events that fire during ticks
+- `actions` shows the action listing in log entries
+- State file is still saved (check that `scripts/playtest-state.json` is updated)
+
+Fix any issues found. Run `make check`.
+
+---
+
+## Phase 5: Makefile + docs
+
+### Prompt
+
+Update the Makefile and documentation:
+
+1. Verify the `census` Makefile target works: `make census`
+
+2. Update `CLAUDE.md` — add census to the Makefile section:
+   ```
+   make census        — run bot census (50 seeds, default grades)
+   ```
+
+3. Update `CLAUDE.md` — add `--json` flag to the playtest harness usage examples:
+   ```
+   node scripts/playtest.js --json "status"          # structured JSON output
+   ```
+
+4. Update `docs/BOT-PLAYER.md` — add a Census section documenting the script usage and output format.
+
+Run `make check` after changes.

--- a/docs/dev-sessions/2026-03-19-1221-playtest-harness-tooling/spec.md
+++ b/docs/dev-sessions/2026-03-19-1221-playtest-harness-tooling/spec.md
@@ -1,0 +1,118 @@
+# Playtest Harness Tooling — Spec
+
+_Session: 2026-03-19-1221 | Issue: #65_
+
+## Problem
+
+The game has a working bot player and playtest harness, but no tools for systematic balance analysis:
+
+- No way to run many seeds and see aggregate stats (success rate, cash distribution, alert patterns)
+- Playtest harness output is human-readable text only — scripts and LLMs must parse it with regex
+- Event log is ad-hoc strings with inconsistent formatting
+
+## Deliverables
+
+### 1. Bot Census Script (`scripts/bot/census.js`)
+
+A CLI tool that runs the bot across many seeds at specified grades and produces aggregate statistics.
+
+**Usage:**
+
+```bash
+node scripts/bot/census.js --seeds 100 --threat C --wealth B
+node scripts/bot/census.js --seeds 50 --threat S --wealth A --full
+```
+
+**Flags:**
+- `--seeds N` — number of seeds to run (default: 50)
+- `--threat`, `--wealth`, `--complexity`, `--depth` — grade spec (default: C/B/C/C)
+- `--full` — include per-seed raw BotRunStats array in output
+- `--network <name>` — use a static network instead of generated (optional)
+
+**Output:** JSON to stdout. Summary object with aggregate stats:
+
+```json
+{
+  "config": { "seeds": 100, "spec": { "threat": "C", "wealth": "B", ... } },
+  "summary": {
+    "successRate": 0.82,
+    "failReasons": { "caught": 12, "stuck": 6 },
+    "avgTicksElapsed": 450,
+    "avgNodesOwned": 8.3,
+    "avgCash": 4200,
+    "avgCardsUsed": 5.1,
+    "peakAlertDistribution": { "green": 5, "yellow": 30, "red": 65 },
+    "traceFiredRate": 0.18,
+    "avgIceDetections": 2.4,
+    "avgIceEvasions": 0.8,
+    "avgStoreVisits": 1.2
+  },
+  "runs": [ ... ]  // only with --full
+}
+```
+
+**Error handling:** If a bot run throws (bad network gen, etc.), record it as `{ success: false, failReason: "error", error: "message" }` and continue. Don't crash the whole census.
+
+**Makefile:** Repurpose the existing `make census` target (currently points at missing `network-census.js`) to run the bot census with sensible defaults.
+
+### 2. JSON Mode for Playtest Harness (`--json` flag)
+
+A global flag on `scripts/playtest.js` that switches all output to structured JSON.
+
+**Usage:**
+
+```bash
+node scripts/playtest.js --json "target gateway"
+node scripts/playtest.js --json "status"
+node scripts/playtest.js --json "probe"
+node scripts/playtest.js --json "tick 50"
+```
+
+**Output envelope** (same shape for every command):
+
+```json
+{
+  "events": [
+    { "type": "PLAYER_NAVIGATED", "payload": { "nodeId": "gateway", ... } },
+    { "type": "ACTION_FEEDBACK", "payload": { "action": "probe", "phase": "start", ... } }
+  ],
+  "state": { ... },
+  "log": [
+    { "text": "[NODE] Gateway: probing...", "type": "system" }
+  ]
+}
+```
+
+**Behavior:**
+- `--json` is a global flag, not per-command — affects all output
+- `events` — typed event objects captured during command execution (replaces ad-hoc text)
+- `state` — full game state snapshot after command execution
+- `log` — log entries generated during the command (the human-readable text, preserved for reference)
+- Non-JSON output (the current text mode) is unchanged — `--json` is purely additive
+- State file persistence (save after each command) still happens silently in `--json` mode — the JSON envelope goes to stdout, the state file is a side effect
+- `reset` command includes state in the envelope
+- `tick N` includes all events that fired during the tick window
+
+**Event types** use the existing `E.*` constants from `events.js` as the `type` field. Payloads match the existing event payload shapes. No new event types needed — just capture what already fires.
+
+### Implementation approach
+
+**Census script:**
+- Import `runBot` from `scripts/bot/run.js`
+- Loop over seeds (`seed-0` through `seed-N`), collect BotRunStats array
+- Compute aggregates (mean, distribution counts)
+- Print JSON to stdout
+
+**JSON mode:**
+- Add `--json` flag parsing to playtest.js arg handling
+- When active, install a temporary event listener that captures all `E.*` events into an array
+- After command execution, serialize the envelope and print as JSON
+- Suppress the normal text output handlers (or let them write to log array instead of stdout)
+- `state` comes from `serializeState()` which already exists
+
+## Out of scope
+
+- LLM gameplay agent (#86) — deferred
+- ActionContext wiring (#87) — deferred
+- Changes to the browser UI or visual rendering
+- Changing the default (non-JSON) text output format

--- a/scripts/bot/census.js
+++ b/scripts/bot/census.js
@@ -1,0 +1,125 @@
+// @ts-check
+// Bot Census — run the bot across many seeds and aggregate stats.
+//
+// Usage:
+//   node scripts/bot/census.js --seeds 100 --threat C --wealth B
+//   node scripts/bot/census.js --seeds 50 --threat S --wealth A --full
+//   node scripts/bot/census.js --seeds 20 --network corporate-foothold
+
+import { runBot } from "./run.js";
+import { buildNetwork as buildCorporateFoothold } from "../../data/networks/corporate-foothold.js";
+import { buildNetwork as buildResearchStation } from "../../data/networks/research-station.js";
+import { buildNetwork as buildCorporateExchange } from "../../data/networks/corporate-exchange.js";
+import { buildNetwork as buildGenerated } from "../../data/networks/generated.js";
+
+const NETWORKS = {
+  "corporate-foothold": buildCorporateFoothold,
+  "research-station": buildResearchStation,
+  "corporate-exchange": buildCorporateExchange,
+};
+
+// ── Arg parsing ─────────────────────────────────────────────
+
+let seedCount = 50;
+let threat = "C", wealth = "B", complexity = "C", depth = "C";
+let networkName = null;
+let full = false;
+
+const argv = process.argv.slice(2);
+for (let i = 0; i < argv.length; i++) {
+  if (argv[i] === "--seeds" && argv[i + 1]) seedCount = parseInt(argv[++i], 10) || 50;
+  else if (argv[i] === "--threat" && argv[i + 1]) threat = argv[++i];
+  else if (argv[i] === "--wealth" && argv[i + 1]) wealth = argv[++i];
+  else if (argv[i] === "--complexity" && argv[i + 1]) complexity = argv[++i];
+  else if (argv[i] === "--depth" && argv[i + 1]) depth = argv[++i];
+  else if (argv[i] === "--network" && argv[i + 1]) networkName = argv[++i];
+  else if (argv[i] === "--full") full = true;
+}
+
+const spec = { threat, wealth, complexity, depth };
+
+// ── Run census ──────────────────────────────────────────────
+
+/** @type {any[]} */
+const runs = [];
+
+for (let i = 0; i < seedCount; i++) {
+  const seed = `census-${i}`;
+  try {
+    /** @returns {{ graphDef: any, meta: any }} */
+    const buildFn = () => {
+      if (networkName) {
+        const fn = NETWORKS[networkName];
+        if (!fn) {
+          throw new Error(`Unknown network: ${networkName}. Available: ${Object.keys(NETWORKS).join(", ")}`);
+        }
+        return fn();
+      }
+      return buildGenerated({ seed, spec });
+    };
+    const stats = runBot(buildFn, { seed });
+    runs.push(stats);
+  } catch (e) {
+    runs.push({ success: false, failReason: "error", error: e.message });
+  }
+  // Progress to stderr (doesn't pollute JSON stdout)
+  if ((i + 1) % 10 === 0 || i === seedCount - 1) {
+    process.stderr.write(`\r  ${i + 1}/${seedCount} seeds...`);
+  }
+}
+process.stderr.write("\n");
+
+// ── Aggregate ───────────────────────────────────────────────
+
+function avg(arr, field) {
+  const vals = arr.filter(r => r[field] !== undefined).map(r => r[field]);
+  if (vals.length === 0) return 0;
+  return Math.round((vals.reduce((a, b) => a + b, 0) / vals.length) * 100) / 100;
+}
+
+function countBy(arr, field) {
+  const counts = {};
+  for (const r of arr) {
+    const key = r[field] ?? "unknown";
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
+
+const successCount = runs.filter(r => r.success).length;
+const traceCount = runs.filter(r => r.traceFired).length;
+
+const summary = {
+  successRate: Math.round((successCount / runs.length) * 1000) / 1000,
+  failReasons: countBy(runs.filter(r => !r.success), "failReason"),
+  avgTicksElapsed: avg(runs, "ticksElapsed"),
+  avgNodesOwned: avg(runs, "nodesOwned"),
+  avgNodesTotal: avg(runs, "nodesTotal"),
+  avgCash: avg(runs, "cashRemaining"),
+  avgCashSpent: avg(runs, "cashSpent"),
+  avgCardsUsed: avg(runs, "cardsUsed"),
+  avgCardsBurned: avg(runs, "cardsBurned"),
+  avgStoreVisits: avg(runs, "storeVisits"),
+  peakAlertDistribution: countBy(runs, "peakAlert"),
+  traceFiredRate: Math.round((traceCount / runs.length) * 1000) / 1000,
+  avgIceDetections: avg(runs, "iceDetections"),
+  avgIceEvasions: avg(runs, "iceEvasions"),
+  avgDisarmActions: avg(runs, "disarmActionsUsed"),
+};
+
+// ── Output ──────────────────────────────────────────────────
+
+const output = {
+  config: {
+    seeds: seedCount,
+    spec,
+    network: networkName ?? "generated",
+  },
+  summary,
+};
+
+if (full) {
+  output.runs = runs;
+}
+
+console.log(JSON.stringify(output, null, 2));

--- a/scripts/playtest.js
+++ b/scripts/playtest.js
@@ -40,11 +40,14 @@ let graphFileArg = null;
 let generatedArg = false;
 let threatArg = "C", wealthArg = "B", complexityArg = "C", depthArg = "C";
 let recipeArg = null, lanGradeArg = null;
+let jsonMode = false;
 
 {
   const argv = process.argv.slice(2);
   for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === "--state" && argv[i + 1]) {
+    if (argv[i] === "--json") {
+      jsonMode = true;
+    } else if (argv[i] === "--state" && argv[i + 1]) {
       stateFile = argv[++i];
     } else if (argv[i] === "--seed" && argv[i + 1]) {
       seedArg = argv[++i];
@@ -131,57 +134,98 @@ initHeadlessEngine({
 
 // ── Event → output ─────────────────────────────────────────
 
+// In text mode: lines collects human-readable output, printed at end.
+// In JSON mode: capturedEvents/capturedLog collect structured data for the envelope.
 const lines = [];
-function out(msg) { lines.push(String(msg)); }
+/** @type {{ type: string, payload: any }[]} */
+const capturedEvents = [];
+/** @type {{ text: string, type: string }[]} */
+const capturedLog = [];
 
-// All LOG_ENTRY events → output (covers console.js command output + direct emits)
-on(E.LOG_ENTRY, ({ text }) => out(text));
+function out(msg) {
+  if (jsonMode) {
+    capturedLog.push({ text: String(msg), type: "system" });
+  } else {
+    lines.push(String(msg));
+  }
+}
 
-// Game events not covered by log-renderer (which isn't loaded in the harness)
-on(E.NODE_ALERT_RAISED,    ({ label, prev, next })     => out(`[NODE] ${label}: alert ${prev} → ${next}.`));
-on(E.NODE_ACCESSED,        ({ label, prev, next })     => out(`[NODE] ${label}: ${prev} → ${next.toUpperCase()}.`));
-on(E.NODE_REVEALED,        ({ label, unlocked })       => { if (unlocked) out(`[NODE] ${label}: node accessible.`); });
-// Timed action lifecycle
-on(E.ACTION_FEEDBACK, ({ nodeId, action, phase, durationTicks }) => {
-  const s = getState();
-  const label = s.nodes[nodeId]?.label ?? nodeId;
-  if (phase === "start") {
-    const secs = Math.round((durationTicks ?? 0) / 10);
-    out(`[${action.toUpperCase()}] ${label}: ${action === A.XPLOIT ? "executing" : "running"} (${secs}s)...`);
-  } else if (phase === "cancel") {
-    out(`[${action.toUpperCase()}] ${label}: cancelled.`);
+// LOG_ENTRY: always capture (text mode → lines, json mode → capturedLog)
+on(E.LOG_ENTRY, ({ text, type }) => {
+  if (jsonMode) {
+    capturedLog.push({ text, type: type ?? "system" });
+  } else {
+    out(text);
   }
 });
-// Action resolutions
-on(E.ACTION_RESOLVED, ({ action, label, success, detail }) => {
-  if (action === A.PROBE) out(`[NODE] ${label}: vulnerabilities scanned.`);
-  else if (action === A.XPLOIT) {
-    const d = detail ?? {};
-    out(`[EXPLOIT] ${label} — ${d.exploitName}: ${success ? "SUCCESS" : "FAIL"} (roll ${d.roll} vs ${d.successChance}%)`);
+
+if (jsonMode) {
+  // JSON mode: capture raw events into structured array
+  const CAPTURE_EVENTS = [
+    E.NODE_REVEALED, E.NODE_ACCESSED, E.NODE_ALERT_RAISED,
+    E.EXPLOIT_DISCLOSED, E.EXPLOIT_PARTIAL_BURN, E.EXPLOIT_SURFACE,
+    E.ALERT_GLOBAL_RAISED, E.ALERT_TRACE_STARTED, E.ALERT_TRACE_CANCELLED, E.ALERT_PROPAGATED,
+    E.PLAYER_NAVIGATED,
+    E.ICE_MOVED, E.ICE_DETECT_PENDING, E.ICE_DETECTED, E.ICE_EJECTED, E.ICE_REBOOTED, E.ICE_DISABLED,
+    E.MISSION_STARTED, E.MISSION_COMPLETE,
+    E.ACTION_FEEDBACK, E.ACTION_RESOLVED,
+    E.RUN_STARTED, E.RUN_ENDED,
+  ];
+  for (const eventType of CAPTURE_EVENTS) {
+    on(eventType, (payload) => {
+      // Clone payload to avoid circular refs from live state objects
+      try {
+        capturedEvents.push({ type: eventType, payload: JSON.parse(JSON.stringify(payload)) });
+      } catch {
+        capturedEvents.push({ type: eventType, payload: String(payload) });
+      }
+    });
   }
-  else if (action === A.DUMP) out(`[NODE] ${label}: ${detail?.macguffinCount ?? 0} item(s) found.`);
-  else if (action === A.FETCH) out(`[NODE] ${label}: looted ${detail?.items} item(s) — ¥${(detail?.total ?? 0).toLocaleString()}.`);
-  else if (action === A.CORRUPT) out(`[NODE] ${label}: event forwarding disabled.`);
-  else if (action === "reboot-start") out(`[NODE] ${label}: rebooting.`);
-  else if (action === "reboot-complete") out(`[NODE] ${label}: online.`);
-});
-on(E.EXPLOIT_DISCLOSED,    ({ exploitName })           => out(`[EXPLOIT] ${exploitName}: disclosed.`));
-on(E.EXPLOIT_PARTIAL_BURN, ({ exploitName, usesRemaining }) =>
-  out(`[EXPLOIT] ${exploitName}: partial burn (${usesRemaining} uses left).`));
-on(E.ALERT_GLOBAL_RAISED,  ({ prev, next })            => out(`[ALERT] Global: ${prev} → ${next.toUpperCase()}`));
-on(E.ALERT_TRACE_STARTED,   ({ seconds })               => out(`[ALERT] ⚠ TRACE INITIATED — ${seconds}s`));
-on(E.ALERT_TRACE_CANCELLED, ()                          => out(`[ALERT] Trace cancelled. Alert: RED`));
-on(E.ALERT_PROPAGATED,     ({ fromLabel, toLabel })    => out(`[ALERT] ${fromLabel} → ${toLabel}: alert propagated.`));
-on(E.ICE_MOVED,            ({ fromLabel, toLabel, fromVisible, toVisible }) => {
-  if (fromVisible || toVisible) out(`[ICE] Moving: ${fromLabel} → ${toLabel}`);
-});
-on(E.ICE_DETECTED,         ({ label })                 => out(`[ICE] ⚠ Detected at ${label}.`));
-on(E.ICE_EJECTED,          ({ fromId, toId })          => out(`[ICE] Ejected: ${fromId} → ${toId}.`));
-on(E.ICE_REBOOTED,         ({ residentLabel })         => out(`[ICE] Rebooted to ${residentLabel}.`));
-on(E.ICE_DISABLED,         ()                          => out(`[ICE] Disabled.`));
-on(E.MISSION_STARTED,      ({ targetName })            => out(`[MISSION] Target: ${targetName}`));
-on(E.MISSION_COMPLETE,     ({ targetName })            => out(`[MISSION] ★ Complete: ${targetName}`));
-on(E.RUN_ENDED,            ({ outcome })               => out(`[RUN] ${outcome.toUpperCase()}`));
+} else {
+  // Text mode: human-readable event handlers (same as before)
+  on(E.NODE_ALERT_RAISED,    ({ label, prev, next })     => out(`[NODE] ${label}: alert ${prev} → ${next}.`));
+  on(E.NODE_ACCESSED,        ({ label, prev, next })     => out(`[NODE] ${label}: ${prev} → ${next.toUpperCase()}.`));
+  on(E.NODE_REVEALED,        ({ label, unlocked })       => { if (unlocked) out(`[NODE] ${label}: node accessible.`); });
+  on(E.ACTION_FEEDBACK, ({ nodeId, action, phase, durationTicks }) => {
+    const s = getState();
+    const label = s.nodes[nodeId]?.label ?? nodeId;
+    if (phase === "start") {
+      const secs = Math.round((durationTicks ?? 0) / 10);
+      out(`[${action.toUpperCase()}] ${label}: ${action === A.XPLOIT ? "executing" : "running"} (${secs}s)...`);
+    } else if (phase === "cancel") {
+      out(`[${action.toUpperCase()}] ${label}: cancelled.`);
+    }
+  });
+  on(E.ACTION_RESOLVED, ({ action, label, success, detail }) => {
+    if (action === A.PROBE) out(`[NODE] ${label}: vulnerabilities scanned.`);
+    else if (action === A.XPLOIT) {
+      const d = detail ?? {};
+      out(`[EXPLOIT] ${label} — ${d.exploitName}: ${success ? "SUCCESS" : "FAIL"} (roll ${d.roll} vs ${d.successChance}%)`);
+    }
+    else if (action === A.DUMP) out(`[NODE] ${label}: ${detail?.macguffinCount ?? 0} item(s) found.`);
+    else if (action === A.FETCH) out(`[NODE] ${label}: looted ${detail?.items} item(s) — ¥${(detail?.total ?? 0).toLocaleString()}.`);
+    else if (action === A.CORRUPT) out(`[NODE] ${label}: event forwarding disabled.`);
+    else if (action === "reboot-start") out(`[NODE] ${label}: rebooting.`);
+    else if (action === "reboot-complete") out(`[NODE] ${label}: online.`);
+  });
+  on(E.EXPLOIT_DISCLOSED,    ({ exploitName })           => out(`[EXPLOIT] ${exploitName}: disclosed.`));
+  on(E.EXPLOIT_PARTIAL_BURN, ({ exploitName, usesRemaining }) =>
+    out(`[EXPLOIT] ${exploitName}: partial burn (${usesRemaining} uses left).`));
+  on(E.ALERT_GLOBAL_RAISED,  ({ prev, next })            => out(`[ALERT] Global: ${prev} → ${next.toUpperCase()}`));
+  on(E.ALERT_TRACE_STARTED,   ({ seconds })               => out(`[ALERT] ⚠ TRACE INITIATED — ${seconds}s`));
+  on(E.ALERT_TRACE_CANCELLED, ()                          => out(`[ALERT] Trace cancelled. Alert: RED`));
+  on(E.ALERT_PROPAGATED,     ({ fromLabel, toLabel })    => out(`[ALERT] ${fromLabel} → ${toLabel}: alert propagated.`));
+  on(E.ICE_MOVED,            ({ fromLabel, toLabel, fromVisible, toVisible }) => {
+    if (fromVisible || toVisible) out(`[ICE] Moving: ${fromLabel} → ${toLabel}`);
+  });
+  on(E.ICE_DETECTED,         ({ label })                 => out(`[ICE] ⚠ Detected at ${label}.`));
+  on(E.ICE_EJECTED,          ({ fromId, toId })          => out(`[ICE] Ejected: ${fromId} → ${toId}.`));
+  on(E.ICE_REBOOTED,         ({ residentLabel })         => out(`[ICE] Rebooted to ${residentLabel}.`));
+  on(E.ICE_DISABLED,         ()                          => out(`[ICE] Disabled.`));
+  on(E.MISSION_STARTED,      ({ targetName })            => out(`[MISSION] Target: ${targetName}`));
+  on(E.MISSION_COMPLETE,     ({ targetName })            => out(`[MISSION] ★ Complete: ${targetName}`));
+  on(E.RUN_ENDED,            ({ outcome })               => out(`[RUN] ${outcome.toUpperCase()}`));
+}
 
 // ── Main dispatch ──────────────────────────────────────────
 
@@ -246,4 +290,13 @@ try {
   out(`[SYS] Failed to save state: ${e.message}`);
 }
 
-lines.forEach((line) => console.log(line));
+if (jsonMode) {
+  const envelope = {
+    events: capturedEvents,
+    state: serializeState(),
+    log: capturedLog,
+  };
+  console.log(JSON.stringify(envelope, null, 2));
+} else {
+  lines.forEach((line) => console.log(line));
+}


### PR DESCRIPTION
## Summary

Two tools for systematic balance analysis:

**Bot census** (`scripts/bot/census.js`) — runs the bot across N seeds and outputs aggregate JSON stats:
```bash
node scripts/bot/census.js --seeds 100 --threat B --wealth A
make census SEEDS=50 THREAT=S
```

**Playtest --json mode** — global flag that switches all output to a structured JSON envelope:
```bash
node scripts/playtest.js --json "tick 50"
# → { events: [...], state: {...}, log: [...] }
```

Also spun off #86 (LLM gameplay agent) and #87 (ActionContext wiring) as separate issues.

## Test plan

- [x] `make check` — 608 tests pass, lint clean
- [x] Census: valid JSON at F/F and C/B grades, --full includes per-seed data
- [x] Census: `make census SEEDS=3` produces clean piped JSON
- [x] JSON mode: reset, target, probe, tick, status, actions all produce valid envelopes
- [x] JSON mode: state file persistence still works
- [x] Text mode: unchanged behavior (no regressions)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)