### PR TITLE
ICE reinvention: vision spec + paradigm doc

### DIFF
--- a/docs/ICE.md
+++ b/docs/ICE.md
@@ -1,0 +1,241 @@
+# ICE — Intrusion Counter Electronics
+
+This document describes the **data-driven, multi-instance ICE model**. It is
+the evergreen paradigm reference. Player-facing mechanics live in
+`MANUAL.md`; the game-design-document lives in `SPEC.md`; this document
+describes the conceptual model and its architectural shape.
+
+For the vision that drove the design and its multi-session rollout plan, see
+`docs/dev-sessions/2026-04-24-1243-ice-reinvention/spec.md`.
+
+---
+
+## The model
+
+ICE is a first-class, data-driven entity **installed at a host node**. A LAN
+may carry zero, one, or many ICE instances. Each instance is composed from
+named atoms resolved at construction:
+
+```
+IceInstance {
+  id, typeId, hostNodeId, active, enabled,
+  focus,             // "stationary" | "roaming"
+  behaviorPattern,   // named pattern atom
+  triggers,          // list of trigger atoms
+  effects,           // list of effect atoms
+  detectionConfig,   // dwell time, alert ladder, ...
+  repeat,            // "one-shot" | { mode: "cooldown", ticks: N }
+  revealed, grade
+}
+```
+
+### Two focus classes
+
+- **Stationary** ICE is confined to its host node. It springs like a trap when
+  a player action on the host matches its trigger list. Examples: a Trapwire
+  that detonates on `on-select`, a vault honeypot that fires on `on-probe-fail`.
+- **Roaming** ICE patrols the graph. Its behavior pattern decides where to go
+  each tick (`patrol-random`, `disturbance-tracker`, `player-hunter`,
+  `sentry-radius`, etc.). It reports through its host's IDS chain the same way
+  the current singleton does.
+
+Both share the same `hostNodeId`. The host is the management anchor: owning it
+unlocks the hack verbs (§ below) that let the player uninstall, disable, or
+reprogram the ICE.
+
+### Composition from atoms
+
+Three atom types, all living in the registry at `js/core/ice/`:
+
+- **Trigger atoms** — "when does this ICE act?" — `on-select`, `on-probe`,
+  `on-exploit`, `on-exploit-fail`, `on-dwell-N-ticks`, `on-detect-presence`,
+  ...
+- **Behavior-pattern atoms** — "how does the ICE move and schedule itself?" —
+  `trap` (stationary), `patrol-random`, `patrol-route`, `disturbance-tracker`,
+  `player-hunter`, `sentry-radius`, `relocate-on-activate`, `player-avoid`,
+  `freeze`.
+- **Effect atoms** — "what does it do when it activates?" — `raise-alert`,
+  `damage-health`, `damage-deck`, `steal-cash`, `shred-card`, `degrade-card`,
+  `steal-card`, `lock-node`, `patch-vulns`, `force-reboot`, `deselect-player`,
+  `cancel-action`, `accelerate`, `broadcast-alert-adjacent`, ...
+
+Effect atoms receive a selector when they need to pick a target. Selector
+grammar: `self-host`, `player-selected`, `random-owned`, `random-compromised`,
+`random-revealed`, `adjacent-to-self`, `farthest-from-player`, `stash-tagged`.
+
+### Catalog
+
+Named presets — authored in the registry — combine all three axes. Procgen
+picks from the catalog weighted by LAN grade and host node type. Example:
+
+```
+Thief-C = {
+  focus:   "roaming",
+  pattern: "disturbance-tracker",
+  triggers: ["on-dwell-short"],
+  effects: [
+    { atom: "steal-cash", params: { amount: 50, stashSelector: "stash-tagged" } },
+    { atom: "damage-deck", params: { amount: 5 } }
+  ],
+  repeat:  { mode: "cooldown", ticks: 300 },
+  canTempDisable: true,
+  reprogramAllowlist: { effects: ["steal-cash"], stashSelectors: ["player-wallet"] }
+}
+```
+
+---
+
+## Discovery and visibility
+
+ICE starts hidden. It is revealed when any of:
+
+- The player **probes** its host (probe report enumerates installed ICE).
+- The player **dumps** its host.
+- A stationary ICE **activates** (trap springs).
+- A roaming ICE **detects** the player or enters a node the player owns.
+
+The graph uses two distinct markers:
+
+- **Host badge** on the installed-at node — revealed ICE permanently shown.
+- **Attention cursor** (red diamond) — roaming ICE's current patrol location.
+  Follows the ICE as it moves.
+
+Counter-play: `scan-for-ice` action on owned/compromised nodes reveals ICE
+without triggering it. Reveals typeId, focus, and pattern; does not reveal
+effects.
+
+---
+
+## Player resources as loss clocks
+
+Alongside the existing trace, two integer pools on `PlayerState` serve as
+additional loss conditions:
+
+- **Health** (`health: { current, max }`) — reaches 0 → run ends `burned`.
+- **Deck integrity** (`deckIntegrity: { current, max }`) — reaches 0 → run
+  ends `bricked`.
+
+Damage is monotonic within a run; jack-out resets both pools. No mid-run
+healing in the current model — attritional ICE creates decision pressure
+("push on or jack out with what I have?") rather than a treadmill.
+
+Loss clocks, unified:
+
+| Clock | Trigger | Outcome |
+|---|---|---|
+| Trace | alert → trace timer expires | `caught` |
+| Health | `health.current <= 0` | `burned` |
+| Deck integrity | `deckIntegrity.current <= 0` | `bricked` |
+| Jack out | player action | `success` / `escaped` |
+
+---
+
+## Stash and recovery gameplay
+
+Some effects create **stashes** — stolen player resources deposited into a
+node in the network. This turns attritional damage into a recovery quest:
+steal-cash drops cash somewhere the player must find; steal-card similarly.
+
+- Stash nodes are just nodes with a `stash: true` attribute. Procgen tags a
+  small number per map — often deep leaves, or nodes behind heavy IDS.
+- The `cryptowallet` node type is a stash-preset variant; dumping it reveals
+  deposits the same way dumping a macguffin-bearing node works.
+- Stash discovery is **diegetic** — the player dumps nodes to find them, no
+  HUD indicator of "you have 340¢ stashed somewhere."
+
+---
+
+## Hack / reprogram layer
+
+Once the player owns the host, a sidebar group appears listing installed ICE
+with per-ICE actions. Verbs:
+
+| Verb | Availability | Effect |
+|---|---|---|
+| `uninstall-ice` | Owned host | Removes the instance entirely |
+| `disable-ice` | Compromised host, type-gated | Disables for a short timer (type declares `canTempDisable`) |
+| `swap-pattern` | Owned host, type-gated | Swap behavior pattern from an allowed set |
+| `reprogram-effects` | Owned host, type-gated | Swap effect atoms from an allowed set |
+
+`reprogram-effects` is the most strategic: it's how a captured Thief ICE can
+be redirected to deposit stolen cash into the player's wallet instead of a
+stash node.
+
+### Cost and risk
+
+Hack verbs are not free:
+
+- **Backfire** — chance to fail, triggering the ICE hostilely once. Inverse
+  to grade.
+- **Alert bump** on every attempt, like a failed exploit.
+- **Timed action** (~3–8 s) during which roaming ICE can still detect the
+  player on the host.
+
+### Reprogram allowlists
+
+Each catalog entry declares what's legal to reprogram. A `Trapwire` won't let
+itself be turned into a thief; a `Thief-B` can have its stash selector
+redirected. Prevents "every ICE becomes a Recruited ally" from breaking the
+game.
+
+---
+
+## Alert and IDS relationship
+
+**Current model (MVP):** global alert and global trace, unchanged. Every ICE
+reports `raise-alert` through its host's IDS chain, exactly as the former
+singleton did. Multiple ICE in different zones feed the same monitor. IDS
+subversion still severs the chain for ICE whose path runs through it.
+
+**North-star model (separate session):** per-zone alert. Each ICE reports
+through a designated IDS in its zone; IDS subversion blinds only its own ICE.
+Multiple concurrent traces possible. Requires broader alert-system rethink;
+scheduled for a dedicated session.
+
+Non-alert effects (steal-cash, damage-health, etc.) do **not** route through
+IDS. They mutate state directly with their own log entries. Alert remains
+reserved for detection / surveillance fiction.
+
+---
+
+## Architectural shape
+
+- `js/core/ice/registry.js` — catalog of ICE types
+- `js/core/ice/atoms.js` — trigger + effect atom registries
+- `js/core/ice/runtime.js` — per-tick dispatcher iterating `s.ice.instances`
+- `js/core/ice/patterns/*.js` — one file per behavior pattern; pure, no DOM
+
+State: `s.ice.instances` keyed by instance id; each instance serializable
+for save/load round-tripping.
+
+Events on `js/core/events.js` include `ICE_INSTALLED`, `ICE_REVEALED`,
+`ICE_ACTIVATED`, `ICE_EFFECT_APPLIED`, `ICE_HACKED`, `ICE_STASH_DEPOSITED`.
+Existing events (`ICE_MOVED`, `ICE_DETECTED`, etc.) carry `iceId` to
+disambiguate among concurrent instances.
+
+Determinism: stash selection, backfire rolls, and probabilistic triggers use
+a named RNG stream (`RNG.ICE_EFFECT`). Bot census seeds reproduce exactly.
+
+The three parallel entry points (`js/ui/main.js`, `scripts/playtest.js`,
+`scripts/bot-player.js`) share timer wiring and action dispatch; all three
+must iterate `s.ice.instances` rather than reading a singleton.
+
+---
+
+## What this replaces
+
+The pre-reinvention ICE model was a singleton at `s.ice` with hardcoded
+grade-tiered behavior. Key differences:
+
+| Pre-reinvention | Reinvention |
+|---|---|
+| One ICE per run | Many ICE per LAN |
+| Grade (F–S) dictates movement | Named behavior-pattern atoms; grade is a procgen weight only |
+| Fixed resident node (security monitor) | Any node can host; configurable via network meta |
+| Single effect (raise-alert → trace) | Catalog of composable effect atoms |
+| Disable via owning resident | Uninstall / disable / swap / reprogram verbs on host |
+| No player health / deck integrity | Two new loss clocks |
+| No recovery gameplay from ICE effects | Stash nodes create recovery hunts |
+
+See `docs/dev-sessions/2026-04-24-1243-ice-reinvention/spec.md` for the vision
+spec and session decomposition that produced this model.

