### PR TITLE
Vector CRT rendering pass

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -86,9 +86,10 @@ Each node in the LAN has a **type** that determines what it does and why you wan
 | **Security Mon.** | Scope + crosshair | Owned        | Aggregates IDS alerts. Must own to see connections. Can cancel trace. |
 
 Every node is drawn as a 12-sided container holding a small glyph of the device
-it represents. The glyph (and its color) tells you *what kind* of node it is; the
-container's border and fill tell you its *state* — locked, compromised, owned, or
-on alert.
+it represents, rendered as a glowing vector outline. The glyph (and its color)
+tells you *what kind* of node it is; the container's border plus a fence-hatch
+pattern inside it tell you its *state* — the hatching gets denser as a node goes
+from locked to compromised to owned, and the border color/pulse shows alert.
 
 The **Gate** column shows when a node reveals its connections to neighboring nodes.
 "Probe" means probing the node is enough to see what's connected. "Compromised" or
@@ -197,7 +198,7 @@ improves your odds significantly.
 
 On a compromised or owned node, `dump` extracts data from the node's filesystem —
 data packages, files, anything of value. This takes time, scaled by node grade.
-A random pie-sector animation fills the node as data is extracted. You can cancel
+The node's 12 facets light up in random order as data is extracted. You can cancel
 with `abort`, and navigating away cancels automatically.
 
 Once complete, you'll see what macguffins are present and whether your mission

--- a/css/style.css
+++ b/css/style.css
@@ -22,6 +22,11 @@
   --text-dim:   #336633;
   --border:     #0a3a3a;
   --font-mono:  "Courier New", "Lucida Console", monospace;
+
+  /* Glow scale — keep chrome bloom consistent with the graph's vector bloom. */
+  --glow-sm: 0 0 4px;
+  --glow-md: 0 0 8px;
+  --glow-lg: 0 0 14px;
 }
 
 html, body {
@@ -73,7 +78,6 @@ html, body {
   position: relative;
   overflow: hidden;
   min-height: 0;
-  /* Scanline overlay */
   background-color: var(--bg);
   background-image:
     linear-gradient(rgba(0, 255, 255, 0.04) 1px, transparent 1px),
@@ -115,7 +119,7 @@ html, body {
   color: var(--cyan);
   font-size: 0.8rem;
   white-space: nowrap;
-  text-shadow: 0 0 6px var(--cyan);
+  text-shadow: var(--glow-md) var(--cyan);
 }
 
 #console-input {
@@ -133,24 +137,27 @@ html, body {
   color: var(--cyan-dim);
 }
 
-#graph-container::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: repeating-linear-gradient(
-    to bottom,
-    transparent 0px,
-    transparent 3px,
-    rgba(0, 0, 0, 0.18) 3px,
-    rgba(0, 0, 0, 0.18) 4px
-  );
-  pointer-events: none;
-  z-index: 5;
+/* Vector CRT bloom — colored phosphor halo on the graph + overlay layers.
+   Single SVG <filter> def injected by graph.js (#starnet-bloom). */
+#cy, #overlay-layer {
+  filter: url(#starnet-bloom);
 }
 
 #cy {
   width: 100%;
   height: 100%;
+}
+
+/* The overlay layer must be an explicit absolute overlay sharing #cy's origin.
+   Without an explicit position it is static and sits below the full-height #cy;
+   the bloom `filter` above then makes it the containing block for the
+   absolutely-positioned overlay <svg>s at that wrong (bottom-of-graph) origin,
+   shifting every animation off-screen. Anchoring it here keeps overlays on
+   their nodes. pointer-events:none so it never intercepts graph clicks. */
+#overlay-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
 }
 
 #cy canvas {
@@ -188,7 +195,7 @@ html, body {
 }
 
 .mission-status-active   { font-size: 0.7rem; color: var(--yellow); }
-.mission-status-complete { font-size: 0.7rem; color: var(--green); text-shadow: 0 0 4px var(--green); }
+.mission-status-complete { font-size: 0.7rem; color: var(--green); text-shadow: var(--glow-sm) var(--green); }
 .mission-status-failed   { font-size: 0.7rem; color: var(--red); }
 
 #sidebar-node {
@@ -212,7 +219,7 @@ html, body {
   font-weight: bold;
   color: var(--cyan);
   letter-spacing: 0.15em;
-  text-shadow: 0 0 8px var(--cyan);
+  text-shadow: var(--glow-md) var(--cyan);
   margin-right: auto;
 }
 
@@ -225,7 +232,7 @@ html, body {
 #hud .hud-value {
   color: var(--green);
   font-size: 0.9rem;
-  text-shadow: 0 0 6px var(--green);
+  text-shadow: var(--glow-md) var(--green);
 }
 
 #hud .hud-alert {
@@ -239,12 +246,12 @@ html, body {
   height: 10px;
   border-radius: 50%;
   background: var(--green);
-  box-shadow: 0 0 6px var(--green);
+  box-shadow: var(--glow-md) var(--green);
 }
 
 #hud .alert-dot.yellow {
   background: var(--yellow);
-  box-shadow: 0 0 6px var(--yellow);
+  box-shadow: var(--glow-md) var(--yellow);
   animation: pulse 1s ease-in-out infinite;
   will-change: opacity;
 }
@@ -258,7 +265,7 @@ html, body {
 
 #hud .alert-dot.trace {
   background: var(--red);
-  box-shadow: 0 0 14px var(--red);
+  box-shadow: var(--glow-lg) var(--red);
   animation: pulse 0.3s ease-in-out infinite;
   will-change: opacity;
 }
@@ -279,12 +286,12 @@ html, body {
 
 #hud .hud-conn-dot.active {
   background: var(--magenta);
-  box-shadow: 0 0 6px var(--magenta);
+  box-shadow: var(--glow-md) var(--magenta);
 }
 
 #hud .hud-conn-dot.detecting {
   background: var(--yellow);
-  box-shadow: 0 0 8px var(--yellow);
+  box-shadow: var(--glow-md) var(--yellow);
   animation: pulse 0.6s ease-in-out infinite;
   will-change: opacity;
 }
@@ -319,19 +326,19 @@ html, body {
   letter-spacing: 0.1em;
   padding: 0.3rem 0.8rem;
   cursor: pointer;
-  text-shadow: 0 0 6px var(--cyan);
-  box-shadow: 0 0 6px rgba(0, 255, 255, 0.3);
+  text-shadow: var(--glow-md) var(--cyan);
+  box-shadow: var(--glow-md) rgba(0, 255, 255, 0.3);
   transition: background 0.15s, box-shadow 0.15s;
 }
 
 #new-run-btn:hover, #pause-btn:hover, #save-btn:hover, #load-btn:hover {
   background: rgba(0, 255, 255, 0.1);
-  box-shadow: 0 0 12px rgba(0, 255, 255, 0.5);
+  box-shadow: var(--glow-lg) rgba(0, 255, 255, 0.5);
 }
 
 #pause-btn.active {
   background: rgba(0, 255, 255, 0.15);
-  box-shadow: 0 0 14px rgba(0, 255, 255, 0.7);
+  box-shadow: var(--glow-lg) rgba(0, 255, 255, 0.7);
 }
 
 #jack-out-btn {
@@ -344,14 +351,14 @@ html, body {
   letter-spacing: 0.1em;
   padding: 0.3rem 0.8rem;
   cursor: pointer;
-  text-shadow: 0 0 6px var(--red);
-  box-shadow: 0 0 6px rgba(255, 32, 32, 0.3);
+  text-shadow: var(--glow-md) var(--red);
+  box-shadow: var(--glow-md) rgba(255, 32, 32, 0.3);
   transition: background 0.15s, box-shadow 0.15s;
 }
 
 #jack-out-btn:hover {
   background: rgba(255, 32, 32, 0.15);
-  box-shadow: 0 0 12px rgba(255, 32, 32, 0.6);
+  box-shadow: var(--glow-lg) rgba(255, 32, 32, 0.6);
 }
 
 #jack-out-btn:disabled {
