### PR TITLE
Bot player: eject ICE command (#43)

### DIFF
--- a/scripts/bot/execute.js
+++ b/scripts/bot/execute.js
@@ -134,10 +134,17 @@ function tickUntilResolved(choice, budget) {
     off(E.RUN_ENDED, onRunEnded);
   }
 
-  // If interrupted by ICE, abort the current action and untarget
+  // If interrupted by ICE: eject if we own the node (keeps action going),
+  // otherwise abort and untarget to hide.
   if (interrupted && !resolved && !runEnded) {
-    emitEvent("starnet:action", { actionId: A.ABORT, nodeId: targetNodeId });
-    emitEvent("starnet:action", { actionId: A.UNTARGET });
+    const s = getState();
+    const node = targetNodeId ? s.nodes[targetNodeId] : null;
+    if (node && node.accessLevel === "owned" && s.ice?.active && s.ice.attentionNodeId === targetNodeId) {
+      emitEvent("starnet:action", { actionId: A.EJECT, nodeId: targetNodeId });
+    } else {
+      emitEvent("starnet:action", { actionId: A.ABORT, nodeId: targetNodeId });
+      emitEvent("starnet:action", { actionId: A.UNTARGET });
+    }
   }
 
   return { completed: resolved || runEnded, interrupted, ticksUsed };

--- a/scripts/bot/heuristics/evasion.js
+++ b/scripts/bot/heuristics/evasion.js
@@ -7,6 +7,7 @@
 import { A } from "../../../js/core/action-ids.js";
 
 const STRATEGY = "evasion";
+const ICE_ON_NODE_EJECT = 850;
 const ICE_ON_NODE_CANCEL = 800;
 const TRACE_JACKOUT = 100;
 const POST_ACTION_DESELECT = 15;
@@ -19,8 +20,21 @@ export function evasionStrategy(world) {
   /** @type {ScoredAction[]} */
   const proposals = [];
 
-  // If ICE is on the currently selected node, propose deselecting
+  // If ICE is on the currently selected node:
+  // - If we own the node, eject ICE (keeps us in position)
+  // - Otherwise, untarget to hide
   if (world.ice.isOnSelectedNode && world.player.selectedNodeId) {
+    const nodeId = world.player.selectedNodeId;
+    const node = world.nodes.get(nodeId);
+    if (node && node.accessLevel === "owned") {
+      proposals.push({
+        action: A.EJECT,
+        nodeId,
+        score: ICE_ON_NODE_EJECT,
+        reason: "ICE on owned node — eject to stay in position",
+        strategy: STRATEGY,
+      });
+    }
     proposals.push({
       action: A.UNTARGET,
       nodeId: null,


### PR DESCRIPTION
## Summary

Bot now ejects ICE when it arrives at an owned node instead of always fleeing (abort + untarget). This keeps the bot in position to continue its current action.

- Evasion heuristic proposes eject (score 850) above untarget (score 800) when node is owned
- Execute layer: mid-action ICE interruption ejects if node is owned, falls back to abort+untarget otherwise
- Reboot deferred — too strategic for the dumb bot

## Test plan

- [x] `make check` — 608 tests pass, lint clean
- [x] Census at B/B: evasion strategy used 1-7 times per run, bot successfully ejects

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)