### PR TITLE
Obscure node identity until probed (#121)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -41,8 +41,9 @@ And when they find you, the clock starts.
 ```
 
 **Network Graph** — The LAN rendered as a node graph. Your accessible nodes glow cyan.
-Unknown nodes appear as `???`. ICE appears as a red diamond when it moves onto a node
-you control.
+Nodes you've detected but not yet identified appear as unlabelled signal contacts tagged
+`sig-1`, `sig-2`, … — their real identity (id, type, grade) stays hidden until you probe
+them. ICE appears as a red diamond when it moves onto a node you control.
 
 **Node Info Panel** — Details for your targeted node: type, grade, access level, alert
 state, vulnerabilities (after probing), and available actions.
@@ -118,8 +119,11 @@ An IDS at this level can be corrupted to stop forwarding alerts.
 ### 1. Select a Node
 
 Click a node on the graph or type `target <node-id>`. Only nodes you have access to
-are targetable. Unknown `???` nodes appear on the graph when you exploit a neighboring
-node — click one to connect to it and begin working.
+are targetable. Detected-but-unidentified nodes appear as signal contacts (`sig-1`,
+`sig-2`, …) when you exploit a neighboring node — click one to connect to it and begin
+working. **Connecting does not reveal what the node is.** Its identity (id, type, grade)
+stays hidden behind the `sig-N` tag until you probe it (or land a blind exploit on it);
+until then you refer to it by that tag, both on the graph and in console commands.
 
 ### 2. Probe
 
@@ -127,10 +131,13 @@ node — click one to connect to it and begin working.
 > probe
 ```
 
-Scanning a node reveals its **vulnerabilities** — the specific weaknesses in its software
-you can exploit. Probing takes time — higher-grade nodes take longer to scan. A clockwise
-sweep animation shows progress. You can cancel a scan in progress with `abort`,
-and navigating away from the node cancels it automatically.
+Scanning a node reveals its **identity** — its id, type, and grade, which were hidden
+behind its `sig-N` tag until now — along with its **vulnerabilities**, the specific
+weaknesses in its software you can exploit. Probing takes time — higher-grade nodes take
+longer to scan. A clockwise sweep animation shows progress. You can cancel a scan in
+progress with `abort`, and navigating away from the node cancels it automatically.
+(A successful blind exploit also counts as a probe, so it reveals the node's identity
+and vulnerabilities the same way.)
 
 For most node types, probing also reveals **neighboring connections** — you'll see new
 `???` nodes appear on the graph. However, security infrastructure (firewalls, IDS,
@@ -508,7 +515,9 @@ Actions depend on the selected node's type and access level:
 
 ## CONSOLE COMMANDS
 
-The console accepts the following commands. Tab-complete works on node IDs.
+The console accepts the following commands. Tab-complete works on node IDs — and on the
+`sig-N` tags of detected-but-unidentified nodes, which you refer to by tag (not id) until
+you probe them. `status node sig-N` reports `[???]` for an unidentified node's type/grade.
 
 ```
 target <node>          Target a node. Alias: t

--- a/docs/dev-sessions/2026-06-09-0955-obscure-node-id-until-probe/notes.md
+++ b/docs/dev-sessions/2026-06-09-0955-obscure-node-id-until-probe/notes.md
@@ -1,0 +1,60 @@
+# Notes — obscure node identity until probe (#121)
+
+## Summary
+
+A discovered-but-unprobed node now hides its real identity (id, label, type, grade)
+behind its `sig-N` signal alias across **all three display channels** — graph, console,
+and the sidebar node-panel — until the player probes it or lands a blind exploit (both
+set `probed`). Connecting to / navigating into a node makes it actionable but no longer
+discloses what it is. Navigation/traversal logic itself is unchanged; this is display-only.
+
+## Implementation
+
+One predicate, consulted everywhere identity was previously gated on `visibility === "revealed"`:
+
+```js
+isObscured(node) = Boolean(node.sigAlias) && !node.probed   // js/core/state/node.js
+```
+
+- **Phase 1** — `isObscured` + unit truth-table (`state/node.js`, `node.test.js`).
+- **Phase 2** — console: `getRevealedAliases` → `getObscuredAliases`; `resolveNode`,
+  `fromNodes` completion, `cmdStatus` summary, `cmdStatusNode`, and the `actions` target
+  list all key off `isObscured`. Obscured nodes resolve/complete by alias only; `status
+  node` shows `[???]` for type/label/grade. End-to-end regression test in `commands.test.js`
+  drives the real `revealNeighbors` + `navigateTo` path.
+- **Phase 3** — graph: `node.obscured` stylesheet rule overrides the accessible label back
+  to `data(sigAlias)`; `updateNodeStyle` toggles the class and forces a generic ellipse so
+  the node type isn't telegraphed. Accessible styling otherwise retained for reachability.
+- **Phase 4** — sidebar: the "[???] UNKNOWN NODE" view triggers on `isObscured`, with hint
+  text that adapts ("Run PROBE to identify this node." once reachable).
+- **Phase 5** — MANUAL.md updated; final `make check` + bot census.
+
+## Verification
+
+- `make check`: full suite passes, lint clean.
+- **Browser (Playwright, real game):** owned gateway → `router-1` revealed as `sig-1` →
+  navigated in (accessible, unprobed). Confirmed: graph node carries classes
+  `["obscured","accessible"]`, label `sig-1`, ellipse shape; sidebar shows
+  "[???] UNKNOWN NODE / Run PROBE to identify this node"; console references it only by
+  `sig-1`. After probe completed: `obscured` class dropped, graph label → `router-1`,
+  sidebar → `[ROUTER] router-1 GRADE…`, `status node router-1` resolves by real id. No
+  console errors.
+- **Bot census:** unaffected by design — the bot reads raw state and dispatches by real id,
+  importing none of the changed modules (grep-confirmed). Easy-grade smoke (10 seeds) ~70%,
+  nodes owned normally, no crash.
+
+## Decisions of note
+
+- Gated on `probed` rather than clearing `sigAlias` on probe — the alias stays as the
+  historical signal handle; gating reads cleaner. (See spec.)
+- Scope = **full identity** (id/label/type/grade), not just the id string. This folded in a
+  pre-existing leak: `status node` already exposed type/grade for *revealed* nodes. Hiding
+  only the id would have left an obvious console oracle and broken GUI/console symmetry.
+- Obscured-accessible nodes keep accessible styling + generic ellipse + `sig-N` label, so
+  "reached" still reads distinctly from "merely revealed."
+
+## Follow-ups / observations
+
+- `window._starnetState` appears to be a stale/snapshot reference in the browser; use
+  `window.starnet.state()` for live reads when scripting Playwright verification. (Cost me a
+  `target undefined` misfire during verification — harmless, but worth remembering.)

--- a/docs/dev-sessions/2026-06-09-0955-obscure-node-id-until-probe/plan.md
+++ b/docs/dev-sessions/2026-06-09-0955-obscure-node-id-until-probe/plan.md
@@ -1,0 +1,201 @@
+# Obscure node identity until probe — Implementation Plan
+
+**Goal:** A discovered-but-unprobed node shows only its `sig-N` alias (hiding id/label/type/grade) across graph, console, and sidebar, until probe or blind-exploit success reveals it.
+
+**Approach:** Replace the scattered `visibility === "revealed"` identity checks with one predicate `isObscured(node) = !!node.sigAlias && !node.probed`, defined once in `js/core/state/node.js`. Each display channel consults it. Navigation/traversal is unchanged — only display.
+
+**Tech stack:** Vanilla JS ES modules, JSDoc `@ts-check`, node:test, Cytoscape.js (graph), Lit (components).
+
+---
+
+## Phase 1: Central predicate `isObscured`
+
+Add the pure predicate and lock its truth table with a unit test. Foundation for all later phases.
+
+**Files:**
+- Modify: `js/core/state/node.js` — add and export `isObscured(node)`.
+- Test: `js/core/state/node.test.js` — truth-table cases.
+
+**Key changes:**
+```js
+/**
+ * A node's identity (id, label, type, grade) is obscured behind its sig-N alias
+ * until the player probes it or lands a blind exploit (both set node.probed).
+ * sigAlias is assigned only on hidden→revealed, so foothold nodes (no alias) are never obscured.
+ * @param {NodeState} node
+ * @returns {boolean}
+ */
+export function isObscured(node) {
+  return Boolean(node?.sigAlias) && !node.probed;
+}
+```
+
+**Verification — automated:**
+- [ ] New test fails before the function exists, passes after.
+- [ ] `make lint` passes (JSDoc/types).
+- [ ] `make test` passes.
+
+**Truth table to assert:**
+- `{sigAlias:"sig-1", probed:false}` → true
+- `{sigAlias:"sig-1", probed:true}` → false
+- `{probed:false}` (no alias, e.g. gateway) → false
+- `{}` / undefined-ish → false
+
+---
+
+## Phase 2: Console obscures identity (the regression slice)
+
+Make every console path key identity off `isObscured` instead of `visibility === "revealed"`. Start with a failing test that reproduces the leak: an **accessible, unprobed, aliased** node must not expose its real id/label/type/grade.
+
+**Files:**
+- Modify: `js/core/console-commands/completions.js` — rename `getRevealedAliases` → `getObscuredAliases`; predicate `isObscured(n)` at the map (was `:66`) and in `fromNodes` (was `:85`).
+- Modify: `js/core/console-commands/resolvers.js` — `resolveNode`: obscured nodes resolve by alias only; exclude obscured nodes from id/label matching; update import.
+- Modify: `js/core/console-commands/cmd-status.js` — summary list (`:146-149`) partitions by `isObscured`; `cmdStatusNode` (`:205-219`) shows `[???]` for label/type/grade when obscured; update import.
+- Modify: `js/core/console-commands/commands.js` — actions `target` line (`:106-116`) lists obscured nodes by alias; update import.
+- Modify: `js/core/console-commands/index.js` — re-export rename.
+- Test: `js/core/console-commands/completions.test.js` — rename refs; add accessible-unprobed-aliased cases.
+- Test: `js/core/console-commands/resolvers.test.js` (create if absent) — accessible-unprobed node: resolvable by alias, NOT by real id/label.
+
+**Key changes (resolveNode — exclude obscured from id/label match):**
+```js
+// Accessible & NOT obscured: match by real id or label prefix.
+const byId = s.nodes[token];
+if (byId && byId.visibility === "accessible" && !isObscured(byId)) return byId;
+
+const labelMatches = Object.values(s.nodes).filter(
+  (n) => n.visibility === "accessible" && !isObscured(n) && n.label?.toLowerCase().startsWith(lower)
+);
+// ... ambiguity handling unchanged ...
+
+// Obscured nodes (revealed OR accessible-unprobed): match by alias only.
+const obscuredAliases = getObscuredAliases(s.nodes);
+for (const [nodeId, alias] of obscuredAliases) {
+  if (alias.toLowerCase() === lower) return s.nodes[nodeId];
+}
+```
+
+**Key changes (`getObscuredAliases`):**
+```js
+export function getObscuredAliases(nodes) {
+  const map = new Map();
+  for (const n of Object.values(nodes)) {
+    if (isObscured(n)) map.set(n.id, n.sigAlias);
+  }
+  return map;
+}
+```
+
+**Key changes (`cmdStatus` summary list):** partition visible nodes into obscured vs known; obscured render as `- ${alias}  [???]  ${node.visibility}`; known render with full detail as today. (The current `revealed`/`accessible` split at `cmd-status.js:118-149` becomes obscured/known.)
+
+**Key changes (`cmdStatusNode`):**
+```js
+if (isObscured(node)) {
+  lines.push(`## STATUS: NODE ${node.sigAlias}`);
+  lines.push(`- label: [???]  type: [???]  grade: [???]`);
+  lines.push(`- visibility: ${node.visibility}  probed: ${node.probed}`);
+  lines.forEach((l) => addLogEntry(l, "meta"));
+  return;
+}
+// ...existing full detail unchanged...
+```
+
+**Verification — automated:**
+- [ ] New resolver/completion tests fail before edits, pass after.
+- [ ] `make lint` passes.
+- [ ] `make test` passes (existing completions/resolver tests updated for rename).
+
+**Verification — manual (playtest harness):**
+- [ ] `node scripts/playtest.js reset` → compromise a node, then `actions` lists the new neighbor by `sig-N`, not real id.
+- [ ] `status node sig-N` on a navigated-but-unprobed node shows `[???]`, not type/grade.
+
+---
+
+## Phase 3: Graph rendering obscures identity
+
+The graph shows `sig-N` + generic ellipse for obscured nodes while keeping accessible styling for reachability.
+
+**Files:**
+- Modify: `js/ui/graph.js` — stylesheet: add `node.obscured { label: "data(sigAlias)" }` ordered AFTER `node.accessible` (so it overrides `label: data(id)`); `updateNodeStyle`: toggle the `obscured` class via `isObscured(nodeState)`, populate `sigAlias` data whenever obscured (not only when `revealed`), and force ellipse shape when obscured.
+
+**Key changes (`updateNodeStyle`, was `:462-499`):**
+```js
+const obscured = isObscured(nodeState);
+
+node.removeClass("hidden revealed accessible");
+node.addClass(nodeState.visibility);
+node.toggleClass("obscured", obscured);
+
+if (obscured) {
+  node.data("sigAlias", nodeState.sigAlias ?? "???");
+}
+// ...accessible block unchanged except shape:
+const shape = obscured ? "ellipse" : (NODE_SHAPES[type] || "ellipse");
+node.style("shape", shape);
+```
+
+**Stylesheet addition (after the `node.accessible.*` rules):**
+```js
+{ selector: "node.obscured", style: { label: "data(sigAlias)" } },
+```
+
+**Verification — automated:**
+- [ ] `make lint` passes (graph.js is `@ts-nocheck`; lint still runs).
+- [ ] `make test` passes.
+
+**Verification — manual (browser, `make bundle-vendor` + `make serve`):**
+- [ ] Compromise a node; neighbor shows `sig-N`. Click it → it gains the solid/actionable accessible look but STILL shows `sig-N` and a generic ellipse (not its type shape).
+- [ ] Probe it (or land a blind exploit) → label flips to real id and the type shape appears.
+- [ ] Gateway/foothold node always shows its real id (never obscured).
+
+---
+
+## Phase 4: Node-panel sidebar obscures identity
+
+The sidebar's "[???] UNKNOWN NODE" view currently triggers on `visibility === "revealed"`; extend to `isObscured`, with messaging that fits an accessible-but-unprobed node.
+
+**Files:**
+- Modify: `js/ui/components/starnet-node-panel.js` — gate the obscured view (`:38`) on `isObscured(node)`; branch the helper text: not-yet-reachable (revealed) vs reachable-unprobed (accessible) → "Run PROBE to identify this node."
+
+**Key changes (`:37-44`):**
+```js
+if (isObscured(node)) {
+  const hint = node.visibility === "accessible"
+    ? html`Connection established.<br />Run PROBE to identify this node.`
+    : html`Signal detected on network.<br />Gain access to a connected node<br />to probe further.`;
+  return html`<div class="sidebar-placeholder">
+    [???] UNKNOWN NODE<br /><br />${hint}
+  </div>`;
+}
+```
+
+**Verification — automated:**
+- [ ] `make lint` passes.
+- [ ] `make test` passes.
+
+**Verification — manual (browser):**
+- [ ] Select a navigated-but-unprobed node → sidebar shows "[???] UNKNOWN NODE / Run PROBE to identify this node", NOT type/label/grade.
+- [ ] After probe → sidebar shows full detail.
+
+---
+
+## Phase 5: Manual + final verification
+
+Update `MANUAL.md` to describe obscure-until-probe, and run the full check + bot smoke.
+
+**Files:**
+- Modify: `MANUAL.md` — node discovery section (`~:121-138`): connecting to a `sig-N` node makes it actionable but does NOT reveal its identity; probe (or a successful blind exploit) reveals id/type/grade. Update `status` command notes and the `???`/signal language accordingly.
+
+**Verification — automated:**
+- [ ] `make check` (lint + test) passes.
+- [ ] `node scripts/bot-census.js --time F --money F --seeds 10` still ~80% success (bot reads raw state; expected unaffected — confirm no crash).
+
+**Verification — manual:**
+- [ ] Re-read changed MANUAL sections against actual in-browser behavior — they match.
+
+---
+
+## Notes
+
+- **Bot & playtest harness unaffected:** both read raw state (`node.id`, `accessLevel`, `visibility`) and dispatch by real id, not via console alias resolution. No bot strategy change needed. Confirm in Phase 5 the census doesn't crash.
+- **Navigation is intentionally untouched.** The fix is display-only; `navigateTo()` still promotes revealed→accessible on connect.
+- **One commit per phase**, message `Phase N: <name>`.

--- a/docs/dev-sessions/2026-06-09-0955-obscure-node-id-until-probe/research.md
+++ b/docs/dev-sessions/2026-06-09-0955-obscure-node-id-until-probe/research.md
@@ -1,0 +1,73 @@
+# Research — obscure node ID until probe
+
+Issue: #121. Bug: clicking a `sig-N` (revealed) node promotes it to `accessible` via
+traversal, which unmasks its real node id — before any probe or exploit.
+
+## The `sigAlias` marker
+
+- `sigAlias` is assigned **only** by `revealNeighbors()` on the `hidden → revealed`
+  transition: `js/core/state/index.js:216-228`. Guarded by `neighbor.visibility === "hidden" && !neighbor.concealed`.
+- Setter: `js/core/state/node.js:151-158` (`setNodeSigAlias`).
+- Therefore `sigAlias` is precisely the marker "discovered by signal, identity still unknown."
+  Starting/foothold nodes (e.g. gateway) are accessible but have **no** `sigAlias`.
+
+## Where `probed` is set (the reveal triggers)
+
+- Probe timed action completes: `js/core/node-graph/game-ctx.js:191` → `setNodeProbed(nodeId)`.
+- Exploit success (the blind-exploit path): `js/core/combat.js:241` → `setNodeProbed(nodeId)`.
+- Setter: `js/core/state/node.js:60-64`.
+
+So gating identity on `probed` covers **both** triggers Les named (probe succeeds OR blind
+exploit lands). A successful blind exploit already counts as a probe.
+
+## The bug path
+
+1. Click a `sig-N` node → TARGET action → `navigateTo()` (`js/core/navigation.js:19-44`).
+2. If `visibility === "revealed"` and it has an `accessible` neighbor, it is promoted
+   `revealed → accessible` (`navigation.js:33-40`) — "signal traced. Node accessible." — with
+   **no probe/exploit gate**.
+3. Graph styling keys the label off the visibility CSS class (below), so the label flips
+   from the alias to the real id.
+
+## Identity gated on `visibility === "revealed"` (every leak site)
+
+The codebase uses `visibility === "revealed"` as a proxy for "identity unknown." That proxy
+is wrong: a node can be `accessible` yet unprobed. Sites:
+
+1. **Graph label** — `js/ui/graph.js:283-325`:
+   - `node.revealed` → `label: "data(sigAlias)"` (line 297)
+   - `node.accessible` → `label: "data(id)"` (line 315)  ← leak
+   - `updateNodeStyle` only populates `sigAlias` data while `visibility === "revealed"` (`graph.js:466-469`).
+   - Note: `node.accessible` base block (306-324) sets **no** `shape`; `node.revealed` forces `ellipse`.
+     Shape source for accessible nodes needs confirming in the plan (type-driven selector or data(shape)).
+2. **Console alias map** — `js/core/console-commands/completions.js:63-69` (`getRevealedAliases`):
+   only includes `n.visibility === "revealed" && n.sigAlias`. This is the central gate consumed by:
+   - `fromNodes` completion — `completions.js:78-99` (accessible → id/label; revealed → alias)
+   - `resolveNode` — `js/core/console-commands/resolvers.js:15-41` (accessible → id/label; revealed → alias only)
+   - `cmdStatus` summary list — `js/core/console-commands/cmd-status.js:146-149`
+   - actions list (`target` line) — `js/core/console-commands/commands.js:106-116`
+3. **`status node` detail** — `cmd-status.js:205-219`: prints `node.id`, `label`, `type`, `grade`
+   unconditionally. **Pre-existing broader leak:** this already exposes type/grade/label for a
+   *revealed* (never-probed) node today, independent of the navigation bug.
+
+## Implication for the fix
+
+Replace the `visibility === "revealed"` discriminator with a single predicate:
+
+```
+isObscured(node) = !!node.sigAlias && !node.probed
+```
+
+- Revealed nodes: have alias, not probed → obscured (unchanged behavior).
+- Navigated-but-unprobed nodes: have alias, accessible, not probed → obscured (the fix).
+- Gateway / foothold: no alias → never obscured (correct — identity known).
+- After probe or blind-exploit success: `probed = true` → identity revealed everywhere at once.
+
+Central helper home: a pure read predicate importable by both `js/core/*` (console) and
+`js/ui/graph.js`. `js/core/state/node.js` is a candidate.
+
+## Tests / fixtures touching this
+
+- `js/core/console-commands/completions.test.js:260-262` — builds revealed nodes with sigAlias.
+- `js/core/state/node.test.js:34` — `setNodeProbed`.
+- Snapshot/integration suites exercise navigation + visibility.

--- a/docs/dev-sessions/2026-06-09-0955-obscure-node-id-until-probe/spec.md
+++ b/docs/dev-sessions/2026-06-09-0955-obscure-node-id-until-probe/spec.md
@@ -1,0 +1,111 @@
+# Obscure node identity until probe — Spec
+
+**Goal:** A discovered-but-unprobed node hides its real identity (id, label, type, grade) behind its `sig-N` signal alias — on the graph *and* the console — until the player probes it or lands a blind exploit on it. Connecting to / navigating into a node no longer reveals what it is.
+
+**Source:** Issue #121 (GitHub). User request, 2026-06-08.
+
+## Current state
+
+The codebase uses `visibility === "revealed"` as a proxy for "identity unknown." That proxy
+breaks the moment a node is promoted `revealed → accessible` by traversal without a probe.
+See `research.md` for the full site list. Load-bearing facts:
+
+- `sigAlias` is assigned **only** on `hidden → revealed` (`js/core/state/index.js:216-228`). It is
+  exactly the marker "discovered by signal, identity unknown." Foothold nodes (gateway) have none.
+- `probed` is set in exactly two places: probe completion (`js/core/node-graph/game-ctx.js:191`)
+  and exploit success (`js/core/combat.js:241`). Gating on `probed` covers both reveal triggers.
+- Clicking a `sig-N` node → `navigateTo()` promotes it to `accessible` (`js/core/navigation.js:33-40`),
+  which flips the graph label from `data(sigAlias)` to `data(id)` (`js/ui/graph.js:297` vs `:315`)
+  and switches every console path to the real id/label.
+- Identity-leak sites: graph label + shape (`graph.js:283-325`, `:495-499`, `:466-469`); console
+  alias map `getRevealedAliases` (`completions.js:63-69`) and its consumers — `fromNodes`
+  (`completions.js:78-99`), `resolveNode` (`resolvers.js:15-41`), `cmdStatus` summary
+  (`cmd-status.js:146-149`), actions/target list (`commands.js:106-116`); and `status node` detail
+  (`cmd-status.js:205-219`), which already leaks type/grade/label for *revealed* nodes today.
+
+## Desired end state
+
+A single predicate defines obscurity:
+
+```js
+isObscured(node) = Boolean(node.sigAlias) && !node.probed
+```
+
+For an obscured node, the **only** identity the player sees is its `sig-N` alias and the fact
+that it exists. Hidden until probed: real `id`, `label`, `type`, `grade`. On probe **or** a
+successful blind exploit (`probed = true`), the real identity is revealed everywhere at once.
+
+User-visible behavior:
+
+- **Graph:** an obscured node keeps its current rendering style for its visibility state
+  (revealed = dashed/dim; accessible = solid/actionable glow) but shows the `sig-N` label and a
+  **generic ellipse shape** instead of its type shape. Navigating into a node makes it look
+  reachable/actionable without disclosing what it is.
+- **Console targeting/listing:** obscured nodes are referenced by `sig-N` alias only — completion,
+  `target`/`select` resolution, the actions `target` line, and the `status` summary list. Their
+  real id/label are not accepted or shown.
+- **`status node sig-N`:** header and fields show the alias and `[???]` placeholders for
+  label/type/grade; `visibility`/`probed` still shown. After probe, shows full detail.
+- **GUI/console symmetry** (CLAUDE.md): both channels obscure identically.
+
+Navigation/traversal behavior is **unchanged** — connecting to a node still works exactly as the
+manual describes; only what's *displayed* changes.
+
+## Design decisions
+
+- **Decision:** One predicate `isObscured(node) = !!node.sigAlias && !node.probed`, defined once
+  as a pure read helper in `js/core/state/node.js` and imported by both console code and `js/ui/graph.js`.
+  - **Why:** `sigAlias` is the precise "identity-unknown" marker and `probed` is the precise reveal
+    trigger (covers probe + blind exploit). Foothold nodes have no alias, so they're never obscured —
+    correct. Centralizing prevents the current scattered `visibility === "revealed"` checks from drifting.
+  - **Rejected:** Keeping the `visibility === "revealed"` discriminator and special-casing accessible —
+    that's the bug's root cause and would re-leak on any future state that sets `accessible` early.
+  - **Rejected:** Clearing `sigAlias` on probe instead of gating on `probed` — extra mutation, and the
+    alias is still useful as the historical signal handle; gating reads cleaner.
+
+- **Decision:** Obscure the **full identity** (id, label, type, grade), not just the id string.
+  - **Why:** Hiding only the id while `status node` still prints `type: ids grade: A` doesn't actually
+    obscure the node — the player just reads it from the console. Folds in the pre-existing
+    `status node` leak on revealed nodes (same surface, one PR).
+  - **Rejected:** ID/label-only scope — leaves an obvious console oracle; fails GUI/console symmetry.
+
+- **Decision:** Connected-but-unprobed nodes keep **accessible styling** but a **generic ellipse
+  shape** + `sig-N` label.
+  - **Why:** The player must be able to tell they've reached a node (it's targetable/probeable) without
+    learning its type. Generic shape hides the type tell (shape ↔ node type per MANUAL table).
+  - **Rejected:** Rendering them identically to not-yet-reached revealed nodes — loses the "you've
+    connected" cue.
+
+- **Decision:** Rename `getRevealedAliases` → `getObscuredAliases` and update its 4 import sites.
+  - **Why:** Its semantics change from "revealed nodes" to "obscured nodes (revealed + accessible-
+    unprobed)." A misleading name is a readability cost; the rename is mechanical.
+
+## Patterns to follow
+
+- Replace each `n.visibility === "revealed"` identity check with `isObscured(n)`:
+  `completions.js:66,85`, `resolvers.js:22-37`, `cmd-status.js:147`, `commands.js:109-114`.
+- Graph: mirror the existing class-driven label approach — add an `obscured` class toggled in
+  `updateNodeStyle` (`graph.js:462-469`) and a stylesheet rule `node.obscured { label: data(sigAlias) }`
+  ordered after `node.accessible` so it wins; force ellipse at `graph.js:495-499` when obscured;
+  populate `sigAlias` data whenever obscured (not just when `revealed`).
+- `status node` detail (`cmd-status.js:205-219`): mirror the `[???]` placeholder style already used in
+  the summary list (`cmd-status.js:148`).
+- Console alias resolution stays the single chokepoint: `getObscuredAliases` feeds completion,
+  resolution, and listings — fix it once and consumers inherit.
+
+## What we're NOT doing
+
+- **Not changing navigation/traversal.** `navigateTo()` still promotes revealed→accessible on connect;
+  that's intended per `MANUAL.md:121-122`. Only display changes.
+- **Not clearing `sigAlias`** on probe or otherwise mutating it.
+- **Not hiding vulnerabilities differently** — vuln reveal is already gated by probe and is out of scope.
+- **Not redesigning visuals** beyond label + shape (no new colors, animations, or borders for the
+  obscured-accessible state — reuse existing accessible styling).
+- **Not touching procedural generation, ICE, alert, or scoring.**
+
+## Open questions
+
+- **Should the obscured-accessible node's HUD/node-panel sidebar also obscure identity?** Default: yes —
+  audit the node-panel component for the same `id/label/type/grade` exposure and apply `isObscured`
+  there too if present. (Resolved by the "full identity, both channels" decision; flagged so `plan`
+  explicitly checks the sidebar component, not just graph + console commands.)

--- a/js/core/console-commands/cmd-status.js
+++ b/js/core/console-commands/cmd-status.js
@@ -5,8 +5,8 @@ import { getState, isIceVisible } from "../state.js";
 import { addLogEntry } from "../log.js";
 import { getVisibleTimers } from "../timers.js";
 import { exploitSortKey } from "../exploits.js";
-import { getRevealedAliases } from "./completions.js";
 import { resolveNode, resolveImplicitNode } from "./resolvers.js";
+import { isObscured } from "../state/node.js";
 import { mineYieldChance } from "../mining.js";
 
 export function cmdStatusSummary() {
@@ -116,7 +116,11 @@ export function cmdStatusFull() {
   lines.push(`### SELECTED`);
   if (s.selectedNodeId) {
     const sel = s.nodes[s.selectedNodeId];
-    lines.push(`- ${s.selectedNodeId}  [${sel.type}]  access: ${sel.accessLevel}  alert: ${sel.alertState}`);
+    if (isObscured(sel)) {
+      lines.push(`- ${sel.sigAlias}  [???]  access: ${sel.accessLevel}  alert: ${sel.alertState}`);
+    } else {
+      lines.push(`- ${s.selectedNodeId}  [${sel.type}]  access: ${sel.accessLevel}  alert: ${sel.alertState}`);
+    }
   } else {
     lines.push(`- none`);
   }
@@ -127,10 +131,12 @@ export function cmdStatusFull() {
   const recipeStr = s.spec?.recipeId ?? "flat";
   const lanGradeStr = s.spec?.lanGrade ?? "—";
   lines.push(`- spec: ${specStr}  recipe: ${recipeStr}  LAN: ${lanGradeStr}  nodes: ${totalNodes}`);
-  const accessible = Object.values(s.nodes).filter((n) => n.visibility === "accessible");
-  const revealed = Object.values(s.nodes).filter((n) => n.visibility === "revealed");
+  // Known = visible nodes whose identity is no longer hidden (probed or never aliased).
+  // Obscured = visible nodes still behind a sig-N alias (revealed, or accessible-but-unprobed).
+  const known    = Object.values(s.nodes).filter((n) => n.visibility !== "hidden" && !isObscured(n));
+  const obscured = Object.values(s.nodes).filter((n) => isObscured(n));
 
-  accessible.forEach((node) => {
+  known.forEach((node) => {
     const selected = node.id === s.selectedNodeId ? "  [SELECTED]" : "";
     const probed   = node.probed ? "  probed" : "";
     lines.push(`- ${node.id}  [${node.type}]  ${node.accessLevel}  alert:${node.alertState}${probed}${selected}`);
@@ -143,9 +149,9 @@ export function cmdStatusFull() {
     }
   });
 
-  const revAliases = getRevealedAliases(s.nodes);
-  revealed.forEach((node) => {
-    lines.push(`- ${revAliases.get(node.id) ?? node.id}  [???]  revealed`);
+  obscured.forEach((node) => {
+    const selected = node.id === s.selectedNodeId ? "  [SELECTED]" : "";
+    lines.push(`- ${node.sigAlias}  [???]  ${node.visibility}${selected}`);
   });
 
   lines.push(`### HAND`);
@@ -206,6 +212,20 @@ export function cmdStatusNode(args) {
   const s = getState();
   const node = args.length >= 1 ? resolveNode(args[0]) : resolveImplicitNode();
   if (!node) return;
+
+  // Obscured nodes hide their identity (id/label/type/grade) until probed.
+  if (isObscured(node)) {
+    const lines = [
+      `## STATUS: NODE ${node.sigAlias}`,
+      `- label: [???]  type: [???]  grade: [???]`,
+      `- access: ${node.accessLevel}  alert: ${node.alertState}`,
+      `- visibility: ${node.visibility}  probed: ${node.probed}`,
+      `- Run PROBE to reveal this node's identity.`,
+    ];
+    lines.forEach((l) => addLogEntry(l, "meta"));
+    return;
+  }
+
   const lines = [`## STATUS: NODE ${node.id}`];
   lines.push(`- label: ${node.label}  type: ${node.type}  grade: ${node.grade ?? "N/A"}`);
   lines.push(`- access: ${node.accessLevel}  alert: ${node.alertState}`);

--- a/js/core/console-commands/commands.js
+++ b/js/core/console-commands/commands.js
@@ -7,11 +7,12 @@ import { exploitSortKey, getStoreCatalog } from "../exploits.js";
 import { getAvailableActions } from "../actions/node-actions.js";
 import { buyFromStore } from "../store-logic.js";
 import {
-  fromList, fromNodes, fromCards, fromVulnIds, completeNodeArg, getRevealedAliases,
+  fromList, fromNodes, fromCards, fromVulnIds, completeNodeArg, getObscuredAliases,
 } from "./completions.js";
 import {
   resolveNode, resolveImplicitNode, resolveCard, dispatch, resolveWanAccess,
 } from "./resolvers.js";
+import { isObscured } from "../state/node.js";
 import { A } from "../action-ids.js";
 import {
   cmdStatusSummary, cmdStatusFull, cmdStatusIce, cmdStatusHand,
@@ -104,15 +105,17 @@ export const COMMANDS = [
       }
 
       if (has.has(A.TARGET)) {
-        const accessible = Object.values(s.nodes)
-          .filter((n) => n.visibility === "accessible" && !n.rebooting && n.id !== s.selectedNodeId);
-        const revealed = Object.values(s.nodes)
-          .filter((n) => n.visibility === "revealed" && n.id !== s.selectedNodeId);
-        const revAliases = getRevealedAliases(s.nodes);
+        // Known (identified) accessible nodes list by id; obscured nodes (revealed or
+        // accessible-but-unprobed) list by their sig-N alias — real ids stay hidden.
+        const known = Object.values(s.nodes)
+          .filter((n) => n.visibility === "accessible" && !isObscured(n) && !n.rebooting && n.id !== s.selectedNodeId);
+        const obscured = Object.values(s.nodes)
+          .filter((n) => isObscured(n) && n.id !== s.selectedNodeId);
+        const aliases = getObscuredAliases(s.nodes);
         const parts = [];
-        if (accessible.length > 0) parts.push(`accessible: ${accessible.map((n) => n.id).join(", ")}`);
-        if (revealed.length > 0) parts.push(`traverse: ${revealed.map((n) => revAliases.get(n.id) ?? n.id).join(", ")}`);
-        lines.push(`  target <nodeId>          — ${parts.join("  |  ")}`);
+        if (known.length > 0) parts.push(`accessible: ${known.map((n) => n.id).join(", ")}`);
+        if (obscured.length > 0) parts.push(`traverse: ${obscured.map((n) => aliases.get(n.id) ?? n.id).join(", ")}`);
+        lines.push(`  target <node|sig-N>      — ${parts.join("  |  ")}`);
       }
 
       if (sel) {

--- a/js/core/console-commands/commands.test.js
+++ b/js/core/console-commands/commands.test.js
@@ -17,8 +17,10 @@ import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 
 import { buildNetwork as buildCorporateFoothold } from "../../../data/networks/corporate-foothold.js";
-import { initGame, getState } from "../state.js";
+import { initGame, getState, revealNeighbors } from "../state.js";
 import { navigateTo } from "../navigation.js";
+import { resolveNode } from "./resolvers.js";
+import { cmdStatusNode } from "./cmd-status.js";
 import { addCardToHand } from "../state/player.js";
 import { setNodeAccessLevel } from "../state/node.js";
 import { generateExploit, exploitSortKey } from "../exploits.js";
@@ -283,5 +285,51 @@ describe("darknet / buy — WAN access guard", () => {
     navigateTo(wanId);
     const ls = logs(() => getCommand("darknet").execute([]));
     assert.ok(ls.some((l) => l.text.includes("DARKNET BROKER")));
+  });
+});
+
+// ── Obscured identity until probe (#121) ───────────────────────────────────────
+//
+// Navigating to a sig-N neighbor makes it accessible (traversal) but must NOT
+// reveal its real id/label/type/grade until it is probed (or a blind exploit lands).
+
+describe("obscured identity: navigated-but-unprobed node", () => {
+  /** Reveal gateway's neighbor as sig-N, then traverse into it (accessible, unprobed). */
+  function navigateToRevealedNeighbor() {
+    revealNeighbors("gateway");
+    const revealed = Object.values(getState().nodes).find((n) => n.visibility === "revealed");
+    assert.ok(revealed, "expected a revealed neighbor after revealNeighbors");
+    navigateTo(revealed.id);
+    return getState().nodes[revealed.id];
+  }
+
+  it("the node is now accessible but still unprobed and aliased", () => {
+    const node = navigateToRevealedNeighbor();
+    assert.equal(node.visibility, "accessible");
+    assert.equal(node.probed, false);
+    assert.ok(node.sigAlias, "expected a sig-N alias");
+  });
+
+  it("resolves by its sig-N alias", () => {
+    const node = navigateToRevealedNeighbor();
+    assert.equal(resolveNode(node.sigAlias), node);
+  });
+
+  it("does NOT resolve by its real id (identity hidden until probed)", () => {
+    const node = navigateToRevealedNeighbor();
+    assert.equal(resolveNode(node.id), null);
+  });
+
+  it("does NOT resolve by its real label", () => {
+    const node = navigateToRevealedNeighbor();
+    if (!node.label || node.label === node.sigAlias) return;
+    assert.equal(resolveNode(node.label), null);
+  });
+
+  it("status node shows [???], not the real type/label/grade", () => {
+    const node = navigateToRevealedNeighbor();
+    const text = logs(() => cmdStatusNode([node.sigAlias])).map((l) => l.text).join("\n");
+    assert.ok(text.includes("[???]"), "expected obscured placeholders");
+    assert.ok(!text.includes(node.type), "type must not leak");
   });
 });

