### PR TITLE
Fix cross-run listener leak corrupting the bot census

### DIFF
--- a/docs/BOT-PLAYER.md
+++ b/docs/BOT-PLAYER.md
@@ -255,3 +255,14 @@ These omissions are intentional — they make the bot a pessimistic baseline:
 
 Same seed + same network = identical stats. The bot uses the game's seeded PRNG
 and drives the clock deterministically via `tick()`.
+
+**Cross-run isolation.** The census runs many games in one process. The event bus
+and timer queue are process-global, so `resetGame()` (in `scripts/lib/headless-engine.js`)
+does a full `clearHandlers()` + `clearAllTimers()` + re-wire on every run. Without
+this, listeners registered by `initGraphBridge()` / `initDynamicActions()` (and the
+module-load handlers in `ice.js` / `alert.js` / `game-ctx.js`) stack up and the Nth
+run is driven by N copies of every handler — silently corrupting every seed after
+the first. Guarded by `tests/headless-run-isolation.test.js`. **If you add a new
+module-load `on(...)` listener in `js/core/`, expose it via an `init*Handlers()`
+function and add it to `wireRunHandlers()`**, or it will be wiped (browser) /
+leak (headless).

--- a/js/core/node-graph/game-ctx.js
+++ b/js/core/node-graph/game-ctx.js
@@ -305,11 +305,14 @@ export function buildGameCtx(opts = {}) {
   return ctx;
 }
 
-// ── Cancel timed actions on navigation (module-level, runs once) ──
+// ── Cancel timed actions on navigation ──
 // When the player selects a different node or deselects, cancel any in-progress
 // timed action. Critical for evasion gameplay — the player must be able to
-// disengage quickly.
-on(E.PLAYER_NAVIGATED, () => {
+// disengage quickly. Wrapped in an init function so the headless harness can
+// re-register it after clearHandlers() between runs; the browser registers it
+// once at module load (see call below).
+export function initNavigationCancelHandler() {
+  on(E.PLAYER_NAVIGATED, () => {
   const s = getState();
   const graph = s.nodeGraph;
   if (!graph) return;
@@ -339,5 +342,9 @@ on(E.PLAYER_NAVIGATED, () => {
       emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.FETCH, phase: "cancel", progress: 0 });
     }
   }
-});
+  });
+}
+
+// Register once at module load for the browser entry point (one run per page load).
+initNavigationCancelHandler();
 

--- a/scripts/lib/headless-engine.js
+++ b/scripts/lib/headless-engine.js
@@ -4,56 +4,85 @@
 //
 // Extracts the timer wiring, action context, and game init sequence that
 // was previously duplicated across entry points.
+//
+// IMPORTANT — cross-run isolation. The event bus and timer queue are
+// process-global module state. Running multiple games in one process (the bot
+// census, batch playtests) MUST start each run from a clean bus, or listeners
+// registered by initGraphBridge()/initDynamicActions()/etc. stack up and the
+// Nth run is driven by N copies of every handler. resetGame() therefore does a
+// full bus reset + re-wire on every run. See tests/headless-run-isolation.test.js.
 
 import { initGame, getState, serializeState, deserializeState } from "../../js/core/state.js";
 import { buildActionContext, initActionDispatcher } from "../../js/core/actions/action-context.js";
-import { startIce, handleIceTick, handleIceDetect } from "../../js/core/ice.js";
-import { on, off, emitEvent, E } from "../../js/core/events.js";
-import { tick, TIMER } from "../../js/core/timers.js";
-import { handleTraceTick } from "../../js/core/alert.js";
-import { initLog } from "../../js/core/log.js";
+import { startIce, handleIceTick, handleIceDetect, initIceHandlers } from "../../js/core/ice.js";
+import { handleTraceTick, initAlertHandlers } from "../../js/core/alert.js";
+import { initNavigationCancelHandler } from "../../js/core/node-graph/game-ctx.js";
 import { initGraphBridge } from "../../js/core/graph-bridge.js";
 import { initDynamicActions } from "../../js/core/console-commands/dynamic-actions.js";
+import { initLog } from "../../js/core/log.js";
+import { on, off, emitEvent, E, clearHandlers } from "../../js/core/events.js";
+import { tick, TIMER, clearAll as clearAllTimers } from "../../js/core/timers.js";
 