@@ -420,7 +427,7 @@ html, body {
 .nd-label {
   font-size: 1rem;
   color: var(--green);
-  text-shadow: 0 0 6px var(--green);
+  text-shadow: var(--glow-md) var(--green);
   letter-spacing: 0.1em;
 }
 
@@ -460,7 +467,7 @@ html, body {
 
 .ice-timer-detect {
   color: #ff2020;
-  text-shadow: 0 0 6px #ff2020;
+  text-shadow: var(--glow-md) #ff2020;
 }
 
 .ice-timer-reboot {
@@ -469,12 +476,12 @@ html, body {
 
 .ice-timer-executing {
   color: var(--cyan);
-  text-shadow: 0 0 6px var(--cyan-dim);
+  text-shadow: var(--glow-md) var(--cyan-dim);
 }
 
 .ice-timer-scanning {
   color: var(--cyan);
-  text-shadow: 0 0 6px var(--cyan-dim);
+  text-shadow: var(--glow-md) var(--cyan-dim);
 }
 
 .nd-actions {
@@ -490,7 +497,7 @@ html, body {
 }
 
 /* Grade color coding */
-.grade-S, .grade-A { color: var(--red); text-shadow: 0 0 6px var(--red); }
+.grade-S, .grade-A { color: var(--red); text-shadow: var(--glow-md) var(--red); }
 .grade-B           { color: var(--yellow); }
 .grade-C           { color: var(--cyan); }
 .grade-D, .grade-F { color: var(--text-dim); }
@@ -557,7 +564,7 @@ html, body {
   padding: 0.5rem;
   background: var(--bg-panel);
   border: 1px solid var(--cyan);
-  box-shadow: 0 0 12px rgba(0, 255, 255, 0.35);
+  box-shadow: var(--glow-lg) rgba(0, 255, 255, 0.35);
 }
 
 #action-choices .ac-header {
@@ -764,7 +771,7 @@ html, body {
 .nd-hand.exploit-hand-executing .exploit-card.executing {
   opacity: 1;
   border-color: var(--cyan);
-  box-shadow: 0 0 6px rgba(0, 200, 255, 0.4);
+  box-shadow: var(--glow-md) rgba(0, 200, 255, 0.4);
   position: relative;
   overflow: hidden;
 }
@@ -792,7 +799,7 @@ html, body {
   font-size: 0.6rem;
   letter-spacing: 0.05em;
   margin-top: auto; /* push to card bottom */
-  text-shadow: 0 0 6px var(--cyan-dim);
+  text-shadow: var(--glow-md) var(--cyan-dim);
   position: relative; /* keep above the ::before fill */
   visibility: hidden;
   white-space: nowrap; /* prevents text wrapping which would shift card content */
@@ -833,7 +840,7 @@ html, body {
 
 .ec-cancel-overlay:hover .ec-cancel-x {
   opacity: 1;
-  box-shadow: 0 0 8px rgba(204, 0, 204, 0.5);
+  box-shadow: var(--glow-md) rgba(204, 0, 204, 0.5);
 }
 
 /* ── Action Log ─────────────────────────────────────────── */
@@ -848,8 +855,8 @@ html, body {
 #console-input, .log-entry { font-size: 15px; }
 
 .log-entry           { color: #4daa55; }
-.log-entry.log-success { color: #7fff7f; font-weight: bold; text-shadow: 0 0 4px rgba(0, 255, 65, 0.5); }
-.log-entry.log-failure { color: var(--red); font-weight: bold; text-shadow: 0 0 4px rgba(255, 32, 32, 0.5); }
+.log-entry.log-success { color: #7fff7f; font-weight: bold; text-shadow: var(--glow-sm) rgba(0, 255, 65, 0.5); }
+.log-entry.log-failure { color: var(--red); font-weight: bold; text-shadow: var(--glow-sm) rgba(255, 32, 32, 0.5); }
 .log-entry.log-meta    { color: #517a57; }
 .log-entry.log-command { color: var(--cyan); }
 .log-entry.log-error   { color: var(--red); }
@@ -880,7 +887,7 @@ html, body {
 
 .macguffin.mission-target .mg-name {
   color: var(--yellow);
-  text-shadow: 0 0 4px rgba(255, 255, 0, 0.4);
+  text-shadow: var(--glow-sm) rgba(255, 255, 0, 0.4);
 }
 
 .mg-mission-tag {
@@ -894,7 +901,7 @@ html, body {
 
 .trace-countdown {
   color: var(--red) !important;
-  text-shadow: 0 0 8px var(--red);
+  text-shadow: var(--glow-md) var(--red);
   animation: pulse 0.5s ease-in-out infinite;
   will-change: opacity;
   letter-spacing: 0.1em;
@@ -945,9 +952,9 @@ html, body {
 }
 
 .end-key { color: var(--text-dim); letter-spacing: 0.08em; }
-.end-val { color: var(--green); text-shadow: 0 0 4px var(--green); }
-.end-val.end-zero { color: var(--red); text-shadow: 0 0 4px var(--red); }
-.end-val.end-mission-complete { color: var(--yellow); text-shadow: 0 0 6px rgba(255, 255, 0, 0.5); }
+.end-val { color: var(--green); text-shadow: var(--glow-sm) var(--green); }
+.end-val.end-zero { color: var(--red); text-shadow: var(--glow-sm) var(--red); }
+.end-val.end-mission-complete { color: var(--yellow); text-shadow: var(--glow-md) rgba(255, 255, 0, 0.5); }
 
 .end-btn {
   background: transparent;
@@ -972,7 +979,7 @@ html, body {
   color: var(--magenta);
   font-size: 0.75rem;
   letter-spacing: 0.15em;
-  text-shadow: 0 0 8px var(--magenta);
+  text-shadow: var(--glow-md) var(--magenta);
   animation: pulse 1.5s ease-in-out infinite;
   will-change: opacity;
 }
@@ -1198,7 +1205,7 @@ html, body {
 .level-select-select:focus {
   outline: none;
   border-color: var(--cyan);
-  box-shadow: 0 0 6px rgba(0, 200, 255, 0.2);
+  box-shadow: var(--glow-md) rgba(0, 200, 255, 0.2);
 }
 
 .level-select-select option {

--- a/docs/dev-sessions/2026-06-10-1013-vector-crt-rendering/notes.md
+++ b/docs/dev-sessions/2026-06-10-1013-vector-crt-rendering/notes.md
@@ -1,0 +1,128 @@
+# Notes — Vector CRT Rendering Pass
+
+## Summary
+
+Reworked the network-graph presentation into a glowing **vector CRT display**
+(Asteroids / Tempest / Black Widow): blooming strokes on near-black, no solid
+fills, fence-hatch state encoding, no raster scanline, faceted (12-gon) overlay
+effects, straight edges, and a runtime-adjustable bloom.
+
+Done on branch `worktree-vector-crt-display` (an isolated worktree — see
+"Branch collision" below). Presentation-only: no gameplay/state/event changes;
+console + log channel untouched; `make check` green throughout (700 tests).
+
+## What shipped
+
+**Core graph**
+- `node-glyphs.js`: `nodeFaceDataUri(type, accessLevel)` — one stroke-only SVG =
+  dodecagon-clipped fence hatch (density encodes access level, dimmed hue) + the
+  type glyph. Derived from the existing `CONTAINER_POLYGON_POINTS`.
+- `graph.js`: nodes use the face; solid `background-color` fills → transparent;
+  native Cytoscape border kept (so alert/ICE/reboot pulses still work and the
+  border stays the brightest element).
+- Bloom via CSS `filter: url(#starnet-bloom)` on `#cy` + `#overlay-layer`; the
+  SVG `<filter>` (feGaussianBlur ×2 + feMerge, wide halo merged twice) is injected
+  once by `ensureBloomFilter()` in `initGraph` — covers all three entrypoints.
+- Scanline (`#graph-container::after`) removed. Reference grid kept.
+- `flashNode` → expanding faceted "ripple" ping in the overlay layer (was a
+  border-color flash; before that, a solid-fill flash).
+
+**Dynamic bloom** (added mid-session at Les's request)
+- `setBloomIntensity(mult)` / `getBloomIntensity()` rescale the live filter; base
+  radii are module constants. Exposed on `window` for experimentation. Seam for a
+  future **deck-damage** mechanic (crank bloom toward illegible on injury). The
+  multiplier's source of truth should live in game state when that's built.
+
+**Effects coherence pass** (added mid-session — "no curves, no fills")
+- New pure helper `js/ui/overlays/facet.js` (`facetVertices`/`ringPoints`/
+  `arcPoints`, 12-gon, vertex at 12 o'clock) + tests.
+- Edges: `curve-style` bezier → straight.
+- `probe-sweep`: filled pie + circle → **chunky LED segments** (12 dodecagon
+  edges brighten from dim to lit as the CW sweep front crosses them) + radial hand.
+- `read-sectors`: filled pie wedges → the 12 facets light up (stroke-only wedge
+  outlines) in random order.
+- `ice-detect`: smooth arc → faceted CCW polyline arc.
+- `selection-reticle`: `<circle>` → dashed faceted 12-gon (spin/ticks kept).
+- `loot-rings`: expanding circles → thin faceted "ripple" rings; spawn cadence
+  thins as the node drains (dense when full → sparse). (`exploit-brackets` and
+  `mine-scan` were already line-based and left as-is.)
+
+**Chrome**
+- `--glow-sm/md/lg` glow scale in `:root`; prominent HUD/log/card glows migrated
+  to it. A few off-scale ambient/escalation glows intentionally left.
+
+**Preview harness**: access-state demo nodes (locked/compromised/owned) so the
+fence density is tunable without playing through.
+
+**MANUAL.md**: updated the node-state and DUMP descriptions (fill → fence/facets).
+
+## Tuning values (as shipped — all easily adjustable)
+
+- Bloom: `BLOOM_WIDE=5`, `BLOOM_TIGHT=2`, filter region `-80%/260%`, wide halo
+  merged twice. `setBloomIntensity(1)` default.
+- Fence: `FENCE_OPACITY=0.42`, width `0.8`; gaps locked 11 / compromised 7 /
+  owned 4.5; dimmed hues locked `#246060`, compromised `#1c6a85`, owned `#1c8a4a`.
+- Loot ripples: stroke `1.5 + rand*0.7` (crisp, not soft), opacity `0.95`,
+  `PAD=20` travel, spawn delay `100 + progress*500` ms.
+- Flash ripple: 2 staggered rings, `DUR=420ms`, `STAGGER=120ms`, `PAD=18`.
+
+## Decisions
+
+- **No solid fills, no smooth curves.** A real vector CRT can't fill regions or
+  hold curves; fence-hatch fakes "fill," and all rings/arcs are faceted 12-gons
+  matching the node container.
+- **Bloom mechanism**: CSS → inline SVG `<filter>` (true colored halo, ~zero JS).
+  Rejected `drop-shadow` (monochrome). **Iteration path for more punch** (not built):
+  `feBlend mode="screen"` for additive, then a manual second-canvas copy with
+  `globalCompositeOperation='lighter'` for true accumulating phosphor blowout.
+- **State pulses** kept on the native Cytoscape border rather than baked into the
+  face image, so smooth alert/ICE/reboot animation still works.
+
+## The overlay-anchoring bug (root-caused, fixed)
+
+After adding the bloom filter, all action animations rendered ~one graph-height
+**below** their nodes. Root cause: `#overlay-layer` had no `position`, so it was
+`static` and sat after the full-height `#cy` in normal flow (origin at the bottom
+of the graph). The `filter` made it the **containing block** for its absolutely-
+positioned overlay `<svg>`s — at that wrong bottom origin. Verified empirically
+(overlay svg center y=965 vs node y=65, off by exactly the 900px graph height).
+Fix: `#overlay-layer { position:absolute; inset:0; pointer-events:none }` so the
+containing block shares `#cy`'s origin. Re-verified anchoring dx=dy=0 with bloom
+on, and node clicks still reach the canvas. The code reviewer had predicted this
+exact failure mode for the filter change.
+
+## Verification note
+
+Most logic is covered by `node:test` (facet + node-glyphs geometry). The
+CSS-layout/overlay-anchoring bug and the visual look are **browser-verified via
+Playwright** (measuring overlay anchoring, LED opacities, bloom filter scaling),
+not node-unit-tested — they're layout/visual properties with no logic surface.
+
+## Process
+
+- Brainstormed look via the visual companion (fence-fill, dimmed-hue, density=state).
+- Subagent-driven execution: implementer + spec + code-quality review per task;
+  visual iteration done inline with Playwright screenshots (subagents can't see).
+- **Branch collision**: a second concurrent session was committing an unrelated
+  "ICE legibility" feature onto the originally-shared `vector-crt-rendering`
+  branch. Moved this work into an isolated worktree (`worktree-vector-crt-display`)
+  and cherry-picked the 4 vector-CRT commits onto a clean branch off `main`,
+  leaving the other session untouched.
+
+## Scope growth (vs original spec)
+
+Original spec = nodes/bloom/scanline/overlays-tune/chrome. Grew mid-session, all
+on the same vector-CRT surface: (1) runtime-adjustable bloom for future deck
+damage, (2) full effects-coherence rework (facet helper + 6 effects + straight
+edges), (3) iterative effect tuning (loot ripples, probe LEDs, flash ripples).
+
+## Backlog / follow-ups
+
+- Additive over-bright bloom (feBlend screen → canvas-copy `lighter`) if we want
+  more phosphor blowout.
+- Wire `setBloomIntensity` to a real deck-damage stat in game state.
+- `glyphDataUri`/`glyphSvg` are now production-dead (only `nodeFaceDataUri` is
+  used + their own tests) — retained as standalone glyph helpers; remove if they
+  stay unused.
+- `ice-detect` is still a continuous faceted sweep; could become LED-segment to
+  match probe if we want the two sweeps to share a language.

--- a/docs/dev-sessions/2026-06-10-1013-vector-crt-rendering/plan.md
+++ b/docs/dev-sessions/2026-06-10-1013-vector-crt-rendering/plan.md
@@ -1,0 +1,606 @@
+# Vector CRT Rendering Pass — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the network graph render like a glowing vector CRT display — blooming strokes on near-black, no solid fills, fence-hatch state encoding, no raster scanline.
+
+**Architecture:** Bake a dodecagon-clipped fence hatch + the type glyph into each node's `background-image` SVG (density = access level, dimmed hue). Drop solid fills to transparent; keep the native Cytoscape border for state pulses. Add a single inline SVG `<filter>` (Gaussian-blur bloom) applied via CSS to the `#cy` and `#overlay-layer` layers. Delete the scanline.
+
+**Tech Stack:** Vanilla JS ES modules, Cytoscape.js (canvas renderer), SVG filters, CSS. Tests via `node:test` + `node:assert`. Type-check via `tsc --checkJs` on JSDoc-annotated files (`node-glyphs.js` is checked; `graph.js`/`main.js`/`preview.js` are not).
+
+**Key facts established during planning:**
+- All three HTML entrypoints (`index.html`, `preview.html`, `playground.html`) link `css/style.css` and call `initGraph()` — so CSS rules and the JS-injected filter def reach all three with no per-file edits.
+- `node-glyphs.js` is pure and unit-tested (`tests/node-glyphs.test.js`); `glyphDataUri`/`glyphSvg` must stay exported (tests + back-compat).
+- `graph.js:526` is the single place a node's glyph `background-image` is set, inside the `visibility === "accessible"` block, where `nodeState.accessLevel` is available.
+- Access levels are `"locked"`, `"compromised"`, `"owned"`.
+- `make check` = `make lint` (tsc) + `make test` (node --test). `make bundle-vendor` must have run once so `dist/vendor.js` exists before opening a browser.
+
+---
+
+## Phase 1 — Core graph
+
+### Task 1: `nodeFaceDataUri` — fence + glyph in node-glyphs.js
+
+**Files:**
+- Modify: `js/ui/node-glyphs.js`
+- Test: `tests/node-glyphs.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/node-glyphs.test.js` (extend the import on lines 3–11 to include `fenceYs, nodeFaceSvg, nodeFaceDataUri`):
+
+```js
+test("fenceYs density increases with access level", () => {
+  assert.ok(fenceYs("locked").length < fenceYs("compromised").length);
+  assert.ok(fenceYs("compromised").length < fenceYs("owned").length);
+});
+
+test("fenceYs is empty for an unknown access level", () => {
+  assert.deepEqual(fenceYs("weird"), []);
+});
+
+test("nodeFaceSvg embeds the type glyph, a clip path, and fence lines", () => {
+  const svg = nodeFaceSvg("fileserver", "owned");
+  assert.ok(svg.startsWith("<svg"));
+  assert.match(svg, /viewBox="0 0 64 64"/);
+  assert.ok(svg.includes(NODE_GLYPHS.fileserver.body), "glyph body present");
+  assert.ok(svg.includes("clipPath"), "fence clip path present");
+  assert.ok(svg.includes("<line"), "fence lines present");
+});
+
+test("nodeFaceSvg for an unknown access level draws the glyph but no fence group", () => {
+  const svg = nodeFaceSvg("router", "weird");
+  assert.ok(svg.includes(NODE_GLYPHS.router.body));
+  assert.ok(!svg.includes('clip-path="url(#sf)"'), "no fence group when level unknown");
+});
+
+test("nodeFaceDataUri returns an encoded svg data uri (no raw #)", () => {
+  const uri = nodeFaceDataUri("mine", "compromised");
+  assert.ok(uri.startsWith("data:image/svg+xml,"));
+  assert.ok(!uri.slice("data:image/svg+xml,".length).includes("#"), "hex # must be percent-encoded");
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test tests/node-glyphs.test.js`
+Expected: FAIL — `fenceYs`/`nodeFaceSvg`/`nodeFaceDataUri` are not exported (ReferenceError / undefined import).
+
+- [ ] **Step 3: Implement the fence + face functions**
+
+Append to `js/ui/node-glyphs.js` (after `glyphDataUri`, before EOF). The dodecagon is derived from the existing `CONTAINER_POLYGON_POINTS` so there is one source of truth for the shape:
+
+```js
+// ── Node face: dodecagon-clipped fence hatch + glyph (issue: vector CRT pass) ──
+// State is NOT baked into the glyph; the fence-hatch density + dimmed hue encode
+// access level. The dodecagon OUTLINE is intentionally absent here — it stays as
+// the native Cytoscape border so border-driven state pulses keep working.
+
+const FACE_C = 32; // glyph viewBox center
+const FACE_R = 30; // dodecagon radius on the 0..64 box
+
+/** Dodecagon points on the 0..64 glyph viewBox, derived from CONTAINER_POLYGON_POINTS. */
+const FACE_POLYGON_POINTS = (() => {
+  const n = CONTAINER_POLYGON_POINTS.trim().split(/\s+/).map(Number);
+  const pts = [];
+  for (let i = 0; i < n.length; i += 2) {
+    pts.push(`${(FACE_C + n[i] * FACE_R).toFixed(2)},${(FACE_C + n[i + 1] * FACE_R).toFixed(2)}`);
+  }
+  return pts.join(" ");
+})();
+
+/**
+ * Fence-hatch tuning per access level: line gap (px on the 0..64 box) + a dimmed,
+ * desaturated shade of the state color (so the border stays the brightest element).
+ * @type {Record<string, { gap: number, color: string }>}
+ */
+const FENCE = {
+  locked:      { gap: 11,  color: "#1d4444" },
+  compromised: { gap: 7,   color: "#1c6a85" },
+  owned:       { gap: 4.5, color: "#1c8a4a" },
+};
+const FENCE_OPACITY = 0.28;
+const FENCE_WIDTH = 0.8;
+
+/**
+ * Y positions (on the 0..64 box) of the fence-hatch lines for an access level.
+ * Empty array for any unmapped level (e.g. obscured / unknown).
+ * @param {string} accessLevel
+ * @returns {number[]}
+ */
+export function fenceYs(accessLevel) {
+  const cfg = FENCE[accessLevel];
+  if (!cfg) return [];
+  const ys = [];
+  for (let y = FACE_C - FACE_R + 1; y < FACE_C + FACE_R; y += cfg.gap) {
+    ys.push(Number(y.toFixed(1)));
+  }
+  return ys;
+}
+
+/**
+ * Full standalone node-face SVG: dodecagon-clipped fence hatch (state) + glyph (type).
+ * @param {string} type
+ * @param {string} accessLevel
+ * @returns {string}
+ */
+export function nodeFaceSvg(type, accessLevel) {
+  const { color, body } = glyphFor(type);
+  const cfg = FENCE[accessLevel];
+  let fence = "";
+  if (cfg) {
+    const lines = fenceYs(accessLevel)
+      .map((y) => `<line x1="0" y1="${y}" x2="64" y2="${y}"/>`)
+      .join("");
+    fence =
+      `<defs><clipPath id="sf"><polygon points="${FACE_POLYGON_POINTS}"/></clipPath></defs>` +
+      `<g clip-path="url(#sf)" stroke="${cfg.color}" stroke-width="${FENCE_WIDTH}" opacity="${FENCE_OPACITY}">${lines}</g>`;
+  }
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none" stroke-linejoin="round" stroke-linecap="round">` +
+    fence +
+    `<g stroke="${color}" stroke-width="2">${body}</g>` +
+    `</svg>`
+  );
+}
+
+/**
+ * Node face as a Cytoscape-ready `background-image` data URI (# percent-encoded).
+ * @param {string} type
+ * @param {string} accessLevel
+ * @returns {string}
+ */
+export function nodeFaceDataUri(type, accessLevel) {
+  return "data:image/svg+xml," + encodeURIComponent(nodeFaceSvg(type, accessLevel));
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test tests/node-glyphs.test.js`
+Expected: PASS (all existing + 5 new tests).
+
+- [ ] **Step 5: Type-check**
+
+Run: `make lint`
+Expected: no errors (node-glyphs.js is type-checked; the new JSDoc must satisfy tsc).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add js/ui/node-glyphs.js tests/node-glyphs.test.js
+git commit -m 'feat: nodeFaceDataUri — fence-hatch + glyph node face' -m 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>'
+```
+
+---
+
+### Task 2: Wire the face into graph.js; drop solid fills
+
+**Files:**
+- Modify: `js/ui/graph.js` (import line 5; stylesheet ~291/319/335-346/385; glyph set at 526)
+
+- [ ] **Step 1: Swap the import**
+
+Change `js/ui/graph.js:5` from:
+
+```js
+import { CONTAINER_POLYGON_POINTS, glyphDataUri } from "./node-glyphs.js";
+```
+
+to:
+
+```js
+import { CONTAINER_POLYGON_POINTS, nodeFaceDataUri } from "./node-glyphs.js";
+```
+
+- [ ] **Step 2: Use the face data URI for accessible nodes**
+
+Change `js/ui/graph.js:526` from:
+
+```js
+    node.style("background-image", obscured ? "none" : glyphDataUri(type));
+```
+
+to:
+
+```js
+    node.style("background-image", obscured ? "none" : nodeFaceDataUri(type, nodeState.accessLevel));
+```
+
+(Obscured nodes keep showing a bare dodecagon — no face, no fence — so type and state aren't telegraphed pre-probe.)
+
+- [ ] **Step 3: Drop the solid fills in the stylesheet**
+
+In `buildStylesheet()`:
+
+- `node.revealed` (line ~291): change `"background-color": "#0d0d14",` → `"background-color": "transparent",`
+- `node.accessible` (line ~319): change `"background-color": "#14141f",` → `"background-color": "transparent",`
+- `node.accessible.compromised` (lines ~334-339): delete the entire rule object — its only declaration was the cyan fill, now carried by the fence. Remove:
+
+```js
+    // Access level — compromised (cyan fill = foothold)
+    {
+      selector: "node.accessible.compromised",
+      style: {
+        "background-color": "#1a4d70",
+      },
+    },
+```
+
+- `node.accessible.owned` (lines ~341-347): remove the `"background-color": "#1a5530",` line, keep the rule and its `"border-width": 1,`.
+- `node.ice-traced` (line ~385): change `"background-color": "#1a0010",` → `"background-color": "transparent",`
+
+- [ ] **Step 4: Verify nothing broke at the unit level**
+
+Run: `make check`
+Expected: PASS (graph.js is not type-checked or unit-tested; this confirms node-glyphs + the rest of the suite still pass and tsc is clean).
+
+- [ ] **Step 5: Visual sanity check in the preview harness**
+
+```bash
+make bundle-vendor   # once, if dist/vendor.js is missing
+make serve           # background; serves http://localhost:3000
+```
+
+Open `http://localhost:3000/preview.html`. The glyph gallery nodes should now show transparent centers with the type glyph, no solid fills. (Fence density across access states is exercised in Task 5; here just confirm fills are gone and glyphs still render.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add js/ui/graph.js
+git commit -m 'feat: render node faces (fence+glyph), drop solid fills' -m 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>'
+```
+
+---
+
+### Task 3: Bloom filter + scanline removal
+
+**Files:**
+- Modify: `js/ui/graph.js` (`initGraph`, ~line 145)
+- Modify: `css/style.css` (`#cy` ~151; `#graph-container::after` 136-149)
+
+- [ ] **Step 1: Inject the bloom filter def once, in initGraph**
+
+In `js/ui/graph.js`, add this helper near the top-level functions (e.g. just above `initGraph`):
+
+```js
+/**
+ * Inject the shared SVG bloom <filter> into the DOM once. All entrypoints call
+ * initGraph(), so this covers index / preview / playground without per-file edits.
+ * The filter is a two-radius Gaussian blur merged under the crisp source — a
+ * blurred copy beneath the original, i.e. colored phosphor halo.
+ */
+function ensureBloomFilter() {
+  if (document.getElementById("starnet-bloom-defs")) return;
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("id", "starnet-bloom-defs");
+  svg.setAttribute("width", "0");
+  svg.setAttribute("height", "0");
+  svg.setAttribute("aria-hidden", "true");
+  svg.style.position = "absolute";
+  svg.innerHTML =
+    '<filter id="starnet-bloom" x="-60%" y="-60%" width="220%" height="220%">' +
+    '<feGaussianBlur stdDeviation="3.2" result="b1"/>' +
+    '<feGaussianBlur in="SourceGraphic" stdDeviation="1.1" result="b2"/>' +
+    '<feMerge><feMergeNode in="b1"/><feMergeNode in="b2"/><feMergeNode in="SourceGraphic"/></feMerge>' +
+    '</filter>';
+  document.body.appendChild(svg);
+}
+```
+
+Then call it at the start of `initGraph()` (immediately after the function opens, before the `cytoscape({...})` call at line 145):
+
+```js
+export function initGraph(networkData, onNodeClick, onBackgroundTap) {
+  ensureBloomFilter();
+  // ...existing body...
+```
+
+- [ ] **Step 2: Apply the filter via CSS and delete the scanline**
+
+In `css/style.css`, replace the scanline block (lines 136-149):
+
+```css
+#graph-container::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0px,
+    transparent 3px,
+    rgba(0, 0, 0, 0.18) 3px,
+    rgba(0, 0, 0, 0.18) 4px
+  );
+  pointer-events: none;
+  z-index: 5;
+}
+```
+
+with the bloom rule (applied to the two graph layers only — NOT `#graph-container`, so context menus / action-choices stay crisp):
+
+```css
+/* Vector CRT bloom — colored phosphor halo on the graph + overlay layers.
+   Single SVG <filter> def injected by graph.js (#starnet-bloom). */
+#cy, #overlay-layer {
+  filter: url(#starnet-bloom);
+}
+```
+
+- [ ] **Step 3: Verify the bloom on the real game and the preview**
+
+```bash
+make bundle-vendor   # if needed
+make serve
+```
+
+- Open `http://localhost:3000/` (index) and `http://localhost:3000/preview.html`.
+- Confirm: strokes glow (nodes, edges, glyphs, fence); no horizontal scanline; reference grid still visible; context menu (right-click a node in-game) is NOT bloomed.
+- Watch a probe / pulse animation and confirm no obvious stutter from the filter re-compositing. If it stutters badly, reduce `stdDeviation` (e.g. `2.2` / `0.8`) — note the change in `notes.md`.
+
+- [ ] **Step 4: make check**
+
+Run: `make check`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/ui/graph.js css/style.css
+git commit -m 'feat: SVG bloom filter on graph + overlays; remove scanline' -m 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>'
+```
+
+---
+
+### Task 4: Rework fill-flash animations to border flashes
+
+**Files:**
+- Modify: `js/ui/graph.js` (`flashNode`, lines 982-1018)
+
+Solid-fill flashes no longer read now that fills are transparent. Flash the border instead.
+
+- [ ] **Step 1: Replace flashNode**
+
+Replace the body of `flashNode` (lines 982-1018) with:
+
+```js
+export function flashNode(nodeId, type) {
+  if (!cy) return;
+  const node = cy.getElementById(nodeId);
+  if (!node || node.length === 0) return;
+
+  // [bright peak, dim settle] border colors per flash type.
+  const FLASH = {
+    success: ["#9ffff0", "#00d0c0"],
+    failure: ["#ff6060", "#cc1100"],
+    reveal:  ["#7fd0ff", "#1c6a85"],
+  };
+  const pair = FLASH[type];
+  if (!pair) return;
+
+  node.animate(
+    { style: { "border-color": pair[0], "border-width": 3 } },
+    { duration: 150, complete: () => {
+      node.animate(
+        { style: { "border-color": pair[1], "border-width": 2 } },
+        { duration: 350, complete: () => node.removeStyle("border-color border-width") }
+      );
+    }}
+  );
+}
+```
+
+> Note: if a node is mid alert-pulse (red/yellow), the pulse loop re-asserts its border on its next cycle (≤1.2s) after this flash's `removeStyle`. A brief visual overlap is acceptable; revisit only if it reads as a glitch.
+
+- [ ] **Step 2: Verify the flashes in the playground**
+
+```bash
+make serve
+```
+
+Open `http://localhost:3000/playground.html` (it imports `flashNode`) or trigger success/failure in-game (`http://localhost:3000/`) by running an exploit. Confirm the node border flashes bright→dim and settles back, with the bloom making it flare.
+
+- [ ] **Step 3: make check + commit**
+
+Run: `make check` → PASS
+
+```bash
+git add js/ui/graph.js
+git commit -m 'feat: border-based node flash (success/failure/reveal)' -m 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>'
+```
+
+---
+
+### Task 5: Preview harness — access-state demo nodes
+
+**Files:**
+- Modify: `js/ui/preview.js` (`ALERT_NODES` block ~58-63; node lists ~67; state overrides ~96-98)
+
+So fence density / opacity / blur can be tuned without playing through.
+
+- [ ] **Step 1: Add access-state demo nodes**
+
+After the `ALERT_NODES` array (line 63), add:
+
+```js
+// Access-state demo nodes — show fence density across locked/compromised/owned
+// so the vector-CRT fence treatment can be tuned in isolation.
+const ACCESS_NODES = [
+  { id: "acc-locked",      label: "LOCKED",      type: "fileserver", grade: "C", x: 150, y: 850 },
+  { id: "acc-compromised", label: "COMPROMISED", type: "fileserver", grade: "C", x: 380, y: 850 },
+  { id: "acc-owned",       label: "OWNED",       type: "fileserver", grade: "C", x: 610, y: 850 },
+];
+```
+
+- [ ] **Step 2: Include them in the graph**
+
+Change the `allNodes` line (~67) from:
+
+```js
+const allNodes = [...EFFECT_NODES, SELECT_NODE, FLASH_NODE, ...SHAPE_NODES, ...ALERT_NODES];
+```
+
+to:
+
+```js
+const allNodes = [...EFFECT_NODES, SELECT_NODE, FLASH_NODE, ...SHAPE_NODES, ...ALERT_NODES, ...ACCESS_NODES];
+```
+
+- [ ] **Step 3: Set their access states (after the existing alert overrides, ~line 98)**
+
+Add immediately after the `updateNodeStyle("alert-reboot", ...)` line:
+
+```js
+// Access-state demo overrides (the generic loop above set every node to "owned")
+updateNodeStyle("acc-locked",      { visibility: "accessible", accessLevel: "locked",      alertState: "green", rebooting: false });
+updateNodeStyle("acc-compromised", { visibility: "accessible", accessLevel: "compromised", alertState: "green", rebooting: false });
+updateNodeStyle("acc-owned",       { visibility: "accessible", accessLevel: "owned",       alertState: "green", rebooting: false });
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+make serve
+```
+
+Open `http://localhost:3000/preview.html`, scroll/zoom to the LOCKED / COMPROMISED / OWNED row. Confirm fence density visibly increases locked → compromised → owned, dimmed hue, border brightest.
+
+- [ ] **Step 5: make check + commit**
+
+Run: `make check` → PASS (verify `tests/preview-card-gallery.test.js` still passes; it targets the card gallery, not these nodes, but confirm).
+
+```bash
+git add js/ui/preview.js
+git commit -m 'feat(preview): access-state fence demo nodes' -m 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>'
+```
+
+---
+
+## Phase 2 — Action overlays
+
+### Task 6: Verify and tune overlay bloom
+
+The bloom CSS from Task 3 already applies `filter: url(#starnet-bloom)` to `#overlay-layer`, so the probe-sweep / exploit-brackets / ICE-detect / loot-ring overlays glow automatically. This task is verification + light tuning only.
+
+**Files:**
+- Possibly modify: `js/ui/overlays/*.js` (stroke widths / colors), only if needed
+
+- [ ] **Step 1: Drive each overlay in the preview harness**
+
+```bash
+make serve
+```
+
+Open `http://localhost:3000/preview.html` and run each effect via its slider/control: probe sweep, exploit brackets, ICE detect, loot rings, selection reticle. Confirm each blooms consistently with the new node look.
+
+- [ ] **Step 2: Tune only what clashes**
+
+If an overlay's stroke is too thin to bloom well or its color fights the node palette, adjust the stroke width/color in the relevant `js/ui/overlays/<name>.js`. Make the smallest change that harmonizes it. If nothing needs changing, record that in `notes.md` and skip to commit.
+
+- [ ] **Step 3: make check + commit (only if files changed)**
+
+Run: `make check` → PASS
+
+```bash
+git add js/ui/overlays
+git commit -m 'tune: overlay strokes for vector bloom consistency' -m 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>'
+```
+
+---
+
+## Phase 3 — Chrome harmonization
+
+### Task 7: Consolidate glow vocabulary; harmonize chrome
+
+**Files:**
+- Modify: `css/style.css` (`:root` ~9-25; HUD/log/card glow rules)
+
+The HUD/log/cards use ad-hoc `text-shadow`/`box-shadow` radii (`0 0 4px`/`6px`/`8px`/`12px`). Introduce a small glow scale and apply it to the most visible chrome so the whole UI reads at one bloom intensity. Exhaustive migration of every shadow is out of scope — migrate the prominent ones; leave the rest to opportunistic cleanup.
+
+- [ ] **Step 1: Add glow-scale custom properties**
+
+In `:root` (after line 24, before the closing `}`), add:
+
+```css
+  /* Glow scale — keep chrome bloom consistent with the graph's vector bloom. */
+  --glow-sm: 0 0 4px;
+  --glow-md: 0 0 8px;
+  --glow-lg: 0 0 14px;
+```
+
+- [ ] **Step 2: Apply the scale to prominent chrome glows**
+
+Migrate the highest-visibility shadows to the scale (color still per-rule). Concretely:
+
+- HUD title/value glows that use `text-shadow: 0 0 8px var(--cyan)` (style.css ~215) → `text-shadow: var(--glow-md) var(--cyan);`
+- Alert-red HUD text `text-shadow: 0 0 8px var(--red)` (~897) → `text-shadow: var(--glow-md) var(--red);`
+- Log success/failure entries `0 0 4px rgba(...)` (~851-852) → `var(--glow-sm) rgba(...)`.
+- Exploit card hover/active `box-shadow` 6px/8px (e.g. ~767, ~836) → `var(--glow-md) <color>`.
+
+Match each replacement to the nearest scale step (4px→sm, 8px→md, 12-14px→lg). Leave 6px-only decorative borders alone if a swap shifts them noticeably.
+
+- [ ] **Step 3: Verify the whole UI reads as one display**
+
+```bash
+make serve
+```
+
+Open `http://localhost:3000/`. Confirm HUD, log, and hand glows feel consistent with the graph bloom — no element looking flat-and-dull or blown-out relative to the rest.
+
+- [ ] **Step 4: make check + commit**
+
+Run: `make check` → PASS
+
+```bash
+git add css/style.css
+git commit -m 'style: glow-scale custom properties; harmonize chrome bloom' -m 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>'
+```
+
+---
+
+## Wrap-up
+
+### Task 8: Manual, notes, screenshots, PR
+
+**Files:**
+- Modify: `MANUAL.md` (visual descriptions), `docs/dev-sessions/2026-06-10-1013-vector-crt-rendering/notes.md`
+
+- [ ] **Step 1: Update MANUAL.md**
+
+Scan `MANUAL.md` for visual descriptions that reference solid fills, the scanline, or fill-based state, and update them to describe the vector look (fence-hatch state encoding, bloom, no fills). Only change descriptions that are now inaccurate.
+
+- [ ] **Step 2: Capture before/after-style screenshots**
+
+```bash
+make serve
+```
+
+Use the Playwright MCP to navigate to `http://localhost:3000/` and `http://localhost:3000/preview.html`, take screenshots, and confirm the look. Save anything worth keeping into the session dir.
+
+- [ ] **Step 3: Write notes.md**
+
+Record: final bloom `stdDeviation` values, fence opacity/width/gaps actually shipped, any overlay tuning, the perf observation, and the documented iteration path (feBlend screen → additive canvas-copy) carried from the spec.
+
+- [ ] **Step 4: Final make check**
+
+Run: `make check`
+Expected: PASS.
+
+- [ ] **Step 5: Commit docs and open the PR**
+
+```bash
+git add MANUAL.md docs/dev-sessions/2026-06-10-1013-vector-crt-rendering/notes.md
+git commit -m 'docs: manual + session notes for vector CRT pass' -m 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>'
+git push -u origin vector-crt-rendering
+gh pr create --title 'Vector CRT rendering pass' --body '...'
+```
+
+(Single PR for all three phases, per the spec.)
+
+---
+
+## Self-review notes (planner)
+
+- **Spec coverage:** fence fills (Task 1), no solid fills (Task 2), bloom via SVG filter (Task 3), scanline removal (Task 3), keep grid (untouched — verified in Task 3), keep native border for pulses (Task 2 keeps borders), fill-flash rework (Task 4), preview harness (Task 5), overlay bloom (Task 3 CSS + Task 6 tuning), chrome harmonization (Task 7), three entrypoints (covered by shared CSS + initGraph injection — Tasks 2/3), MANUAL (Task 8), iteration path documented (spec + notes Task 8). All spec sections map to a task.
+- **Type consistency:** `nodeFaceDataUri(type, accessLevel)` / `nodeFaceSvg(type, accessLevel)` / `fenceYs(accessLevel)` signatures are consistent across Task 1 (def), Task 2 (call), Task 5 (exercised via updateNodeStyle). Filter id `starnet-bloom` and def container id `starnet-bloom-defs` consistent across Task 3 JS + CSS.
+- **No placeholders:** every code step shows the exact code; every run step has expected output.

--- a/docs/dev-sessions/2026-06-10-1013-vector-crt-rendering/spec.md
+++ b/docs/dev-sessions/2026-06-10-1013-vector-crt-rendering/spec.md
@@ -1,0 +1,135 @@
+# Spec — Vector CRT Rendering Pass
+
+## Goal
+
+Push the network graph's visual flavor toward a glowing **vector CRT display** —
+the look of Atari *Asteroids*, *Tempest*, and *Black Widow*. Bright blooming
+strokes on near-black, no solid fills, no raster scanline. State is encoded by
+stroke and fence-hatch, the way a real vector system would have had to fake a
+"fill."
+
+This is a presentation-layer change only. No gameplay, state, or event logic
+changes. The console/log channel and all command behavior stay identical.
+
+## Aesthetic decisions (validated via mockups)
+
+- **No solid fills.** A real vector CRT couldn't draw filled regions.
+- **Fence-hatch fills**, dimmed-hue variant: horizontal hatch lines clipped to
+  the dodecagon, drawn in a *desaturated/darker* shade of the state color so the
+  **border stays the brightest element**.
+- **Density encodes access state:** locked = sparse, compromised = medium,
+  owned = tight. (Density carries the meaning; color tracks it secondarily.)
+- **Bloom on every stroke** — node borders, glyphs, fence lines, edges, and the
+  action-animation overlays all glow.
+- **Scanline removed.** The raster `repeating-linear-gradient` overlay is deleted.
+- **Reference grid: keep.** The faint cyan playfield grid reads as space
+  (Tempest-like), not as a raster artifact, and gives a useful stationary
+  reference pattern for motion in the graph. It stays — dimmed only if it
+  visibly competes with the bloom.
+
+## Bloom mechanism
+
+**Chosen approach: CSS `filter: url(#bloom)` → inline SVG `<filter>`.**
+
+A single inline SVG `<filter>` (`feGaussianBlur` + `feMerge` of the blurred copy
+under `SourceGraphic`) applied to the `#cy` canvas layer and the `#overlay-layer`.
+The browser flattens Cytoscape's stacked canvases into one image, blurs a copy,
+and merges it under the crisp original — colored halo, GPU-composited, zero JS,
+trivially reversible.
+
+This is the same filter used in the brainstorming mockups.
+
+**Why not the alternatives (recorded for iteration):**
+
+- `filter: drop-shadow()` — monochrome halo only; loses per-color glow. Rejected.
+- **Manual second-canvas copy + additive composite** — `drawImage` Cytoscape's
+  stacked canvases into a second canvas (hooked via `cy.on('render')` or rAF),
+  blur it, composite *under* the original with `globalCompositeOperation =
+  'lighter'` (or `mix-blend-mode: screen`). This is the only path to true
+  **additive over-bright blowout** (overlapping glows accumulate past white — the
+  signature vector-CRT phosphor flare), which the alpha-merged SVG filter does not
+  give for free. `feBlend mode="screen"` in the SVG filter is a lighter-weight
+  middle step toward the same effect.
+
+  **Iteration path:** ship the SVG filter first. If the glow reads flat and we
+  want accumulating flare, escalate — first try `feBlend mode="screen"` in the
+  filter, then the manual additive canvas-copy as a contained follow-up. Do not
+  build the heavier machinery up front.
+
+**Perf risk to watch:** a full-canvas SVG blur re-composites on every redraw. At
+prototype scale (dozens of nodes) this should be fine; verify no stutter during
+animations (probe sweep, pulses, layout). Fallback if it stutters: reduce blur
+radius, or drop to `drop-shadow`.
+
+## Scope — three phases
+
+### Phase 1 — Core graph
+
+- Extend `js/ui/node-glyphs.js`: add `nodeFaceDataUri(type, accessLevel)` (or
+  equivalent) producing one **stroke-only** SVG data-URI containing the
+  **dodecagon-clipped fence hatch** (density by access level, dimmed hue) **+ the
+  type glyph**. Keep `node-glyphs.js` pure and unit-testable.
+- Wire that into `js/ui/graph.js` where the glyph `background-image` is set
+  (currently graph.js:526). The face image now carries fence + glyph.
+- Drop the solid `background-color` fills (graph.js:291/319/337/344/385) to
+  transparent / none.
+- **Keep the native Cytoscape dodecagon border** so the existing alert / ICE /
+  reboot border pulses keep working and the border stays the brightest element.
+- Add the SVG bloom `<filter>` def to the DOM and apply `filter: url(#bloom)` to
+  `#cy` in CSS.
+- Delete the scanline overlay (`#graph-container::after`, style.css:136).
+- Dim the reference grid (style.css:78–81) if it competes with the bloom.
+- **Rework the three fill-flash animations** (reboot pulse / movement ping,
+  graph.js:989–1013) that animate `background-color` — flash border or a brief
+  glow instead, since fills are now transparent.
+
+### Phase 2 — Action overlays
+
+- Apply `filter: url(#bloom)` to `#overlay-layer`.
+- The probe-sweep, exploit-brackets, ICE-detect, and loot-ring overlays
+  (`js/ui/overlays/`) are already stroke SVG; confirm they bloom correctly and
+  tune stroke widths / colors for consistency with the new node look.
+
+### Phase 3 — Chrome harmonization
+
+- Audit the existing `text-shadow` / `box-shadow` glow on HUD / log / cards
+  against the new graph bloom so the whole UI reads as one vector display.
+- Consolidate the glow vocabulary into a small set of CSS custom properties
+  (e.g. `--glow-sm`, `--glow-lg`) and apply consistently.
+
+## Cross-cutting requirements
+
+- **Three HTML entrypoints** mount `#cy` + `#overlay-layer` and must each get the
+  bloom filter def + scanline removal: `index.html`, `preview.html`, and the
+  playground entrypoint. (See memory: visual-renderer-three-entrypoints.)
+- **Preview harness** (`preview.html` / `js/ui/preview.js` / `preview-cards.js`)
+  must show the new node faces (all three access states) and the bloom so we can
+  tune fence density / opacity / blur radius without playing through. New visual
+  effects must be demoable in the harness (project rule).
+- **MANUAL.md**: update any visual descriptions that no longer match.
+- **`make check`** (tsc + tests) must pass. `node-glyphs.js` additions get unit
+  coverage.
+- **Bot / playtest / console parity unaffected** — this is presentation only; the
+  log + `status` channel is untouched.
+
+## Out of scope
+
+- Additive / over-bright bloom (documented above as the iteration upgrade).
+- Any gameplay, state, event, or balance change.
+- Screenshake, glitch, or other new effects beyond the bloom treatment.
+- Audio.
+
+## Success criteria
+
+- The graph reads as a glowing vector display: blooming strokes, no solid fills,
+  fence-hatch state encoding, no scanline.
+- All three access states are legible at a glance (density + border).
+- Alert / ICE / reboot states still pulse and read clearly.
+- No stutter during animations at prototype graph scale.
+- `make check` passes; preview harness shows the new look; manual is current.
+- Console/log/command behavior is byte-for-byte unchanged.
+
+## Delivery
+
+All three phases land in a **single PR** off branch `vector-crt-rendering`.
+Phases structure the work and commit history, not separate reviews.

--- a/js/ui/graph.js
+++ b/js/ui/graph.js
@@ -2,8 +2,9 @@
 // Graph rendering and Cytoscape.js management
 
 import { isIceVisible, isObscured } from "../core/state.js";
-import { CONTAINER_POLYGON_POINTS, glyphDataUri } from "./node-glyphs.js";
+import { CONTAINER_POLYGON_POINTS, nodeFaceDataUri } from "./node-glyphs.js";
 import { iceStrikeCage } from "./ice-glyphs.js";
+import { ringPoints } from "./overlays/facet.js";
 
 // Still playing with what might be the best default here
 // const DEFAULT_LAYOUT_ALGO = "breadthfirst";
@@ -56,16 +57,19 @@ function stopRedPulse(node) {
   node.removeStyle("border-color border-width");
 }
 
+// Thin strobe blink (not a fattening breathe): a thin constant-width border that
+// flickers bright→dim, so under the global bloom it reads as a vector alarm
+// strobe rather than a throbbing halo. Red strobes fast (urgent).
 function runRedPulse(node) {
   const id = node.id();
   if (!pulsingNodes.has(id)) return;
   node.animate(
-    { style: { "border-color": "#ff4040", "border-width": 3 } },
-    { duration: 400, complete: () => {
+    { style: { "border-color": "#ff3030", "border-width": 1.5 } },
+    { duration: 220, complete: () => {
       if (!pulsingNodes.has(id)) return;
       node.animate(
-        { style: { "border-color": "#cc1100", "border-width": 2 } },
-        { duration: 700, complete: () => runRedPulse(node) }
+        { style: { "border-color": "#5a1010", "border-width": 1.5 } },
+        { duration: 420, complete: () => runRedPulse(node) }
       );
     }}
   );
@@ -84,16 +88,17 @@ function stopYellowPulse(node) {
   node.removeStyle("border-color border-width");
 }
 
+// Yellow strobes slower/softer than red (lower urgency), same thin-blink idea.
 function runYellowPulse(node) {
   const id = node.id();
   if (!yellowPulsingNodes.has(id)) return;
   node.animate(
-    { style: { "border-color": "#cc8800", "border-width": 2 } },
-    { duration: 900, complete: () => {
+    { style: { "border-color": "#ffcc00", "border-width": 1.5 } },
+    { duration: 480, complete: () => {
       if (!yellowPulsingNodes.has(id)) return;
       node.animate(
-        { style: { "border-color": "#553300", "border-width": 2 } },
-        { duration: 1200, complete: () => runYellowPulse(node) }
+        { style: { "border-color": "#4a3800", "border-width": 1.5 } },
+        { duration: 720, complete: () => runYellowPulse(node) }
       );
     }}
   );
@@ -132,7 +137,63 @@ function runRebootPulse(node) {
 let _networkNodes = new Map();  // id → { id, label, type, grade }
 let _networkEdges = [];         // [{ source, target }]
 
+// Bloom is a central, runtime-adjustable rendering property. These are the base
+// blur radii (px); the wide halo (b1) is merged twice for the phosphor blowout,
+// a tight inner glow (b2) sits under the crisp source. setBloomIntensity() scales
+// them live — the seam for future deck-damage degradation (crank bloom toward
+// illegible as the deck takes injury). When that lands, the multiplier's source
+// of truth belongs in game state; this module just applies it.
+const BLOOM_WIDE = 5;
+const BLOOM_TIGHT = 2;
+let bloomIntensity = 1;
+
+/**
+ * Inject the shared SVG bloom <filter> into the DOM once. All entrypoints call
+ * initGraph(), so this covers index / preview / playground without per-file edits.
+ * The filter is a two-radius Gaussian blur merged under the crisp source — a
+ * blurred copy beneath the original, i.e. colored phosphor halo.
+ */
+function ensureBloomFilter() {
+  if (document.getElementById("starnet-bloom-defs")) return;
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("id", "starnet-bloom-defs");
+  svg.setAttribute("width", "0");
+  svg.setAttribute("height", "0");
+  svg.setAttribute("aria-hidden", "true");
+  svg.style.position = "absolute";
+  svg.innerHTML =
+    '<filter id="starnet-bloom" x="-80%" y="-80%" width="260%" height="260%">' +
+    `<feGaussianBlur in="SourceGraphic" stdDeviation="${BLOOM_WIDE * bloomIntensity}" result="b1"/>` +
+    `<feGaussianBlur in="SourceGraphic" stdDeviation="${BLOOM_TIGHT * bloomIntensity}" result="b2"/>` +
+    '<feMerge><feMergeNode in="b1"/><feMergeNode in="b1"/><feMergeNode in="b2"/><feMergeNode in="SourceGraphic"/></feMerge>' +
+    '</filter>';
+  document.body.appendChild(svg);
+  // Expose for live experimentation / future deck-damage hookup.
+  if (typeof window !== "undefined") window.setBloomIntensity = setBloomIntensity;
+}
+
+/**
+ * Set the bloom intensity multiplier (1 = default vector-CRT bloom). Higher
+ * widens the halo toward illegibility — the hook for deck-damage degradation.
+ * Updates the live filter immediately; no graph re-init needed.
+ * @param {number} mult
+ */
+export function setBloomIntensity(mult) {
+  bloomIntensity = Math.max(0, mult);
+  const filter = document.getElementById("starnet-bloom");
+  if (!filter) return;
+  const blurs = filter.querySelectorAll("feGaussianBlur");
+  if (blurs[0]) blurs[0].setAttribute("stdDeviation", String(BLOOM_WIDE * bloomIntensity));
+  if (blurs[1]) blurs[1].setAttribute("stdDeviation", String(BLOOM_TIGHT * bloomIntensity));
+}
+
+/** @returns {number} current bloom intensity multiplier (1 = default). */
+export function getBloomIntensity() {
+  return bloomIntensity;
+}
+
 export function initGraph(networkData, onNodeClick, onBackgroundTap) {
+  ensureBloomFilter();
   // Store full topology for deferred node addition
   _networkNodes = new Map();
   for (const n of networkData.nodes) {
@@ -289,7 +350,7 @@ function buildStylesheet() {
         "shape-polygon-points": CONTAINER_POLYGON_POINTS,
         width: 36,
         height: 36,
-        "background-color": "#0d0d14",
+        "background-color": "transparent",
         "border-width": 1,
         "border-color": "#223333",
         "border-style": "dashed",
@@ -317,7 +378,7 @@ function buildStylesheet() {
         "background-clip": "none",
         width: 46,
         height: 46,
-        "background-color": "#14141f",
+        "background-color": "transparent",
         "border-width": 1,
         "border-color": "#1a3333",
         label: "data(id)",
@@ -331,35 +392,20 @@ function buildStylesheet() {
         "text-outline-width": 2,
       },
     },
-    // Access level — compromised (cyan fill = foothold)
-    {
-      selector: "node.accessible.compromised",
-      style: {
-        "background-color": "#1a4d70",
-      },
-    },
-    // Access level — owned (green fill = territory)
-    {
-      selector: "node.accessible.owned",
-      style: {
-        "background-color": "#1a5530",
-        "border-width": 1,
-      },
-    },
-    // Alert state: yellow — amber border (pulse driven by JS animation)
+    // Alert state: yellow — thin amber border (strobe-blinked by JS animation)
     {
       selector: "node.accessible.alert-yellow",
       style: {
         "border-color": "#996600",
-        "border-width": 2,
+        "border-width": 1.5,
       },
     },
-    // Alert state: red — red border (pulse driven by JS animation)
+    // Alert state: red — thin red border (strobe-blinked by JS animation)
     {
       selector: "node.accessible.alert-red",
       style: {
         "border-color": "#cc1100",
-        "border-width": 2,
+        "border-width": 1.5,
       },
     },
     // Obscured — identity hidden behind sig-N alias until probed. Keeps the
@@ -383,7 +429,7 @@ function buildStylesheet() {
         "shape-polygon-points": CONTAINER_POLYGON_POINTS,
         width: 20,
         height: 20,
-        "background-color": "#1a0010",
+        "background-color": "transparent",
         "border-color": "#aa0066",
         "border-width": 1,
         "border-style": "dashed",
@@ -417,7 +463,7 @@ function buildStylesheet() {
       style: {
         "line-color": "#112222",
         "target-arrow-shape": "none",
-        "curve-style": "bezier",
+        "curve-style": "straight",
         width: 1,
         opacity: 0.2,
       },
@@ -429,7 +475,7 @@ function buildStylesheet() {
         display: "element",
         "line-color": "#0a4433",
         "target-arrow-shape": "none",
-        "curve-style": "bezier",
+        "curve-style": "straight",
         width: 1.5,
         opacity: 0.7,
       },
@@ -524,7 +570,7 @@ export function updateNodeStyle(nodeId, nodeState) {
     // shape itself is the dodecagon for all nodes (set in the stylesheet);
     // type identity rides on this glyph image, state stays on border/fill.
     const type = node.data("type");
-    node.style("background-image", obscured ? "none" : glyphDataUri(type));
+    node.style("background-image", obscured ? "none" : nodeFaceDataUri(type, nodeState.accessLevel));
   }
 
   // Show/hide connected edges when a node becomes accessible
@@ -976,42 +1022,74 @@ export function fitGraph(theCy) {
   }
 }
 
-// Flash a node with a brief animated pulse.
-// type: 'success' (cyan→white→cyan), 'failure' (red flash), 'reveal' (dim cyan pulse)
+// Flash a node with an expanding faceted "ripple" — a sonar ping in the overlay
+// layer (which blooms), rather than a border glow. Fire-and-forget: two staggered
+// rings expand from inside the node out past its rim, fading, then self-remove.
+// type: 'success' (cyan-green), 'failure' (red), 'reveal' (dim cyan).
+const FLASH_RGB = {
+  success: "0,255,200",
+  failure: "255,64,64",
+  reveal: "127,208,255",
+};
+
 export function flashNode(nodeId, type) {
   if (!cy) return;
   const node = cy.getElementById(nodeId);
   if (!node || node.length === 0) return;
+  const rgb = FLASH_RGB[type];
+  if (!rgb) return;
+  const layer = document.getElementById("overlay-layer");
+  if (!layer) return;
+  spawnFlashRipple(layer, node.renderedPosition(), node.renderedWidth() / 2, rgb);
+}
 
-  if (type === "success") {
-    node.animate(
-      { style: { "background-color": "#0d3a3a" } },
-      { duration: 150, complete: () => {
-        node.animate(
-          { style: { "background-color": "#041820" } },
-          { duration: 350, complete: () => node.removeStyle("background-color") }
-        );
-      }}
-    );
-  } else if (type === "failure") {
-    node.animate(
-      { style: { "background-color": "#2a0505" } },
-      { duration: 150, complete: () => {
-        node.animate(
-          { style: { "background-color": "#150202" } },
-          { duration: 350, complete: () => node.removeStyle("background-color") }
-        );
-      }}
-    );
-  } else if (type === "reveal") {
-    node.animate(
-      { style: { "background-color": "#061525" } },
-      { duration: 250, complete: () => {
-        node.animate(
-          { style: { "background-color": "#080810" } },
-          { duration: 500, complete: () => node.removeStyle("background-color") }
-        );
-      }}
-    );
+/**
+ * Append a transient ripple SVG (two staggered faceted rings) to the overlay
+ * layer, anchored at a node's rendered position. Self-removes when done.
+ */
+function spawnFlashRipple(layer, pos, r, rgb) {
+  const PAD = 18;
+  const half = r + PAD;
+  const cx = half, cy = half;
+  const startR = r * 0.6;
+  const maxR = half - 1;
+  const DUR = 420;
+  const STAGGER = 120;
+
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.style.position = "absolute";
+  svg.style.left = `${pos.x - half}px`;
+  svg.style.top = `${pos.y - half}px`;
+  svg.style.width = `${half * 2}px`;
+  svg.style.height = `${half * 2}px`;
+  svg.style.overflow = "visible";
+  svg.style.pointerEvents = "none";
+
+  const rings = [0, 1].map((i) => {
+    const p = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
+    p.setAttribute("fill", "none");
+    p.setAttribute("stroke-width", "2");
+    p.setAttribute("stroke-linejoin", "round");
+    p.setAttribute("points", ringPoints(cx, cy, startR));
+    svg.appendChild(p);
+    return { el: p, delay: i * STAGGER };
+  });
+  layer.appendChild(svg);
+
+  const start = performance.now();
+  function animate(now) {
+    let alive = false;
+    for (const { el, delay } of rings) {
+      const t = (now - start - delay) / DUR;
+      if (t < 0) { alive = true; continue; }
+      if (t >= 1) { el.setAttribute("points", ""); continue; }
+      alive = true;
+      const cur = startR + t * (maxR - startR);
+      el.setAttribute("points", ringPoints(cx, cy, cur));
+      el.setAttribute("stroke", `rgba(${rgb},${(0.85 * (1 - t)).toFixed(3)})`);
+    }
+    if (alive) requestAnimationFrame(animate);
+    else svg.remove();
   }
+  requestAnimationFrame(animate);
 }

--- a/js/ui/ice-glyphs.js
+++ b/js/ui/ice-glyphs.js
@@ -18,7 +18,7 @@ export const ICE_MAGENTA = "#ff00aa";
 export function iceStrikeCage() {
   const seg = `fill="none" stroke="${ICE_RED}" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"`;
   return `<svg viewBox="0 0 100 100" overflow="visible" style="overflow:visible">
-    <g class="ice-cage" style="filter:drop-shadow(0 0 3px ${ICE_RED}) drop-shadow(0 0 9px ${ICE_RED}aa)">
+    <g class="ice-cage">
       <polyline ${seg} points="14,-34 50,-52 86,-34"/>
       <polyline ${seg} points="14,-34 6,-6 14,20 34,32"/>
       <polyline ${seg} points="86,-34 94,-6 86,20 66,32"/>

--- a/js/ui/node-glyphs.js
+++ b/js/ui/node-glyphs.js
@@ -85,3 +85,86 @@ export function glyphSvg(type) {
 export function glyphDataUri(type) {
   return "data:image/svg+xml," + encodeURIComponent(glyphSvg(type));
 }
+
+// ── Node face: dodecagon-clipped fence hatch + glyph (vector CRT pass) ──
+// State is NOT baked into the glyph; the fence-hatch density + dimmed hue encode
+// access level. The dodecagon OUTLINE is intentionally absent here — it stays as
+// the native Cytoscape border so border-driven state pulses keep working.
+
+const FACE_C = 32; // glyph viewBox center
+const FACE_R = 30; // dodecagon radius on the 0..64 box
+
+/** Dodecagon points on the 0..64 glyph viewBox, derived from CONTAINER_POLYGON_POINTS. */
+const FACE_POLYGON_POINTS = (() => {
+  const n = CONTAINER_POLYGON_POINTS.trim().split(/\s+/).map(Number);
+  const pts = [];
+  for (let i = 0; i < n.length; i += 2) {
+    pts.push(`${(FACE_C + n[i] * FACE_R).toFixed(2)},${(FACE_C + n[i + 1] * FACE_R).toFixed(2)}`);
+  }
+  return pts.join(" ");
+})();
+
+/**
+ * Fence-hatch tuning per access level: line gap (px on the 0..64 box) + a dimmed,
+ * desaturated shade of the state color (so the border stays the brightest element).
+ * @type {Record<string, { gap: number, color: string }>}
+ */
+const FENCE = {
+  locked:      { gap: 11,  color: "#246060" },
+  compromised: { gap: 7,   color: "#1c6a85" },
+  owned:       { gap: 4.5, color: "#1c8a4a" },
+};
+const FENCE_OPACITY = 0.42;
+const FENCE_WIDTH = 0.8;
+
+/**
+ * Y positions (on the 0..64 box) of the fence-hatch lines for an access level.
+ * Empty array for any unmapped level (e.g. obscured / unknown).
+ * @param {string} accessLevel
+ * @returns {number[]}
+ */
+export function fenceYs(accessLevel) {
+  const cfg = FENCE[accessLevel];
+  if (!cfg) return [];
+  const ys = [];
+  for (let y = FACE_C - FACE_R + 1; y < FACE_C + FACE_R; y += cfg.gap) {
+    ys.push(Number(y.toFixed(1)));
+  }
+  return ys;
+}
+
+/**
+ * Full standalone node-face SVG: dodecagon-clipped fence hatch (state) + glyph (type).
+ * @param {string} type
+ * @param {string} accessLevel
+ * @returns {string}
+ */
+export function nodeFaceSvg(type, accessLevel) {
+  const { color, body } = glyphFor(type);
+  const cfg = FENCE[accessLevel];
+  let fence = "";
+  if (cfg) {
+    const lines = fenceYs(accessLevel)
+      .map((y) => `<line x1="0" y1="${y}" x2="64" y2="${y}"/>`)
+      .join("");
+    fence =
+      `<defs><clipPath id="sf"><polygon points="${FACE_POLYGON_POINTS}"/></clipPath></defs>` +
+      `<g clip-path="url(#sf)" stroke="${cfg.color}" stroke-width="${FENCE_WIDTH}" opacity="${FENCE_OPACITY}">${lines}</g>`;
+  }
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none" stroke-linejoin="round" stroke-linecap="round">` +
+    fence +
+    `<g stroke="${color}" stroke-width="2">${body}</g>` +
+    `</svg>`
+  );
+}
+
+/**
+ * Node face as a Cytoscape-ready `background-image` data URI (# percent-encoded).
+ * @param {string} type
+ * @param {string} accessLevel
+ * @returns {string}
+ */
+export function nodeFaceDataUri(type, accessLevel) {
+  return "data:image/svg+xml," + encodeURIComponent(nodeFaceSvg(type, accessLevel));
+}

--- a/js/ui/overlays/facet.js
+++ b/js/ui/overlays/facet.js
@@ -1,0 +1,68 @@
+// @ts-check
+// Pure faceted-geometry helpers for vector-CRT overlay effects. A real vector
+// CRT draws straight segments, so overlay rings/sweeps are polygonal (default
+// 12-gon, matching the dodecagon node container with a vertex at 12 o'clock)
+// rather than smooth circles/arcs. No DOM here — unit-testable.
+
+/** Polygon side count matching the node dodecagon. */
+export const FACET_SIDES = 12;
+
+/** First vertex at 12 o'clock (straight up). SVG y is down, so up = -PI/2. */
+const TOP = -Math.PI / 2;
+
+/**
+ * Vertices of a regular polygon, first at 12 o'clock, stepping clockwise.
+ * @param {number} cx @param {number} cy @param {number} r
+ * @param {number} [sides] @param {number} [rot] start angle (radians)
+ * @returns {{x:number,y:number}[]}
+ */
+export function facetVertices(cx, cy, r, sides = FACET_SIDES, rot = TOP) {
+  const step = (2 * Math.PI) / sides;
+  const out = [];
+  for (let i = 0; i < sides; i++) {
+    const a = rot + i * step;
+    out.push({ x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) });
+  }
+  return out;
+}
+
+/** Join vertices into an SVG points string. @param {{x:number,y:number}[]} verts */
+function toPointsStr(verts) {
+  return verts.map((p) => `${p.x.toFixed(2)},${p.y.toFixed(2)}`).join(" ");
+}
+
+/**
+ * Closed regular-polygon points string for `<polygon points=...>`.
+ * @returns {string}
+ */
+export function ringPoints(cx, cy, r, sides = FACET_SIDES, rot = TOP) {
+  return toPointsStr(facetVertices(cx, cy, r, sides, rot));
+}
+
+/**
+ * Faceted-arc polyline points for `<polyline points=...>`, from 12 o'clock
+ * through `progress` (0..1) of a full turn. dir=+1 clockwise, -1 counter-cw.
+ * Walks the polygon vertices crossed, then appends the exact swept endpoint so
+ * the leading edge tracks progress. Empty string for progress<=0; full closed
+ * ring (sides points) for progress>=1.
+ * @param {number} cx @param {number} cy @param {number} r
+ * @param {number} progress @param {number} [dir]
+ * @param {number} [sides] @param {number} [rot]
+ * @returns {string}
+ */
+export function arcPoints(cx, cy, r, progress, dir = 1, sides = FACET_SIDES, rot = TOP) {
+  if (progress <= 0) return "";
+  if (progress >= 1) return ringPoints(cx, cy, r, sides, rot);
+  const full = 2 * Math.PI;
+  const sweep = progress * full;
+  const step = full / sides;
+  const at = (ang) => ({ x: cx + r * Math.cos(ang), y: cy + r * Math.sin(ang) });
+  const pts = [at(rot)];
+  for (let k = 1; k <= sides; k++) {
+    const seg = k * step;
+    if (seg < sweep) pts.push(at(rot + dir * seg));
+    else break;
+  }
+  pts.push(at(rot + dir * sweep)); // exact leading edge
+  return toPointsStr(pts);
+}

--- a/js/ui/overlays/ice-detect.js
+++ b/js/ui/overlays/ice-detect.js
@@ -30,9 +30,10 @@ class IceDetectOverlay extends NodeOverlay {
     // and interpolating `html` <line> templates would create HTML-namespace
     // elements that never paint — so we build real SVG nodes directly, the same
     // way loot-rings.js does.)
+    // No own glow — the global graph bloom (#overlay-layer SVG filter) handles it.
     return html`
       <svg style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:6;
-                  transition:opacity 0.15s ease; filter:drop-shadow(0 0 4px ${ICE_MAGENTA}) drop-shadow(0 0 10px ${ICE_MAGENTA});">
+                  transition:opacity 0.15s ease;">
       </svg>`;
   }
 

--- a/js/ui/overlays/loot-rings.js
+++ b/js/ui/overlays/loot-rings.js
@@ -1,44 +1,51 @@
 // @ts-check
-// FETCH loot rings: green rings spawn at the node center and expand+fade
-// outward. Rings start fat (node is full) and thin as it drains (progress).
-// Self-running: owns a spawn interval + per-ring RAF. Ported from graph.js
-// syncLootRings / _spawnLootRing.
+// FETCH loot rings: thin faceted (12-gon) "ripple" rings spawn at the node and
+// expand + fade outward. Ripples are dense when the node is full and thin out
+// (spawn less often) as it drains — spawn cadence tracks remaining loot. Stroke-
+// only, vector-CRT. Self-running: a self-rescheduling spawn timer + per-ring RAF.
 
 import { html } from "lit";
 import { NodeOverlay } from "./node-overlay.js";
+import { ringPoints } from "./facet.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
-const LOOT_RING_SPAWN_MS = 200;
 const LOOT_RING_LIFETIME_MS = 800;
-const PAD = 12; // padding for ring expansion
+const SPAWN_MIN_MS = 100;      // dense ripples when the node is full
+const SPAWN_PROGRESS_MS = 500; // + progress*this → sparser as it drains
+const PAD = 20; // ripples travel this far past the node rim
 
 class LootRingsOverlay extends NodeOverlay {
   constructor() {
     super();
-    this._intervalId = null;
+    this._timer = null;
+    this._running = false;
   }
 
   sync(nodeId, progress) {
     super.sync(nodeId, progress);
-    if (this._intervalId === null) {
-      this._spawn(); // immediate first ring
-      this._intervalId = setInterval(() => this._spawn(), LOOT_RING_SPAWN_MS);
+    if (!this._running) {
+      this._running = true;
+      this._tick();
     }
   }
 
+  _tick() {
+    if (!this._running) return;
+    this._spawn();
+    const delay = SPAWN_MIN_MS + this.progress * SPAWN_PROGRESS_MS;
+    this._timer = setTimeout(() => this._tick(), delay);
+  }
+
   clear() {
-    if (this._intervalId !== null) {
-      clearInterval(this._intervalId);
-      this._intervalId = null;
-    }
+    this._running = false;
+    if (this._timer !== null) { clearTimeout(this._timer); this._timer = null; }
     this.nodeId = null;
     this.progress = 0;
     const svg = this._svg();
     if (svg) {
       svg.style.opacity = "0";
-      // Clear any lingering ring elements after fade
       setTimeout(() => {
-        if (!this.nodeId && svg) svg.querySelectorAll("circle").forEach((c) => c.remove());
+        if (!this.nodeId && svg) svg.querySelectorAll("polygon").forEach((c) => c.remove());
       }, 200);
     }
   }
@@ -65,38 +72,28 @@ class LootRingsOverlay extends NodeOverlay {
     const a = this._anchor();
     if (!a) return;
     const r = a.r;
-    const cx = r + PAD;
-    const cy = r + PAD;
-    // Rings start fat (node is full) and thin out as it's drained
-    const remaining = 1 - this.progress;
-    const minWidth = 0.5 + remaining * remaining * r * 0.6;
-    const variance = 1 + remaining * 3;
-    const strokeWidth = minWidth + Math.random() * variance;
+    const cx = r + PAD, cy = r + PAD;
+    const strokeWidth = 1.5 + Math.random() * 0.7; // crisp ripple line
 
-    const ring = document.createElementNS(SVG_NS, "circle");
-    ring.setAttribute("cx", String(cx));
-    ring.setAttribute("cy", String(cy));
-    ring.setAttribute("r", "2");
+    const ring = document.createElementNS(SVG_NS, "polygon");
     ring.setAttribute("fill", "none");
-    ring.setAttribute("stroke", "rgba(0,255,160,0.35)");
+    ring.setAttribute("stroke", "rgba(0,255,160,0.95)");
     ring.setAttribute("stroke-width", String(strokeWidth));
+    ring.setAttribute("stroke-linejoin", "round");
+    ring.setAttribute("points", ringPoints(cx, cy, 2));
     svg.appendChild(ring);
 
     const startTime = performance.now();
-    const maxR = r + 8;
+    const maxR = r + PAD - 1;
 
     function animate(now) {
-      const elapsed = now - startTime;
-      const t = Math.min(1, elapsed / LOOT_RING_LIFETIME_MS);
+      const t = Math.min(1, (now - startTime) / LOOT_RING_LIFETIME_MS);
       const currentR = 2 + t * (maxR - 2);
-      const opacity = 0.35 * (1 - t); // fade out as it expands
-      ring.setAttribute("r", String(currentR));
+      const opacity = 0.95 * (1 - t); // fade as it expands
+      ring.setAttribute("points", ringPoints(cx, cy, currentR));
       ring.setAttribute("stroke", `rgba(0,255,160,${opacity})`);
-      if (t < 1) {
-        requestAnimationFrame(animate);
-      } else {
-        ring.remove();
-      }
+      if (t < 1) requestAnimationFrame(animate);
+      else ring.remove();
     }
     requestAnimationFrame(animate);
   }

--- a/js/ui/overlays/probe-sweep.js
+++ b/js/ui/overlays/probe-sweep.js
@@ -1,16 +1,24 @@
 // @ts-check
-// PROBE sweep: cyan pie-slice arc sweeping clockwise from 12 o'clock (player
-// action convention). Pure progress-driven. Ported from graph.js _renderProbeSweep.
+// PROBE sweep: a clockwise radar sweep (player-action convention) that lights up
+// the node's 12 dodecagon edges as discrete "LED" segments — each brightens from
+// dim to full as the sweep front crosses it, then stays lit. Chunky + stroke-only
+// (vector-CRT). A faint radial "hand" marks the sweep front.
 
 import { html } from "lit";
 import { NodeOverlay } from "./node-overlay.js";
+import { FACET_SIDES, facetVertices } from "./facet.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const TOP = -Math.PI / 2; // 12 o'clock, matching facet.js
+const OFF = 0.12; // unlit segment opacity (the dim ring)
+const ON = 0.95;  // fully-lit segment opacity
 
 class ProbeSweepOverlay extends NodeOverlay {
   render() {
     return html`
       <svg style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
-        <path class="fill" fill="rgba(0,255,255,0.18)"></path>
-        <circle class="ring" fill="none" stroke="#00ffff" stroke-width="1" stroke-opacity="0.45"></circle>
+        <g class="leds"></g>
+        <line class="hand" stroke="#00ffff" stroke-width="1.5" stroke-opacity="0.8"></line>
       </svg>`;
   }
 
@@ -21,27 +29,49 @@ class ProbeSweepOverlay extends NodeOverlay {
     if (!a) { svg.style.opacity = "0"; return; }
     const { pos, r } = a;
     this._place(svg, pos, r);
+    const rr = r - 1;
 
-    const ring = svg.querySelector(".ring");
-    ring.setAttribute("cx", String(r));
-    ring.setAttribute("cy", String(r));
-    ring.setAttribute("r", String(r - 1));
+    // Lazily create the 12 LED segment lines once.
+    const group = svg.querySelector(".leds");
+    if (group.childElementCount !== FACET_SIDES) {
+      group.replaceChildren();
+      for (let i = 0; i < FACET_SIDES; i++) {
+        const seg = document.createElementNS(SVG_NS, "line");
+        seg.setAttribute("stroke", "#00ffff");
+        seg.setAttribute("stroke-width", "3");
+        seg.setAttribute("stroke-linecap", "round");
+        group.appendChild(seg);
+      }
+    }
 
-    const fill = svg.querySelector(".fill");
+    const v = facetVertices(r, r, rr); // 12 vertices, first at 12 o'clock, clockwise
+    const segs = group.children;
     const p = this.progress;
+    const front = p * FACET_SIDES; // fractional count of segments the sweep has crossed
+    for (let i = 0; i < FACET_SIDES; i++) {
+      const a1 = v[i];
+      const a2 = v[(i + 1) % FACET_SIDES];
+      const seg = segs[i];
+      seg.setAttribute("x1", a1.x.toFixed(2)); seg.setAttribute("y1", a1.y.toFixed(2));
+      seg.setAttribute("x2", a2.x.toFixed(2)); seg.setAttribute("y2", a2.y.toFixed(2));
+      let op;
+      if (front >= i + 1) op = ON;                              // fully crossed → lit
+      else if (front > i) op = OFF + (ON - OFF) * (front - i);  // sweep crossing → brightening
+      else op = OFF;                                            // not yet reached → dim
+      seg.setAttribute("stroke-opacity", op.toFixed(3));
+    }
+
+    // Radial hand marks the sweep front (collapsed to a point at rest).
+    const hand = svg.querySelector(".hand");
+    hand.setAttribute("x1", String(r));
+    hand.setAttribute("y1", String(r));
     if (p <= 0) {
-      fill.setAttribute("d", "");
-    } else if (p >= 1) {
-      // Full circle — two half-arcs to avoid degenerate arc case
-      fill.setAttribute("d",
-        `M ${r},${r} m 0,-${r} a ${r},${r} 0 1,1 0,${r * 2} a ${r},${r} 0 1,1 0,-${r * 2} Z`);
+      hand.setAttribute("x2", String(r));
+      hand.setAttribute("y2", String(r));
     } else {
-      // Pie slice from 12 o'clock sweeping clockwise
-      const angle = p * 2 * Math.PI;
-      const endX = r + r * Math.sin(angle);
-      const endY = r - r * Math.cos(angle);
-      fill.setAttribute("d",
-        `M ${r},${r} L ${r},${0} A ${r},${r} 0 ${p > 0.5 ? 1 : 0},1 ${endX},${endY} Z`);
+      const ang = TOP + p * 2 * Math.PI;
+      hand.setAttribute("x2", (r + rr * Math.cos(ang)).toFixed(2));
+      hand.setAttribute("y2", (r + rr * Math.sin(ang)).toFixed(2));
     }
   }
 }

--- a/js/ui/overlays/read-sectors.js
+++ b/js/ui/overlays/read-sectors.js
@@ -1,37 +1,33 @@
 // @ts-check
-// DUMP read-sectors: green pie wedges filling in random order as the dump
-// progresses. Sector count + fill order reseed on a new target. Progress is
-// scaled so all sectors are full at 90% (looks complete just before done).
-// Ported from graph.js _renderReadSectors.
+// DUMP read-sectors: the node's 12 dodecagon facets light up (stroke-only wedge
+// outlines) in random order as the dump progresses. Faceted to match the node
+// container; no fills. Progress scaled so all facets are lit at 90%.
 
 import { html } from "lit";
 import { NodeOverlay } from "./node-overlay.js";
+import { FACET_SIDES, facetVertices, ringPoints } from "./facet.js";
 
 class ReadSectorsOverlay extends NodeOverlay {
   constructor() {
     super();
-    this._count = 0;
     this._order = [];
   }
 
   sync(nodeId, progress) {
     if (nodeId !== this.nodeId) {
-      this._count = 7 + Math.floor(Math.random() * 14); // 7–20
-      this._order = Array.from({ length: this._count }, (_, i) => i);
-      // Fisher-Yates shuffle
+      // Visual-only shuffle of the 12 facets (per the visual-randomness convention).
+      this._order = Array.from({ length: FACET_SIDES }, (_, i) => i);
       for (let i = this._order.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
         [this._order[i], this._order[j]] = [this._order[j], this._order[i]];
       }
     }
     this.nodeId = nodeId;
-    // Scale so all sectors are filled at 90% progress
     this.progress = Math.max(0, Math.min(1, progress / 0.9));
     if (this._ready) this._render();
   }
 
   clear() {
-    this._count = 0;
     this._order = [];
     super.clear();
   }
@@ -39,8 +35,8 @@ class ReadSectorsOverlay extends NodeOverlay {
   render() {
     return html`
       <svg style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
-        <path class="fill" fill="rgba(0,255,65,0.15)"></path>
-        <circle class="ring" fill="none" stroke="#00ff41" stroke-width="1" stroke-opacity="0.45"></circle>
+        <polygon class="ring" fill="none" stroke="#00ff41" stroke-width="1" stroke-opacity="0.35"></polygon>
+        <path class="sectors" fill="none" stroke="#00ff41" stroke-width="1.2" stroke-opacity="0.85"></path>
       </svg>`;
   }
 
@@ -51,42 +47,21 @@ class ReadSectorsOverlay extends NodeOverlay {
     if (!a) { svg.style.opacity = "0"; return; }
     const { pos, r } = a;
     this._place(svg, pos, r);
+    const rr = r - 1;
+    svg.querySelector(".ring").setAttribute("points", ringPoints(r, r, rr));
 
-    const ring = svg.querySelector(".ring");
-    ring.setAttribute("cx", String(r));
-    ring.setAttribute("cy", String(r));
-    ring.setAttribute("r", String(r - 1));
-
-    const fill = svg.querySelector(".fill");
-    const p = this.progress;
-    const filledCount = Math.floor(p * this._count);
-
-    if (filledCount <= 0) {
-      fill.setAttribute("d", "");
-      return;
-    }
-    if (filledCount >= this._count) {
-      // Full circle
-      fill.setAttribute("d",
-        `M ${r},${r} m 0,-${r} a ${r},${r} 0 1,1 0,${r * 2} a ${r},${r} 0 1,1 0,-${r * 2} Z`);
-      return;
-    }
-
-    // Build path from filled sectors (each is a pie wedge)
-    const sliceAngle = (2 * Math.PI) / this._count;
+    const sectors = svg.querySelector(".sectors");
+    const filled = Math.floor(this.progress * FACET_SIDES);
+    if (filled <= 0) { sectors.setAttribute("d", ""); return; }
+    const v = facetVertices(r, r, rr);
     let d = "";
-    for (let i = 0; i < filledCount; i++) {
+    for (let i = 0; i < filled; i++) {
       const idx = this._order[i];
-      const startAngle = idx * sliceAngle - Math.PI / 2; // start from 12 o'clock
-      const endAngle = startAngle + sliceAngle;
-      const x1 = r + r * Math.cos(startAngle);
-      const y1 = r + r * Math.sin(startAngle);
-      const x2 = r + r * Math.cos(endAngle);
-      const y2 = r + r * Math.sin(endAngle);
-      const largeArc = sliceAngle > Math.PI ? 1 : 0;
-      d += `M ${r},${r} L ${x1},${y1} A ${r},${r} 0 ${largeArc},1 ${x2},${y2} Z `;
+      const p1 = v[idx];
+      const p2 = v[(idx + 1) % FACET_SIDES];
+      d += `M ${r},${r} L ${p1.x.toFixed(2)},${p1.y.toFixed(2)} L ${p2.x.toFixed(2)},${p2.y.toFixed(2)} Z `;
     }
-    fill.setAttribute("d", d.trim());
+    sectors.setAttribute("d", d.trim());
   }
 }
 

--- a/js/ui/overlays/selection-reticle.js
+++ b/js/ui/overlays/selection-reticle.js
@@ -1,12 +1,11 @@
 // @ts-check
-// Selection reticle: a dashed, slowly-spinning ring with cardinal tick marks
-// that anchors to the selected node. Unlike the action effects it's
-// selection-driven (not in the action registry) and progress is unused —
-// sync(nodeId) shows it, clear() hides it. The slow spin is CSS (.reticle-group
-// + reticle-spin keyframes in style.css). Ported from graph.js syncReticle.
+// Selection reticle: a dashed, slowly-spinning faceted (12-gon) ring with
+// cardinal tick marks, anchored to the selected node. Faceted to match the node
+// container. Selection-driven; progress unused. Spin is CSS (.reticle-group).
 
 import { html } from "lit";
 import { NodeOverlay } from "./node-overlay.js";
+import { ringPoints } from "./facet.js";
 
 const GAP = 12; // node radius → ring gap
 
@@ -15,8 +14,7 @@ class SelectionReticle extends NodeOverlay {
     return html`
       <svg class="selection-reticle" style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:6;">
         <g class="reticle-group">
-          <circle class="ring" cx="30" cy="30" r="28" fill="none" stroke="#cc00cc"
-                  stroke-width="1.5" stroke-dasharray="6 3" stroke-opacity="0.75"></circle>
+          <polygon class="ring" fill="none" stroke="#cc00cc" stroke-width="1.5" stroke-dasharray="6 3" stroke-opacity="0.75"></polygon>
           <line class="tick-n" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"></line>
           <line class="tick-s" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"></line>
           <line class="tick-e" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"></line>
@@ -37,12 +35,9 @@ class SelectionReticle extends NodeOverlay {
     const ringR = r - 2;
     const tickLen = Math.max(6, ringR * 0.22); // ~22% of ring radius, min 6px
 
-    const ring = svg.querySelector(".ring");
-    ring.setAttribute("cx", String(r));
-    ring.setAttribute("cy", String(r));
-    ring.setAttribute("r", String(ringR));
+    svg.querySelector(".ring").setAttribute("points", ringPoints(r, r, ringR));
 
-    // Four inward-pointing tick marks at cardinal positions
+    // Four inward-pointing tick marks at cardinal positions (which are 12-gon vertices)
     const ticks = {
       n: [r, r - ringR, r, r - ringR + tickLen],
       s: [r, r + ringR, r, r + ringR - tickLen],

--- a/js/ui/preview.js
+++ b/js/ui/preview.js
@@ -67,9 +67,17 @@ const ALERT_NODES = [
   { id: "alert-reboot",  label: "REBOOT",   type: "router", grade: "C", x: 750, y: 720 },
 ];
 
+// Access-state demo nodes — show fence density across locked/compromised/owned
+// so the vector-CRT fence treatment can be tuned in isolation.
+const ACCESS_NODES = [
+  { id: "acc-locked",      label: "LOCKED",      type: "fileserver", grade: "C", x: 150, y: 850 },
+  { id: "acc-compromised", label: "COMPROMISED", type: "fileserver", grade: "C", x: 380, y: 850 },
+  { id: "acc-owned",       label: "OWNED",       type: "fileserver", grade: "C", x: 610, y: 850 },
+];
+
 // ── Initialize Cytoscape ─────────────────────────────────────
 
-const allNodes = [...EFFECT_NODES, SELECT_NODE, FLASH_NODE, ...SHAPE_NODES, ...ALERT_NODES];
+const allNodes = [...EFFECT_NODES, SELECT_NODE, FLASH_NODE, ...SHAPE_NODES, ...ALERT_NODES, ...ACCESS_NODES];
 const networkData = {
   nodes: allNodes.map(n => ({ id: n.id, label: n.label, type: n.type, grade: n.grade })),
   edges: [],
@@ -101,6 +109,11 @@ for (const n of allNodes) {
 updateNodeStyle("alert-yellow", { visibility: "accessible", accessLevel: "owned", alertState: "yellow", rebooting: false });
 updateNodeStyle("alert-red", { visibility: "accessible", accessLevel: "owned", alertState: "red", rebooting: false });
 updateNodeStyle("alert-reboot", { visibility: "accessible", accessLevel: "owned", alertState: "green", rebooting: true });
+
+// Access-state demo overrides (the generic loop above set every node to "owned")
+updateNodeStyle("acc-locked",      { visibility: "accessible", accessLevel: "locked",      alertState: "green", rebooting: false });
+updateNodeStyle("acc-compromised", { visibility: "accessible", accessLevel: "compromised", alertState: "green", rebooting: false });
+updateNodeStyle("acc-owned",       { visibility: "accessible", accessLevel: "owned",       alertState: "green", rebooting: false });
 
 // Fit the view to show all nodes
 cy.fit(undefined, 40);

--- a/tests/node-glyphs.test.js
+++ b/tests/node-glyphs.test.js
@@ -8,6 +8,9 @@ import {
   glyphFor,
   glyphSvg,
   glyphDataUri,
+  fenceYs,
+  nodeFaceSvg,
+  nodeFaceDataUri,
 } from "../js/ui/node-glyphs.js";
 
 const CORE = ["wan", "gateway", "router", "firewall", "workstation", "ids", "security-monitor", "fileserver", "cryptovault", "mine"];
@@ -58,4 +61,34 @@ test("gallery type list (ALL_GLYPH_TYPES) includes every mapped type for the pre
   assert.ok(ALL_GLYPH_TYPES.includes("mine"), "mine must be demoable (it used to fall through to a circle)");
   assert.ok(ALL_GLYPH_TYPES.includes("alarm-latch"), "set-piece types must be demoable");
   assert.equal(ALL_GLYPH_TYPES.length, CORE.length + SETPIECE.length);
+});
+
+test("fenceYs density increases with access level", () => {
+  assert.ok(fenceYs("locked").length < fenceYs("compromised").length);
+  assert.ok(fenceYs("compromised").length < fenceYs("owned").length);
+});
+
+test("fenceYs is empty for an unknown access level", () => {
+  assert.deepEqual(fenceYs("weird"), []);
+});
+
+test("nodeFaceSvg embeds the type glyph, a clip path, and fence lines", () => {
+  const svg = nodeFaceSvg("fileserver", "owned");
+  assert.ok(svg.startsWith("<svg"));
+  assert.match(svg, /viewBox="0 0 64 64"/);
+  assert.ok(svg.includes(NODE_GLYPHS.fileserver.body), "glyph body present");
+  assert.ok(svg.includes("clipPath"), "fence clip path present");
+  assert.ok(svg.includes("<line"), "fence lines present");
+});
+
+test("nodeFaceSvg for an unknown access level draws the glyph but no fence group", () => {
+  const svg = nodeFaceSvg("router", "weird");
+  assert.ok(svg.includes(NODE_GLYPHS.router.body));
+  assert.ok(!svg.includes('clip-path="url(#sf)"'), "no fence group when level unknown");
+});
+
+test("nodeFaceDataUri returns an encoded svg data uri (no raw #)", () => {
+  const uri = nodeFaceDataUri("mine", "compromised");
+  assert.ok(uri.startsWith("data:image/svg+xml,"));
+  assert.ok(!uri.slice("data:image/svg+xml,".length).includes("#"), "hex # must be percent-encoded");
 });

--- a/tests/overlay-facet.test.js
+++ b/tests/overlay-facet.test.js
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { FACET_SIDES, facetVertices, ringPoints, arcPoints } from "../js/ui/overlays/facet.js";
+
+const near = (a, b, eps = 1e-6) => Math.abs(a - b) <= eps;
+
+test("FACET_SIDES is 12", () => assert.equal(FACET_SIDES, 12));
+
+test("facetVertices returns `sides` points, first at 12 o'clock", () => {
+  const v = facetVertices(50, 50, 10);
+  assert.equal(v.length, 12);
+  assert.ok(near(v[0].x, 50) && near(v[0].y, 40), "first vertex is top (cx, cy-r)");
+  for (const p of v) assert.ok(near(Math.hypot(p.x - 50, p.y - 50), 10), "all on radius");
+});
+
+test("facetVertices second vertex steps clockwise (toward +x, +y)", () => {
+  const v = facetVertices(0, 0, 10);
+  assert.ok(v[1].x > 0 && v[1].y > v[0].y, "clockwise: next vertex is right of and below the top");
+});
+
+test("ringPoints returns `sides` 'x,y' pairs", () => {
+  const s = ringPoints(0, 0, 10);
+  assert.equal(s.trim().split(/\s+/).length, 12);
+});
+
+test("arcPoints empty at progress<=0", () => {
+  assert.equal(arcPoints(0, 0, 10, 0), "");
+  assert.equal(arcPoints(0, 0, 10, -0.5), "");
+});
+
+test("arcPoints clockwise half-turn ends near 6 o'clock", () => {
+  const pts = arcPoints(0, 0, 10, 0.5, 1).trim().split(/\s+/).map(s => s.split(",").map(Number));
+  const last = pts[pts.length - 1];
+  assert.ok(near(last[0], 0, 1e-3) && near(last[1], 10, 1e-3), "ends at (0, +r)");
+});
+
+test("arcPoints counter-clockwise half-turn also ends near 6 o'clock but via the left", () => {
+  const pts = arcPoints(0, 0, 10, 0.5, -1).trim().split(/\s+/).map(s => s.split(",").map(Number));
+  const last = pts[pts.length - 1];
+  assert.ok(near(last[0], 0, 1e-3) && near(last[1], 10, 1e-3), "ends at (0, +r)");
+  // a midpoint should be on the left (negative x) for CCW
+  const mid = pts[Math.floor(pts.length / 2)];
+  assert.ok(mid[0] <= 1e-6, "CCW sweep passes through negative x (left side)");
+});
+
+test("arcPoints point count grows with progress", () => {
+  const n = p => arcPoints(0, 0, 10, p, 1).trim().split(/\s+/).length;
+  assert.ok(n(0.25) < n(0.6) && n(0.6) < n(0.95));
+});
+
+test("arcPoints at progress>=1 is the full closed ring (sides points)", () => {
+  assert.equal(arcPoints(0, 0, 10, 1, 1).trim().split(/\s+/).length, 12);
+});


### PR DESCRIPTION
## Summary

Reworks the network-graph presentation into a glowing **vector CRT display** (Asteroids / Tempest / Black Widow): blooming strokes on near-black, no solid fills, fence-hatch state encoding (density = access level), no raster scanline, faceted (12-gon) overlay effects, straight edges, and a runtime-adjustable bloom. Presentation-only — no gameplay/state/event changes; the console + log channel are untouched.

### Highlights
- **Node faces**: dodecagon-clipped fence hatch + glyph (`nodeFaceDataUri`); solid fills → transparent; native Cytoscape border kept so state/alert pulses still work and stay the brightest element.
- **Global bloom**: one SVG `<filter>` on `#cy` + `#overlay-layer` (colored phosphor halo); scanline removed; faint reference grid kept.
- **Dynamic bloom**: `setBloomIntensity()` rescales the live filter — a seam for a future deck-damage mechanic (crank toward illegible on injury).
- **Effects coherence** (no curves, no fills): new pure `overlays/facet.js`; probe = chunky LED segments brightening as the sweep crosses; dump = the 12 facets light up; ICE-detect / reticle / loot-rings faceted; edges straight; loot + flash reworked as expanding ripple rings.
- **Chrome**: glows harmonized to a `--glow-sm/md/lg` scale.
- **Rebased atop PR #131** (ICE legibility): dropped the ICE-specific drop-shadows so the ICE presence + detection ride the single global bloom instead of double-glowing.

## Test plan
- [x] `make check` — 704 tests pass, lint clean
- [x] Browser-verified (preview + live game): bloom, fence density across locked/compromised/owned, all overlays anchored correctly, ICE single-bloom, node clicks still reach the canvas
- [ ] Reviewer: open `preview.html`, PLAY each overlay + the NODE FLASH buttons, toggle ICE; confirm the vector look in the live game

Session docs: `docs/dev-sessions/2026-06-10-1013-vector-crt-rendering/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)