### PR TITLE
Visual preview harness (#63)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ When you notice a command being run frequently during development, consider addi
 
 ```
 index.html              — entry point, layout, loads dist/vendor.js + main.js
+preview.html            — visual preview harness (effects, shapes, alerts — no game engine)
 css/style.css           — all styles (cyberpunk vector phosphene aesthetic)
 js/
   types.js              — JSDoc @typedef definitions (no runtime code)
@@ -348,6 +349,8 @@ it is set is not testing the circuit — it's testing that assignment works.
 ---
 
 ## Design Principles
+
+- **New visual effects must be added to the preview harness.** When adding an SVG overlay, node animation, or other graph-level visual effect, add a demo node and controls for it in `preview.html` / `js/ui/preview.js`. The harness lets us test and tune effects without playing through to the right game state.
 
 - **Every visual game event must have a corresponding console log entry.** If the player can see something happen on the graph or HUD, there must be a matching textual record in the log. This is both an accessibility and a game-feel requirement — the log is the player's "decker readout" and should be a complete record of what the system is doing.
 

--- a/docs/dev-sessions/2026-03-19-1415-visual-preview-harness/notes.md
+++ b/docs/dev-sessions/2026-03-19-1415-visual-preview-harness/notes.md
@@ -1,0 +1,27 @@
+# Visual Preview Harness — Notes
+
+_Session: 2026-03-19-1415 | Issue: #63_
+
+## Execution Log
+
+### Phase 1-3: Full preview harness (combined) ✓
+- Created `preview.html` with two-panel layout (graph + control panel)
+- Created `js/ui/preview.js` — imports graph.js functions, sets up fake nodes
+- All 6 SVG overlay effects working with sliders + play/reset buttons
+- Node flash demo (success/failure/reveal) working
+- Shape gallery shows all 9 node types with distinct shapes + grade border colors
+- Alert state demos: green, yellow (pulse), red (pulse), rebooting (opacity pulse)
+- Play All / Reset All + speed control (0.5x-4x)
+- No graph.js changes needed — all functions already exported
+- Used `initGraph()` with fake network data + `getCy().add()` for positioned nodes
+- SVG overlay elements copied from index.html into preview.html
+- Verified in browser: zero console errors, all effects render correctly
+
+### Key decisions
+- Used `initGraph()` with no-op callbacks rather than trying to bypass it
+- Nodes added directly to Cytoscape via `getCy().add()` with preset positions
+- `updateNodeStyle()` with mock state objects drives shapes + alert pulses
+- graph.js imports `isIceVisible` from state.js at module level but it never executes — no game engine init needed
+
+### Phase 4: Docs ✓
+- Added `preview.html` to CLAUDE.md file structure

--- a/docs/dev-sessions/2026-03-19-1415-visual-preview-harness/plan.md
+++ b/docs/dev-sessions/2026-03-19-1415-visual-preview-harness/plan.md
@@ -1,0 +1,153 @@
+# Visual Preview Harness — Plan
+
+_Session: 2026-03-19-1415 | Issue: #63_
+
+## Strategy
+
+Build incrementally: start with a working page that shows one effect, then add the rest. The key risk is graph.js integration — once `initGraph()` works with fake data, everything else is straightforward wiring.
+
+---
+
+## Phase 0: Commit session docs
+
+---
+
+## Phase 1: Minimal preview.html + one overlay
+
+Get the foundation working: preview.html with Cytoscape, one demo node, and probe sweep.
+
+### Prompt
+
+Create `preview.html` at the project root. This is a standalone visual preview harness for testing game effects.
+
+**HTML structure:**
+- Load `dist/vendor.js` (Cytoscape) and `css/style.css`
+- Two-panel layout: left = graph container, right = control panel
+- Graph container (`#graph-container`) with `#cy` div inside, plus all 6 SVG overlay elements copied from `index.html` lines 46–101 (probe-sweep, ice-detect-sweep, loot-rings, read-sectors, exploit-brackets, selection-reticle)
+- Control panel with cyberpunk styling (dark background, monospace, cyan accents)
+- Load `js/ui/preview.js` as `type="module"`
+
+**CSS (inline or in a `<style>` block):**
+- Body: `#0a0a0f` background, monospace font, no margin
+- Two-column flexbox layout: graph takes ~65% width, controls take ~35%
+- Graph container: same styling as the game (`position: relative; overflow: hidden; background: #0a0a0f`)
+- Control panel: scrollable, padding, border-left with `var(--border)` color
+- Slider inputs styled for dark theme
+- Buttons: bordered, cyan on hover
+
+**`js/ui/preview.js`:**
+- Import `initGraph`, `syncProbeSweep`, `clearProbeSweep` from `./graph.js`
+- Define fake network data with one demo node: `{ nodes: [{ id: "demo-probe", label: "PROBE", type: "router", grade: "C" }], edges: [] }`
+- Call `initGraph(networkData, () => {}, () => {})` to initialize Cytoscape
+- After init, manually add the node to Cytoscape as visible+accessible (since initGraph starts empty and reveals nodes on demand): use `getCy()` or access the cy instance
+- Wire up a slider (0–1 range, step 0.01) that calls `syncProbeSweep("demo-probe", value)` on input
+- Wire up a "Play" button that animates the slider from 0 to 1 over 3 seconds using requestAnimationFrame
+- Wire up a "Reset" button that calls `clearProbeSweep()` and resets slider to 0
+
+**Important:** `initGraph()` starts with an empty graph and adds nodes only when they become "visible" during gameplay. For the preview, we need to add nodes directly to Cytoscape after init. Check if graph.js exports `getCy()` or if we need to add that export. The nodes need `data.type` set so the stylesheet maps their shape correctly.
+
+Also check: `addNode` is exported from graph.js and is used to add visible nodes. We may be able to call it directly with the right data shape, or we may need to add nodes via `cy.add()` after getting the cy reference.
+
+Test by opening `preview.html` in a browser via `make serve`. Verify the probe sweep renders and the slider drives it.
+
+---
+
+## Phase 2: All 6 SVG overlay effects
+
+Add the remaining 5 effects with their own demo nodes and controls.
+
+### Prompt
+
+Extend `preview.html` and `js/ui/preview.js` to include all 6 SVG overlay effects.
+
+**Add 5 more demo nodes** to the fake network, positioned in a grid or column layout so they don't overlap. Each gets a label matching its effect:
+- `demo-read` (Read Sectors)
+- `demo-loot` (Loot Rings)
+- `demo-exploit` (Exploit Brackets)
+- `demo-ice` (ICE Detection)
+- `demo-select` (Selection Reticle)
+
+**Import** the additional functions from graph.js:
+- `syncReadSectors`, `clearReadSectors`
+- `syncLootRings`, `clearLootRings`
+- `syncExploitBrackets`, `clearExploitBrackets`
+- `syncIceDetectSweep`, `clearIceDetectSweep`
+- `syncSelection`
+
+**For each effect**, add a control panel section with:
+- Effect name as header
+- Slider (0–1, step 0.01) wired to the sync function
+- Play button (animate 0→1 over 3s)
+- Reset button (clear function + reset slider)
+
+**Special cases:**
+- Loot Rings: `syncLootRings` spawns interval-based rings — the slider drives `currentLootProgress` but rings spawn over time. Play button is more natural here.
+- Exploit Brackets: also starts zap effects. Play triggers the full animation.
+- Selection Reticle: no progress — just a toggle button (on/off). `syncSelection("demo-select")` to show, `syncSelection(null)` to hide.
+
+Test each effect in the browser.
+
+---
+
+## Phase 3: Node flash + shape gallery + alert states
+
+Add the non-overlay visual features.
+
+### Prompt
+
+Extend the preview to include node flash, shape gallery, and alert state demos.
+
+**Node Flash section:**
+- One demo node (`demo-flash`)
+- Three buttons: "Success", "Failure", "Reveal"
+- Each calls `flashNode("demo-flash", type)`
+- Import `flashNode` from graph.js
+
+**Node Shape Gallery:**
+- Add a row of nodes to the graph, one per type from `NODE_SHAPES`: wan, gateway, router, firewall, workstation, ids, security-monitor, fileserver, cryptovault
+- Each labeled with its type name
+- Position them in a horizontal row below the effect demo nodes
+- Cycle grades across the gallery (F, D, C, B, A, S, F, D, C) so border colors vary
+- These are display-only — no controls needed
+
+**Node Alert States:**
+- Four demo nodes in a row: `demo-alert-green`, `demo-alert-yellow`, `demo-alert-red`, `demo-alert-reboot`
+- Import `updateNodeStyle` from graph.js
+- After adding nodes, call `updateNodeStyle` with mock state objects:
+  - Green: `{ alertState: "green", accessLevel: "owned", visibility: "accessible" }`
+  - Yellow: `{ alertState: "yellow", accessLevel: "owned", visibility: "accessible" }`
+  - Red: `{ alertState: "red", accessLevel: "owned", visibility: "accessible" }`
+  - Rebooting: `{ alertState: "green", accessLevel: "owned", visibility: "accessible", rebooting: true }`
+- The pulse animations should start automatically from `updateNodeStyle`
+
+Position all sections vertically in the graph area with enough spacing to avoid overlap.
+
+Test in browser: shapes render correctly, flash works, alert states pulse.
+
+---
+
+## Phase 4: Polish + Play All
+
+### Prompt
+
+Final polish pass:
+
+1. **"Play All" button** at the top of the control panel — triggers all 6 effects simultaneously so you can see the full visual vocabulary at once.
+
+2. **Speed control** — a dropdown or slider for animation speed (0.5x, 1x, 2x, 4x) that scales the play button duration.
+
+3. **Visual polish:**
+   - Section headers with cyan underlines
+   - Slider value display (e.g. "0.45" next to each slider)
+   - Compact layout so all controls fit without excessive scrolling
+   - Add a title: "STARNET — Visual Preview Harness"
+
+4. Add `preview.html` to `.gitignore` exclusion if needed (it's a dev tool but should be tracked).
+
+5. Update `CLAUDE.md` — add a note about `preview.html` in the architecture section.
+
+Run `make check` to verify no lint/test regressions.
+
+## Notes
+
+All needed graph.js functions are already exported: `initGraph`, `getCy`, all `sync*`/`clear*` functions, `flashNode`, `updateNodeStyle`, `syncSelection`. No graph.js changes needed.

--- a/docs/dev-sessions/2026-03-19-1415-visual-preview-harness/spec.md
+++ b/docs/dev-sessions/2026-03-19-1415-visual-preview-harness/spec.md
@@ -1,0 +1,102 @@
+# Visual Preview Harness — Spec
+
+_Session: 2026-03-19-1415 | Issue: #63_
+
+## Problem
+
+Visual effects (probe sweep, exploit brackets, loot rings, etc.) can only be seen by playing the game and reaching the right state. Designing, tuning, and debugging animations requires going through gameplay each time. There's no way to isolate and inspect an effect at a specific progress point.
+
+## Goal
+
+A standalone HTML page (`preview.html`) that renders each visual effect in isolation with interactive controls. No game engine — just a minimal Cytoscape graph with fake nodes, the existing graph.js overlay functions, and a control panel.
+
+## Approach
+
+**Lightweight / minimal Cytoscape**: stand up a small Cytoscape instance with a few positioned nodes, call the existing `graph.js` overlay functions directly with nodeId + progress values. Accepts the existing Cytoscape coupling, works within it.
+
+## Page Layout
+
+Two-panel layout in the cyberpunk aesthetic:
+
+- **Left**: Cytoscape graph container with a handful of positioned nodes (one per effect demo + a node shape gallery row)
+- **Right**: Control panel with sections for each effect
+
+## Sections
+
+### 1. SVG Overlay Effects
+
+Six effects, each with:
+- **Slider** (0–1) for manual progress scrubbing
+- **Play button** that animates 0→1 over a configurable duration (default ~3s)
+- **Label** showing effect name and current progress value
+
+Each effect targets a dedicated demo node in the graph:
+
+| Effect | Function | Data needed |
+|--------|----------|-------------|
+| Probe Sweep | `syncProbeSweep(nodeId, progress)` | nodeId + progress 0–1 |
+| Read Sectors | `syncReadSectors(nodeId, progress)` | nodeId + progress 0–1 |
+| Loot Rings | `syncLootRings(nodeId, progress)` | nodeId + progress 0–1 |
+| Exploit Brackets + Zaps | `syncExploitBrackets(nodeId, progress)` | nodeId + progress 0–1 |
+| ICE Detection Sweep | `syncIceDetectSweep(nodeId, progress)` | nodeId + progress 0–1 |
+| Selection Reticle | `syncSelection(nodeId)` | nodeId (no progress — just on/off) |
+
+Each effect has a corresponding `clear*()` function to reset it.
+
+### 2. Node Flash
+
+Three flash types triggered by buttons:
+- **Success** flash (cyan)
+- **Failure** flash (red)
+- **Reveal** flash (blue)
+
+Uses `flashNode(nodeId, type)`.
+
+### 3. Node Shape Gallery
+
+A row of nodes showing every node type with its mapped Cytoscape shape. Each node labeled with its type name. Shows all 9 explicitly mapped types plus a "default" fallback:
+
+| Type | Shape |
+|------|-------|
+| wan | barrel |
+| gateway | diamond |
+| router | ellipse |
+| firewall | pentagon |
+| workstation | ellipse |
+| ids | hexagon |
+| security-monitor | octagon |
+| fileserver | rectangle |
+| cryptovault | diamond |
+
+Also show grade colors on the shapes — the gallery nodes should cycle through grades (F through S) so you can see the border color progression.
+
+### 4. Node Alert States
+
+Demo nodes showing each alert state with their pulsing animations:
+- Green (no pulse)
+- Yellow (slow amber pulse)
+- Red (fast red pulse)
+- Rebooting (opacity pulse)
+
+Uses `updateNodeStyle(nodeId, nodeState)` with mocked state objects.
+
+## Technical Approach
+
+- **`preview.html`** — standalone page, loads `dist/vendor.js` (Cytoscape) + `css/style.css`
+- **`preview.html` must include the SVG overlay elements** from `index.html` (`#probe-sweep`, `#read-sectors`, `#loot-rings`, `#exploit-brackets`, `#ice-detect-sweep`, `#selection-reticle`) inside the graph container div — these are the DOM targets the graph.js overlay functions write to
+- **`js/ui/preview.js`** — ES module, imports from `graph.js` the overlay/flash/style functions it needs
+- Uses `initGraph()` with fake network data (all demo nodes pre-positioned) and no-op callbacks — this sets up the Cytoscape instance that overlays depend on
+- Graph.js imports `isIceVisible` from state.js at module level, but preview never calls the functions that use it — no game engine init needed
+- Graph.js may need minor exports added if some functions are currently private
+- The Cytoscape instance is initialized with a preset layout (fixed positions) — no layout algorithm needed
+- Demo nodes are plain Cytoscape elements, not game NodeDefs — just `{ data: { id, label, type }, position: { x, y } }`
+- Control panel is plain HTML/CSS in the cyberpunk aesthetic (dark background, cyan/green accents, monospace font)
+- No build step — same vanilla JS approach as the rest of the game
+
+## Out of scope
+
+- ICE HTML overlay animation (requires game state visibility checks)
+- ICE path flash / trace path (requires full graph with edges + access levels)
+- HUD elements (alert dot, trace countdown) — these are DOM elements, not graph overlays
+- Decoupling graph.js from Cytoscape — that's a future refactor
+- Exploit card UI preview — separate from graph effects

--- a/js/ui/preview.js
+++ b/js/ui/preview.js
@@ -1,0 +1,235 @@
+// @ts-nocheck — preview harness, no type checking needed
+// Visual Preview Harness — standalone effect viewer
+//
+// Initializes a minimal Cytoscape graph with demo nodes and wires up
+// controls to drive each visual effect independently.
+
+import {
+  initGraph, getCy,
+  syncProbeSweep, clearProbeSweep,
+  syncReadSectors, clearReadSectors,
+  syncLootRings, clearLootRings,
+  syncExploitBrackets, clearExploitBrackets,
+  syncIceDetectSweep, clearIceDetectSweep,
+  syncSelection,
+  flashNode,
+  updateNodeStyle,
+} from "./graph.js";
+
+// ── Demo node definitions ────────────────────────────────────
+
+// Effect demo nodes — positioned in a 2×3 grid
+const EFFECT_NODES = [
+  { id: "demo-probe",   label: "PROBE",   type: "router",     grade: "C", x: 150, y: 120 },
+  { id: "demo-read",    label: "DUMP",    type: "fileserver", grade: "C", x: 350, y: 120 },
+  { id: "demo-loot",    label: "FETCH",   type: "fileserver", grade: "B", x: 550, y: 120 },
+  { id: "demo-exploit", label: "XPLOIT",  type: "firewall",  grade: "B", x: 150, y: 280 },
+  { id: "demo-ice",     label: "ICE DET", type: "ids",        grade: "A", x: 350, y: 280 },
+  { id: "demo-select",  label: "SELECT",  type: "gateway",    grade: "C", x: 550, y: 280 },
+];
+
+// Flash demo node
+const FLASH_NODE = { id: "demo-flash", label: "FLASH", type: "router", grade: "C", x: 750, y: 200 };
+
+// Shape gallery — one per type, cycling grades
+const SHAPE_TYPES = ["wan", "gateway", "router", "firewall", "workstation", "ids", "security-monitor", "fileserver", "cryptovault"];
+const GRADES = ["F", "D", "C", "B", "A", "S"];
+const SHAPE_NODES = SHAPE_TYPES.map((type, i) => ({
+  id: `shape-${type}`,
+  label: type,
+  type,
+  grade: GRADES[i % GRADES.length],
+  x: 80 + i * 100,
+  y: 440,
+}));
+
+// Alert state demo nodes
+const ALERT_NODES = [
+  { id: "alert-green",   label: "GREEN",    type: "router", grade: "C", x: 150, y: 580 },
+  { id: "alert-yellow",  label: "YELLOW",   type: "router", grade: "C", x: 350, y: 580 },
+  { id: "alert-red",     label: "RED",      type: "router", grade: "C", x: 550, y: 580 },
+  { id: "alert-reboot",  label: "REBOOT",   type: "router", grade: "C", x: 750, y: 580 },
+];
+
+// ── Initialize Cytoscape ─────────────────────────────────────
+
+const allNodes = [...EFFECT_NODES, FLASH_NODE, ...SHAPE_NODES, ...ALERT_NODES];
+const networkData = {
+  nodes: allNodes.map(n => ({ id: n.id, label: n.label, type: n.type, grade: n.grade })),
+  edges: [],
+};
+
+initGraph(networkData, () => {}, () => {});
+
+// Add all nodes to Cytoscape with fixed positions
+const cy = getCy();
+for (const n of allNodes) {
+  cy.add({
+    data: { id: n.id, label: n.label, type: n.type, grade: n.grade },
+    position: { x: n.x, y: n.y },
+    classes: ["accessible", "owned"],
+  });
+}
+
+// Apply shapes and styles via updateNodeStyle
+for (const n of allNodes) {
+  updateNodeStyle(n.id, {
+    visibility: "accessible",
+    accessLevel: "owned",
+    alertState: "green",
+    rebooting: false,
+  });
+}
+
+// Set alert states on alert demo nodes
+updateNodeStyle("alert-yellow", { visibility: "accessible", accessLevel: "owned", alertState: "yellow", rebooting: false });
+updateNodeStyle("alert-red", { visibility: "accessible", accessLevel: "owned", alertState: "red", rebooting: false });
+updateNodeStyle("alert-reboot", { visibility: "accessible", accessLevel: "owned", alertState: "green", rebooting: true });
+
+// Fit the view to show all nodes
+cy.fit(undefined, 40);
+cy.userZoomingEnabled(true);
+cy.userPanningEnabled(true);
+
+// ── Animation helpers ────────────────────────────────────────
+
+function getSpeed() {
+  return parseFloat(document.getElementById("speed-select").value) || 1;
+}
+
+const BASE_DURATION = 3000; // ms at 1x speed
+
+/**
+ * Animate a slider from 0→1, calling syncFn on each frame.
+ * Returns an object with a cancel() method.
+ */
+function animateEffect(sliderId, valId, syncFn, nodeId) {
+  const slider = document.getElementById(sliderId);
+  const valEl = document.getElementById(valId);
+  const duration = BASE_DURATION / getSpeed();
+  const start = performance.now();
+  let cancelled = false;
+
+  function frame(now) {
+    if (cancelled) return;
+    const t = Math.min((now - start) / duration, 1);
+    slider.value = t;
+    valEl.textContent = t.toFixed(2);
+    syncFn(nodeId, t);
+    if (t < 1) requestAnimationFrame(frame);
+  }
+  requestAnimationFrame(frame);
+  return { cancel: () => { cancelled = true; } };
+}
+
+// Track running animations so reset can cancel them
+const runningAnimations = {};
+
+// ── Wire up effect controls ──────────────────────────────────
+
+const EFFECTS = [
+  {
+    name: "probe",
+    nodeId: "demo-probe",
+    sync: syncProbeSweep,
+    clear: clearProbeSweep,
+  },
+  {
+    name: "read",
+    nodeId: "demo-read",
+    sync: syncReadSectors,
+    clear: clearReadSectors,
+  },
+  {
+    name: "loot",
+    nodeId: "demo-loot",
+    sync: syncLootRings,
+    clear: clearLootRings,
+  },
+  {
+    name: "exploit",
+    nodeId: "demo-exploit",
+    sync: syncExploitBrackets,
+    clear: clearExploitBrackets,
+  },
+  {
+    name: "ice",
+    nodeId: "demo-ice",
+    sync: syncIceDetectSweep,
+    clear: clearIceDetectSweep,
+  },
+];
+
+for (const effect of EFFECTS) {
+  const slider = document.getElementById(`slider-${effect.name}`);
+  const valEl = document.getElementById(`val-${effect.name}`);
+  const playBtn = document.getElementById(`btn-${effect.name}-play`);
+  const resetBtn = document.getElementById(`btn-${effect.name}-reset`);
+
+  // Slider scrub
+  slider.addEventListener("input", () => {
+    const v = parseFloat(slider.value);
+    valEl.textContent = v.toFixed(2);
+    effect.sync(effect.nodeId, v);
+  });
+
+  // Play
+  playBtn.addEventListener("click", () => {
+    if (runningAnimations[effect.name]) runningAnimations[effect.name].cancel();
+    effect.clear();
+    slider.value = 0;
+    runningAnimations[effect.name] = animateEffect(
+      `slider-${effect.name}`, `val-${effect.name}`, effect.sync, effect.nodeId
+    );
+  });
+
+  // Reset
+  resetBtn.addEventListener("click", () => {
+    if (runningAnimations[effect.name]) runningAnimations[effect.name].cancel();
+    effect.clear();
+    slider.value = 0;
+    valEl.textContent = "0.00";
+  });
+}
+
+// Selection reticle toggle
+let reticleOn = false;
+document.getElementById("btn-reticle-toggle").addEventListener("click", () => {
+  reticleOn = !reticleOn;
+  syncSelection(reticleOn ? "demo-select" : null);
+  document.getElementById("btn-reticle-toggle").classList.toggle("active", reticleOn);
+});
+
+// ── Node flash ───────────────────────────────────────────────
+
+document.getElementById("btn-flash-success").addEventListener("click", () => flashNode("demo-flash", "success"));
+document.getElementById("btn-flash-failure").addEventListener("click", () => flashNode("demo-flash", "failure"));
+document.getElementById("btn-flash-reveal").addEventListener("click", () => flashNode("demo-flash", "reveal"));
+
+// ── Play All / Reset All ─────────────────────────────────────
+
+document.getElementById("btn-play-all").addEventListener("click", () => {
+  for (const effect of EFFECTS) {
+    if (runningAnimations[effect.name]) runningAnimations[effect.name].cancel();
+    effect.clear();
+    document.getElementById(`slider-${effect.name}`).value = 0;
+    runningAnimations[effect.name] = animateEffect(
+      `slider-${effect.name}`, `val-${effect.name}`, effect.sync, effect.nodeId
+    );
+  }
+});
+
+document.getElementById("btn-reset-all").addEventListener("click", () => {
+  for (const effect of EFFECTS) {
+    if (runningAnimations[effect.name]) runningAnimations[effect.name].cancel();
+    effect.clear();
+    const slider = document.getElementById(`slider-${effect.name}`);
+    slider.value = 0;
+    document.getElementById(`val-${effect.name}`).textContent = "0.00";
+  }
+  if (reticleOn) {
+    reticleOn = false;
+    syncSelection(null);
+    document.getElementById("btn-reticle-toggle").classList.remove("active");
+  }
+});

--- a/preview.html
+++ b/preview.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>STARNET — Visual Preview Harness</title>
+  <link rel="stylesheet" href="css/style.css">
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: #0a0a0f;
+      color: #00ff41;
+      font-family: "Courier New", monospace;
+      font-size: 12px;
+    }
+    #preview-layout {
+      display: flex;
+      height: 100vh;
+      width: 100vw;
+    }
+
+    /* ── Graph panel ───────────────────────────── */
+    #graph-panel {
+      flex: 1 1 65%;
+      position: relative;
+      overflow: hidden;
+      background: #0a0a0f;
+    }
+    #graph-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+    }
+    #cy {
+      width: 100%;
+      height: 100%;
+    }
+
+    /* ── Control panel ─────────────────────────── */
+    #control-panel {
+      flex: 0 0 320px;
+      overflow-y: auto;
+      padding: 12px 16px;
+      border-left: 1px solid #1a3333;
+      background: #0d0d14;
+    }
+    #control-panel h1 {
+      font-size: 14px;
+      color: #00ffff;
+      margin: 0 0 12px 0;
+      letter-spacing: 0.15em;
+    }
+    .section {
+      margin-bottom: 16px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid #112222;
+    }
+    .section:last-child { border-bottom: none; }
+    .section h2 {
+      font-size: 11px;
+      color: #00ffff;
+      margin: 0 0 6px 0;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      border-bottom: 1px solid #003333;
+      padding-bottom: 3px;
+    }
+    .section h3 {
+      font-size: 10px;
+      color: #888;
+      margin: 8px 0 4px 0;
+    }
+
+    /* Slider */
+    .effect-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin: 4px 0;
+    }
+    .effect-row label {
+      flex: 0 0 50px;
+      font-size: 10px;
+      color: #668866;
+    }
+    .effect-row input[type="range"] {
+      flex: 1;
+      accent-color: #00ffff;
+      height: 4px;
+    }
+    .effect-row .val {
+      flex: 0 0 32px;
+      font-size: 10px;
+      color: #00ff41;
+      text-align: right;
+    }
+
+    /* Buttons */
+    .btn-row {
+      display: flex;
+      gap: 4px;
+      margin: 4px 0;
+      flex-wrap: wrap;
+    }
+    button {
+      background: none;
+      border: 1px solid #1a3333;
+      color: #668866;
+      font-family: inherit;
+      font-size: 10px;
+      padding: 3px 8px;
+      cursor: pointer;
+      letter-spacing: 0.05em;
+    }
+    button:hover {
+      color: #00ffff;
+      border-color: #00ffff;
+    }
+    button.active {
+      color: #00ffff;
+      border-color: #00ffff;
+    }
+
+    /* Speed control */
+    .speed-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin: 6px 0;
+    }
+    .speed-row label { font-size: 10px; color: #668866; }
+    .speed-row select {
+      background: #0a0a0f;
+      color: #00ff41;
+      border: 1px solid #1a3333;
+      font-family: inherit;
+      font-size: 10px;
+      padding: 2px 4px;
+    }
+  </style>
+</head>
+<body>
+  <div id="preview-layout">
+    <div id="graph-panel">
+      <div id="graph-container">
+        <div id="cy"></div>
+        <!-- SVG overlay elements (same as index.html) -->
+        <svg id="probe-sweep"
+             style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
+          <path id="probe-sweep-fill" fill="rgba(0,255,255,0.18)" />
+          <circle id="probe-sweep-ring" fill="none" stroke="#00ffff" stroke-width="1" stroke-opacity="0.45" />
+        </svg>
+        <svg id="ice-detect-sweep"
+             style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
+          <path id="ice-detect-arc" fill="none" stroke="#ff00aa" stroke-width="4" stroke-linecap="round"/>
+        </svg>
+        <svg id="loot-rings"
+             style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
+        </svg>
+        <svg id="read-sectors"
+             style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
+          <path id="read-sectors-fill" fill="rgba(0,255,65,0.15)" />
+          <circle id="read-sectors-ring" fill="none" stroke="#00ff41" stroke-width="1" stroke-opacity="0.45" />
+        </svg>
+        <svg id="exploit-brackets"
+             style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
+          <defs>
+            <filter id="zap-bloom" x="-50%" y="-50%" width="200%" height="200%">
+              <feGaussianBlur in="SourceGraphic" stdDeviation="2.5" result="blur"/>
+              <feMerge>
+                <feMergeNode in="blur"/>
+                <feMergeNode in="SourceGraphic"/>
+              </feMerge>
+            </filter>
+          </defs>
+          <line id="bracket-tl-h" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+          <line id="bracket-tl-v" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+          <line id="bracket-tr-h" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+          <line id="bracket-tr-v" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+          <line id="bracket-br-h" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+          <line id="bracket-br-v" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+          <line id="bracket-bl-h" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+          <line id="bracket-bl-v" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+          <line id="zap-tl" class="exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0" filter="url(#zap-bloom)"/>
+          <line id="zap-tr" class="exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0" filter="url(#zap-bloom)"/>
+          <line id="zap-br" class="exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0" filter="url(#zap-bloom)"/>
+          <line id="zap-bl" class="exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0" filter="url(#zap-bloom)"/>
+        </svg>
+        <svg id="selection-reticle"
+             style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:6;">
+          <g id="reticle-group">
+            <circle id="reticle-ring" cx="30" cy="30" r="28"
+                    fill="none"
+                    stroke="#cc00cc"
+                    stroke-width="1.5"
+                    stroke-dasharray="6 3"
+                    stroke-opacity="0.75"/>
+            <line id="reticle-tick-n" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+            <line id="reticle-tick-s" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+            <line id="reticle-tick-e" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+            <line id="reticle-tick-w" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"/>
+          </g>
+        </svg>
+      </div>
+    </div>
+
+    <div id="control-panel">
+      <h1>STARNET PREVIEW</h1>
+
+      <!-- Global controls -->
+      <div class="section">
+        <div class="speed-row">
+          <label>Speed:</label>
+          <select id="speed-select">
+            <option value="0.5">0.5x</option>
+            <option value="1" selected>1x</option>
+            <option value="2">2x</option>
+            <option value="4">4x</option>
+          </select>
+          <button id="btn-play-all">PLAY ALL</button>
+          <button id="btn-reset-all">RESET ALL</button>
+        </div>
+      </div>
+
+      <!-- SVG Overlay Effects -->
+      <div class="section">
+        <h2>Overlay Effects</h2>
+
+        <h3>Probe Sweep</h3>
+        <div class="effect-row">
+          <label>progress</label>
+          <input type="range" id="slider-probe" min="0" max="1" step="0.01" value="0">
+          <span class="val" id="val-probe">0.00</span>
+        </div>
+        <div class="btn-row">
+          <button id="btn-probe-play">PLAY</button>
+          <button id="btn-probe-reset">RESET</button>
+        </div>
+
+        <h3>Read Sectors</h3>
+        <div class="effect-row">
+          <label>progress</label>
+          <input type="range" id="slider-read" min="0" max="1" step="0.01" value="0">
+          <span class="val" id="val-read">0.00</span>
+        </div>
+        <div class="btn-row">
+          <button id="btn-read-play">PLAY</button>
+          <button id="btn-read-reset">RESET</button>
+        </div>
+
+        <h3>Loot Rings</h3>
+        <div class="effect-row">
+          <label>progress</label>
+          <input type="range" id="slider-loot" min="0" max="1" step="0.01" value="0">
+          <span class="val" id="val-loot">0.00</span>
+        </div>
+        <div class="btn-row">
+          <button id="btn-loot-play">PLAY</button>
+          <button id="btn-loot-reset">RESET</button>
+        </div>
+
+        <h3>Exploit Brackets</h3>
+        <div class="effect-row">
+          <label>progress</label>
+          <input type="range" id="slider-exploit" min="0" max="1" step="0.01" value="0">
+          <span class="val" id="val-exploit">0.00</span>
+        </div>
+        <div class="btn-row">
+          <button id="btn-exploit-play">PLAY</button>
+          <button id="btn-exploit-reset">RESET</button>
+        </div>
+
+        <h3>ICE Detection</h3>
+        <div class="effect-row">
+          <label>progress</label>
+          <input type="range" id="slider-ice" min="0" max="1" step="0.01" value="0">
+          <span class="val" id="val-ice">0.00</span>
+        </div>
+        <div class="btn-row">
+          <button id="btn-ice-play">PLAY</button>
+          <button id="btn-ice-reset">RESET</button>
+        </div>
+
+        <h3>Selection Reticle</h3>
+        <div class="btn-row">
+          <button id="btn-reticle-toggle">TOGGLE</button>
+        </div>
+      </div>
+
+      <!-- Node Flash -->
+      <div class="section">
+        <h2>Node Flash</h2>
+        <div class="btn-row">
+          <button id="btn-flash-success">SUCCESS</button>
+          <button id="btn-flash-failure">FAILURE</button>
+          <button id="btn-flash-reveal">REVEAL</button>
+        </div>
+      </div>
+
+      <!-- Node Shapes (display only) -->
+      <div class="section">
+        <h2>Node Shape Gallery</h2>
+        <p style="color:#445544; font-size:10px; margin:2px 0;">Shapes + grade border colors shown in graph</p>
+      </div>
+
+      <!-- Alert States (display only) -->
+      <div class="section">
+        <h2>Alert States</h2>
+        <p style="color:#445544; font-size:10px; margin:2px 0;">Green / Yellow / Red / Rebooting shown in graph</p>
+      </div>
+    </div>
+  </div>
+
+  <script src="dist/vendor.js"></script>
+  <script type="module" src="js/ui/preview.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Standalone `preview.html` page for testing and tuning visual effects without playing the game.

**Overlay effects** — 6 SVG overlays with slider scrubbing + play/reset:
- Probe sweep, read sectors, loot rings, exploit brackets + zaps, ICE detection arc, selection reticle

**Node flash** — success (cyan), failure (red), reveal (blue) buttons

**Shape gallery** — all 9 node types with their Cytoscape shapes + grade border color progression

**Alert states** — green, yellow (pulse), red (pulse), rebooting (opacity pulse)

**Controls** — Play All, Reset All, speed selector (0.5x–4x)

No game engine, no graph.js changes. Uses `initGraph()` with fake network data and `getCy().add()` for positioned demo nodes.

## Test plan

- [x] `make check` — 608 tests pass, lint clean
- [x] Browser: all 6 overlays render and animate
- [x] Browser: Play All triggers all effects simultaneously
- [x] Browser: zero console errors
- [x] Browser: shape gallery shows distinct shapes
- [x] Browser: alert states pulse correctly

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)