-// Importing alert.js registers NODE_ALERT_RAISED listeners at module load.
-// Importing ice.js registers PLAYER_NAVIGATED / ACTION_FEEDBACK listeners.
-// These side effects are needed for correct game behavior.
+/** @type {import('../../js/core/types.js').ActionContext | null} */
+let _ctx = null;
 
 /**
- * Wire timer handlers and action dispatcher. Call once per process.
- * Returns the action context for callers that need to extend it.
+ * Build the action context once per process. The per-run bus wiring that used
+ * to live here now happens in resetGame() (see module header).
  *
  * @param {{ openDarknetsStore?: (state: any) => void }} [opts]
  * @returns {{ ctx: import('../../js/core/types.js').ActionContext }}
  */
 export function initHeadlessEngine(opts = {}) {
+  _ctx = buildActionContext(opts.openDarknetsStore);
+  return { ctx: _ctx };
+}
+
+/**
+ * Register every event-bus listener and timer handler a game run depends on.
+ * Called after clearHandlers() so each run starts with exactly one copy of each.
+ */
+function wireRunHandlers() {
   // Timer → handler wiring
   on(TIMER.ICE_MOVE,   () => handleIceTick());
   on(TIMER.ICE_DETECT, (payload) => handleIceDetect(payload));
   on(TIMER.TRACE_TICK, () => handleTraceTick());
 
-  // Action dispatcher
-  const ctx = buildActionContext(opts.openDarknetsStore);
-  initActionDispatcher(ctx);
+  // Unified action dispatcher
+  if (_ctx) initActionDispatcher(_ctx);
 
-  // Log buffer (needed for getRecentLog / log command)
+  // Log buffer (registers a LOG_ENTRY listener)
   initLog();
 
-  return { ctx };
+  // Game-logic listeners that are normally auto-registered at module import.
+  // clearHandlers() wiped those, so re-register them explicitly per run.
+  initIceHandlers();
+  initAlertHandlers();
+  initNavigationCancelHandler();
+  initGraphBridge();
+  initDynamicActions();
 }
 
 /**
  * Initialize a fresh game from a network builder function.
- * Sets up graph bridge, dynamic actions, and ICE.
+ *
+ * Starts every run from a clean event bus + timer queue, then re-wires all
+ * handlers — guaranteeing run N behaves identically whether it's the first or
+ * the fiftieth game in this process.
  *
  * @param {() => { graphDef: any, meta: any }} buildNetworkFn
  * @param {string} [seed]
  * @returns {import('../../js/core/types.js').GameState}
  */
 export function resetGame(buildNetworkFn, seed) {
+  // Full reset: wipe all listeners and pending timers from any prior run.
+  clearHandlers();
+  clearAllTimers();
+
+  // Re-wire everything before building the game so init-time events are seen.
+  wireRunHandlers();
+
   const state = initGame(buildNetworkFn, seed);
-  initGraphBridge();
-  initDynamicActions();
   startIce();
   return state;
 }

--- a/tests/headless-run-isolation.test.js
+++ b/tests/headless-run-isolation.test.js
@@ -1,0 +1,42 @@
+// @ts-check
+// Regression: running multiple games in one process must not leak event-bus
+// listeners (or timers) across runs. Before the fix, resetGame() re-registered
+// initGraphBridge()/initDynamicActions() listeners every run without clearing,
+// so the Nth run was driven by N stacked copies of every bridge handler and
+// progressively corrupted — the bot census reported false "stuck" results for
+// every seed after the first.
+//
+// Honest test: run the SAME seed twice in one process and assert identical
+// observable outcomes. Same seed + same network must be fully deterministic;
+// any difference between run 1 and run 2 is cross-run contamination.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { runBot } from "../scripts/bot/run.js";
+import { buildNetwork as buildCorporateFoothold } from "../data/networks/corporate-foothold.js";
+
+test("same seed run twice in one process yields identical results", () => {
+  const buildFn = () => buildCorporateFoothold();
+  const seed = "isolation-seed-1";
+
+  const first = runBot(buildFn, { seed });
+  const second = runBot(buildFn, { seed });
+
+  assert.equal(second.success, first.success, "success differs between runs");
+  assert.equal(second.failReason, first.failReason, "failReason differs between runs");
+  assert.equal(second.nodesOwned, first.nodesOwned, "nodesOwned differs between runs");
+  assert.equal(second.cardsUsed, first.cardsUsed, "cardsUsed differs between runs");
+});
+
+test("three consecutive runs are all identical (no progressive corruption)", () => {
+  const buildFn = () => buildCorporateFoothold();
+  const seed = "isolation-seed-2";
+
+  const runs = [runBot(buildFn, { seed }), runBot(buildFn, { seed }), runBot(buildFn, { seed })];
+
+  for (let i = 1; i < runs.length; i++) {
+    assert.equal(runs[i].nodesOwned, runs[0].nodesOwned, `run ${i} nodesOwned drifted`);
+    assert.equal(runs[i].success, runs[0].success, `run ${i} success drifted`);
+  }
+});


### PR DESCRIPTION
Found while starting the core-loop tuning work (PR #111): **the multi-seed bot census has been producing garbage.**

## The bug
The census runs many games in one process. `resetGame()` re-registered `initGraphBridge()` / `initDynamicActions()` event-bus listeners on **every run with no teardown**, so the Nth run was driven by N stacked copies of every bridge handler. The corruption is progressive:

- seed 0 → plays correctly (10/12 nodes owned)
- seed 1 → owns ~1 node, "stuck"
- seed 2 → owns 0 nodes, "stuck"

So every seed after the first was meaningless. The same seed run via `cli.js` (fresh process) or as a single-seed census **wins**, but in a 20-seed loop reports "stuck" — which is where the inflated stuck-rates in recent balance analysis came from.

## The fix
`resetGame()` now does a **full bus reset + re-wire on every run**: `clearHandlers()` + `clearAllTimers()`, then re-register all timer handlers, the dispatcher, and every game-logic listener. Module-load handlers in `ice.js`/`alert.js` were already re-callable (`init*Handlers()`); the one bare top-level listener in `node-graph/game-ctx.js` (cancel-timed-actions-on-navigation) was extracted into `initNavigationCancelHandler()` so it can be re-registered too.

## Browser is unaffected
`initGame()` already clears timers, the end-screen run-again path does not re-register listeners, and the HUD new-run goes through a page reload (`level-select` sets `location.href`). The leak was headless-only.

## Verification
- New regression test `tests/headless-run-isolation.test.js` — same seed twice in one process must yield identical results (fails on `main`, passes here).
- `make check` green (620 tests, lint clean).
- Census is now **deterministic** across repeated runs and reflects real balance (foothold @ startCash 0: ~15-20% success / ~4.6 of 12 owned, vs the corrupted 0.55).

## Why it matters now
The core-loop tuning plan (#111) leans on the census as its regression gate at each phase boundary. That gate has to be trustworthy before any balance tuning. Recommend merging this first, then rebasing the tuning branch on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)