--- a/js/core/console-commands/completions.js
+++ b/js/core/console-commands/completions.js
@@ -7,6 +7,7 @@
 
 import { registry } from "./registry.js";
 import { VULNERABILITY_TYPES } from "../exploits.js";
+import { isObscured } from "../state/node.js";
 
 // ── Completion infrastructure ─────────────────────────────────────────────────
 
@@ -55,35 +56,36 @@ export function fromList(candidates, partial) {
 }
 
 /**
- * Returns the stable alias map for revealed (???) nodes.
- * Aliases are assigned when a node is first revealed and stored in node.sigAlias.
+ * Returns the stable alias map for obscured nodes — those still hiding their
+ * identity behind a sig-N alias (revealed, or accessible-but-unprobed). See
+ * isObscured(). Aliases are assigned on hidden→revealed and stored in node.sigAlias.
  * @param {Object.<string, NodeState>} nodes
  * @returns {Map<string, string>}  nodeId → alias
  */
-export function getRevealedAliases(nodes) {
+export function getObscuredAliases(nodes) {
   const map = new Map();
   for (const n of Object.values(nodes)) {
-    if (n.visibility === "revealed" && n.sigAlias) map.set(n.id, n.sigAlias);
+    if (isObscured(n)) map.set(n.id, n.sigAlias);
   }
   return map;
 }
 
 /**
- * Node completion: matches accessible nodes by id/label prefix, revealed nodes by alias.
- * Hidden nodes and revealed nodes' real identities are excluded.
+ * Node completion: matches known nodes by id/label prefix, obscured nodes by alias.
+ * Hidden nodes and obscured nodes' real identities are excluded.
  * @param {Object.<string, NodeState>} nodes
  * @param {string} partial
  * @returns {{ insertTexts: string[], displayTexts: string[] }}
  */
 export function fromNodes(nodes, partial, { includeAll = false } = {}) {
   const lc = partial.toLowerCase();
-  const revAliases = getRevealedAliases(nodes);
+  const obscuredAliases = getObscuredAliases(nodes);
   const insertTexts = [];
   const displayTexts = [];
   for (const n of Object.values(nodes)) {
     if (!includeAll && n.visibility === "hidden") continue;
-    if (!includeAll && n.visibility === "revealed") {
-      const alias = revAliases.get(n.id) ?? n.id;
+    if (!includeAll && isObscured(n)) {
+      const alias = obscuredAliases.get(n.id) ?? n.id;
       if (alias.toLowerCase().startsWith(lc)) {
         insertTexts.push(alias);
         displayTexts.push(alias);

--- a/js/core/console-commands/completions.test.js
+++ b/js/core/console-commands/completions.test.js
@@ -300,6 +300,40 @@ describe("tabComplete: revealed node alias completion", () => {
   });
 });
 
+// ── Accessible-but-unprobed (obscured) node completion (#121) ─────────────────
+
+describe("tabComplete: navigated-but-unprobed node stays obscured", () => {
+  // An accessible node that has a sig-N alias and is not yet probed — the state
+  // produced by traversing into a revealed neighbor. Identity must stay hidden.
+  function makeObscuredAccessible(id, label, sigAlias) {
+    return { ...makeNode(id, label, "accessible"), sigAlias, probed: false };
+  }
+
+  const state = makeState({
+    nodes: {
+      gateway:    makeNode("gateway", "INET-GW-01", "accessible"),
+      "ids-9":    makeObscuredAccessible("ids-9", "IDS-EDGE", "sig-7"),
+    },
+  });
+
+  it("completes by its sig-N alias", () => {
+    const r = tabComplete("target sig-7", state);
+    assert.equal(r.completed, "target sig-7 ");
+  });
+
+  it("is NOT reachable by real id prefix", () => {
+    const r = tabComplete("target ids", state);
+    assert.equal(r.completed, null);
+    assert.deepEqual(r.suggestions, []);
+  });
+
+  it("is NOT reachable by real label prefix", () => {
+    const r = tabComplete("target IDS-E", state);
+    assert.equal(r.completed, null);
+    assert.deepEqual(r.suggestions, []);
+  });
+});
+
 // ── buy vuln-id completion ────────────────────────────────
 
 describe("tabComplete: buy vuln-id completion", () => {

--- a/js/core/console-commands/index.js
+++ b/js/core/console-commands/index.js
@@ -6,13 +6,13 @@
 //
 // Sub-module layout:
 //   registry.js    — CommandDef typedef, registry Map, registerCommand, getCommand
-//   completions.js — completion providers, getRevealedAliases, tabComplete
+//   completions.js — completion providers, getObscuredAliases, tabComplete
 //   resolvers.js   — resolveNode/Card/ImplicitNode, dispatch, resolveWanAccess
 //   cmd-status.js  — status sub-command implementations
 //   commands.js    — all CommandDef objects
 
 export { registerCommand, getCommand } from "./registry.js";
-export { tabComplete, getRevealedAliases } from "./completions.js";
+export { tabComplete, getObscuredAliases } from "./completions.js";
 
 import { registry, registerCommand } from "./registry.js";
 import { COMMANDS } from "./commands.js";

--- a/js/core/console-commands/resolvers.js
+++ b/js/core/console-commands/resolvers.js
@@ -5,24 +5,26 @@ import { getState } from "../state.js";
 import { addLogEntry } from "../log.js";
 import { emitEvent } from "../events.js";
 import { exploitSortKey } from "../exploits.js";
-import { getRevealedAliases } from "./completions.js";
+import { getObscuredAliases } from "./completions.js";
+import { isObscured } from "../state/node.js";
 
 /**
  * Resolve a node token (id, label prefix, or sig-N alias) to a NodeState.
- * Accessible nodes match by real id or label prefix.
- * Revealed nodes match by alias only — real id/label are hidden.
+ * Known (accessible, non-obscured) nodes match by real id or label prefix.
+ * Obscured nodes (revealed, or accessible-but-unprobed) match by alias only —
+ * their real id/label stay hidden until probed.
  */
 export function resolveNode(token) {
   const s = getState();
   if (!token) return null;
   const lower = token.toLowerCase();
 
-  // Accessible nodes: match by real id or label prefix.
+  // Known nodes (accessible and not obscured): match by real id or label prefix.
   const byId = s.nodes[token];
-  if (byId && byId.visibility === "accessible") return byId;
+  if (byId && byId.visibility === "accessible" && !isObscured(byId)) return byId;
 
   const labelMatches = Object.values(s.nodes).filter(
-    (n) => n.visibility === "accessible" && n.label?.toLowerCase().startsWith(lower)
+    (n) => n.visibility === "accessible" && !isObscured(n) && n.label?.toLowerCase().startsWith(lower)
   );
   if (labelMatches.length === 1) return labelMatches[0];
   if (labelMatches.length > 1) {
@@ -30,9 +32,9 @@ export function resolveNode(token) {
     return null;
   }
 
-  // Revealed nodes: match by alias only (real id/label are hidden).
-  const revAliases = getRevealedAliases(s.nodes);
-  for (const [nodeId, alias] of revAliases) {
+  // Obscured nodes: match by alias only (real id/label are hidden).
+  const obscuredAliases = getObscuredAliases(s.nodes);
+  for (const [nodeId, alias] of obscuredAliases) {
     if (alias.toLowerCase() === lower) return s.nodes[nodeId];
   }
 

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -22,7 +22,7 @@ export {
 export {
   setNodeVisible, setNodeAccessLevel, setNodeProbed, setNodeAlertState,
   setNodeRead, collectMacguffins, setNodeLooted, setNodeRebooting,
-  setNodeEventForwarding, setNodeVulnHidden, setNodeGraph,
+  setNodeEventForwarding, setNodeVulnHidden, setNodeGraph, isObscured,
 } from "./state/node.js";
 
 export {

--- a/js/core/state/node.js
+++ b/js/core/state/node.js
@@ -4,6 +4,8 @@
 
 import { getState, mutate } from "./index.js";
 
+/** @typedef {import('../types.js').NodeState} NodeState */
+
 /** @type {import('../node-graph/runtime.js').NodeGraph | null} */
 let _graph = null;
 let _syncingToGraph = false;
@@ -63,6 +65,19 @@ export function setNodeProbed(nodeId) {
     if (node) node.probed = true;
   });
   syncToGraph(nodeId, "probed", true);
+}
+
+/**
+ * True when a node's identity (id, label, type, grade) should stay hidden behind
+ * its sig-N alias. A node is obscured while it has a signal alias and has not yet
+ * been probed — and a successful blind exploit also sets `probed`, so it reveals too.
+ * `sigAlias` is assigned only on hidden→revealed, so foothold nodes (no alias) are
+ * never obscured. Read-only predicate; consulted by the graph, console, and sidebar.
+ * @param {NodeState} [node]
+ * @returns {boolean}
+ */
+export function isObscured(node) {
+  return Boolean(node?.sigAlias) && !node.probed;
 }
 
 /** Sets node.alertState ('green' | 'yellow' | 'red'). */

--- a/js/core/state/node.test.js
+++ b/js/core/state/node.test.js
@@ -8,7 +8,7 @@ import { clearAll } from "../timers.js";
 import {
   setNodeVisible, setNodeAccessLevel, setNodeProbed, setNodeAlertState,
   setNodeRead, collectMacguffins, setNodeLooted, setNodeRebooting,
-  setNodeEventForwarding, setNodeVulnHidden,
+  setNodeEventForwarding, setNodeVulnHidden, isObscured,
 } from "./node.js";
 
 describe("state/node — node mutations", () => {
@@ -111,5 +111,31 @@ describe("state/node — node mutations", () => {
     setNodeVisible("nonexistent", "accessible");
     // Version still bumps (mutate always increments) but no crash
     assert.equal(getVersion(), v + 1);
+  });
+});
+
+describe("state/node — isObscured", () => {
+  it("aliased and unprobed node is obscured", () => {
+    assert.equal(isObscured({ sigAlias: "sig-1", probed: false }), true);
+  });
+
+  it("aliased but probed node is NOT obscured (probe revealed it)", () => {
+    assert.equal(isObscured({ sigAlias: "sig-1", probed: true }), false);
+  });
+
+  it("node without an alias is never obscured (e.g. foothold/gateway)", () => {
+    assert.equal(isObscured({ probed: false }), false);
+  });
+
+  it("accessible-but-unprobed aliased node is obscured (the navigation case)", () => {
+    assert.equal(
+      isObscured({ sigAlias: "sig-2", visibility: "accessible", probed: false }),
+      true
+    );
+  });
+
+  it("nullish / empty node is not obscured", () => {
+    assert.equal(isObscured(undefined), false);
+    assert.equal(isObscured({}), false);
   });
 });

--- a/js/ui/components/starnet-node-panel.js
+++ b/js/ui/components/starnet-node-panel.js
@@ -3,6 +3,7 @@
 
 import { html, nothing } from "lit";
 import { StarnetElement } from "./starnet-element.js";
+import { isObscured } from "../../core/state.js";
 
 class StarnetNodePanel extends StarnetElement {
   static properties = {
@@ -34,12 +35,16 @@ class StarnetNodePanel extends StarnetElement {
 
     const node = this.node;
 
-    // Unknown/unrevealed node
-    if (node.visibility === "revealed") {
+    // Obscured node — identity (type/label/grade) hidden behind the sig-N alias
+    // until probed. Once accessible, the player can probe directly; before that,
+    // they must reach it through a connected node.
+    if (isObscured(node)) {
+      const hint = node.visibility === "accessible"
+        ? html`Connection established.<br />Run PROBE to identify this node.`
+        : html`Signal detected on network.<br />Gain access to a connected node<br />to probe further.`;
       return html`<div class="sidebar-placeholder">
         [???] UNKNOWN NODE<br /><br />
-        Signal detected on network.<br />
-        Gain access to a connected node<br />to probe further.
+        ${hint}
       </div>`;
     }
 

--- a/js/ui/graph.js
+++ b/js/ui/graph.js
@@ -1,7 +1,7 @@
 // @ts-nocheck — Cytoscape.js has no bundled types; skipping type checking for this file.
 // Graph rendering and Cytoscape.js management
 
-import { isIceVisible } from "../core/state.js";
+import { isIceVisible, isObscured } from "../core/state.js";
 
 // Still playing with what might be the best default here
 // const DEFAULT_LAYOUT_ALGO = "breadthfirst";
@@ -344,6 +344,16 @@ function buildStylesheet() {
         "border-width": 2,
       },
     },
+    // Obscured — identity hidden behind sig-N alias until probed. Keeps the
+    // accessible styling (so reachability reads) but shows the alias, not the id.
+    // Placed after node.accessible so this label rule wins. Shape is forced to a
+    // generic ellipse in updateNodeStyle() so the node type isn't telegraphed.
+    {
+      selector: "node.obscured",
+      style: {
+        label: "data(sigAlias)",
+      },
+    },
     // (ICE is now an HTML overlay, not a Cytoscape node)
     // Trace-back waypoint nodes (hidden nodes revealed as part of ICE trace)
     {
@@ -453,8 +463,15 @@ export function updateNodeStyle(nodeId, nodeState) {
   node.removeClass("hidden revealed accessible");
   node.addClass(nodeState.visibility);
 
-  // Assign alias label for revealed (???) nodes so the graph matches the console.
-  if (nodeState.visibility === "revealed") {
+  // Obscured: identity (id/label/type) hidden behind the sig-N alias until probed.
+  // The node.obscured stylesheet rule swaps the label to data(sigAlias); the shape
+  // override below keeps the type from being telegraphed.
+  const obscured = isObscured(nodeState);
+  node.toggleClass("obscured", obscured);
+  // Populate the alias label for any node whose label is driven by data(sigAlias):
+  // obscured nodes (sig-N), and `revealed` nodes that lack an alias (e.g. set-piece
+  // reveals via revealNode) which fall back to "???".
+  if (obscured || nodeState.visibility === "revealed") {
     node.data("sigAlias", nodeState.sigAlias ?? "???");
   }
 
@@ -482,10 +499,11 @@ export function updateNodeStyle(nodeId, nodeState) {
       if (yellowPulsingNodes.has(nodeId)) stopYellowPulse(node);
     }
 
-    // Shape by node type
+    // Shape by node type — but an obscured node shows a generic ellipse so its
+    // type isn't telegraphed before it's probed.
     const networkNode = cy.getElementById(nodeId);
     const type = networkNode.data("type");
-    const shape = NODE_SHAPES[type] || "ellipse";
+    const shape = obscured ? "ellipse" : (NODE_SHAPES[type] || "ellipse");
     node.style("shape", shape);
   }
 


### PR DESCRIPTION
## Summary
- A node discovered via signal shows as a `sig-N` contact. Previously, merely **navigating into it** (traversal) promoted it to `accessible` and unmasked its real id/label/type/grade — on the graph, in the console, and in the sidebar — before any probe.
- Identity should stay hidden behind the `sig-N` alias until the player **probes** the node or lands a **blind exploit** on it. This fix gates identity on that condition consistently across all three display channels.

## Design Decisions
- **One predicate, consulted everywhere identity was previously gated on `visibility === "revealed"`:**
  ```js
  isObscured(node) = Boolean(node.sigAlias) && !node.probed
  ```
  `sigAlias` is assigned only on `hidden → revealed`, so foothold nodes (gateway, no alias) are never obscured. `probed` is set by both the probe action and a successful exploit, so either reveals identity — a blind exploit that lands already counts as a probe.
- **Full identity** (id/label/type/grade) is obscured, not just the id string — `status node` already leaked type/grade for revealed nodes, which would have remained an obvious console oracle and broken GUI/console symmetry.
- **Navigation/traversal is unchanged.** Connecting to a node still works exactly as the manual describes; only what's *displayed* changes. Obscured-accessible nodes keep their accessible styling (so reachability reads) but show a generic ellipse + `sig-N` label so the node type isn't telegraphed.

## Changes
- `js/core/state/node.js` — `isObscured()` predicate (+ unit truth-table).
- **Console** (`completions.js`, `resolvers.js`, `cmd-status.js`, `commands.js`, `index.js`) — `resolveNode` / completion / `status` summary / `status node` / actions list key off `isObscured`; `getRevealedAliases` → `getObscuredAliases`. Obscured nodes are referenced by `sig-N` alias only; `status node` shows `[???]` until probed.
- **Graph** (`js/ui/graph.js`) — `node.obscured` class overrides the accessible label back to `data(sigAlias)` and forces a generic ellipse; accessible styling otherwise retained.
- **Sidebar** (`starnet-node-panel.js`) — "[???] UNKNOWN NODE" view triggers on `isObscured`, with hint text that adapts once reachable.
- `MANUAL.md` — documents obscure-until-probe; notes `sig-N` tags in tab-complete / `status node`.

## Test Plan
- [x] `make check` — 668 tests pass, lint clean
- [x] New end-to-end regression test (`commands.test.js`) drives the real `revealNeighbors` + `navigateTo` path and asserts the navigated-but-unprobed node stays obscured
- [x] Verified in-browser (Playwright): navigated-but-unprobed `router-1` showed `sig-1` + generic ellipse on the graph and "[???] UNKNOWN NODE" in the sidebar; after the probe completed, identity revealed everywhere (`router-1` / `[ROUTER]` / resolvable by id)
- [x] Bot census run — unaffected by design (bot reads raw state and dispatches by real id; imports none of the changed modules)

## References
- Spec: `docs/dev-sessions/2026-06-09-0955-obscure-node-id-until-probe/spec.md`
- Plan: `docs/dev-sessions/2026-06-09-0955-obscure-node-id-until-probe/plan.md`
- Closes #121