--- a/docs/dev-sessions/2026-04-24-1243-ice-reinvention/spec.md
+++ b/docs/dev-sessions/2026-04-24-1243-ice-reinvention/spec.md
@@ -1,0 +1,502 @@
+# ICE Reinvention — Vision Spec
+
+**Status:** vision / multi-session roadmap
+**Date:** 2026-04-24
+**Related issues:** closes/supersedes #36, #40, #42; partially covers #49
+
+---
+
+## 1. Motivation
+
+Today's ICE is a singleton. One entity per run, grade-tiered (F–S), with a single
+effect: raise the global alert until the trace countdown fires. Counter-play is
+three verbs (eject, reboot, disable-via-owning-resident). It has been useful as
+a prototype but is too narrow to carry long-term gameplay interest.
+
+The reinvented model makes ICE a first-class, data-driven, multi-instance system:
+
+- Multiple concurrent ICE instances per LAN, each *installed* at a host node
+- Two focus classes — **stationary** (trap) and **roaming** (patroller)
+- A catalog of named types composed from **trigger atoms**, **behavior-pattern
+  atoms**, and **effect atoms**
+- Effects well beyond raise-alert: damage player HP / deck integrity, steal cash
+  or cards into stash nodes the player must hunt down, sabotage owned nodes, etc.
+- New player resources (health, deck integrity) as additional loss clocks
+  alongside the existing trace
+- A **hack / reprogram** layer — once the host is owned, ICE can be uninstalled,
+  temporarily disabled, have its behavior pattern swapped, or its effects
+  reprogrammed (e.g. redirect a Thief ICE to deposit into the player's wallet)
+
+This spec is the multi-session **vision**. It decomposes into a sequence of
+implementation sessions, each filed as its own issue.
+
+---
+
+## 2. Taxonomy and composition model
+
+ICE becomes a first-class entity composed from named atoms. Each instance:
+
+```
+IceInstance {
+  id                      // runtime id
+  typeId                  // catalog entry, e.g. "thief-C", "trapwire-S", "defender-B"
+  hostNodeId              // install node
+  active, enabled         // lifecycle flags
+  focus: "stationary" | "roaming"
+  behaviorPattern         // name: "trap" | "patrol-random" | "patrol-route" |
+                          // "disturbance-tracker" | "player-hunter" |
+                          // "sentry-radius" | "relocate-on-activate" |
+                          // "player-avoid" | "freeze" | ...
+  triggers                // list of trigger atoms
+  effects                 // list of effect atoms
+  detectionConfig         // dwell time, per-instance alert ladder, etc.
+  repeat                  // "one-shot" | { mode: "cooldown", ticks: N }
+  revealed                // false until probed, dumped, or activated
+  grade                   // retained for procgen + tuning, not dictating movement
+}
+```
+
+**Three composition axes, all data:**
+
+- **Focus** — stationary vs. roaming. Selects which runtime dispatcher handles
+  ticks.
+- **Triggers** — what makes the ICE act. Stationary ICE can bind any node action
+  (`on-select`, `on-probe`, `on-exploit`, `on-exploit-fail`, `on-dump`,
+  `on-fetch`, etc.). Roaming ICE adds movement-based triggers
+  (`on-dwell-N-ticks`, `on-detect-player-presence`).
+- **Effects** — what it does when it acts. Effects stack; a single ICE may
+  `steal-cash` and `damage-deck` on the same activation.
+
+**Behavior pattern** is its own atom type owning movement / scheduling logic.
+`trap` is the stationary pattern; everything else is a roaming variant. Behavior
+patterns can read instance config and mutate their own state (e.g.
+`relocate-on-activate` moves the ICE after an effect fires).
+
+**Why atoms rather than inheritance:** mirrors the existing
+`js/core/node-graph/` trait system, so tooling, mental model, and tests carry
+over. Hack verbs become literal atom-list mutations on the instance.
+
+**Catalog** — named presets combining all axes, authored in a registry file.
+Example:
+
+```js
+Thief-C = {
+  focus:   "roaming",
+  pattern: "disturbance-tracker",
+  triggers: ["on-dwell-short"],
+  effects: [
+    { atom: "steal-cash",   params: { amount: 50, stashSelector: "stash-tagged" } },
+    { atom: "damage-deck",  params: { amount: 5 } }
+  ],
+  repeat: { mode: "cooldown", ticks: 300 }
+}
+```
+
+Procgen picks from the catalog weighted by LAN grade and host node type.
+
+---
+
+## 3. Effect atom catalog
+
+Each effect is a single-purpose atom with a stable name, a parameter schema,
+and a pure `apply(iceInstance, state, ctx)` function returning events. Catalog
+is declarative so hack/reprogram can swap entries at runtime.
+
+| Category | Atom id | Parameters | Effect |
+|---|---|---|---|
+| Trace | `raise-alert` | `{ amount }` | Preserves current behavior — reports through host's IDS chain |
+| Trace | `start-trace` | — | Direct trace start, bypasses escalation |
+| Resources | `damage-health` | `{ amount }` | Subtract from player HP |
+| Resources | `damage-deck` | `{ amount }` | Subtract from deck HP |
+| Cash | `steal-cash` | `{ amount, stashSelector }` | Remove cash, deposit to stash-tagged node |
+| Loot | `destroy-macguffin` | `{ selector }` | Mark a macguffin destroyed |
+| Loot | `relocate-macguffin` | `{ selector, toSelector }` | Move a macguffin between nodes |
+| Hand | `shred-card` | `{ selector }` | Remove a card from hand |
+| Hand | `degrade-card` | `{ selector, steps }` | `fresh → worn → disclosed` |
+| Hand | `steal-card` | `{ selector, stashSelector }` | Remove card, deposit to stash |
+| Sabotage | `lock-node` | `{ target }` | Revert access level — Defender ICE from #42 |
+| Sabotage | `patch-vulns` | `{ target }` | Re-patch vulnerabilities |
+| Sabotage | `force-reboot` | `{ target }` | Force target node into reboot |
+| Positional | `deselect-player` | — | Forces untarget; breaks in-progress exploit |
+| Positional | `cancel-action` | `{ kind? }` | Cancels in-flight probe/exploit/dump/fetch |
+| Self-buff | `accelerate` | `{ factor, duration }` | Speeds own move interval |
+| Self-buff | `broadcast-alert-adjacent` | `{ amount }` | Raises alert on adjacent nodes too |
+
+### Selector grammar
+
+Most effects need to pick *what* they act on. A small selector DSL covers ~90%
+of cases:
+
+`self-host`, `player-selected`, `random-owned`, `random-compromised`,
+`random-revealed`, `adjacent-to-self`, `farthest-from-player`, `stash-tagged`.
+
+Stash nodes are just nodes with a `stash: true` attribute — selectors resolve
+against that.
+
+### Session 1 scope
+
+Every atom above exists as a named function with a unit test. Initial ICE types
+in the catalog use only `raise-alert`, `damage-health`, `damage-deck`.
+Everything else is dormant until a later session wires it into a concrete ICE
+type.
+
+---
+
+## 4. Player resources and loss conditions
+
+`PlayerState` gains two integer pools:
+
+```js
+PlayerState {
+  cash,                  // existing
+  hand,                  // existing
+  health:    { current, max },      // NEW
+  deckIntegrity: { current, max },  // NEW
+}
+```
+
+**Starting values** — set in network meta alongside `startCash` / `startHand`:
+`startHealth`, `startDeckIntegrity`. Default `100/100` each; tunable per LAN in
+procgen.
+
+**No mid-run healing or repair in MVP.** Damage is monotonic within a run;
+jack-out resets both pools. Deliberate choice so attritional ICE creates
+decision pressure rather than a treadmill.
+
+**Unified loss conditions:**
+
+| Clock | Trigger | Outcome |
+|---|---|---|
+| TRACE (existing) | Global / per-zone alert → trace timer expires | Run ends — `caught` |
+| HEALTH | `health.current <= 0` | Run ends — new outcome `burned` |
+| DECK INTEGRITY | `deckIntegrity.current <= 0` | Run ends — new outcome `bricked` |
+| JACK OUT (existing) | Player action | Run ends — `success` / `escaped` |
+
+Each loss reports its cause in the end screen.
+
+**HUD** — two new readouts next to alert/trace. Bars (not numbers) for feel,
+numeric tooltip on hover. Flash-damage feedback on drops.
+
+**Deferred to backlog:**
+- Textured health model (wounds / debuffs impairing specific actions)
+- Deck-systems inventory with named subsystems (targeting, render,
+  card-resolution, action-execution) and glitch effects — visual flicker,
+  action segfaults, retries
+- Mid-run healing via medical / augment systems
+- Persistent cross-run consequences for `burned` / `bricked`
+
+---
+
+## 5. Discovery, counter-play, and visibility
+
+**Discovery rules.** ICE installed on a node is hidden by default
+(`revealed: false`). Revealed when any of:
+
+- Player **probes** the host — probe report enumerates installed ICE (typeId,
+  grade, `dormant` flag if not yet triggered)
+- Player **dumps** the host — dump listing shows ICE alongside macguffins
+- Stationary ICE **activates** (trap springs) — revealed on that node for the
+  rest of the run
+- Roaming ICE **detects** the player or **enters a node the player owns** —
+  revealed globally for the rest of the run (matches today's "visible in owned
+  territory" rule)
+
+Once revealed, the graph shows an ICE marker on the host — visually distinct
+from the roaming-ICE attention cursor.
+
+**Graph markers:**
+
+- **Host badge** — "ICE installed here." Appears on revealed hosts. Stationary
+  ICE has only this marker.
+- **Attention cursor** (today's red diamond) — roaming ICE's current patrol
+  location; follows the ICE.
+
+**Counter-play — `scan-for-ice`.** New action on owned / compromised nodes:
+reveals installed ICE without triggering stationary triggers. Shows typeId,
+focus, and behavior pattern but **not** effects. Adjacent-scan is backlog.
+
+**Log entries** — every reveal, activation, trigger, and effect emits a log
+entry. Trap springs get prominent formatting (`!TRAP!` prefix or similar).
+
+---
+
+## 6. Hack / reprogram layer
+
+All hack verbs are actions on the host node, gated by access level. Owning the
+host adds a sidebar group listing installed ICE with per-ICE action menus.
+
+### MVP verbs
+
+| Verb | Availability | Effect | Notes |
+|---|---|---|---|
+| `uninstall-ice` | Owned host | Removes ICE instance | Table stakes |
+| `disable-ice` | Compromised host, type-gated | Sets `enabled: false` for 30–90s | Only on ICE flagged `canTempDisable: true`; weighted toward lower-grade LANs |
+| `swap-pattern` | Owned host, type-gated | Swap `behaviorPattern` from allowed set | Set may include *degenerate* patterns (`player-avoid`, `freeze`) |
+| `reprogram-effects` | Owned host, type-gated | Swap one or more effect atoms from allowed set | The "thief → mule" flow: redirect `steal-cash` stash selector to `player-wallet` |
+
+**Reprogram allowlists** — each catalog type declares what's legal to
+reprogram. `Trapwire` can't become a thief; `Thief-B` can have its stash
+selector redirected. Prevents "every ICE becomes a Recruited ally" abuse.
+
+### Cost and risk
+
+Hack verbs must not be free:
+
+- **Backfire** — each verb has a chance to fail, triggering the ICE hostilely
+  once as punishment. Probability inverse to ICE grade.
+- **Alert bump** on every hack attempt (same as failed exploit).
+- **Timed action** (~3–8 s) during which roaming ICE can still detect you.
+
+### Deferred to backlog
+- `retarget` verb (change trigger list or target selectors on installed ICE)
+- `recruit` verb (turn ICE into a pet that autonomously exploits nodes)
+- Custom atom-list editing UI (MVP is presets only)
+
+---
+
+## 7. Alert, IDS, and reporting
+
+### MVP (session 1 migration path)
+
+- Global alert and global trace persist unchanged.
+- Every ICE instance reports `raise-alert` events through the host node's
+  existing IDS chain, as today's singleton does. Multiple ICE in different
+  zones simply feed the same monitor. IDS subversion still severs chains for
+  ICE whose path runs through them.
+- Detection thresholds and trace countdown constants stay identical. Bot
+  census should show near-zero regression for carried-over networks.
+
+### North-star (separate session)
+
+- Alert becomes a per-zone computed value. A zone = subgraph of nodes feeding a
+  given security monitor.
+- Each ICE reports through a *designated* IDS in its zone (usually nearest by
+  graph distance). Reconfiguring that IDS blinds only its ICE.
+- Multiple concurrent traces possible — first to complete ends the run.
+- Security-monitor ownership cancels an active trace in its zone.
+
+### Non-alert effects
+
+Effects that aren't `raise-alert` / `start-trace` do **not** route through IDS.
+A Thief stealing cash is not an alert-raising event — it's a direct resource
+mutation with its own log entry. Keeps alert reserved for detection/surveillance
+fiction.
+
+`start-trace` skips IDS entirely — rare, reserved for apex ICE.
+
+### Explicit non-goals for this roadmap
+
+"Rethink/rebuild the alert system broadly" — Les's words, his call, filed as
+its own issue. Likely a prerequisite for session 7 (per-zone alert).
+
+---
+
+## 8. Architecture
+
+### State shape
+
+```js
+GameState {
+  ...
+  ice: {
+    instances: { [id]: IceInstance },   // was: single object
+    // global fields remain for MVP (disturbance tracking, etc.)
+    // migrate to per-instance in per-zone session
+  }
+}
+```
+
+A `getPrimaryIce()` compat shim returning the first active instance smooths
+migration for read-only sites not yet iterated. Used sparingly; removed as each
+site is converted.
+
+### Module split
+
+Three new modules under `js/core/ice/`:
+
+- `js/core/ice/registry.js` — catalog of ICE types (named presets: triggers +
+  pattern + effects + reprogram allowlists + `canTempDisable` + grade weights).
+  Pure data + selector helpers.
+- `js/core/ice/atoms.js` — effect and trigger atom registries. Each atom:
+  `{ id, schema, apply(iceInstance, state, ctx) }`. Pure, no renderer imports.
+- `js/core/ice/runtime.js` — per-tick dispatcher. Iterates
+  `s.ice.instances`, invokes each instance's behavior pattern, which fires
+  triggers and invokes effect atoms. Replaces current `js/core/ice.js`
+  monolith.
+
+Behavior patterns in `js/core/ice/patterns/` — one file per pattern (`trap.js`,
+`patrol-random.js`, `disturbance-tracker.js`, `player-hunter.js`,
+`relocate-on-activate.js`, `player-avoid.js`, `freeze.js`, `sentry-radius.js`,
+`patrol-route.js`). Each exports
+`{ id, onTick(instance, state, ctx), onTriggerFired(instance, state, ctx, triggerResult) }`.
+Pure — no DOM, no Cytoscape.
+
+### Event surface
+
+New events on `js/core/events.js`:
+
+- `ICE_INSTALLED` `{ iceId, hostNodeId, typeId }`
+- `ICE_REVEALED` `{ iceId, reason: "probe"|"dump"|"activate"|"detect" }`
+- `ICE_ACTIVATED` `{ iceId, trigger, hostNodeId }`
+- `ICE_EFFECT_APPLIED` `{ iceId, effect, result }`
+- `ICE_HACKED` `{ iceId, verb, success }`
+- `ICE_STASH_DEPOSITED` `{ nodeId, kind: "cash"|"card"|"macguffin", amount }` —
+  drives the recovery gameplay loop
+
+Existing events (`ICE_MOVED`, `ICE_EJECTED`, `ICE_REBOOTED`, `ICE_DETECTED`,
+`ICE_DETECT_PENDING`, `ICE_DISABLED`) gain `iceId` in their payloads.
+Breaking change; listeners updated in the same session as the state shape.
+
+### Determinism
+
+Every atom that rolls randomness uses a named RNG stream. New stream
+`RNG.ICE_EFFECT` for stash selection, backfire rolls, probabilistic triggers.
+Bot census seeds reproduce exactly.
+
+### Serialization
+
+Collection + per-instance structure must round-trip through save/load. Covered
+by `tests/integration/ice-serialization.test.js` — install three instances
+(stationary, roaming, disabled), serialize, deserialize, compare.
+
+### Three parallel entry points
+
+Per CLAUDE.md, `js/ui/main.js`, `scripts/playtest.js`, and
+`scripts/bot-player.js` share timer wiring and action dispatch. All three read
+`s.ice` today. All three need updating in session 1.
+
+### Test strategy for session 1
+
+- Per-atom unit tests (pure functions — cheap and thorough)
+- Pattern-handler tests (each pattern against a tiny 3-node fixture)
+- Integration test: probe reveals ICE → trigger fires → effect applies →
+  alert rises
+- Bot census regression run with default content (unchanged gameplay)
+
+---
+
+## 9. Network generation
+
+ICE placement becomes a content + procgen concern.
+
+### Meta format
+
+Today:
+```js
+meta: { ice: { grade: "B", startNode: "sec/monitor" } }
+```
+Becomes:
+```js
+meta: {
+  ice: [
+    { typeId: "patrol-B", hostNodeId: "sec/monitor" },
+    // more entries optional
+  ]
+}
+```
+
+Empty array = ICE-free network (useful for tutorials). Session 1 keeps a shim
+translating singleton declaration → one-element instances array so hand-crafted
+networks don't break.
+
+### Procgen weighting
+
+A small catalog query layer picks types by LAN grade and host node type:
+
+- **LAN grade** caps and skews the pool. F/D LANs pull from grade-F/D types;
+  C/B from F–B; A/S from the full catalog.
+- **Host node type** filters by compatibility. Roaming ICE: compatible with
+  `security-monitor`, `router`, `switch`. Stationary trap ICE: compatible with
+  `workstation`, `vault`, `cryptowallet`, macguffin-bearing types. Each catalog
+  entry declares its compatibility list.
+- **Density** — per-LAN ICE-point budget drawn from LAN grade, preventing
+  procgen dumping 15 apex ICE in one map.
+
+### Stash placement
+
+The `stash: true` attribute is set by procgen on a small number of nodes per
+map that are compatible hosts (deep leaf nodes, nodes behind multiple IDS,
+unusual types). Thief effects target stash-tagged nodes via selector. Stash
+tagging does not make the node look special — discovery is diegetic via dump.
+
+### Cryptowallet node type
+
+Small new type with one behavior: valid stash target; dump reveals deposited
+contents like macguffins. Added in the session introducing `steal-cash`, not
+session 1.
+
+### Tutorial / progression implications
+
+- F-grade LANs in `data/networks/` should get 0–1 ICE (gentle onboarding)
+- Higher-grade LANs get mixed stationary + roaming, occasional stacks
+- Session 1 only changes state shape; actual procgen selection lands later
+
+---
+
+## 10. Session decomposition and issue roadmap
+
+### New issues to file
+
+| # | Session | Scope |
+|---|---|---|
+| 1 | ICE architecture rebuild | State shape, `js/core/ice/` module split, atom/pattern/registry scaffolding, full atom catalog (tested but mostly dormant), HP + deckIntegrity pools, iceId-threaded events, bot census regression gate. One concrete ICE type ported from today's singleton so gameplay is unchanged. |
+| 2 | Stationary trap ICE + trigger system | First new real ICE type (Trapwire), configurable trigger list, host-badge reveal, `uninstall-ice` verb, MANUAL.md + docs/ICE.md updates. |
+| 3 | Thief ICE + stash + recovery loop | Thief roaming type, `stash` attribute + selector, cryptowallet node type, `steal-cash`/`shred-card`/`steal-card` wired, `ICE_STASH_DEPOSITED` log-driven discovery. |
+| 4 | Defender ICE + sabotage effects | `lock-node` wired (closes #42), `patch-vulns`, `force-reboot`, node-repair counter-play. |
+| 5 | Hack / reprogram verbs | `disable-ice` (timer), `swap-pattern`, `reprogram-effects`, reprogram allowlists, backfire rolls, installed-ICE management sidebar. |
+| 6 | Counter-play scan refinement | `scan-for-ice` deeper output, adjacent-scan exploration. |
+| 7 | Per-zone alert system | Per-zone alert computation, concurrent traces, IDS-per-ICE routing. Depends on broader alert-rethink conversation first. |
+| 8 | Procgen population & tuning | Catalog weighting, density budgets, stash placement, bot-census-driven tuning pass. |
+
+### Deferred backlog issues (not in sequence, parked)
+
+- Recruit ICE verb — autonomous pet ICE that exploits nodes for the player;
+  powerful, needs its own design pass
+- Retarget verb — change trigger list or target selectors on installed ICE;
+  subtle, needs design
+- Deck subsystems inventory + glitch effects (deeper deck integrity model)
+- Textured health model (wounds / debuffs impairing actions)
+- Mid-run healing / medical-aug system
+- Persistent cross-run consequences for `burned` / `bricked`
+- Alert system broad rethink (prerequisite for session 7)
+
+### Existing issues to update / close
+
+- **#36** (ICE system overhaul — multiple instances) — umbrella; link to
+  sessions 1 + 7; close when both merge.
+- **#40** (ICE resident node relocation) — superseded by "ICE installed in host
+  node." Close when session 1 merges.
+- **#42** (Defender ICE — reverse-access) — superseded by effect-atom model
+  (`lock-node`). Close when session 4 merges.
+- **#49** (Countermeasures beyond ICE — firewalls, honeypots) — partially
+  covered. Leave open with comment: ICE now handles effect variety;
+  firewalls-degrade-cards and honeypots remain distinct concepts that could
+  either become ICE catalog entries or stay separate countermeasure entities.
+  Revisit post-session-5.
+
+### Deliverables from this conversation
+
+1. This vision spec (`docs/dev-sessions/2026-04-24-1243-ice-reinvention/spec.md`)
+2. Paradigm doc (`docs/ICE.md`) — shorter, evergreen, sits alongside SPEC.md /
+   PROCGEN.md / BOT-PLAYER.md
+3. Filed issues per the table above
+4. Updated / closed existing issues per the table above
+
+---
+
+## Open questions / risks
+
+- **Session 1 anticlimax risk.** A lot of structural work with minimal visible
+  gameplay change. Mitigation: make the bot-census regression check the
+  definition of done; the visible change for players is "none," and that's the
+  correct outcome for a foundation session.
+- **Alert rethink sequencing.** Session 7 (per-zone alert) depends on the
+  broader alert-system rethink that Les flagged wanting. That rethink is its
+  own brainstorm conversation; don't start session 7 until it happens.
+- **Bot player maintenance.** The bot reads `s.ice.attentionNodeId` directly.
+  Session 1 must update it to iterate instances or the bot breaks silently on
+  the census. Covered in session 1 scope (see §8 "Three parallel entry
+  points").
+- **Save/load format change.** State shape change is a breaking save-format
+  change. If save files in the wild matter, a one-way migration is needed.
+  Current assumption: prototype stage, no migration burden.


### PR DESCRIPTION
## Summary

- **Vision spec** at `docs/dev-sessions/2026-04-24-1243-ice-reinvention/spec.md` — ten sections covering taxonomy, atom catalog, player resources, discovery, hack/reprogram layer, alert relationship, architecture, procgen, an 8-session implementation roadmap, and open questions.
- **Evergreen paradigm doc** at `docs/ICE.md` — concise reference for the data-driven, multi-instance ICE model. Sits alongside `SPEC.md` / `PROCGEN.md` / `BOT-PLAYER.md`.

Docs-only PR. No code changes. Follow-up work decomposes into sessions already filed as issues #92–#99, with deferred backlog items at #100–#106.

## What changes in the model

| Pre-reinvention | Reinvention |
|---|---|
| One ICE per run | Many ICE per LAN |
| Grade (F–S) dictates movement | Named behavior-pattern atoms; grade is a procgen weight |
| Fixed resident node (security monitor) | Any node can host; configurable via network meta |
| Single effect (raise-alert → trace) | Catalog of composable effect atoms |
| Disable via owning resident | Uninstall / disable / swap / reprogram verbs on host |
| No player health / deck integrity | Two new loss clocks (`burned`, `bricked`) |
| No recovery gameplay from ICE effects | Stash nodes create recovery hunts |

## Related issues

- Closes (when downstream sessions merge): #36, #40, #42
- Partially covers: #49
- Kicks off sessions: #92 (foundation), #93–#99, plus backlog #100–#106

## Test plan
- [ ] Read the vision spec end-to-end; verify sections 1–10 still reflect the current design
- [ ] Read `docs/ICE.md` cold and confirm it makes sense without the vision spec loaded
- [ ] Verify each session issue (#92–#99) references the correct spec sections and has plausible acceptance criteria
- [ ] Verify backlog issue titles + scopes (#100–#106) are actionable if picked up later
- [ ] Confirm comments on #36, #40, #42, #49 correctly describe the supersede-on-merge relationships

🤖 Generated with [Claude Code](https://claude.com/claude-code)