### PR TITLE
docs: correct mine census attribution (#122)

### DIFF
--- a/docs/BOT-PLAYER.md
+++ b/docs/BOT-PLAYER.md
@@ -264,6 +264,18 @@ These omissions are intentional — they make the bot a pessimistic baseline:
 - **Mine exhausted nodes** — skips nodes where `mine` is no longer available;
   no retry loops
 
+### What the census therefore cannot validate
+
+Because the bot is a supply-flush greedy baseline, it almost never falls back to
+**tight-spot** mechanics — the ones that only matter when a thinking player is
+out of matching cards, cash-poor, and under ICE pressure. `mine` is the first
+shipped example: across 100 seeds it fires ~never (corporate-foothold 0/100,
+corporate-exchange ~3/100), so the census tells us mine is bounded, deterministic,
+and curve-correct — but **nothing about whether it's balanced or a meaningful
+choice**. That judgment needs a human or LLM player (issues #122 and #86). When adding a mechanic that's a
+deliberate escape hatch rather than a primary path, don't expect the census to
+gate it.
+
 ---
 
 ## Determinism

--- a/docs/dev-sessions/2026-06-08-1031-research-pentest-action/notes.md
+++ b/docs/dev-sessions/2026-06-08-1031-research-pentest-action/notes.md
@@ -4,8 +4,14 @@
 
 Shipped the `mine` owned-node action across 5 phases + 1 review fix + 1 bot fix.
 `make check`: **639 tests green**. Census: corporate-foothold **100% deterministic**
-(byte-identical x2), corporate-exchange **53.3%** (up from 46.7% baseline). GUI verified
-via Playwright (mine yields a card, log + `status node` legible). PR #115.
+(byte-identical x2), corporate-exchange **~46% = baseline** (unchanged by mine). GUI
+verified via Playwright (mine yields a card, log + `status node` legible). PR #115.
+
+> **Correction (issue #122):** an earlier draft of this section claimed exchange rose
+> **53.3% (up from 46.7%)** "due to mine." That is **not supported by the data** — see
+> the Tuning pass below. The 53.3% came from a 30-seed run and was noise; the 100-seed
+> rate is ~46%, equal to baseline. Mine fires ~never in the supply-flush greedy bot, so
+> it cannot account for that swing. The mechanic works; the bot-impact attribution does not.
 
 ## Key design decisions (brainstorm)
 

--- a/docs/dev-sessions/2026-06-08-1031-research-pentest-action/plan.md
+++ b/docs/dev-sessions/2026-06-08-1031-research-pentest-action/plan.md
@@ -477,7 +477,7 @@ test("no proposal when nothing is minable (all exhausted)", () => {
 - [x] `make test` passes (bot perception/run still green)
 - [x] `make check` passes (638 tests)
 - [x] `node scripts/bot/census.js --seeds 30 --network corporate-foothold` — 100% success, no regression
-- [x] `node scripts/bot/census.js --seeds 30 --network corporate-exchange` — 53.3% (up from 46.7% baseline; no regression — mine converted 1 stuck + 1 timeout to success)
+- [x] `node scripts/bot/census.js --seeds 30 --network corporate-exchange` — 53.3% (no regression). **Correction (issue #122):** the "up from 46.7% baseline — mine converted 1 stuck + 1 timeout to success" attribution is **not supported**; 53.3% was 30-seed noise, the 100-seed rate is ~46% = baseline, and mine fires ~never in the greedy bot. The swing is variance, not mine.
 - [x] Re-run corporate-foothold census twice → byte-identical summary (deterministic)
 
 **Verification — manual:**


### PR DESCRIPTION
Resolves #122.

## What this does

**Corrects the unsupported attribution** that PR #115 made for `mine`:
- The corporate-exchange census swing (46.7% → 53.3%) was attributed to the `mine` action. Not supported by the data — 53.3% was a 30-seed noise reading; the 100-seed rate is ~46% = baseline, and `mine` fires ~never in the supply-flush greedy bot. The notes file already self-corrected this in its Tuning pass section; the Outcome header and the `plan.md` checklist line had not been reconciled with it.
- Fixed `notes.md` (Outcome section) and `plan.md:480` with explicit correction callouts.

**Documents the census limitation** in `docs/BOT-PLAYER.md` ("What the census therefore cannot validate") — the greedy bot is a pessimistic gate and structurally never exercises tight-spot mechanics like `mine`, so the census can confirm it is bounded/deterministic/curve-correct but cannot judge its balance or feel.

## Priority bump lives on the issue, not BACKLOG.md
Per the move from `BACKLOG.md` to issues/project: instead of editing the backlog file, **issue #86 (LLM gameplay agent)** was bumped to **P2**, taken out of `backlog`, with a comment citing #122 as the motivating case (and noting its precondition #65 is now closed). The project Priority field synced to P2.

## Not done (deliberately)
- **Option (b)** — tuning `mineStrategy` so the bot prefers mine: rejected. It would distort the pure greedy baseline just to light up a code path.
- The merged PR #115 body still contains the original claim; rewriting merged-PR history silently is worse than correcting the in-repo canonical docs.

Docs-only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
