### PR TITLE
Phase 3: pressure tuning — make ICE/trace decide a run (#114)

### DIFF
--- a/data/networks/corporate-foothold.js
+++ b/data/networks/corporate-foothold.js
@@ -78,7 +78,12 @@ export function buildNetwork() {
       startCash: 1000,
       moneyCost: "C",
       startHand: ["common", "common", "uncommon", "uncommon"],
-      ice: null,
+      // Gentle intro ICE (#114). Grade C is the most forgiving disturbance-tracking
+      // tier (move 7s, dwell 5.5s, noise threshold 5) and takes 2 detections to
+      // trace — real pressure that teaches the mechanic without being punishing.
+      // Stationed at the router-1 hub so it patrols the whole LAN and crosses the
+      // player's path; losses are clean trace losses, not stuck/tick-cap.
+      ice: { grade: "C", startNode: "router-1" },
     },
   };
 }

--- a/data/networks/networks.test.js
+++ b/data/networks/networks.test.js
@@ -109,9 +109,18 @@ validateNetwork("Corporate Exchange", buildCorporateExchange);
 // ── Network-specific checks ──────────────────────────────────
 
 describe("Corporate Foothold specifics", () => {
-  it("has no ICE", () => {
+  // Gentle intro ICE added in #114 — forgiving, but present (no longer null).
+  it("has gentle ICE defined", () => {
     const { meta } = buildCorporateFoothold();
-    assert.equal(meta.ice, null);
+    assert.ok(meta.ice, "foothold should have ICE");
+    assert.ok(meta.ice.grade);
+    assert.ok(meta.ice.startNode);
+  });
+
+  it("ICE start node exists in the network", () => {
+    const { graphDef, meta } = buildCorporateFoothold();
+    const nodeIds = new Set(graphDef.nodes.map(n => n.id));
+    assert.ok(nodeIds.has(meta.ice.startNode), `ICE start node "${meta.ice.startNode}" not in graph`);
   });
 
   it("has 10-15 nodes", () => {

--- a/docs/BOT-PLAYER.md
+++ b/docs/BOT-PLAYER.md
@@ -135,8 +135,9 @@ infinite retry (set-piece disarm actions lack post-conditions).
 
 ### evasion
 
-ICE on targeted node → untarget (800). Trace active → jackout (100).
-Idle targeting → untarget (15).
+ICE on targeted node → eject if owned (850, keeps position) else untarget (800).
+Trace active → jackout (100). Idle targeting → untarget (15). (Mid-action ICE
+handling lives in `execute.js` — see ICE Handling below.)
 
 ### cards
 
@@ -158,16 +159,23 @@ so mining is tried before giving up.
 
 ## ICE Handling
 
-### Interrupt During Timed Actions
+### Commit to the hack, bail on detection
 
-If ICE arrives at the player's node mid-action, `execute.js` cancels the
-action and untargets. The main loop adds the node to `iceCooldown` — a
-one-cycle score penalty (-20) that encourages the bot to try a different
-node before retrying.
+ICE *arriving* on the player's node does **not** abort the action. Detection
+requires ICE to dwell (grade-scaled, ~45–90 ticks), so the hack and the dwell
+race — `execute.js` keeps ticking the action and only aborts + untargets if
+detection actually fires (`ICE_DETECTED`). On an **owned** node it ejects ICE
+on arrival (free) and keeps working. The main loop adds the node to
+`iceCooldown` only on a real detection — a one-cycle score penalty (-20)
+encouraging a different node before retrying.
+
+This replaced an earlier "panic-abort on ICE arrival" behavior that never
+actually got detected (so ICE was toothless) yet thrashed by abandoning and
+restarting actions — the root of the corporate-exchange tick-cap (#114).
 
 ### Cooldown Lifecycle
 
-- ICE interrupts → node added to cooldown set
+- ICE detection interrupts the action → node added to cooldown set
 - Next non-interrupted cycle → cooldown cleared
 - Cooled-down nodes get penalty, not hard skip (avoids "no proposals" when
   there's only one path forward)
@@ -202,9 +210,12 @@ The bot drives the game clock via `tick()`. After dispatching a timed action,
 `tickUntilResolved()` advances in 1-tick increments until:
 
 - `ACTION_RESOLVED` fires for the target node/action
-- `ICE_MOVED` to the targeted node (interrupted)
+- `ICE_DETECTED` on the targeted node (caught mid-action → abort + untarget)
 - `RUN_ENDED` fires
 - Per-action tick budget (500) exhausted
+
+(`ICE_MOVED` onto an owned targeted node triggers an `eject` but does not stop
+the action — see ICE Handling above.)
 
 A per-run tick cap (default: 5000) prevents infinite loops.
 
@@ -252,9 +263,10 @@ Each `runBot()` call returns a `BotRunStats` object:
 
 These omissions are intentional — they make the bot a pessimistic baseline:
 
-- **Eject ICE** — never pushes ICE to an adjacent node
 - **Reboot nodes** — never forces ICE back to its resident node
-- **Strategic patience** — doesn't wait for ICE to move away before re-engaging
+- **Strategic patience** — doesn't wait for ICE to move away before re-engaging,
+  and doesn't bail early when an in-progress hack won't beat the detection dwell
+  (it commits and eats the detection if the gamble loses)
 - **Manage card decay** — doesn't preserve high-value cards for hard nodes
 - **Plan ahead** — no lookahead; greedy scoring of current moment only
 - **Anticipate ICE movement** — only reacts when ICE arrives, doesn't track

--- a/docs/dev-sessions/2026-06-09-1703-phase3-pressure-tuning/notes.md
+++ b/docs/dev-sessions/2026-06-09-1703-phase3-pressure-tuning/notes.md
@@ -1,0 +1,206 @@
+# Notes — Phase 3 Pressure Tuning
+
+Issue #114. Branch `worktree-phase3-pressure-tuning`.
+
+## Decisions (brainstorm)
+- Tick-cap: **diagnose first, then minimal both** (bot evasion + ICE tuning as
+  evidence dictates).
+- Foothold ICE target: **75–90% bot success**, losses attributable to ICE/trace.
+- Stale-issue correction: the bot **already ejects** on owned selected nodes
+  (`scripts/bot/heuristics/evasion.js`); it still lacks reboot + patience.
+- traceFired anomaly likely a pre-#112 listener-leak artifact — re-check before
+  fixing.
+
+## Baseline census (Task B1) — 30 seeds each, this worktree
+
+| Network | success | failReasons | owned/total | ICE detect | ICE evasions | peak alert | traceFiredRate |
+|---|---|---|---|---|---|---|---|
+| corporate-foothold | 1.000 | {} | 8.8/12 | 0 | 0 | 30 green | 0 |
+| corporate-exchange | 0.533 | tick-cap 12, stuck 2 | 8.0/14 | 0.47 | **55.8** | 25 green / 5 red | 0.067 |
+
+Matches the issue table (exchange 0.533 vs 0.567 is a ~1-seed delta — trustworthy
+instrument). Notes:
+- **Foothold traceFiredRate is now 0**, not the ~0.95 the issue cited — the
+  *foothold-specific* anomaly was a pre-#112 artifact. BUT a default-spec
+  `generated` census shows `traceFiredRate 0.78` with peakAlert 46 green / 2
+  yellow / 2 red and 0 ICE detections → the discrepancy persists there. The real
+  contradiction: `traceFired` (≈39/50 runs) vs peakAlert (only 2 red). WS3 = live
+  bug, branch C (find stat vs mechanic).
+- **Exchange avgIceEvasions 55.8/run** — heavy evasion thrash; early evidence the
+  tick-cap is partly the untarget/retarget oscillation (WS2 bot side).
+
+## WS3 — traceFired anomaly → it's a STAT bug, fixed ✅
+
+**Root cause (stat, not mechanic):** `scripts/bot/stats.js` had
+`ALERT_RANK = { green:0, yellow:1, red:2 }` with **no `trace` entry**.
+`updatePeakAlert` does `(ALERT_RANK[level] ?? 0) > (ALERT_RANK[peak] ?? 0)`, so a
+`trace`-level raise resolved to rank 0 and could never update `peakAlert`. The
+mechanic is correct: `recomputeGlobalAlert` (alert.js:98) sets `globalAlert`
+straight to `"trace"` when `redMonitors>=1`/`redDetectors>=2`, emits
+`ALERT_GLOBAL_RAISED{next:"trace"}` and `ALERT_TRACE_STARTED` together — so
+`traceFired` was right; `peakAlert` undercounted. (Also why pre-fix runs showed
+low `red`: alert jumps green/yellow→trace, skipping a distinct red raise.)
+
+**Fix:** add `trace: 3` to `ALERT_RANK` (one line; mirrors `GLOBAL_ALERT_ORDER`).
+
+**Regression test:** `tests/bot-stats.test.js` — `updatePeakAlert("trace")`
+records trace; trace outranks red and isn't lowered by a later raise; peakAlert
+and traceFired can't contradict. Failed 3/3 before, passes after.
+
+**Validation (deterministic targets):**
+- exchange: was `25 green / 5 red`, traceFired 0.067 → now `25 green / 3 red /
+  2 trace`, traceFired 0.067. The 2 trace runs were the mis-bucketed reds; stat
+  now reconciles exactly (0.067 = 2/30).
+- foothold: all green / 0 — unchanged, consistent.
+
+**Out-of-scope discovery (flagged, not fixed):** the `generated` census produces
+`peakAlert: "unknown"` / `success: 0` for some procgen topologies (verified
+identical with/without this fix at seed "phase3" — pre-existing). The bot appears
+to fail to finalize stats on certain generated networks. Not a #114 target; worth
+a separate issue.
+
+## WS3 — second bug found: trace mechanic bypassed global alert ✅
+
+While tuning WS1, the foothold sweep showed runs with `traceFired=true` but
+`peakAlert=green` and `det=0` *even after* the ALERT_RANK fix. Root cause #2
+(mechanic, this time): set-piece alarms fire trace via `ctx.startTrace()` →
+`startTraceCountdown()` (game-ctx.js:54), which **never set `globalAlert` to
+"trace"** — it only set the countdown + emitted `ALERT_TRACE_STARTED`. So
+alarm-triggered traces left the alert level at green/yellow (the issue's "trace
+can start without a visible alert escalation"). Fix: `startTraceCountdown()` now
+guarantees `globalAlert==="trace"` (+ emits `ALERT_GLOBAL_RAISED`) for ALL
+callers; the escalation paths already set it first so they skip the redundant
+raise. Test: integration.test.js "Trace: startTraceCountdown drives global alert
+to trace". `make check` 661 green.
+
+## WS1 — foothold ICE: BLOCKED on a shared root cause (decision needed)
+
+ICE placement/grade sweep on foothold (30 seeds), post both WS3 fixes:
+
+| grade @ start | succ | iceDet | iceEva | trace | fails |
+|---|---|---|---|---|---|
+| F @ router-1 | 100% | 0 | 0.8 | 0 | — |
+| D @ router-1 | 93.3% | 0 | 1.4 | 2 | stuck 2 |
+| C @ router-1 | 100% | 0 | 10.8 | 0 | — |
+| B @ router-1 | 96.7% | 0.2 | 13.2 | 1 | stuck 1 |
+| C @ office/fileserver | 100% | 0.1 | 9.1 | 0 | — |
+| B @ vault/vault-node | 100% | 0.2 | 9.9 | 0 | — |
+
+**Two blockers, both rooted in the bot's evasion heuristic:**
+
+1. **ICE detections ≈ 0 at any gentle grade.** The bot abandons its action the
+   instant ICE arrives (`execute` returns `interrupted` → bot deselects, cools the
+   node one cycle, retries) — so ICE essentially never completes a dwell on the
+   bot. The trace that *does* fire on foothold comes from the **nthAlarm
+   set-piece**, not ICE. Acceptance wants `avgIceDetections > 0`; gentle ICE
+   cannot produce that against this bot.
+
+2. **Loss attribution.** When trace fires and the bot smartly jacks out to save
+   loot (census-22: owned 8/12, ¥17k, then bailed), the run is tagged `stuck`
+   (jackout → outcome "success" → `stats.success=false` via incomplete mission →
+   failReason defaults to "stuck"). Only countdown-expiry ("caught") is tagged
+   "trace". So trace-pressure losses masquerade as `stuck`.
+
+**Same root drives WS2:** the abandon-and-retry oscillation is the exchange
+`iceEvasions 55.8`/run thrash → tick-cap. Fixing the bot's evasion is the lever
+for BOTH networks. → Re-sequence: do the bot-evasion work (WS2) first, then
+re-tune foothold ICE against the improved bot. Surfaced to Les before changing
+bot behavior (see decision below).
+
+## WS2 — exchange tick-cap: DIAGNOSED + bot fixed ✅ (pressure tuning = open fork)
+
+**Diagnosis:** tick-cap was the bot's abandon-and-retry thrash. `execute.js`
+aborted the in-progress action the instant ICE *arrived* on the node — but
+detection needs a grade-scaled *dwell* (45–90 ticks). So ICE never actually
+detected the bot (toothless), yet the bot abandoned + restarted actions endlessly
+(`iceEvasions 55.8/run`, ticks ~3200 → tick-cap).
+
+**Fix (committed):** the hack and the dwell now race — the bot keeps working
+through ICE arrival (ejecting on owned nodes, which is free) and bails only when
+detection actually fires. Exchange: success 0.53→1.00, ticks 3200→1300,
+iceEvasions 56→0.8, iceDetections 0.47→0.77. **Tick-cap eliminated.** Plus loss
+attribution fix (bail-under-trace → "trace", not "stuck").
+
+**STRUCTURAL FINDING — ICE can't drive trace on these networks.** Both have
+exactly **1 IDS detector + 1 monitor**. Trace fires on `redDetectors>=2`
+(impossible — 1 detector) OR `redMonitors>=1` (monitor only escalates if ICE
+detects the player on a node *adjacent* to it — rare). So ICE detections peg the
+alert at **red but never trace**; trace comes from set-piece alarms (nthAlarm /
+probeBurst / noise / honeypot), which are play-dependent, not ICE-grade-dependent.
+With the now-competent bot, both networks sit ~100%.
+
+**Foothold sweep (new bot, 30 seeds):** F/D@router-1 → 100%/det0; C@router-1 →
+100%/det0.37; B@router-1 → 100%/det1.43 (15 red peaks, still 100% — recovers);
+B@vault → 96.7%/det0.73/1 trace.
+
+**Exchange sweep (new bot, 30 seeds):**
+| grade @ start | succ | det | losses |
+|---|---|---|---|
+| B @ sec/monitor (current) | 100% | 0.77 | — |
+| B @ switch-1 | 96.7% | 0.63 | trace 1 |
+| A @ switch-1 | 93.3% | 22.0 | trace 1, tick-cap 1 |
+| A @ sec/monitor | 83.3% | 18.5 | trace 3, tick-cap 2 |
+| S @ switch-1 | 13.3% | 217 | tick-cap 26 |
+
+**The fork:** gentle/clean ICE → bot wins ~95–100% (no real losses); harsh ICE
+(A) → 83–93% with trace losses BUT det explodes (18–22/run = oppressive) and the
+flee-on-detection thrash starts creeping back (S = 13%/tick-cap 26). The
+"commit-to-hack" fix is clean at *occasional* detection, not at *saturation* —
+harsh ICE needs a bot patience/back-off heuristic (don't re-engage a node until
+ICE leaves) to stay clean. Decision needed from Les (see below).
+
+## ROOT CAUSE & RESOLUTION — ICE→trace never matched the manual
+
+Stepping back (Les asked "is this even legible/fun?") surfaced the real bug:
+**MANUAL.md describes ICE detection driving trace directly** ("each detection
+steps the alert GREEN→YELLOW→RED→TRACE; N detections to trace, grade-scaled
+S/A:1, B/C:2, D/F:3") — but the **code never implemented it**.
+`DETECTION_TRACE_THRESHOLD` and `ice.detectionCount` were defined and never read
+(dead code). Instead ICE detection routed through the *exploit-failure* IDS-node
+coloring path, where trace needs `≥2 red detectors` (impossible on a 1-detector
+network) or a red monitor (rare). So ICE could peg the alert at red but never
+trace — mechanically toothless by accident, and illegible.
+
+**Fix (matches the manual):** `recordIceDetection` now steps the global alert and
+starts the trace countdown at `DETECTION_TRACE_THRESHOLD[grade]` detections;
+removed the `propagateAlertEvent` conflation from `triggerDetection` (ICE = the
+pursuit layer, driving global alert directly; IDS→monitor propagation stays the
+separate exploit-failure puzzle layer). Grade-scaled tests in integration.test.js
+(single IDS suffices). This dissolved the whole pressure-tuning problem: gentle
+ICE now meaningfully threatens, and grade/placement control difficulty as
+designed. **No MANUAL.md change needed — the manual was right; the code now
+conforms.**
+
+## Closeout — final census (official, this worktree)
+
+| Network | config | success | failReasons | iceDet | peak alert | tick-cap/stuck |
+|---|---|---|---|---|---|---|
+| corporate-foothold | grade C @ router-1 (was `null`) | 0.94 (50s) / 0.933 (30s) | trace only | 0.34 | 36g/11y/3 trace | **0** |
+| corporate-exchange | grade B @ sec/monitor (unchanged) | 0.84 (50s) | trace only | 0.76 | 19g/23r/8 trace | **0** |
+
+Determinism re-verified (same seeds → identical summary). `make check` green
+(666 tests). Foothold lands at 94% (slightly above the 75–90% band) — among
+gentle grade-C placements router-1 is the only one that bites (vault 98% / office
+100%); grade B drops to 50–80% but isn't "gentle". 94% with clean trace losses is
+the right read for a tutorial-adjacent network. **Confirm with Les.**
+
+## Acceptance criteria (issue #114)
+- [x] foothold has gentle ICE; no longer a 100% walkover (94%); losses all trace.
+- [x] exchange tick-cap eliminated; outcomes are clean wins or clean trace losses.
+- [x] both networks: failure reasons dominated by trace/ICE (100% trace, 0
+      stuck/tick-cap); `avgIceDetections > 0` (0.34 / 0.76).
+- [x] traceFired discrepancy resolved — TWO bugs (ALERT_RANK stat + alarm-path
+      mechanic), both with regression tests.
+- [x] bot remains a meaningful gate (completes both at 0.94 / 0.84); BOT-PLAYER.md
+      updated for the commit-to-hack evasion change.
+- [x] MANUAL.md current (no change needed — code conformed to it); `make check`
+      green; census deterministic.
+
+## Out-of-scope discoveries (flagged for separate issues)
+- `generated` census produces `peakAlert: "unknown"` / `success: 0` on some
+  procgen topologies (pre-existing, verified independent of these fixes) — the
+  bot fails to finalize stats on certain generated networks.
+- A bot **patience/back-off** heuristic (don't re-engage a node until ICE leaves;
+  bail early when a hack won't beat the dwell) would let *harsh* ICE (grade A/S)
+  produce clean trace losses without saturation thrash — not needed for the two
+  tuning networks at C/B, but the lever if future networks want grade-A pressure.

--- a/docs/dev-sessions/2026-06-09-1703-phase3-pressure-tuning/plan.md
+++ b/docs/dev-sessions/2026-06-09-1703-phase3-pressure-tuning/plan.md
@@ -1,0 +1,185 @@
+# Phase 3 Pressure Tuning — Implementation Plan
+
+**Goal:** Make census losses on both tuning networks dominated by `trace`/ICE
+(not `stuck`/`tick-cap`), `avgIceDetections > 0`, both winnable at sensible
+rates.
+
+**Architecture:** A balance-tuning session, not a feature build. Most tasks are
+**diagnose → change → census → read distribution → repeat** loops with explicit
+measurement gates, plus one genuine code/test task (the `traceFired` regression).
+Three workstreams executed WS3 → WS1 → WS2, re-censused at the end.
+
+**Tech Stack:** Vanilla JS game engine; `scripts/bot/census.js` (deterministic
+post-#112), `scripts/playtest.js` (replay harness), Node test runner (`make
+check`).
+
+---
+
+## Establish honest baseline first (gate for the whole session)
+
+- [ ] **B1.** Re-confirm the issue's baseline in this worktree (the branch is
+      fresh from origin/main; verify #113 is present):
+      `node scripts/bot/census.js --seeds 30 --network corporate-foothold`
+      `node scripts/bot/census.js --seeds 30 --network corporate-exchange`
+      Record `success`, `failReasons`, `avgIceDetections`, `peakAlertDistribution`,
+      `traceFiredRate` for both in `notes.md`. **If these diverge materially from
+      the issue table, stop and reconcile before tuning** (the measurement
+      instrument must be trustworthy — lesson from #112).
+
+---
+
+## WS3 — `traceFired` anomaly (first; cheap, de-risks the stat)
+
+### Task 3a: Reproduce / characterize
+**Files:** read only — `scripts/bot/loop.js`, `scripts/bot/stats.js`,
+`js/core/alert.js`.
+
+- [ ] **Step 1.** From B1's foothold census (no ICE → alert can't reach `trace`),
+      read `traceFiredRate`. Expected if healthy: `0`. If high (~0.95), the
+      anomaly still reproduces post-#112.
+- [ ] **Step 2.** Record the observed rate and the verdict (reproduces / does
+      not) in `notes.md`.
+
+### Task 3b (branch A — does NOT reproduce): lock it down with a regression test
+**Files:** Test: `tests/integration.test.js` (new focused case) or a new
+`tests/trace-fired-stat.test.js`.
+
+- [ ] **Step 1: Write the test.** Drive a headless run on a no-ICE network (or
+      assemble state where alert never escalates past `yellow`), advance ticks,
+      assert the bot stats `traceFired === false` and that `E.ALERT_TRACE_STARTED`
+      never emits.
+
+```js
+// Pseudocode shape — match existing integration-test harness helpers:
+// 1. reset to corporate-foothold (ice: null) with a fixed seed
+// 2. run the bot / tick to completion capturing events
+// 3. assert no E.ALERT_TRACE_STARTED was emitted
+// 4. assert stats.traceFired === false
+```
+
+- [ ] **Step 2: Run it, confirm PASS** (documents current correct behavior):
+      `make test` (or the focused file). Expected: PASS.
+- [ ] **Step 3.** Note in `notes.md` that the anomaly was a pre-#112 listener-leak
+      artifact, now covered by a regression test. **Commit.**
+
+### Task 3c (branch B — DOES still reproduce): find stat-vs-mechanic, fix
+**Files:** `scripts/bot/loop.js` / `scripts/bot/stats.js` (stat side) **or**
+`js/core/alert.js` (mechanic side).
+
+- [ ] **Step 1: Failing test.** Same shape as 3b Step 1 but it will FAIL against
+      current behavior — confirm it fails for the right reason (trace event fires,
+      or stat set, when it shouldn't).
+- [ ] **Step 2: Diagnose.** Determine whether `E.ALERT_TRACE_STARTED` is genuinely
+      emitting without a visible escalation (mechanic bug in `alert.js`) or the
+      stat is being set by a stale/leaked listener / wrong event (stat bug in
+      `loop.js`/`stats.js`).
+- [ ] **Step 3: Fix the wrong one only.** Smallest change.
+- [ ] **Step 4: Run test, confirm PASS.** `make test`. **Commit.**
+
+---
+
+## WS1 — Foothold gentle ICE (target 75–90% bot success)
+
+### Task 1a: Add forgiving ICE, start at the gentlest knob
+**Files:** Modify `data/networks/corporate-foothold.js` (`meta.ice`).
+
+- [ ] **Step 1.** Inspect foothold topology to pick a `startNode` deep enough that
+      gateway + first-hop nodes are safe early:
+      `node scripts/playtest.js --network corporate-foothold reset`
+      then `node scripts/playtest.js "status full"` (read node ids / adjacency).
+- [ ] **Step 2.** Set `ice: { grade: "F", startNode: "<deep-node-id>" }`
+      (grade F = MOVE 14000 / DWELL 10000 / NOISE 9 — gentlest available).
+- [ ] **Step 3.** `make check` to confirm types/tests still green (ICE now active
+      on a network that had none).
+
+### Task 1b: Census-tune to the 75–90% band
+- [ ] **Step 1.** `node scripts/bot/census.js --seeds 30 --network corporate-foothold`
+- [ ] **Step 2.** Read `success`, `failReasons`, `avgIceDetections`. Decision:
+      - success **> 90%** and detections ≈ 0 → ICE too gentle / startNode too deep.
+        Move startNode nearer the action or step grade F→D. Re-census.
+      - success **< 75%** → too harsh for a gentle intro. Soften (grade up toward F,
+        startNode deeper). Re-census.
+      - **75–90% with losses tagged `trace`/ICE and `avgIceDetections > 0`** → done.
+- [ ] **Step 3.** Record the final `meta.ice` and the census line in `notes.md`.
+      **Commit** the network change.
+
+> Tuning constraint: prefer moving `startNode` / picking grade over editing the
+> global `js/core/ice.js` tables for foothold — table edits ripple to every
+> network of that grade.
+
+---
+
+## WS2 — Exchange tick-cap (diagnose → minimal both)
+
+### Task 2a: Diagnose why tick-cap happens
+**Files:** read only + scratch transcripts.
+
+- [ ] **Step 1.** `node scripts/bot/census.js --json --seeds 30 --network corporate-exchange`
+      Capture per-run outcomes; list the seeds that ended `tick-cap`.
+- [ ] **Step 2.** Replay 2–3 of those seeds with event logging:
+      `node scripts/bot/census.js --json --seeds 1 --seed "<seed>" --network corporate-exchange`
+      (or via `scripts/playtest.js --seed`), and inspect the tail event stream.
+- [ ] **Step 3.** Classify each seed in `notes.md`:
+      - **oscillation** — bot repeats untarget→retarget→untarget around ICE;
+      - **ICE pin** — ICE parks on the only productive node, bot has no progress path;
+      - **slow-but-progressing** — bot was winning, just ran past the tick budget.
+- [ ] **Step 4.** Decide the minimal fix mix from the evidence (bot, ICE, or both).
+      Record the decision + rationale before changing anything.
+
+### Task 2b (if bot is a factor): teach reboot + patience
+**Files:** Modify `scripts/bot/heuristics/evasion.js`; check action ids in
+`js/core/action-ids.js`; Test: `tests/integration.test.js` (or bot-focused test);
+Docs: `docs/BOT-PLAYER.md`.
+
+- [ ] **Step 1: Failing/characterizing test.** Construct a state reproducing the
+      diagnosed pathology (e.g. ICE on the bot's only productive owned node) and
+      assert the bot's chosen action is the new sane one (reboot, or wait) rather
+      than the oscillation. Confirm it fails against current `evasion.js`.
+- [ ] **Step 2: Implement.** Add a `REBOOT` proposal and/or a wait/patience
+      proposal in `evasionStrategy` — guarded so it does not thrash (e.g. wait out
+      ICE rather than untarget→retarget when no other productive node exists).
+      Use the existing scored-proposal pattern; pick scores relative to the
+      existing `ICE_ON_NODE_*` constants.
+- [ ] **Step 3: Run test, confirm PASS.** `make test`.
+- [ ] **Step 4.** Update `docs/BOT-PLAYER.md` ("What the bot does NOT do" → moves
+      reboot/patience into the does-do list). **Commit.**
+
+### Task 2c (if ICE pressure is a factor): tune grade-B windows
+**Files:** Modify `js/core/ice.js` (`MOVE_INTERVALS`/`DWELL_TIMES` for `B`).
+
+- [ ] **Step 1.** Make the smallest grade-B adjustment the diagnosis implies
+      (e.g. longer move interval or shorter dwell so the player gets a workable
+      window). **Flag in `notes.md` that this is a global per-grade change** — list
+      any other grade-B networks affected (`grep -rn "grade: \"B\"" data/networks`).
+- [ ] **Step 2.** `make check` (snapshot ICE-detection tests may shift — review,
+      don't blindly re-baseline).
+- [ ] **Step 3.** If the change shouldn't be global, **stop and surface the
+      per-network-ICE-override question to Les** rather than building it. (Out of
+      scope unless approved.)
+
+### Task 2d: Census-confirm tick-cap is gone
+- [ ] **Step 1.** `node scripts/bot/census.js --seeds 30 --network corporate-exchange`
+- [ ] **Step 2.** Confirm `tick-cap` is no longer a dominant fail reason; outcomes
+      are clean wins or clean `trace`/ICE losses; `avgIceDetections > 0`; success
+      at a sensible rate. Iterate 2b/2c minimally if not. Record in `notes.md`.
+      **Commit.**
+
+---
+
+## Closeout
+
+- [ ] **C1.** Final census, both networks, 30 seeds. Paste the two summary lines
+      into `notes.md`. Confirm all acceptance criteria from `spec.md` are met.
+- [ ] **C2.** Update `MANUAL.md` for any ICE/alert/trace behavior change (foothold
+      now has ICE; any bot/trace mechanic change). Per CLAUDE.md the manual is the
+      canonical behavior reference.
+- [ ] **C3.** `make check` green; confirm census determinism (same seed → same
+      result across two runs).
+- [ ] **C4.** Write the session summary in `notes.md`. Open PR to `main`.
+
+## Self-review notes
+- Spec coverage: WS1↔AC1, WS2↔AC2/AC3, WS3↔AC4, bot/docs↔AC5, manual/check↔AC6 —
+  all four acceptance criteria map to tasks. ✔
+- The plan is branch-structured (3b/3c, 2b/2c) because the fix depends on a
+  diagnosis we haven't run yet — each branch has concrete steps, no placeholders.
+- Global-table risk is gated explicitly in 2c with a stop-and-ask.

--- a/docs/dev-sessions/2026-06-09-1703-phase3-pressure-tuning/spec.md
+++ b/docs/dev-sessions/2026-06-09-1703-phase3-pressure-tuning/spec.md
@@ -1,0 +1,99 @@
+# Spec — Phase 3: Pressure Tuning
+
+Issue: [#114](https://github.com/lmorchard/starnet/issues/114). Phase 3 of the
+core-loop tuning session (`docs/dev-sessions/2026-06-05-1428-core-loop-reassessment/`).
+
+## Goal
+
+Make **pressure (ICE / alert / trace) the thing that decides a run.** On both
+tuning networks, census **losses should be dominated by `trace` / ICE, not
+`stuck` / `tick-cap`**, with `avgIceDetections > 0`, and both networks remain
+winnable at sensible rates.
+
+Phase 2 (#113, research/mine action) is merged, so we tune against the final
+supply model.
+
+## Baseline (post-#112 census fix, 30 seeds — from the issue)
+
+| Network | success | dominant fail | owned/total | ICE detect | peak alert |
+|---|---|---|---|---|---|
+| corporate-foothold | 1.00 | — (no ICE) | 8.8/12 | 0 | green/yellow |
+| corporate-exchange | 0.567 | `tick-cap` 11, stuck 2 | 8.1/14 | 0.5 | mostly green, 5 red |
+
+## Current tuning surface (verified in-tree)
+
+- **Foothold meta** (`data/networks/corporate-foothold.js`): `startCash: 1000`,
+  `moneyCost: "C"` (threat grade C → trace 60s), `startHand: [common, common,
+  uncommon, uncommon]`, **`ice: null`**.
+- **Exchange meta** (`data/networks/corporate-exchange.js`): `startCash: 200`,
+  `moneyCost: "A"` (trace 40s), `startHand: [common, uncommon, uncommon, rare,
+  rare]`, **`ice: { grade: "B", startNode: "sec/monitor" }`**.
+- **ICE tables** (`js/core/ice.js`, grade-keyed, **global per grade**):
+  - `MOVE_INTERVALS = { S:4000, A:5000, B:6000, C:7000, D:12000, F:14000 }`
+  - `DWELL_TIMES   = { S:800, A:1500, B:4500, C:5500, D:9000, F:10000 }`
+  - `ICE_NOISE_THRESHOLD = { S:1, A:2, B:3, C:5, D:7, F:9 }`
+- **Alert/trace** (`js/core/alert.js`): trace fires when global alert reaches
+  `trace` (`redDetectors >= 2 || redMonitors >= 1`). `DETECTION_TRACE_THRESHOLD`
+  grade-keyed; `TRACE_SECONDS = { S:30, A:40, B:45, C:60, D:75, F:90 }`.
+- **Bot evasion** (`scripts/bot/heuristics/evasion.js`): **already ejects** when
+  ICE sits on an owned, selected node (issue's "bot never ejects" is stale).
+  Still lacks **reboot** and any **wait-for-ICE patience**; untargets to hide.
+- **traceFired stat** (`scripts/bot/loop.js` → `stats.js`): set true on
+  `E.ALERT_TRACE_STARTED`. The ~0.95-on-foothold anomaly the issue cites dates to
+  the pre-#112 listener-leak era; needs re-check before "fixing."
+
+## Work (decisions from brainstorm)
+
+### WS1 — Foothold gentle ICE
+Add `meta.ice` to `corporate-foothold`. Start with grade **F** (slowest/most
+forgiving), pick a `startNode` deep enough that early nodes stay safe. Tune
+grade/startNode by census to land **75–90% bot success**, with the occasional
+loss attributable to ICE/trace. Leave threat grade `C` unless census forces a
+change.
+
+### WS2 — Exchange tick-cap: diagnose → minimal both
+1. **Diagnose.** JSON census on exchange; pull 2–3 `tick-cap` seeds; replay via
+   the playtest harness with event logging. Classify each: untarget/retarget
+   oscillation, genuine ICE pin, or slow-but-progressing-past-budget.
+2. **Fix the bot if it's the bot.** Add **reboot** and/or a **wait-for-ICE-to-
+   move patience** heuristic to `evasion.js` (no thrashing — wait rather than
+   oscillate when ICE parks on the only productive node). Update
+   `docs/BOT-PLAYER.md`.
+3. **Tune ICE if it's pressure.** Adjust grade-B `MOVE_INTERVALS`/`DWELL_TIMES`
+   for workable windows — carefully, since these are global per grade.
+
+### WS3 — traceFired anomaly
+Reproduce first via a foothold census. If it no longer reproduces post-#112,
+document that and add a regression test asserting `traceFired` stays false when
+alert never reaches `trace`. If it still reproduces, trace whether stat or
+mechanic is wrong and fix (failing test first, per CLAUDE.md).
+
+## Ordering
+WS3 (cheap, de-risks the stat we read all session) → WS1 (self-contained) →
+WS2 (the hard one). Re-census both at the end.
+
+## Risk flagged
+ICE timing tables are **global per grade**, not per-network. Tuning grade-B for
+exchange could affect future grade-B networks. If exchange needs ICE changes that
+shouldn't be global, prefer choosing a different grade or surface a per-network
+ICE-override proposal to Les — **don't build per-network overrides silently**;
+treat that as out of scope unless diagnosis forces it.
+
+## Acceptance criteria (from issue #114)
+- [ ] `corporate-foothold` has gentle ICE; no longer a 100% walkover but stays
+      winnable (75–90%); losses trace to ICE/trace.
+- [ ] `corporate-exchange` `tick-cap` rate largely eliminated — outcomes are
+      clean wins or clean trace/ICE losses.
+- [ ] On both networks, census failure reasons dominated by `trace`/ICE, not
+      `stuck`/`tick-cap`; `avgIceDetections > 0`.
+- [ ] `traceFired` stat discrepancy resolved (stat or mechanic fixed, with a
+      test).
+- [ ] Updated bot remains a meaningful gate and completes both networks at a
+      sensible rate; `BOT-PLAYER.md` updated if strategy changed.
+- [ ] `MANUAL.md` updated for any ICE/alert/trace behavior changes; `make check`
+      green; census deterministic.
+
+## Validation
+`node scripts/bot/census.js --seeds 30 --network <net>` on both. Watch
+`failReasons`, `avgIceDetections`, `peakAlertDistribution`, `traceFiredRate`.
+`make check` green.

--- a/js/core/alert.js
+++ b/js/core/alert.js
@@ -135,6 +135,16 @@ const TRACE_SECONDS = { S: 30, A: 40, B: 45, C: 60, D: 75, F: 90 };
 
 export function startTraceCountdown() {
   const s = getState();
+  // Trace is the top alert level. Guarantee globalAlert reflects it regardless of
+  // how trace was triggered — alert escalation (recompute/raise paths set it
+  // before calling here) OR a set-piece alarm via ctx.startTrace(), which would
+  // otherwise leave globalAlert at green/yellow and desync the HUD + peakAlert
+  // stat from traceFired (#114 WS3).
+  if (s.globalAlert !== "trace") {
+    const prev = s.globalAlert;
+    setGlobalAlert("trace");
+    emitEvent(E.ALERT_GLOBAL_RAISED, { prev, next: "trace" });
+  }
   const threat = s.spec?.threat ?? "C";
   const seconds = TRACE_SECONDS[threat] ?? 60;
   setTraceCountdown(seconds);
@@ -180,8 +190,12 @@ export function forceGlobalAlert(level) {
 // ── ICE detection ─────────────────────────────────────────
 
 /**
- * Record an ICE detection event. Raises alert on all IDS nodes, which
- * propagate to security monitors via the normal forwarding path.
+ * Record an ICE detection event. Drives the global alert directly: each
+ * detection steps the alert up one level (capped below trace), and once the
+ * grade-scaled detection count is reached (DETECTION_TRACE_THRESHOLD), the trace
+ * countdown begins. This is the ICE pursuit layer — it does NOT colour IDS nodes
+ * or propagate through the security monitor (that's the separate exploit-failure
+ * puzzle layer in recomputeGlobalAlert). See MANUAL.md "Detection".
  */
 export function recordIceDetection(nodeId) {
   const s = getState();
@@ -189,15 +203,25 @@ export function recordIceDetection(nodeId) {
   setIceDetectedAt(nodeId);
   incrementIceDetectionCount();
 
-  // Raise alert on all IDS (detection) nodes
-  const detectors = Object.entries(s.nodes).filter(([, n]) => DETECTOR_TYPES.has(n.type));
-  for (const [detId, det] of detectors) {
-    const prevAlert = det.alertState;
-    const idx = ALERT_ORDER.indexOf(prevAlert);
-    if (idx < ALERT_ORDER.length - 1) {
-      const nextAlert = ALERT_ORDER[idx + 1];
-      setNodeAlertState(detId, nextAlert);
-      emitEvent(E.NODE_ALERT_RAISED, { nodeId: detId, label: det.label, prev: prevAlert, next: nextAlert });
-    }
+  // ICE detection drives the global alert directly (MANUAL.md "Detection"):
+  // each detection steps the alert up; after a grade-scaled number of detections
+  // the trace countdown begins (S/A:1, B/C:2, D/F:3). This is the ICE *pursuit*
+  // layer — distinct from the exploit-failure → IDS → monitor *puzzle* layer
+  // (recomputeGlobalAlert). Trace here is gated purely on detection COUNT, not on
+  // counting red IDS nodes (which is unreachable on a 1-detector network).
+  const count = getState().ice.detectionCount;
+  const threshold = DETECTION_TRACE_THRESHOLD[s.ice.grade] ?? 2;
+  if (count >= threshold) {
+    if (getState().traceSecondsRemaining === null) startTraceCountdown();
+    return;
+  }
+  // Sub-threshold: step the alert up one level for feedback, capped below trace
+  // (trace is threshold-gated for ICE — a later detection starts the clock).
+  const idx = GLOBAL_ALERT_ORDER.indexOf(s.globalAlert);
+  if (idx < GLOBAL_ALERT_ORDER.indexOf("red")) {
+    const prev = s.globalAlert;
+    const next = GLOBAL_ALERT_ORDER[idx + 1];
+    setGlobalAlert(next);
+    emitEvent(E.ALERT_GLOBAL_RAISED, { prev, next });
   }
 }

--- a/js/core/ice.js
+++ b/js/core/ice.js
@@ -8,7 +8,7 @@
 
 import { getState } from "./state.js";
 import { setIceAttention, setIceDetectedAt, setIceDwellTimer, setIceActive, setLastDisturbedNode } from "./state/ice.js";
-import { propagateAlertEvent, recordIceDetection } from "./alert.js";
+import { recordIceDetection } from "./alert.js";
 import { scheduleEvent, scheduleRepeating, cancelAllByType, TIMER } from "./timers.js";
 import { emitEvent, on, E } from "./events.js";
 import { A } from "./action-ids.js";
@@ -217,8 +217,10 @@ export function handleIceDetect({ nodeId }) {
 function triggerDetection(nodeId) {
   const s = getState();
   emitEvent(E.ICE_DETECTED, { nodeId, label: s.nodes[nodeId]?.label ?? nodeId });
-  propagateAlertEvent(nodeId);
-  recordIceDetection(nodeId); // tracks count and may start trace
+  // ICE detection drives the global alert directly (count/grade-gated) inside
+  // recordIceDetection. It does NOT route through the exploit-failure IDS→monitor
+  // propagation path (that's the separate puzzle layer) — see MANUAL.md.
+  recordIceDetection(nodeId); // steps alert; starts trace at the grade threshold
 }
 
 export function cancelIceDwell() {

--- a/scripts/bot/execute.js
+++ b/scripts/bot/execute.js
@@ -82,14 +82,16 @@ export function execute(choice, world, opts = {}) {
 }
 
 /**
- * Tick forward until the timed action resolves, ICE interrupts, or budget expires.
+ * Tick forward until the timed action resolves, ICE actually DETECTS the player
+ * (E.ICE_DETECTED — not mere ICE arrival), the run ends, or the budget expires.
+ * `interrupted` in the return reflects a real mid-action detection.
  * @param {ScoredAction} choice
  * @param {number} budget
  * @returns {{ completed: boolean, interrupted: boolean, ticksUsed: number }}
  */
 function tickUntilResolved(choice, budget) {
   let resolved = false;
-  let interrupted = false;
+  let detected = false;   // ICE completed a dwell and detected us mid-action
   let runEnded = false;
   let ticksUsed = 0;
 
@@ -108,11 +110,24 @@ function tickUntilResolved(choice, budget) {
     }
   };
 
+  // ICE arriving on our node does NOT auto-abort the action. Detection requires
+  // ICE to dwell (grade-scaled), so the hack and the dwell race — a focused
+  // decker keeps working and only bails if the trace actually lands. On an OWNED
+  // node, eject is free, so push ICE off and keep going. (Previously the bot
+  // panic-aborted on mere arrival: ICE never actually detected — so it was
+  // toothless — yet the bot abandoned and restarted actions, the source of the
+  // evasion thrash and exchange tick-cap. #114 WS2.)
   const onIceMoved = ({ toId }) => {
     const s = getState();
-    if (s.selectedNodeId && toId === s.selectedNodeId) {
-      interrupted = true;
+    if (toId !== s.selectedNodeId || toId !== targetNodeId) return;
+    const node = s.nodes[targetNodeId];
+    if (node && node.accessLevel === "owned" && s.ice?.active && s.ice.attentionNodeId === targetNodeId) {
+      emitEvent("starnet:action", { actionId: A.EJECT, nodeId: targetNodeId });
     }
+  };
+
+  const onDetected = ({ nodeId }) => {
+    if (nodeId === targetNodeId) detected = true;
   };
 
   const onRunEnded = () => { runEnded = true; };
@@ -120,10 +135,11 @@ function tickUntilResolved(choice, budget) {
   on(E.ACTION_RESOLVED, onResolved);
   on(E.ACTION_FEEDBACK, onFeedback);
   on(E.ICE_MOVED, onIceMoved);
+  on(E.ICE_DETECTED, onDetected);
   on(E.RUN_ENDED, onRunEnded);
 
   try {
-    for (let i = 0; i < budget && !resolved && !interrupted && !runEnded; i++) {
+    for (let i = 0; i < budget && !resolved && !detected && !runEnded; i++) {
       tick(1);
       ticksUsed++;
     }
@@ -131,21 +147,16 @@ function tickUntilResolved(choice, budget) {
     off(E.ACTION_RESOLVED, onResolved);
     off(E.ACTION_FEEDBACK, onFeedback);
     off(E.ICE_MOVED, onIceMoved);
+    off(E.ICE_DETECTED, onDetected);
     off(E.RUN_ENDED, onRunEnded);
   }
 
-  // If interrupted by ICE: eject if we own the node (keeps action going),
-  // otherwise abort and untarget to hide.
-  if (interrupted && !resolved && !runEnded) {
-    const s = getState();
-    const node = targetNodeId ? s.nodes[targetNodeId] : null;
-    if (node && node.accessLevel === "owned" && s.ice?.active && s.ice.attentionNodeId === targetNodeId) {
-      emitEvent("starnet:action", { actionId: A.EJECT, nodeId: targetNodeId });
-    } else {
-      emitEvent("starnet:action", { actionId: A.ABORT, nodeId: targetNodeId });
-      emitEvent("starnet:action", { actionId: A.UNTARGET });
-    }
+  // Caught mid-action: abort and untarget to hide. Alert has already escalated;
+  // the between-action heuristics (evasion/security) handle trace from here.
+  if (detected && !resolved && !runEnded) {
+    emitEvent("starnet:action", { actionId: A.ABORT, nodeId: targetNodeId });
+    emitEvent("starnet:action", { actionId: A.UNTARGET });
   }
 
-  return { completed: resolved || runEnded, interrupted, ticksUsed };
+  return { completed: resolved || runEnded, interrupted: detected, ticksUsed };
 }

--- a/scripts/bot/stats.js
+++ b/scripts/bot/stats.js
@@ -6,7 +6,10 @@
 
 import { A } from "../../js/core/action-ids.js";
 
-const ALERT_RANK = { green: 0, yellow: 1, red: 2 };
+// Mirrors GLOBAL_ALERT_ORDER in js/core/alert.js. "trace" MUST be included —
+// global alert can escalate straight to "trace", and omitting it here made
+// updatePeakAlert silently drop trace-level raises to rank 0 (issue #114, WS3).
+const ALERT_RANK = { green: 0, yellow: 1, red: 2, trace: 3 };
 
 /**
  * Create a fresh stats object with zeroed counters.
@@ -93,7 +96,11 @@ export function finalizeStats(stats, state) {
   stats.cashRemaining = state.player.cash;
   stats.ticksElapsed = stats.ticksElapsed; // set by loop
   stats.success = state.mission?.complete ?? false;
-  if (!stats.success && !stats.failReason) {
-    stats.failReason = "stuck";
+  if (!stats.success && stats.failReason !== "tick-cap") {
+    // Attribute the loss to trace pressure when a trace fired during the run —
+    // the bot bailed (or was caught) under the trace rather than just running
+    // out of moves. "stuck" is reserved for incomplete runs with no trace
+    // (genuinely no path forward); "tick-cap" (set in the loop) is left intact.
+    stats.failReason = stats.traceFired ? "trace" : (stats.failReason ?? "stuck");
   }
 }

--- a/tests/bot-stats.test.js
+++ b/tests/bot-stats.test.js
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createStats, updatePeakAlert, finalizeStats } from "../scripts/bot/stats.js";
+
+// Minimal GameState stub for finalizeStats (it reads nodes/player.cash/mission).
+function stubState({ complete = false } = {}) {
+  return {
+    nodes: { a: { accessLevel: "owned", type: "router" }, b: { accessLevel: "locked", type: "router" } },
+    player: { cash: 500 },
+    mission: { complete },
+  };
+}
+
+// Regression for the traceFired/peakAlert discrepancy (issue #114, WS3):
+// global alert can escalate straight to "trace", but the census peakAlert stat
+// ranked only green/yellow/red, so a trace-level raise was silently dropped to
+// rank 0 — runs that fired trace reported peakAlert "green". The mechanic is
+// correct; the stat undercounts. peakAlert must be able to record "trace".
+
+test("updatePeakAlert records trace as the highest level", () => {
+  const stats = createStats();
+  updatePeakAlert(stats, "trace");
+  assert.equal(stats.peakAlert, "trace");
+});
+
+test("trace outranks red and is not overwritten by a later lower level", () => {
+  const stats = createStats();
+  updatePeakAlert(stats, "red");
+  updatePeakAlert(stats, "trace");
+  assert.equal(stats.peakAlert, "trace");
+  // Alert never de-escalates in-game; a stale lower raise must not lower the peak.
+  updatePeakAlert(stats, "yellow");
+  assert.equal(stats.peakAlert, "trace");
+});
+
+test("peakAlert and traceFired cannot contradict: if trace fired, peak is trace", () => {
+  // Mirrors the loop.js wiring: ALERT_TRACE_STARTED sets traceFired, and the
+  // accompanying ALERT_GLOBAL_RAISED{next:"trace"} feeds updatePeakAlert.
+  const stats = createStats();
+  stats.traceFired = true;
+  updatePeakAlert(stats, "trace");
+  assert.equal(stats.peakAlert, "trace");
+});
+
+// Loss attribution (issue #114): a bot that bails (jacks out) under trace
+// pressure with an incomplete mission was tagged "stuck" — only the hard
+// countdown-expiry "caught" path set "trace". Trace-pressure losses must be
+// attributed to trace so census fail reasons honestly reflect pressure.
+
+test("finalizeStats: incomplete run with traceFired is attributed to trace", () => {
+  const stats = createStats();
+  stats.traceFired = true; // trace fired during the run; bot jacked out short
+  finalizeStats(stats, stubState({ complete: false }));
+  assert.equal(stats.success, false);
+  assert.equal(stats.failReason, "trace");
+});
+
+test("finalizeStats: incomplete run without trace stays stuck", () => {
+  const stats = createStats();
+  finalizeStats(stats, stubState({ complete: false }));
+  assert.equal(stats.failReason, "stuck");
+});
+
+test("finalizeStats: tick-cap is not overridden by traceFired", () => {
+  const stats = createStats();
+  stats.failReason = "tick-cap";
+  stats.traceFired = true;
+  finalizeStats(stats, stubState({ complete: false }));
+  assert.equal(stats.failReason, "tick-cap");
+});
+
+test("finalizeStats: completed mission is a success regardless of trace", () => {
+  const stats = createStats();
+  stats.traceFired = true;
+  finalizeStats(stats, stubState({ complete: true }));
+  assert.equal(stats.success, true);
+  assert.equal(stats.failReason, null);
+});

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -39,6 +39,7 @@ import { MINE_TAPOUT } from "../js/core/mining.js";
 import { generateExploit } from "../js/core/exploits.js";
 import { launchExploit } from "../js/core/combat.js";
 import { startTraceCountdown, recordIceDetection } from "../js/core/alert.js";
+import { setGlobalAlert } from "../js/core/state/alert.js";
 // Importing alert.js above registers its module-level NODE_ALERT_RAISED /
 // NODE_RECONFIGURED listeners. No separate init call needed.
 // Old executor imports removed — timed actions now graph-native
@@ -267,6 +268,36 @@ describe("Lifecycle: monitor — owning security-monitor cancels active trace", 
   });
 });
 
+// ── Trace ↔ global alert consistency (#114 WS3) ───────────────────────────────
+
+describe("Trace: startTraceCountdown drives global alert to trace", () => {
+  beforeEach(() => {
+    clearAll();
+    initGame(() => buildBasicLAN(), "itest-trace-global");
+  });
+
+  // Regression: set-piece alarms call ctx.startTrace() -> startTraceCountdown()
+  // directly, bypassing alert escalation. Trace must still be the visible alert
+  // level so the HUD and the census peakAlert stat reflect it (matching the
+  // bot-stats traceFired flag). Previously globalAlert stayed green.
+  it("escalates globalAlert to trace even with no alert escalation", () => {
+    assert.equal(getState().globalAlert, "green");
+    const raised = withEvents(E.ALERT_GLOBAL_RAISED, () => startTraceCountdown());
+    assert.equal(getState().globalAlert, "trace", "trace countdown implies trace-level alert");
+    assert.ok(
+      raised.some((e) => e.next === "trace"),
+      "should emit ALERT_GLOBAL_RAISED { next: 'trace' }"
+    );
+  });
+
+  it("does not emit a redundant raise when already at trace", () => {
+    setGlobalAlert("trace");
+    const raised = withEvents(E.ALERT_GLOBAL_RAISED, () => startTraceCountdown());
+    assert.equal(raised.length, 0, "no duplicate raise when already trace");
+    assert.equal(getState().globalAlert, "trace");
+  });
+});
+
 // ── Alert flow ────────────────────────────────────────────────────────────────
 
 describe("Alert flow: ids alert escalates global alert", () => {
@@ -479,51 +510,65 @@ describe("ICE detection: detectedAtNode resets when ICE leaves player's node", (
 
 // ── ICE detection: alert escalation ──────────────────────────────────────────
 
-describe("ICE detection: alert escalation", () => {
-  // buildAlertLAN has an IDS node; recordIceDetection raises alert on all IDS nodes.
-  // recomputeGlobalAlert needs 2 red detectors for trace. Two IDS nodes ensure that
-  // after 2 detections, both reach red (green→yellow, yellow→red) triggering trace.
-  function buildDualIdsLAN() {
+describe("ICE detection: alert escalation (grade-scaled, per MANUAL.md)", () => {
+  // ICE detection steps the global alert up and starts the trace countdown after
+  // a grade-scaled number of detections: S/A=1, B/C=2, D/F=3 (DETECTION_TRACE_
+  // THRESHOLD). A single IDS suffices — trace is detection-count-gated, NOT
+  // gated on counting red IDS nodes. (#114: code now matches the manual.)
+  function buildIceTraceLAN(grade) {
     return {
       graphDef: {
         nodes: [
           createGateway("gateway", { attributes: { visibility: "accessible" } }),
           createIDS("ids-1"),
-          createIDS("ids-2"),
           createSecurityMonitor("mon-1"),
         ],
-        edges: [["gateway", "ids-1"], ["gateway", "ids-2"], ["ids-1", "mon-1"]],
+        edges: [["gateway", "ids-1"], ["ids-1", "mon-1"]],
         triggers: [],
       },
-      meta: { startNode: "gateway", startCash: 0, moneyCost: "C", ice: { grade: "C", startNode: "ids-1" } },
+      meta: { startNode: "gateway", startCash: 0, moneyCost: "C", ice: { grade, startNode: "ids-1" } },
     };
   }
 
-  beforeEach(() => {
+  it("grade A: a single detection starts the trace (instant)", () => {
     clearAll();
-    initGame(() => buildDualIdsLAN(), "itest-14");
+    initGame(() => buildIceTraceLAN("A"), "itest-ice-a");
+    recordIceDetection("gateway");
+    assert.equal(getState().globalAlert, "trace");
+    assert.notEqual(getState().traceSecondsRemaining, null);
   });
 
-  it("first detection escalates global alert from green to yellow", () => {
-    const s = getState();
-    assert.equal(s.globalAlert, "green");
+  it("grade C: first detection raises alert (not trace), second starts trace", () => {
+    clearAll();
+    initGame(() => buildIceTraceLAN("C"), "itest-ice-c");
     recordIceDetection("gateway");
-    assert.equal(s.globalAlert, "yellow");
+    assert.equal(getState().globalAlert, "yellow");
+    assert.equal(getState().traceSecondsRemaining, null, "one detection must not trace at grade C");
+    recordIceDetection("gateway");
+    assert.equal(getState().globalAlert, "trace");
+    assert.notEqual(getState().traceSecondsRemaining, null);
   });
 
-  it("second detection (threshold met) escalates to trace", () => {
-    const s = getState();
+  it("grade F: takes three detections to start the trace (forgiving)", () => {
+    clearAll();
+    initGame(() => buildIceTraceLAN("F"), "itest-ice-f");
     recordIceDetection("gateway");
     recordIceDetection("gateway");
-    assert.equal(s.globalAlert, "trace");
+    assert.notEqual(getState().globalAlert, "trace", "two detections must not trace at grade F");
+    assert.equal(getState().traceSecondsRemaining, null);
+    recordIceDetection("gateway");
+    assert.equal(getState().globalAlert, "trace");
+    assert.notEqual(getState().traceSecondsRemaining, null);
   });
 
-  it("second detection (threshold met) starts trace countdown", () => {
-    const s = getState();
+  it("a single IDS is sufficient (not dependent on counting red detectors)", () => {
+    clearAll();
+    initGame(() => buildIceTraceLAN("C"), "itest-ice-single");
+    const detectorCount = Object.values(getState().nodes).filter(n => n.type === "ids").length;
+    assert.equal(detectorCount, 1);
     recordIceDetection("gateway");
     recordIceDetection("gateway");
-    assert.notEqual(s.traceSecondsRemaining, null,
-      "trace countdown must start when detection threshold is met");
+    assert.equal(getState().globalAlert, "trace");
   });
 });
 


### PR DESCRIPTION
Closes #114. Phase 3 of the core-loop tuning session.

## TL;DR
Stepping back to ask whether the ICE mechanic was even legible surfaced the root cause: **ICE detection never matched the manual.** Fixing that dissolved the whole pressure-tuning problem — both tuning networks now lose to `trace`/ICE, not `stuck`/`tick-cap`.

## Final census (50 seeds, deterministic, `make check` 666 green)
| Network | config | success | losses | iceDet | stuck/tick-cap |
|---|---|---|---|---|---|
| corporate-foothold | grade C @ router-1 (was `null`) | 0.94 | trace only | 0.34 | 0 |
| corporate-exchange | grade B @ sec/monitor (unchanged) | 0.84 | trace only | 0.76 | 0 |

## What changed (per commit)
- **WS3a — peakAlert stat:** `ALERT_RANK` omitted `trace`, so a trace-level raise was dropped to rank 0 and `peakAlert` could never record it (the `traceFired`-vs-`peakAlert` contradiction).
- **WS3b — alarm-path mechanic:** set-piece alarms (`ctx.startTrace`) started the trace countdown without escalating `globalAlert` — the issue’s "trace without a visible alert escalation." `startTraceCountdown()` now guarantees `globalAlert==="trace"` for every caller.
- **WS2 — bot evasion / exchange tick-cap:** the bot panic-aborted the instant ICE *arrived*, even though detection needs a grade-scaled dwell. ICE never actually detected it (toothless), yet the abort/retry oscillation burned the tick budget (`iceEvasions ~56/run`) — the tick-cap. Now the hack races the dwell: commit, eject on owned nodes, bail only on real detection. Exchange: 0.53→1.00 pre-pressure-tune, ticks 3200→1300, tick-cap eliminated. + loss attribution (bail-under-trace → `trace`, not `stuck`).
- **WS1 + root fix — ICE→trace per MANUAL.md:** `DETECTION_TRACE_THRESHOLD` and `ice.detectionCount` were defined but **never read**. ICE detection routed through the exploit-failure IDS-coloring path, where trace needs ≥2 red detectors (impossible on a 1-detector network) — so ICE pegged alert at red but never traced. Now ICE detection steps the global alert and starts trace at the grade threshold (S/A:1, B/C:2, D/F:3), as documented. corporate-foothold gains gentle grade-C ICE.

## Tests
- New regression tests: `tests/bot-stats.test.js` (peakAlert/trace rank, loss attribution), `tests/integration.test.js` (trace→global-alert escalation; grade-scaled ICE→trace with a single IDS).
- `make check`: 666 pass. Census deterministic.

## Docs
- `MANUAL.md`: no change needed — the manual already described the correct ICE→trace behavior; the code now conforms.
- `BOT-PLAYER.md`: updated for the commit-to-hack ICE handling.
- Full diagnosis + decisions in `docs/dev-sessions/2026-06-09-1703-phase3-pressure-tuning/`.

## Notes / follow-ups (out of scope, flagged in session notes)
- foothold lands at 94% (just above the 75–90% target band): among gentle grade-C placements, router-1 is the only one that bites; 94% with clean trace losses reads as appropriately "gentle" for a tutorial-adjacent network. Confirmed to keep.
- `generated` census emits `peakAlert: "unknown"` / `success: 0` on some procgen topologies — pre-existing, verified independent of these fixes; worth a separate issue.
- A bot patience/back-off heuristic would let grade-A/S ICE produce clean trace losses without saturation thrash — the lever if future networks want grade-A pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)