### PR TITLE
Exploit legibility: vuln glyphs, quality color, wear, at-a-glance match (#117)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -239,19 +239,33 @@ Your hand contains five exploit cards, randomly generated at the start of each r
 | Rare      | 3 vuln types | 8             | High–Very High|
 
 **Quality** is shown as a pip meter (█░░░░ to █████). Higher quality means better
-base success chances, especially on unprobed or high-grade nodes.
+base success chances, especially on unprobed or high-grade nodes. The pip meter is
+also **color-coded** along a ramp — dim red (low) → amber → bright green/white
+(high) — so a card's strength reads at a glance. The pip count carries the same
+information without relying on color.
 
-**Decay** — Cards wear out:
+**Vulnerability glyphs** — Each vulnerability type has its own **glyph**, shown on
+both the exploit card (next to each vuln it targets) and on the node panel (next to
+each revealed vulnerability). Color groups the glyphs by rarity tier: teal (common),
+amber (uncommon), magenta (rare). The textual vuln id stays next to the glyph, and
+`status` output is unchanged.
 
-- Each use costs one **use** from the remaining count
-- When uses drop low and the card takes a failure hit, it becomes **worn** — still usable, but flagged
-- A failed exploit can also **disclose** a card — the exploit signature leaks to the blue team,
-  rendering the card useless for further escalation attempts. Disclosed cards stay in your hand
+**Decay** — Cards wear out, and *look* worn as they do:
+
+- Each use costs one **use** from the remaining count; the card progressively
+  **desaturates** as its uses deplete
+- When uses drop low and the card takes a failure hit, it becomes **worn** — still
+  usable, but desaturated and showing hairline cracks
+- A failed exploit can also **disclose** a card — the exploit signature leaks to the
+  blue team, rendering the card useless for further escalation attempts. Disclosed
+  cards stay in your hand (rendered greyed-out, struck-through, and visibly burnt)
   but cannot be played.
 
 When a node is targeted, your hand re-sorts: matching cards first, then usable cards,
 then worn, then disclosed. Cards that match the selected node's known vulnerabilities
-highlight in cyan.
+**glow green and lift**, and the specific shared **vuln glyph lights up** on the card —
+a visual lock-and-key against the node's revealed vulnerabilities. Non-matching cards
+recede (dimmed and desaturated).
 
 The numbers shown next to cards in `status hand` are the numbers to use with
 `xploit <n>` — the sort order changes with your selection, so always check

--- a/css/style.css
+++ b/css/style.css
@@ -644,16 +644,21 @@ html, body {
 
 .nd-vuln {
   display: flex;
-  justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
   font-size: 0.72rem;
-  gap: 0.5rem;
+  gap: 0.4rem;
+}
+
+.nd-vuln-glyph {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
 }
 
 .nd-vuln.patched .vuln-name { text-decoration: line-through; color: var(--text-dim); }
 
 .vuln-name  { color: var(--green); }
-.vuln-rarity { font-size: 0.65rem; }
+.vuln-rarity { font-size: 0.65rem; margin-left: auto; }
 
 .nd-indent { padding: 0.25rem 0; font-size: 0.75rem; }
 
@@ -695,7 +700,40 @@ html, body {
   border-color: #bb0077;
   box-shadow: inset 0 0 10px rgba(255, 0, 200, 0.12);
 }
-.exploit-card.disclosed { opacity: 0.35; }
+/* ── Card wear ──────────────────────────────────────────────
+   Continuous desaturation as --wear drops (1 fresh → 0 spent), plus dramatic
+   discrete end states. --sat-extra is an extra multiplier other states (e.g.
+   .no-match) can set without clobbering the wear ramp; the two-class
+   .worn/.disclosed rules still outrank this base filter by specificity. */
+.exploit-card { filter: saturate(calc((0.4 + 0.6 * var(--wear, 1)) * var(--sat-extra, 1))); }
+
+.exploit-card.worn {
+  filter: saturate(0.45) brightness(0.9);
+}
+/* hairline cracks */
+.exploit-card.worn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(115deg, transparent 48%, rgba(180, 180, 180, 0.25) 49%, transparent 50%),
+    linear-gradient(200deg, transparent 60%, rgba(180, 180, 180, 0.18) 61%, transparent 62%);
+}
+
+.exploit-card.disclosed {
+  opacity: 0.4;
+  filter: grayscale(1) brightness(0.7);
+}
+.exploit-card.disclosed .ec-name { text-decoration: line-through; }
+/* heavy burnt strike */
+.exploit-card.disclosed::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(135deg, transparent 45%, rgba(120, 120, 120, 0.4) 50%, transparent 55%);
+}
 
 .ec-header {
   display: flex;
@@ -727,6 +765,15 @@ html, body {
 .ec-pips { color: var(--green); letter-spacing: 0.05em; }
 .ec-val  { color: var(--green); }
 
+/* Quality color ramp — dim-red (low) → amber → bright-green/white (high).
+   Color is the dramatic signal; the pip count stays the color-blind-safe
+   redundant channel. */
+.ec-pips.q0 { color: #c0392b; }
+.ec-pips.q1 { color: #e08a1e; }
+.ec-pips.q2 { color: #c9d11e; }
+.ec-pips.q3 { color: var(--green); }
+.ec-pips.q4 { color: #b8ffce; text-shadow: var(--glow-sm) var(--green-dim); }
+
 .ec-vulns {
   display: flex;
   flex-direction: column;
@@ -736,9 +783,22 @@ html, body {
 }
 
 .ec-vuln {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
   color: var(--text-dim);
   font-size: 0.65rem;
   white-space: nowrap;
+  overflow: hidden;
+}
+
+.ec-vuln-glyph {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.ec-vuln-label {
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -752,12 +812,29 @@ html, body {
   background: #0d1a0d;
 }
 
+/* Positive match highlight — matching cards glow + lift; the shared glyph(s)
+   light up (the lock-and-key click). Non-matches recede. */
 .exploit-card.match {
   opacity: 1;
+  border-color: var(--green);
+  box-shadow: var(--glow-md) rgba(0, 255, 65, 0.35);
+  transform: translateY(-2px);
 }
 
+/* Recede non-matches; --sat-extra multiplies into the base wear filter so the
+   wear ramp stays visible on no-match cards instead of being overridden. */
 .exploit-card.no-match {
-  opacity: 0.35;
+  opacity: 0.4;
+  --sat-extra: 0.5;
+}
+
+.ec-vuln.matched .ec-vuln-label {
+  color: var(--green);
+  text-shadow: var(--glow-sm) var(--green-dim);
+}
+
+.ec-vuln.matched .ec-vuln-glyph {
+  filter: drop-shadow(0 0 3px rgba(0, 255, 65, 0.7));
 }
 
 
@@ -841,6 +918,36 @@ html, body {
 .ec-cancel-overlay:hover .ec-cancel-x {
   opacity: 1;
   box-shadow: var(--glow-md) rgba(204, 0, 204, 0.5);
+}
+
+/* ── Vuln glyph swatches (preview harness) ──────────────── */
+
+#vuln-swatches {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.4rem;
+}
+
+.vuln-swatch {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 0.3rem 0.2rem;
+  border: 1px solid var(--grey);
+  background: var(--bg-panel2);
+}
+
+.vuln-swatch img {
+  width: 40px;
+  height: 40px;
+}
+
+.vuln-swatch span {
+  color: var(--text-dim);
+  font-size: 0.55rem;
+  text-align: center;
+  word-break: break-word;
 }
 
 /* ── Action Log ─────────────────────────────────────────── */

--- a/docs/dev-sessions/2026-06-10-1549-exploit-legibility/plan.md
+++ b/docs/dev-sessions/2026-06-10-1549-exploit-legibility/plan.md
@@ -1,0 +1,393 @@
+# Exploit Legibility Implementation Plan
+
+**Goal:** Make exploit-card↔node matching, card quality, and card wear readable at a glance — a visual lock-and-key — without changing any game logic.
+
+**Approach:** Consolidate the duplicated match predicate into one source of truth, then layer purely-visual treatments on top: a per-vuln-type SVG glyph vocabulary (shown on card + node panel), a positive match highlight + glyph-lock, a vivid quality-bar color ramp, and continuous wear degradation. All new logic is pure and unit-tested; component/CSS changes are verified in the preview harness.
+
+**Tech stack:** Vanilla ES modules, Lit components (light DOM), stroke-only SVG glyphs (mirroring `js/ui/node-glyphs.js`), CSS custom properties, `node:test` unit tests.
+
+---
+
+## Phase 1: Match predicate as single source of truth
+
+Extract the card↔node match logic (today duplicated in `exploitSortKey` and `starnet-hand.js`) into pure, tested helpers in `js/core/exploits.js`, and route both callers through them. Behavior-preserving refactor — no visual change yet. TDD via a structural-invariant test.
+
+**Files:**
+- Modify: `js/core/exploits.js` — add `matchingVulnIds()` + `cardMatchesNode()`; rewrite `exploitSortKey()` to use them
+- Modify: `js/ui/components/starnet-hand.js` — replace inline match logic (lines 62-67) with `matchingVulnIds()` / `cardMatchesNode()`
+- Test: `js/core/exploits.test.js` — structural-invariant + unit tests
+
+**Key changes:**
+- `matchingVulnIds(card, node): string[]` — new. The vuln ids on `card.targetVulnTypes` that the node reveals (probed, `!patched && !hidden`). `[]` if node missing/unprobed.
+- `cardMatchesNode(card, node): boolean` — new. `matchingVulnIds(card, node).length > 0`.
+
+```js
+// js/core/exploits.js — replaces the inline filter inside exploitSortKey
+export function matchingVulnIds(card, node) {
+  if (!node?.probed) return [];
+  const known = node.vulnerabilities
+    .filter((v) => !v.patched && !v.hidden)
+    .map((v) => v.id);
+  return card.targetVulnTypes.filter((t) => known.includes(t));
+}
+
+export function cardMatchesNode(card, node) {
+  return matchingVulnIds(card, node).length > 0;
+}
+
+// exploitSortKey keeps identical 0/1/2/3 semantics:
+export function exploitSortKey(card, node) {
+  if (card.decayState === "disclosed") return 3;
+  if (card.usesRemaining <= 0) return 2;
+  if (!node?.probed) return 1;
+  return cardMatchesNode(card, node) ? 0 : 1;
+}
+```
+
+```js
+// starnet-hand.js _renderCard — replaces lines 62-67
+let matchedVulnIds = [];
+let matchClass = "";
+if (this.selectedNode?.probed && !isExec) {
+  matchedVulnIds = matchingVulnIds(card, this.selectedNode);
+  matchClass = matchedVulnIds.length ? "match" : "no-match";
+}
+// (matchedVulnIds is threaded into exploitCardBody in Phase 4)
+```
+
+```js
+// js/core/exploits.test.js — structural invariant + units
+import { exploitSortKey, cardMatchesNode, matchingVulnIds } from "./exploits.js";
+// node has unpatched-ssh (visible), open-telnet (patched), zero-day-rce (hidden)
+const node = { probed: true, vulnerabilities: [
+  { id: "unpatched-ssh", patched: false, hidden: false },
+  { id: "open-telnet",  patched: true,  hidden: false },
+  { id: "zero-day-rce", patched: false, hidden: true  },
+]};
+// invariant: for a usable card on a probed node, sortKey===0  <=>  cardMatchesNode===true
+for (const targets of [["unpatched-ssh"], ["open-telnet"], ["zero-day-rce"], ["weak-auth"], ["unpatched-ssh","weak-auth"]]) {
+  const card = { decayState: "fresh", usesRemaining: 3, targetVulnTypes: targets };
+  assert.equal(exploitSortKey(card, node) === 0, cardMatchesNode(card, node));
+}
+// matchingVulnIds is a subset of targets, ignores patched + hidden
+assert.deepEqual(matchingVulnIds({ targetVulnTypes: ["unpatched-ssh","open-telnet","zero-day-rce"], decayState:"fresh", usesRemaining:3 }, node), ["unpatched-ssh"]);
+// unprobed node => no matches
+assert.deepEqual(matchingVulnIds({ targetVulnTypes: ["unpatched-ssh"] }, { probed: false, vulnerabilities: [] }), []);
+```
+
+**Verification — automated:**
+- [x] `make test` passes (new exploits.test.js cases included)
+- [x] `make lint` passes
+- [x] `make check` passes
+
+**Verification — manual:**
+- [x] In the game, with a node selected and probed, the hand still floats matching cards to the top and dims non-matches exactly as before (no behavior change). *Verified: structural-invariant test proves predicate equivalence; live game shows correct match/no-match.*
+
+---
+
+## Phase 2: Vuln-type glyph vocabulary (pure module + preview swatch)
+
+Create the 15-glyph SVG vocabulary as a pure module mirroring `node-glyphs.js`, with a test asserting it fully covers `VULNERABILITY_TYPES`. Add an all-glyphs swatch sheet to the preview harness for visual iteration.
+
+**Files:**
+- Create: `js/ui/vuln-glyphs.js` — glyph vocabulary + accessors (pure, no DOM)
+- Create: `js/ui/vuln-glyphs.test.js` — coverage + shape tests
+- Modify: `js/ui/preview-cards.js` — export a `vulnSwatchGlyphs()` builder; add `mountVulnSwatches()`
+- Modify: `js/ui/preview.js` — mount the vuln-glyph swatch sheet in the control panel
+
+**Key changes:**
+- `VULN_GLYPHS: Record<string, {color, body}>` — 15 entries, keyed by vuln id. Stroke-only inner SVG on a `0 0 64 64` viewBox (same convention as `NODE_GLYPHS`). **Motif scheme (alchemical-inspired, first-pass placeholders to iterate):** glyph *color* encodes vuln rarity tier — common = teal/cyan family, uncommon = amber, rare = magenta — and *shape complexity* climbs with tier (common = single primitive mark, uncommon = paired/crossed mark, rare = 3-element composite), so rarity reads in the glyph family.
+- `vulnGlyphFor(id)`, `vulnGlyphSvg(id)`, `vulnGlyphDataUri(id)`, `ALL_VULN_GLYPH_IDS` — mirror `node-glyphs.js` accessors. Fallback `FALLBACK_VULN_GLYPH` for unknown ids.
+
+```js
+// js/ui/vuln-glyphs.js (structure mirrors node-glyphs.js; 15 entries total)
+// First-stab alchemical/iconographic marks — stroke-only, no curves, centered
+// on the 0 0 64 64 box. Iterate shapes in the preview swatch (Phase 2 manual).
+export const VULN_GLYPHS = {
+  // ── common (teal, simple single marks — the classical elements + salt/cross) ──
+  "unpatched-ssh":  { color: "#3fd9c9", body: `<polygon points="32,18 46,44 18,44"/>` },                                              // fire △
+  "weak-auth":      { color: "#3fd9c9", body: `<polygon points="18,20 46,20 32,46"/>` },                                              // water ▽
+  "stale-firmware": { color: "#3fd9c9", body: `<polygon points="18,20 46,20 32,46"/><line x1="24" y1="30" x2="40" y2="30"/>` },       // earth ▽+bar
+  "open-telnet":    { color: "#3fd9c9", body: `<polygon points="32,18 46,44 18,44"/><line x1="24" y1="36" x2="40" y2="36"/>` },       // air △+bar
+  "buffer-overflow":{ color: "#3fd9c9", body: `<rect x="20" y="20" width="24" height="24"/><line x1="20" y1="32" x2="44" y2="32"/>` },// salt ▢⊖
+  "snmp-public":    { color: "#3fd9c9", body: `<line x1="32" y1="16" x2="32" y2="48"/><line x1="16" y1="32" x2="48" y2="32"/>` },     // cross +
+  // ── uncommon (amber, paired/crossed 2–3 element marks) ──
+  "path-traversal":  { color: "#ffb020", body: `<line x1="18" y1="44" x2="46" y2="44"/><polyline points="22,40 40,22"/><polyline points="31,22 40,22 40,31"/>` }, // escape arrow over a floor
+  "deserialization": { color: "#ffb020", body: `<rect x="18" y="18" width="28" height="28"/><rect x="26" y="26" width="12" height="12"/>` },                       // nested squares
+  "side-channel":    { color: "#ffb020", body: `<line x1="32" y1="19" x2="32" y2="32"/><line x1="32" y1="32" x2="40" y2="38"/><line x1="44" y1="20" x2="20" y2="44" stroke-dasharray="3 3"/>` }, // clock hands + dashed leak
+  "race-condition":  { color: "#ffb020", body: `<line x1="20" y1="27" x2="42" y2="27"/><polyline points="38,23 42,27 38,31"/><line x1="44" y1="39" x2="22" y2="39"/><polyline points="26,35 22,39 26,43"/>` }, // opposing arrows (TOCTOU)
+  "kernel-exploit":  { color: "#ffb020", body: `<polygon points="32,18 45,25 45,39 32,46 19,39 19,25"/><line x1="28" y1="32" x2="36" y2="32"/><line x1="32" y1="28" x2="32" y2="36"/>` }, // ring-0 hexagon + core cross
+  // ── rare (magenta, 3-element composites) ──
+  "zero-day-rce":          { color: "#ff5cc8", body: `<polygon points="32,16 43,33 21,33"/><line x1="32" y1="33" x2="32" y2="48"/><line x1="25" y1="41" x2="39" y2="41"/>` },                                  // sulfur (△ over cross)
+  "supply-chain":          { color: "#ff5cc8", body: `<polygon points="16,32 22,28 28,32 22,36"/><polygon points="26,32 32,28 38,32 32,36"/><polygon points="36,32 42,28 48,32 42,36"/>` },                       // three linked diamonds (chain)
+  "hardware-backdoor":     { color: "#ff5cc8", body: `<rect x="22" y="22" width="20" height="20"/><line x1="27" y1="18" x2="27" y2="22"/><line x1="37" y1="18" x2="37" y2="22"/><line x1="42" y1="42" x2="48" y2="48"/>` }, // chip + pins + hidden tail
+  "cryptographic-weakness":{ color: "#ff5cc8", body: `<polygon points="32,17 45,24 45,40 32,47 19,40 19,24"/><polyline points="33,19 28,32 36,32 31,45"/>` },                                                       // cipher hexagon + lightning crack
+};
+export const FALLBACK_VULN_GLYPH = { color: "#7fd9c9", body: `<polygon points="22,22 42,22 42,42 22,42"/><line x1="22" y1="22" x2="42" y2="42"/>` };
+export const ALL_VULN_GLYPH_IDS = Object.keys(VULN_GLYPHS);
+export function vulnGlyphFor(id) { return VULN_GLYPHS[id] || FALLBACK_VULN_GLYPH; }
+export function vulnGlyphSvg(id) { const { color, body } = vulnGlyphFor(id);
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none" stroke="${color}" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round">${body}</svg>`; }
+export function vulnGlyphDataUri(id) { return "data:image/svg+xml," + encodeURIComponent(vulnGlyphSvg(id)); }
+```
+
+> All 15 bodies above are concrete first-stab marks to be tuned in the preview swatch (Phase 2 manual step); the coverage test guards that none regress to empty/fallback.
+
+```js
+// js/ui/vuln-glyphs.test.js
+import { VULN_GLYPHS, vulnGlyphFor, FALLBACK_VULN_GLYPH } from "./vuln-glyphs.js";
+import { VULNERABILITY_TYPES } from "../core/exploits.js";
+// structural: every vuln type has a distinct, non-empty glyph
+const ids = VULNERABILITY_TYPES.map((v) => v.id);
+assert.equal(Object.keys(VULN_GLYPHS).length, ids.length); // 15
+for (const id of ids) {
+  const g = VULN_GLYPHS[id];
+  assert.ok(g && g.color && g.body && g.body.length > 0, `glyph for ${id}`);
+  assert.notEqual(vulnGlyphFor(id), FALLBACK_VULN_GLYPH, `${id} is not the fallback`);
+}
+// unknown id falls back
+assert.equal(vulnGlyphFor("nope"), FALLBACK_VULN_GLYPH);
+```
+
+```js
+// js/ui/preview-cards.js — add (pure builder + DOM mount)
+import { ALL_VULN_GLYPH_IDS, vulnGlyphDataUri } from "./vuln-glyphs.js";
+export function vulnSwatchGlyphs() { return ALL_VULN_GLYPH_IDS; } // for the swatch sheet
+export function mountVulnSwatches(container) {
+  for (const id of ALL_VULN_GLYPH_IDS) {
+    const cell = document.createElement("div"); cell.className = "vuln-swatch";
+    cell.innerHTML = `<img src="${vulnGlyphDataUri(id)}" width="40" height="40" alt="${id}"/><span>${id}</span>`;
+    container.appendChild(cell);
+  }
+}
+```
+
+**Verification — automated:**
+- [x] `make test` passes (vuln-glyphs.test.js covers all 15 ids)
+- [x] `make lint` passes
+- [x] `make check` passes
+
+**Verification — manual:**
+- [x] `make bundle-vendor` then `make serve`; open `preview.html` — the vuln-glyph swatch sheet shows all 15 glyphs, each visually distinct, legible at ~40px, and color-grouped by rarity tier (teal/amber/magenta). *Verified via Playwright screenshot: all 15 render distinct; tiers read teal/amber/magenta.*
+
+---
+
+## Phase 3: Glyphs on the card and in the node panel
+
+Render the vuln glyph next to each vuln on both surfaces (card `targetVulnTypes`, node-panel vuln list), keeping the text label. This is the lock-and-key identity layer (the *match highlight* comes in Phase 4). Component/CSS only — no new pure logic, so unit-test opt-out; verified in preview + game.
+
+**Files:**
+- Modify: `js/ui/components/exploit-card-view.js` — render a glyph per `.ec-vuln`
+- Modify: `js/ui/components/starnet-node-panel.js` — render a glyph before each `.nd-vuln` name (lines 93-97)
+- Modify: `css/style.css` — `.ec-vuln-glyph` / `.nd-vuln-glyph` sizing; make `.ec-vuln` a flex row so glyph + label align
+- Modify: `js/ui/preview-cards.js` — fix the `MOCK_SELECTED_NODE` no-match demo card to a real vuln id (`"sql-injection"` → `"kernel-exploit"`) so its glyph isn't the fallback
+
+**Key changes:**
+- `exploitCardBody()` `.ec-vulns` row: each target becomes glyph + label:
+```js
+import { vulnGlyphDataUri } from "../vuln-glyphs.js";
+// ...
+<div class="ec-vulns">${card.targetVulnTypes.map((t) => html`
+  <div class="ec-vuln">
+    <img class="ec-vuln-glyph" src=${vulnGlyphDataUri(t)} alt="" />
+    <span class="ec-vuln-label">${t}</span>
+  </div>`)}</div>
+```
+- `starnet-node-panel.js` `_renderVulns` row gains a glyph (keyed by `v.id`):
+```js
+import { vulnGlyphDataUri } from "../vuln-glyphs.js";
+// each visible vuln:
+<div class="nd-vuln ${v.patched ? "patched" : ""}">
+  <img class="nd-vuln-glyph" src=${vulnGlyphDataUri(v.id)} alt="" />
+  <span class="vuln-name">${v.name}</span>
+  <span class="vuln-rarity rarity-${v.rarity}">[${v.rarity.toUpperCase()}]</span>
+</div>
+```
+- CSS:
+```css
+.ec-vuln { display: flex; align-items: center; gap: 0.3rem; white-space: nowrap; }
+.ec-vuln-glyph { width: 16px; height: 16px; flex-shrink: 0; }
+.ec-vuln-label { overflow: hidden; text-overflow: ellipsis; }
+.nd-vuln-glyph { width: 16px; height: 16px; flex-shrink: 0; margin-right: 0.3rem; vertical-align: middle; }
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (no regressions; preview-cards test still green)
+- [x] `make check` passes
+
+**Verification — manual:**
+- [x] Preview card gallery: every card shows a glyph beside each target vuln; node-panel mock shows glyphs beside vuln names. The "Match vs node" group's matching card shares a glyph with the node's vulns; the no-match card shows a different (non-fallback) glyph. *Verified via screenshot.*
+- [x] In the game: probe a node → node panel vulns show glyphs; the same glyphs appear on hand cards that target them. *Verified: probed gateway, panel shows 3 vulns each with a valid glyph; hand cards render glyphs.*
+- [x] `status node <id>` text output is unchanged (still shows textual vuln ids/names). *Verified: git diff shows zero changes to js/core/console-commands/ — status path untouched.*
+
+---
+
+## Phase 4: At-a-glance match — card glow/lift + glyph lock
+
+When a node is selected, matching cards get a positive glow/lift and the *specific* shared glyph(s) light up; non-matches dim. Uses the Phase-1 predicate (already wired into the hand) — this phase threads the matched ids into the card body and adds the CSS. Component/CSS only; verified in preview + game.
+
+**Files:**
+- Modify: `js/ui/components/exploit-card-view.js` — accept `matchedVulnIds`, mark matched glyphs
+- Modify: `js/ui/components/starnet-hand.js` — pass `matchedVulnIds` (from Phase 1) into `exploitCardBody`
+- Modify: `css/style.css` — `.exploit-card.match` glow/lift, tune `.no-match`, `.ec-vuln.matched` glyph emphasis
+
+**Key changes:**
+- New signature `exploitCardBody(card, indexLabel, matchedVulnIds = [])`; the picker call (`starnet-action-choices.js:70`) stays `exploitCardBody(choice.data)` → no per-glyph lit state there (its cards are all matches already), glyphs still render.
+```js
+export function exploitCardBody(card, indexLabel, matchedVulnIds = []) {
+  const matched = new Set(matchedVulnIds);
+  // ... in the .ec-vulns map:
+  // <div class="ec-vuln ${matched.has(t) ? "matched" : ""}"> ...
+}
+```
+- `starnet-hand.js` `_renderCard`: `${exploitCardBody(card, `${index}.`, matchedVulnIds)}` (matchedVulnIds computed in Phase 1).
+- CSS — positive match highlight + glyph lock:
+```css
+.exploit-card.match {
+  opacity: 1;
+  border-color: var(--green);
+  box-shadow: var(--glow-md) rgba(0, 255, 65, 0.35);
+  transform: translateY(-2px);
+}
+.exploit-card.no-match { opacity: 0.4; filter: saturate(0.5); }
+.ec-vuln.matched .ec-vuln-label { color: var(--green); text-shadow: var(--glow-sm) var(--green-dim); }
+.ec-vuln.matched .ec-vuln-glyph { filter: drop-shadow(0 0 3px rgba(0,255,65,0.7)); }
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes
+- [x] `make check` passes
+
+**Verification — manual:**
+- [x] Game: select + probe a node. Cards whose glyph the node shares glow/lift; within those cards, only the matching glyph(s) light up (a multi-target card with one match lights just that one). Non-matching cards dim/desaturate. *Verified: preview match card shows green glow/lift + lit △ glyph; no-match card dimmed. DOM confirms .match + 1 matched glyph vs .no-match + 0.*
+- [x] Preview "Match vs node" group reproduces the same glow + glyph-lock without running the game. *Verified via screenshot.*
+- [x] Keyboard `xploit` flow and the picker still work; picker cards render glyphs. *Verified: probe/target via console API works; picker uses the shared exploitCardBody render path.*
+
+---
+
+## Phase 5: Quality color ramp
+
+Replace the monochrome quality pips with a vivid color ramp (dim-red → amber → bright-green/white), keeping the pip count as the color-blind-safe redundant channel. Rarity border is untouched.
+
+**Files:**
+- Modify: `js/core/exploits.js` — add pure `qualityTier(quality)`
+- Modify: `js/core/exploits.test.js` — threshold tests
+- Modify: `js/ui/components/exploit-card-view.js` — apply tier class to `.ec-pips`
+- Modify: `css/style.css` — `.ec-pips.q-*` colors
+
+**Key changes:**
+- `qualityTier(quality): "q0"|"q1"|"q2"|"q3"|"q4"` — 5 buckets across [0,1]:
+```js
+export function qualityTier(q) {
+  if (q < 0.3)  return "q0"; // dim red
+  if (q < 0.5)  return "q1"; // amber-low
+  if (q < 0.7)  return "q2"; // amber/green
+  if (q < 0.85) return "q3"; // green
+  return "q4";                // bright green/white
+}
+```
+- `exploitCardBody`: `<span class="ec-pips ${qualityTier(card.quality)}">${pips}</span>` (pip string unchanged).
+- CSS:
+```css
+.ec-pips.q0 { color: #c0392b; }            /* dim red */
+.ec-pips.q1 { color: #e08a1e; }            /* amber */
+.ec-pips.q2 { color: #c9d11e; }            /* amber-green */
+.ec-pips.q3 { color: var(--green); }       /* green */
+.ec-pips.q4 { color: #b8ffce; text-shadow: var(--glow-sm) var(--green-dim); } /* bright */
+```
+
+```js
+// exploits.test.js
+assert.equal(qualityTier(0.2), "q0");
+assert.equal(qualityTier(0.45), "q1");
+assert.equal(qualityTier(0.55), "q2");
+assert.equal(qualityTier(0.8), "q3");
+assert.equal(qualityTier(0.95), "q4");
+```
+
+**Verification — automated:**
+- [x] `make test` passes (qualityTier thresholds)
+- [x] `make lint` passes
+- [x] `make check` passes
+
+**Verification — manual:**
+- [x] Preview "Rarity × Quality" group: low cards read dim-red, high cards bright-green/white, with an obvious ramp between — and the pip *count* still distinguishes them with color removed (squint / grayscale check). *Verified via screenshot: rare-low dim-red, rare-mid amber, rare-high bright green; pip counts intact.*
+
+---
+
+## Phase 6: Wear degradation
+
+Make cards visibly degrade as they're used: continuous desaturation/dimming on `usesRemaining/maxUses`, a crack overlay at `worn`, and a struck-through near-monochrome burnt look at `disclosed`.
+
+**Files:**
+- Modify: `js/core/exploits.js` — add pure `wearFraction(card)`
+- Modify: `js/core/exploits.test.js` — wearFraction tests
+- Modify: `js/ui/components/starnet-hand.js` — add `worn` class + `--wear` custom prop to the card container
+- Modify: `js/ui/components/starnet-action-choices.js` — same wear class/prop on its `.exploit-card` (worn cards can appear in the picker)
+- Modify: `css/style.css` — `--wear` desaturation ramp, `.worn` cracks, enhance `.disclosed` burnt
+
+**Key changes:**
+- `wearFraction(card): number` — `usesRemaining / USES_BY_RARITY[rarity]`, clamped [0,1]; `0` if disclosed:
+```js
+// js/core/exploits.js (USES_BY_RARITY already exported from this module)
+export function wearFraction(card) {
+  if (card.decayState === "disclosed") return 0;
+  const max = USES_BY_RARITY[card.rarity] ?? 3;
+  return Math.max(0, Math.min(1, card.usesRemaining / max));
+}
+```
+- `starnet-hand.js` `_renderCard` container: add `worn` to the class list when `card.decayState === "worn"`, and set the custom prop on the card `<div>`:
+```js
+const worn = card.decayState === "worn";
+const classes = ["exploit-card", `rarity-${card.rarity}`, disclosed ? "disclosed" : "", worn ? "worn" : "", matchClass, isSelectable ? "selectable-card" : "", isExec ? "executing" : ""].filter(Boolean).join(" ");
+// <div class="${classes}" style=${`--wear:${wearFraction(card)}`} ...>
+```
+- `starnet-action-choices.js` `_renderChoice`: add `${choice.data.decayState === "worn" ? "worn" : ""}` to the class list and `style=${`--wear:${wearFraction(choice.data)}`}`.
+- CSS — continuous + discrete:
+```css
+/* continuous: less saturation as --wear drops (1 fresh → 0 spent) */
+.exploit-card { filter: saturate(calc(0.4 + 0.6 * var(--wear, 1))); }
+.exploit-card.worn { filter: saturate(0.45) brightness(0.9); }
+.exploit-card.worn::after { /* hairline cracks */
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  background:
+    linear-gradient(115deg, transparent 48%, rgba(180,180,180,0.25) 49%, transparent 50%),
+    linear-gradient(200deg, transparent 60%, rgba(180,180,180,0.18) 61%, transparent 62%);
+}
+.exploit-card.disclosed { opacity: 0.4; filter: grayscale(1) brightness(0.7); }
+.exploit-card.disclosed .ec-name { text-decoration: line-through; }
+.exploit-card.disclosed::after { /* heavy burnt strike */
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  background: linear-gradient(135deg, transparent 45%, rgba(120,120,120,0.4) 50%, transparent 55%);
+}
+```
+
+> Note: `.exploit-card.executing` and `.match`/`.no-match` already set `filter`/`box-shadow`. Verify the wear `filter` composes acceptably — executing/matching cards are typically fresh (`--wear≈1` ≈ no desaturation). Tune in preview. If the `.match` and base `.exploit-card` filters conflict (CSS `filter` doesn't merge across rules — last wins), fold the match/no-match saturation into the same rule or use a wrapper. Resolve during execution against the live preview.
+
+```js
+// exploits.test.js
+assert.equal(wearFraction({ rarity: "common", decayState: "fresh", usesRemaining: 3 }), 1);
+assert.equal(wearFraction({ rarity: "common", decayState: "worn",  usesRemaining: 1 }), 1/3);
+assert.equal(wearFraction({ rarity: "rare",   decayState: "disclosed", usesRemaining: 0 }), 0);
+```
+
+**Verification — automated:**
+- [x] `make test` passes (wearFraction)
+- [x] `make lint` passes
+- [x] `make check` passes
+
+**Verification — manual:**
+- [x] Preview "Wear states" group: fresh = full color, worn = desaturated + hairline cracks, disclosed = grayscale, struck-through, dim — a burnt card looks burnt. *Verified via screenshot: worn card desaturated with visible cracks; disclosed card greyed, struck-through, burnt.*
+- [x] Game: use a card repeatedly; it visibly desaturates approaching worn, shows cracks at worn, and reads as spent/burnt at disclosed. Picker shows a worn card with the same treatment. *Verified via preview wear-states group (same render path); --wear ramp + decay classes confirmed.*
+- [x] Wear treatment composes acceptably with the executing-card fill and the match glow (no muddy double-filter on fresh matching cards). *Verified: fresh matching card (preview match group) shows clean green glow, no muddy filter; specificity ordering holds.*
+
+---
+
+## Final verification (before PR)
+
+- [x] `make check` clean (723 tests pass, lint clean)
+- [x] `make bundle-vendor && make serve` → play a short run: probe a node, confirm the at-a-glance read (which cards match via glow + shared glyph, how strong via quality color, how worn via degradation) works without reading labels. *Verified via Playwright in both preview.html and index.html; 0 console errors.*
+- [x] Bot still runs: `make census SEEDS=10` (CLAUDE.md's `scripts/bot-census.js --time/--money` paths are stale — actual target is `make census`, script `scripts/bot/census.js`). Bot ran 10 seeds cleanly exercising the refactored exploitSortKey/getExploitChoices path; success rate is a balance metric unaffected by visual-only changes.
+- [x] `MANUAL.md` updated: Exploit Cards section notes the vuln glyphs, quality color ramp, wear visuals, and match highlight (corrected the stale "highlight in cyan" line to green glow + glyph lock).

--- a/docs/dev-sessions/2026-06-10-1549-exploit-legibility/research.md
+++ b/docs/dev-sessions/2026-06-10-1549-exploit-legibility/research.md
@@ -1,0 +1,80 @@
+# Research — Exploit Legibility (issue #117)
+
+Documentarian findings. File:line refs over prose.
+
+## 1. Exploit card rendering
+
+`exploitCardBody()` — `js/ui/components/exploit-card-view.js:12`. Emits:
+- `.ec-header` — name + optional `.ec-index` label
+- `.ec-pips` — quality pips, `Math.round(card.quality * 5)` filled `█`, rest `░` (line 15)
+- `.ec-val` — uses row: `usesRemaining` count, or "DISCLOSED" / "(worn)" suffix by `decayState` (line 29)
+- `.ec-vulns` → `.ec-vuln` per `card.targetVulnTypes` (line 31) — raw text id
+
+CSS (`css/style.css`):
+- `.exploit-card` — 160px height, flex col, `--bg-panel2` bg, `#334` border (common) — line 675
+- `.ec-pips` — `#00ff41` green
+- `.ec-val` — `#00ff41` green
+- `.ec-vuln` — `#336633` dim grey, 0.65rem, ellipsis
+- `.exploit-card.rarity-uncommon` — `#009999` border + cyan inset glow (line 691)
+- `.exploit-card.rarity-rare` — `#bb0077` border + magenta inset glow (line 694)
+- `.match` / `.no-match` — opacity 1 / 0.35 (lines 755-761)
+
+Consumers:
+- `starnet-hand.js:6,84` — player hand, 1-based index label
+- `starnet-action-choices.js:9,70` — xploit picker, no index label
+
+## 2. Vuln types & card data model
+
+`VULNERABILITY_TYPES` — `js/core/exploits.js:14-106`. 15 types, each `{id, name, description, rarity}`:
+- **common (6):** unpatched-ssh, weak-auth, stale-firmware, open-telnet, buffer-overflow, snmp-public
+- **uncommon (5):** path-traversal, deserialization, side-channel, race-condition, kernel-exploit
+- **rare (4):** zero-day-rce, supply-chain, hardware-backdoor, cryptographic-weakness
+
+`ExploitCard` — `js/core/types.js:49-59`: `id`, `name`, `rarity` (common|uncommon|rare), `quality` [0,1] (common 0.2-0.55, uncommon 0.45-0.75, rare 0.70-0.95), `targetVulnTypes` (1-3 ids), `decayState` (fresh|worn|disclosed), `usesRemaining`.
+
+`exploitSortKey()` — `exploits.js:183-191`. Sort key vs selected node (lower = higher priority):
+- 0 matches revealed vuln AND usable AND probed, 1 usable but no match / not probed, 2 used up (`usesRemaining<=0`), 3 disclosed
+- match logic (187-190): any `card.targetVulnTypes[i]` ∈ `node.vulnerabilities.filter(v=>!v.patched&&!v.hidden).map(v=>v.id)`
+
+## 3. Node vuln display
+
+`NodeState` — `js/core/types.js:82-88`, open object. `node.vulnerabilities`: `Vulnerability[]` — `{id, name, description, rarity, patched, patchTurn, hidden, unlockedBy}`.
+
+Node panel — `starnet-node-panel.js`:
+- pre-probe: "Run PROBE to reveal vulnerabilities." (line 88)
+- post-probe: `visibleVulns = vulnerabilities.filter(v=>!v.hidden)` (line 57)
+- each vuln → `.nd-vuln` with `.vuln-name` (green, 95) + `.vuln-rarity` (96)
+
+Graph — `js/ui/graph.js:573`: node face = `nodeFaceDataUri(type, accessLevel)` SVG. **Vulns NOT shown on graph node**, only sidebar after probe.
+
+## 4. Preview harness
+
+`preview.html:1-231` — left Cytoscape (65%), right control panel (320px).
+
+Card gallery — `js/ui/preview-cards.js`:
+- `cardGalleryGroups()` (line 46) → 3 groups:
+  1. "Rarity × Quality" — 3 rarities × 3 quality (0.2/0.55/0.9) = 9 cards
+  2. "Wear states" — fresh/worn/disclosed on uncommon = 3 cards
+  3. "Match vs node" — 2 cards vs `MOCK_SELECTED_NODE`: ssh matches, sqli doesn't
+- `MOCK_SELECTED_NODE` (33-39): `{probed:true, vulnerabilities:[{id:"unpatched-ssh"...},{id:"weak-auth"...}]}`
+- `mountCardGallery()` (78) — one `<starnet-hand>` per group with mock props
+
+`js/ui/preview.js` — generates effect demos from `OVERLAY_DESCRIPTORS` (26), shape gallery all 18 node types (52-59), alert/access demos (63-76), effect controls (170-223), ICE toggle (248-261), node flash (273-275). Add a section: new node array → `allNodes` (80) → `updateNodeStyle()` each, wire listeners (ICE pattern, 249).
+
+## 5. Design tokens & glyph vocab
+
+CSS vars (`css/style.css:9-30`):
+- palette: `--cyan #00ffff`, `--green #00ff41`, `--magenta #ff00ff`, `--yellow #ffff00`, `--red #ff2020`
+- dim: `--cyan-dim #004444`, `--green-dim #003311`
+- bg: `--bg #0a0a0f`, `--bg-panel #0d0d14`, `--bg-panel2 #111120`
+- glows: `--glow-sm 0 0 4px`, `--glow-md 0 0 8px`, `--glow-lg 0 0 14px`
+
+Grade colors (`css/style.css:500-503`): S/A red+glow, B yellow, C cyan, D/F dim grey.
+
+Node glyph vocab — `js/ui/node-glyphs.js:26-48`. 18 node types, unique SVG glyphs (stroke-only, `0 0 64 64`). Each `{color, body}` (SVG polygon/line/rect/polyline, no curves). Fallback microchip glyph (66).
+- `glyphFor(type)` (66), `glyphSvg(type)` (75), `glyphDataUri(type)` (85)
+- `nodeFaceDataUri(type, accessLevel)` (168) — composites fence-hatch (state) + glyph in dodecagon clip. Fence gap per access: locked 11 / compromised 7 / owned 4.5px (113-115). Used by `graph.js:573`.
+
+ICE forms — `js/ui/ice-glyphs.js`: `iceStrikeCage()` (red mandibles), `detectionPolygonSegments()` (12-sided detection overlay).
+
+**There is NO existing glyph vocabulary for vulnerability types** — only node types have glyphs.

--- a/docs/dev-sessions/2026-06-10-1549-exploit-legibility/spec.md
+++ b/docs/dev-sessions/2026-06-10-1549-exploit-legibility/spec.md
@@ -1,0 +1,79 @@
+# Exploit Legibility Spec
+
+**Goal:** Let a player tell at a glance — without reading text — whether an exploit card matches a selected node, how strong the card is, and how worn-out it is. Turn card↔node matching from a reading task into a visual lock-and-key.
+
+**Source:** https://github.com/lmorchard/starnet/issues/117
+
+## Current state
+
+The shared card body `exploitCardBody()` (`js/ui/components/exploit-card-view.js:12`) renders:
+- target vulns as **raw text** `.ec-vuln` divs (line 31) — e.g. `unpatched-ssh`
+- quality as **monochrome pips** `Math.round(card.quality*5)` filled `█` (line 15), all `--green`
+- wear as **text only** in `.ec-val` — count, `(worn)`, or `DISCLOSED` (line 29)
+- rarity via **border color** on `.exploit-card` (common `#334`, uncommon cyan `:691`, rare magenta `:694`)
+
+Consumers: `starnet-hand.js:6,84` (hand) and `starnet-action-choices.js:9,70` (xploit picker).
+
+Match today is **sort-order + opacity only**: `exploitSortKey()` (`js/core/exploits.js:183`) floats matches up; `.match`/`.no-match` set opacity 1 / 0.35 (`css/style.css:755`). No visual link between a card's targets and a node's revealed vulns.
+
+Vuln data: 15 `VULNERABILITY_TYPES` (`exploits.js:14-106`), each `{id,name,description,rarity}` (6 common / 5 uncommon / 4 rare). Node vulns live in `node.vulnerabilities` (`Vulnerability[]`, `types.js:82-88`), shown as text in the node panel (`starnet-node-panel.js:86-100`) and `status` output. **Not shown on the Cytoscape graph node** (only the type-glyph + fence-hatch face from `nodeFaceDataUri`, `graph.js:573`).
+
+Wear model: `USES_BY_RARITY = {common:3, uncommon:5, rare:8}` (`exploits.js:124`). Decay in `combat.js:141-161`: `usesRemaining--` per use; `0`→`disclosed`, `1 && fresh`→`worn`, plus a partial-burn chance.
+
+There is **no glyph vocabulary for vuln types** today — only node *types* have glyphs (`js/ui/node-glyphs.js:26-48`, stroke-only SVG, `0 0 64 64`, no curves).
+
+## Desired end state
+
+A player with a node selected glances at the hand and immediately sees:
+1. **Which cards match** — matching cards glow/lift; the specific shared vuln glyph(s) light up on the card (lock-and-key click). Non-matching cards dim.
+2. **How strong each is** — a vivid color ramp on the quality bar (dim-red → amber → bright-green/white), pip count retained for color-blind safety. Rarity still owns the card frame border.
+3. **How worn each is** — continuous desaturation + reduced glow as `usesRemaining` drops; `worn` adds hairline cracks; `disclosed` is struck-through, near-monochrome, visibly burnt.
+4. **What each vuln is** — a distinct SVG glyph per vuln type, shown on the card (its `targetVulnTypes`) and in the node panel vuln list. Same glyph on both surfaces = the match.
+
+Text/console representation is unchanged — glyphs are an additive visual layer; `status` and the node panel keep the textual vuln ids.
+
+## Design decisions
+
+- **Decision:** New `js/ui/vuln-glyphs.js` with 15 SVG stroke glyphs, mirroring `node-glyphs.js`.
+  - **Why:** Reads at any size, matches the existing phosphene vector aesthetic, data-URI-able, and accessible (shape not color). The node-glyph module is a proven pattern to copy (`glyphFor`/`glyphSvg`/`glyphDataUri`).
+  - **Rejected:** Unicode glyphs (inconsistent across fonts/OSes, hard to make 15 distinct + legible small, off-brand). Category-shape+index (weaker per-type identity → weaker lock-and-key).
+
+- **Decision:** Glyphs appear on the **card** and in the **node panel** only — NOT on the Cytoscape graph node face.
+  - **Why:** The graph node face already composites type-glyph + fence-hatch in a dodecagon clip; adding vuln badges clutters it at zoom. Card + panel are the two surfaces a player compares when matching.
+  - **Rejected:** Graph-node vuln badges (clutter, low payoff). Card-only (leaves node side as text — only half the lock-and-key).
+
+- **Decision:** Quality color lives as a **vivid ramp on the quality bar only**; the card frame border stays rarity-colored; pip *count* is retained alongside the color.
+  - **Why:** Rarity already owns border color and match/alert own glow — a whole-card quality tint would fight those layers (especially once wear-desaturation and match-glow stack on the same surface). A bar ramp gives the dramatic signal the issue asks for without channel collision. Pip count keeps it legible under color-blindness / monochrome.
+  - **Rejected:** Whole-card tint (collides with rarity border + wear + match). Bar ramp + numeric tier badge (extra header clutter; pip count already provides the redundant non-color channel).
+
+- **Decision:** Wear is **continuous + discrete end states**. Desaturation/glow ramps on `usesRemaining / USES_BY_RARITY[rarity]`; `worn` adds a crack overlay; `disclosed` adds a struck-through, near-monochrome burnt treatment.
+  - **Why:** A continuous cue shows a card wearing down before it hits `worn`; dramatic terminal states make a spent card unmistakably spent ("a burnt card looks burnt"). The fraction and decayState are both already in card state.
+  - **Rejected:** Three discrete states only (no early-warning ramp). Overlay-on-worn-only (quality color stays full until worn — weakest "wearing down" cue).
+
+- **Decision:** Match emphasis is **card-side only**: matching cards get a positive glow/lift + the shared glyph(s) light up; non-matches dim (keep the existing opacity approach, lighter if needed).
+  - **Why:** The hand is where the player chooses; a positive highlight + per-glyph lock reads faster than sort-order. Bidirectional (lighting node-panel glyphs from hand state) needs hand→panel wiring for marginal gain.
+  - **Rejected:** Bidirectional lock (more wiring, hand state must reach node panel — deferred). Glyph-lock-only keeping current dim (misses the positive highlight that makes matches pop).
+
+## Patterns to follow
+
+- **Glyph module:** mirror `js/ui/node-glyphs.js` — `VULN_GLYPHS` map of `{color, body}`, `glyphFor(id)` with fallback, `glyphSvg(id)`, `glyphDataUri(id)`. Stroke-only, `0 0 64 64`, no curves (`node-glyphs.js:26-48,66,75,85`).
+- **Card body:** extend `exploitCardBody()` (`exploit-card-view.js:12`) — render glyphs in `.ec-vulns`, ramp `.ec-pips`, add wear classes. Keep it a pure function shared by both consumers.
+- **Match computation:** reuse the existing match predicate from `exploitSortKey` (`exploits.js:187-190`: card targets ∩ node's `!patched && !hidden` vuln ids). Extract a small helper (e.g. `cardMatchesNode` / `matchingVulnIds(card, node)`) so the view can highlight the *specific* shared glyph, and `exploitSortKey` can call it too. Pure-JS, unit-testable in `js/core/exploits.test.js`.
+- **Node panel:** add glyphs to the vuln list in `starnet-node-panel.js:86-100` next to existing `.vuln-name`.
+- **CSS:** use existing tokens (`css/style.css:9-30`: `--cyan/--green/--magenta/--yellow/--red`, dims, glows). Quality ramp as a small set of tier color vars.
+- **Preview harness:** extend `js/ui/preview-cards.js` `cardGalleryGroups()` (line 46) — the gallery already covers rarity×quality, wear states, and match-vs-node via `MOCK_SELECTED_NODE`. Add a vuln-glyph swatch sheet (all 15) and ensure wear/quality/match groups exercise the new treatments. Mounted via `mountCardGallery()` (line 78).
+
+## What we're NOT doing
+
+- **Not changing match/decay/combat logic** — purely a visual + a refactor that extracts the existing match predicate. `exploitSortKey` ordering semantics stay identical.
+- **Not adding vuln glyphs to the Cytoscape graph node face** (`graph.js`/`node-glyphs.js` `nodeFaceDataUri`) — card + node panel only.
+- **Not bidirectional match** — node-panel glyphs do NOT light up based on what's in hand (deferred; would need hand→panel state wiring).
+- **Not a numeric/letter quality tier badge** — pip count is the non-color redundancy.
+- **Not touching the console/`status` text representation** of vulns — glyphs are additive; textual ids remain (LLM-legibility requirement).
+- **Not reworking rarity expression** beyond what exists (border color stays; no rarity glow/animation rework).
+- **Not auto-consuming for the bot** — the bot reads state directly; visual-only changes don't affect it (verify bot still runs, but no bot strategy changes).
+
+## Open questions
+
+- **Glyph authoring for 15 types.** Designing 15 distinct, legible, no-curve stroke glyphs is the bulk of the visual work. *Default:* start abstract — take inspiration from **alchemical symbols** (triangles, bars, circles, crosses, composite marks) as a coherent, evocative starting vocabulary, grouped by rarity tier with a shared visual motif per tier (so rarity reads in the glyph family too). These are first-pass placeholders meant to be iterated in the preview harness, not final art. Not a blocker for planning.
+- **Quality ramp exact stops.** *Default:* map quality [0,1] to a 3–5 stop ramp (e.g. ≤0.35 dim-red, ~0.5 amber, ~0.7 green, ≥0.85 bright/white), tuned against the per-rarity quality ranges (common 0.2–0.55, uncommon 0.45–0.75, rare 0.70–0.95) so each rarity still spans visible variation. Tune in preview; not a blocker.

--- a/js/core/exploits.js
+++ b/js/core/exploits.js
@@ -178,16 +178,66 @@ function pickTargetVulns(rarity) {
   return picked;
 }
 
+// Single source of truth for card↔node matching, shared by exploitSortKey
+// (ordering) and the card view (per-glyph match highlight). A vuln matches only
+// if the node is probed and the vuln is revealed (not patched, not hidden).
+/**
+ * The card's target vuln ids that the node currently reveals, in card-target order.
+ * @param {import('./types.js').ExploitCard} card
+ * @param {import('./types.js').NodeState | null | undefined} node
+ * @returns {string[]}
+ */
+export function matchingVulnIds(card, node) {
+  if (!node?.probed) return [];
+  const knownVulnIds = node.vulnerabilities
+    .filter((v) => !v.patched && !v.hidden)
+    .map((v) => v.id);
+  return card.targetVulnTypes.filter((t) => knownVulnIds.includes(t));
+}
+
+/**
+ * Whether the card can hit any vuln the node reveals.
+ * @param {import('./types.js').ExploitCard} card
+ * @param {import('./types.js').NodeState | null | undefined} node
+ * @returns {boolean}
+ */
+export function cardMatchesNode(card, node) {
+  return matchingVulnIds(card, node).length > 0;
+}
+
+/**
+ * Bucket a quality value [0,1] into one of five ascending tiers (q0 lowest →
+ * q4 highest), for the card's quality-bar color ramp. Lower-inclusive bounds.
+ * @param {number} q
+ * @returns {"q0"|"q1"|"q2"|"q3"|"q4"}
+ */
+export function qualityTier(q) {
+  if (q < 0.3) return "q0";
+  if (q < 0.5) return "q1";
+  if (q < 0.7) return "q2";
+  if (q < 0.85) return "q3";
+  return "q4";
+}
+
+/**
+ * Remaining-life fraction [0,1] of a card — `usesRemaining / maxUses(rarity)`,
+ * for the continuous wear desaturation ramp. Disclosed cards read as fully spent.
+ * @param {import('./types.js').ExploitCard} card
+ * @returns {number}
+ */
+export function wearFraction(card) {
+  if (card.decayState === "disclosed") return 0;
+  const max = USES_BY_RARITY[card.rarity] ?? 3;
+  return Math.max(0, Math.min(1, card.usesRemaining / max));
+}
+
 // Sort key for ordering exploit cards relative to a selected node.
 // 0 = matching vuln + usable  →  1 = usable (no match)  →  2 = worn out  →  3 = disclosed
 export function exploitSortKey(card, node) {
   if (card.decayState === "disclosed") return 3;
   if (card.usesRemaining <= 0) return 2;
   if (!node?.probed) return 1;
-  const knownVulnIds = node.vulnerabilities
-    .filter((v) => !v.patched && !v.hidden)
-    .map((v) => v.id);
-  return card.targetVulnTypes.some((t) => knownVulnIds.includes(t)) ? 0 : 1;
+  return cardMatchesNode(card, node) ? 0 : 1;
 }
 
 /**
@@ -195,9 +245,11 @@ export function exploitSortKey(card, node) {
  * Gradual disclosure: before probing, every usable card is a candidate (blind play);
  * after probing, only cards matching the node's revealed vulns are offered. The hand
  * and console remain full-agency override channels for off-target plays.
+ * Each choice carries `matchedVulnIds` (the card's targets the node reveals) so the
+ * picker can light up the shared glyph — empty pre-probe (blind play, no confirmed match).
  * @param {import('./types.js').NodeState} node
  * @param {import('./types.js').GameState} state
- * @returns {Array<{ id: string, payloadKey: string, render: string, data: import('./types.js').ExploitCard }>}
+ * @returns {Array<{ id: string, payloadKey: string, render: string, data: import('./types.js').ExploitCard, matchedVulnIds: string[] }>}
  */
 export function getExploitChoices(node, state) {
   // An owned node is already at max access — the guided picker offers nothing.
@@ -212,6 +264,7 @@ export function getExploitChoices(node, state) {
     payloadKey: "exploitId",
     render: "exploit-card",
     data: c,
+    matchedVulnIds: matchingVulnIds(c, node),
   }));
 }
 

--- a/js/core/exploits.test.js
+++ b/js/core/exploits.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { getExploitChoices, getExploitEmptyReason } from "./exploits.js";
+import { getExploitChoices, getExploitEmptyReason, exploitSortKey, cardMatchesNode, matchingVulnIds, qualityTier, wearFraction } from "./exploits.js";
 
 /** Minimal card factory — only the fields exploitSortKey reads. */
 function card(id, targetVulnTypes, { decayState = "fresh", usesRemaining = 3 } = {}) {
@@ -36,6 +36,18 @@ describe("getExploitChoices", () => {
     assert.deepEqual(choices.map((ch) => ch.id), ["a", "b"]);
   });
 
+  test("probed node populates matchedVulnIds per choice (for picker glyph lock)", () => {
+    const hand = [card("a", ["ssh"]), card("b", ["ssh", "overflow"])];
+    const choices = getExploitChoices(node("db-3", true, ["ssh"]), stateWith(hand));
+    assert.deepEqual(choices.map((ch) => ch.matchedVulnIds), [["ssh"], ["ssh"]]);
+  });
+
+  test("unprobed node leaves matchedVulnIds empty (blind play — no confirmed match)", () => {
+    const hand = [card("a", ["ssh"])];
+    const choices = getExploitChoices(node("db-3", false, ["ssh"]), stateWith(hand));
+    assert.deepEqual(choices[0].matchedVulnIds, []);
+  });
+
   test("probed node with no matching cards offers nothing", () => {
     const hand = [card("a", ["ssh"]), card("b", ["overflow"])];
     const choices = getExploitChoices(node("db-3", true, ["xss"]), stateWith(hand));
@@ -52,6 +64,120 @@ describe("getExploitChoices", () => {
     const hand = [card("a", ["ssh"])];
     const choices = getExploitChoices(node("db-3", true, ["ssh"], "owned"), stateWith(hand));
     assert.deepEqual(choices, []);
+  });
+});
+
+describe("matchingVulnIds / cardMatchesNode", () => {
+  // Node reveals unpatched-ssh (visible), open-telnet (patched), zero-day-rce (hidden).
+  const probedNode = {
+    probed: true,
+    vulnerabilities: [
+      { id: "unpatched-ssh", patched: false, hidden: false },
+      { id: "open-telnet", patched: true, hidden: false },
+      { id: "zero-day-rce", patched: false, hidden: true },
+    ],
+  };
+
+  test("matchingVulnIds returns only visible (unpatched, unhidden) shared targets", () => {
+    const c = card("x", ["unpatched-ssh", "open-telnet", "zero-day-rce", "weak-auth"]);
+    assert.deepEqual(matchingVulnIds(c, probedNode), ["unpatched-ssh"]);
+  });
+
+  test("matchingVulnIds preserves card target order", () => {
+    const node2 = {
+      probed: true,
+      vulnerabilities: [
+        { id: "weak-auth", patched: false, hidden: false },
+        { id: "unpatched-ssh", patched: false, hidden: false },
+      ],
+    };
+    const c = card("x", ["unpatched-ssh", "weak-auth"]);
+    assert.deepEqual(matchingVulnIds(c, node2), ["unpatched-ssh", "weak-auth"]);
+  });
+
+  test("unprobed node => no matches", () => {
+    assert.deepEqual(matchingVulnIds(card("x", ["unpatched-ssh"]), node("n", false, ["unpatched-ssh"])), []);
+  });
+
+  test("missing/null node => no matches", () => {
+    assert.deepEqual(matchingVulnIds(card("x", ["unpatched-ssh"]), null), []);
+    assert.deepEqual(matchingVulnIds(card("x", ["unpatched-ssh"]), undefined), []);
+  });
+
+  test("cardMatchesNode is matchingVulnIds().length > 0", () => {
+    assert.equal(cardMatchesNode(card("x", ["unpatched-ssh"]), probedNode), true);
+    assert.equal(cardMatchesNode(card("x", ["open-telnet"]), probedNode), false); // patched
+    assert.equal(cardMatchesNode(card("x", ["zero-day-rce"]), probedNode), false); // hidden
+    assert.equal(cardMatchesNode(card("x", ["weak-auth"]), probedNode), false); // absent
+  });
+
+  // Structural invariant: for a USABLE card on a PROBED node, exploitSortKey === 0
+  // iff cardMatchesNode === true. Guards the two predicates against future drift.
+  test("invariant: sortKey===0 <=> cardMatchesNode for usable cards on a probed node", () => {
+    const targetSets = [
+      ["unpatched-ssh"],   // visible match
+      ["open-telnet"],     // patched (no match)
+      ["zero-day-rce"],    // hidden (no match)
+      ["weak-auth"],       // absent (no match)
+      ["unpatched-ssh", "weak-auth"], // partial match
+    ];
+    for (const targets of targetSets) {
+      const c = card("x", targets); // fresh, usesRemaining 3 => usable
+      assert.equal(
+        exploitSortKey(c, probedNode) === 0,
+        cardMatchesNode(c, probedNode),
+        `targets=${targets.join(",")}`,
+      );
+    }
+  });
+});
+
+describe("qualityTier", () => {
+  test("maps quality to five ascending buckets q0..q4", () => {
+    assert.equal(qualityTier(0.0), "q0");
+    assert.equal(qualityTier(0.2), "q0");
+    assert.equal(qualityTier(0.45), "q1");
+    assert.equal(qualityTier(0.55), "q2");
+    assert.equal(qualityTier(0.7), "q3");
+    assert.equal(qualityTier(0.8), "q3");
+    assert.equal(qualityTier(0.85), "q4");
+    assert.equal(qualityTier(0.95), "q4");
+    assert.equal(qualityTier(1.0), "q4");
+  });
+
+  test("boundaries are lower-inclusive on the upper bucket", () => {
+    assert.equal(qualityTier(0.299), "q0");
+    assert.equal(qualityTier(0.3), "q1");
+    assert.equal(qualityTier(0.499), "q1");
+    assert.equal(qualityTier(0.5), "q2");
+    assert.equal(qualityTier(0.699), "q2");
+    assert.equal(qualityTier(0.7), "q3");
+    assert.equal(qualityTier(0.849), "q3");
+    assert.equal(qualityTier(0.85), "q4");
+  });
+});
+
+describe("wearFraction", () => {
+  test("fresh card at full uses => 1 (by rarity max)", () => {
+    assert.equal(wearFraction({ rarity: "common", decayState: "fresh", usesRemaining: 3 }), 1);
+    assert.equal(wearFraction({ rarity: "uncommon", decayState: "fresh", usesRemaining: 5 }), 1);
+    assert.equal(wearFraction({ rarity: "rare", decayState: "fresh", usesRemaining: 8 }), 1);
+  });
+
+  test("partial uses => fractional", () => {
+    assert.equal(wearFraction({ rarity: "common", decayState: "worn", usesRemaining: 1 }), 1 / 3);
+    assert.equal(wearFraction({ rarity: "rare", decayState: "fresh", usesRemaining: 4 }), 0.5);
+  });
+
+  test("disclosed => 0 regardless of usesRemaining", () => {
+    assert.equal(wearFraction({ rarity: "rare", decayState: "disclosed", usesRemaining: 0 }), 0);
+    assert.equal(wearFraction({ rarity: "common", decayState: "disclosed", usesRemaining: 2 }), 0);
+  });
+
+  test("clamps to [0,1] and tolerates unknown rarity", () => {
+    assert.equal(wearFraction({ rarity: "common", decayState: "fresh", usesRemaining: 9 }), 1);
+    assert.equal(wearFraction({ rarity: "common", decayState: "fresh", usesRemaining: -2 }), 0);
+    assert.equal(wearFraction({ rarity: "mystery", decayState: "fresh", usesRemaining: 3 }), 1); // fallback max 3
   });
 });
 

--- a/js/ui/components/exploit-card-view.js
+++ b/js/ui/components/exploit-card-view.js
@@ -4,16 +4,20 @@
 // so the two views stay visually identical.
 
 import { html, nothing } from "lit";
+import { vulnGlyphDataUri } from "../vuln-glyphs.js";
+import { qualityTier } from "../../core/exploits.js";
 
 /**
  * @param {import('../../core/types.js').ExploitCard} card
  * @param {string} [indexLabel] - optional left-aligned index label (e.g. "1.") for the hand
+ * @param {string[]} [matchedVulnIds] - card targets that the selected node reveals; their glyphs light up
  */
-export function exploitCardBody(card, indexLabel) {
+export function exploitCardBody(card, indexLabel, matchedVulnIds = []) {
   const disclosed = card.decayState === "disclosed";
   const worn = card.decayState === "worn";
   const qualityPips = Math.round(card.quality * 5);
   const pips = "█".repeat(qualityPips) + "░".repeat(5 - qualityPips);
+  const matched = new Set(matchedVulnIds);
 
   return html`
     <div class="ec-header">
@@ -22,11 +26,15 @@ export function exploitCardBody(card, indexLabel) {
     </div>
     <div class="ec-row">
       <span class="ec-key">QUAL</span>
-      <span class="ec-pips">${pips}</span>
+      <span class="ec-pips ${qualityTier(card.quality)}">${pips}</span>
     </div>
     <div class="ec-row">
       <span class="ec-key">USES</span>
       <span class="ec-val">${disclosed ? "DISCLOSED" : worn ? `${card.usesRemaining} (worn)` : card.usesRemaining}</span>
     </div>
-    <div class="ec-vulns">${card.targetVulnTypes.map((t) => html`<div class="ec-vuln">${t}</div>`)}</div>`;
+    <div class="ec-vulns">${card.targetVulnTypes.map((t) => html`
+      <div class="ec-vuln ${matched.has(t) ? "matched" : ""}">
+        <img class="ec-vuln-glyph" src=${vulnGlyphDataUri(t)} alt="" />
+        <span class="ec-vuln-label">${t}</span>
+      </div>`)}</div>`;
 }

--- a/js/ui/components/starnet-action-choices.js
+++ b/js/ui/components/starnet-action-choices.js
@@ -7,6 +7,7 @@
 import { html, nothing } from "lit";
 import { StarnetElement } from "./starnet-element.js";
 import { exploitCardBody } from "./exploit-card-view.js";
+import { wearFraction } from "../../core/exploits.js";
 
 class StarnetActionChoices extends StarnetElement {
   static properties = {
@@ -63,11 +64,16 @@ class StarnetActionChoices extends StarnetElement {
 
   _renderChoice(choice) {
     if (choice.render === "exploit-card") {
-      // All cards shown here are pre-filtered to applicable choices, so "match" is always correct.
+      // Mirror the hand: light the shared glyph(s) + apply the match glow when the
+      // node reveals a target. Pre-probe (blind play) matchedVulnIds is empty, so
+      // candidates render neutral rather than falsely highlighted.
+      const matched = choice.matchedVulnIds || [];
+      const worn = choice.data.decayState === "worn";
       return html`
-        <div class="exploit-card rarity-${choice.data.rarity} selectable-card match"
+        <div class="exploit-card rarity-${choice.data.rarity} selectable-card ${matched.length ? "match" : ""} ${worn ? "worn" : ""}"
+             style=${`--wear:${wearFraction(choice.data)}`}
              @click=${() => this._pick(choice)}>
-          ${exploitCardBody(choice.data)}
+          ${exploitCardBody(choice.data, undefined, matched)}
         </div>`;
     }
     return nothing;

--- a/js/ui/components/starnet-hand.js
+++ b/js/ui/components/starnet-hand.js
@@ -4,6 +4,7 @@
 import { html, nothing } from "lit";
 import { StarnetElement } from "./starnet-element.js";
 import { exploitCardBody } from "./exploit-card-view.js";
+import { matchingVulnIds, wearFraction } from "../../core/exploits.js";
 
 class StarnetHand extends StarnetElement {
   static properties = {
@@ -57,20 +58,23 @@ class StarnetHand extends StarnetElement {
   _renderCard(card, index) {
     const isExec = this.executingCardId === card.id;
     const disclosed = card.decayState === "disclosed";
+    const worn = card.decayState === "worn";
 
+    // Only usable cards participate in match highlighting — a disclosed or
+    // used-up card can't be played, so it should never read as a match.
+    const usable = !disclosed && card.usesRemaining > 0;
     let matchClass = "";
-    if (this.selectedNode?.probed && !isExec) {
-      const knownVulnIds = this.selectedNode.vulnerabilities
-        .filter((v) => !v.patched && !v.hidden)
-        .map((v) => v.id);
-      const hasMatch = card.targetVulnTypes.some((t) => knownVulnIds.includes(t));
-      matchClass = hasMatch ? "match" : "no-match";
+    let matchedVulnIds = [];
+    if (this.selectedNode?.probed && !isExec && usable) {
+      matchedVulnIds = matchingVulnIds(card, this.selectedNode);
+      matchClass = matchedVulnIds.length > 0 ? "match" : "no-match";
     }
 
     const isSelectable = this.isSelecting && !disclosed;
     const classes = [
       "exploit-card", `rarity-${card.rarity}`,
       disclosed ? "disclosed" : "",
+      worn ? "worn" : "",
       matchClass,
       isSelectable ? "selectable-card" : "",
       isExec ? "executing" : "",
@@ -80,8 +84,9 @@ class StarnetHand extends StarnetElement {
 
     return html`
       <div class="${classes}"
+           style=${`--wear:${wearFraction(card)}`}
            @click=${isSelectable ? () => this._onCardClick(card, index) : null}>
-        ${exploitCardBody(card, `${index}.`)}
+        ${exploitCardBody(card, `${index}.`, matchedVulnIds)}
         <div class="ec-executing-label">▶ EXECUTING — ${execPct}%</div>
         ${isExec ? html`
           <div class="ec-cancel-overlay" @click=${(e) => { e.stopPropagation(); this._onCancel(); }}>

--- a/js/ui/components/starnet-node-panel.js
+++ b/js/ui/components/starnet-node-panel.js
@@ -4,6 +4,7 @@
 import { html, nothing } from "lit";
 import { StarnetElement } from "./starnet-element.js";
 import { isObscured } from "../../core/state.js";
+import { vulnGlyphDataUri } from "../vuln-glyphs.js";
 
 class StarnetNodePanel extends StarnetElement {
   static properties = {
@@ -92,6 +93,7 @@ class StarnetNodePanel extends StarnetElement {
       <div class="nd-vulns">
         ${visibleVulns.map((v) => html`
           <div class="nd-vuln ${v.patched ? "patched" : ""}">
+            <img class="nd-vuln-glyph" src=${vulnGlyphDataUri(v.id)} alt="" />
             <span class="vuln-name">${v.name}</span>
             <span class="vuln-rarity rarity-${v.rarity}">[${v.rarity.toUpperCase()}]</span>
           </div>

--- a/js/ui/preview-cards.js
+++ b/js/ui/preview-cards.js
@@ -7,6 +7,8 @@
 
 /** @typedef {import('../core/types.js').ExploitCard} ExploitCard */
 
+import { ALL_VULN_GLYPH_IDS, vulnGlyphDataUri } from "./vuln-glyphs.js";
+
 const RARITIES = /** @type {const} */ (["common", "uncommon", "rare"]);
 const WEARS = /** @type {const} */ (["fresh", "worn", "disclosed"]);
 const QUALITY = { low: 0.2, mid: 0.55, high: 0.9 };
@@ -65,10 +67,31 @@ export function cardGalleryGroups() {
       selectedNode: MOCK_SELECTED_NODE,
       cards: [
         card({ rarity: "rare", vuln: "unpatched-ssh", name: "match (ssh)" }),
-        card({ rarity: "common", vuln: "sql-injection", name: "no-match (sqli)" }),
+        card({ rarity: "common", vuln: "kernel-exploit", name: "no-match (kernel)" }),
       ],
     },
   ];
+}
+
+/**
+ * Mount the vuln-glyph swatch sheet: one labeled cell per vuln type, so all 15
+ * glyphs can be eyeballed for distinctness/legibility at small size.
+ * @param {HTMLElement} container
+ */
+export function mountVulnSwatches(container) {
+  for (const id of ALL_VULN_GLYPH_IDS) {
+    const cell = document.createElement("div");
+    cell.className = "vuln-swatch";
+    const img = document.createElement("img");
+    img.src = vulnGlyphDataUri(id);
+    img.width = 40;
+    img.height = 40;
+    img.alt = id;
+    const label = document.createElement("span");
+    label.textContent = id;
+    cell.append(img, label);
+    container.appendChild(cell);
+  }
 }
 
 /**

--- a/js/ui/preview.js
+++ b/js/ui/preview.js
@@ -15,7 +15,7 @@ import {
 import { mountOverlays } from "./overlays/index.js";
 import { mountReticle } from "./overlays/selection-reticle.js";
 import { OVERLAY_DESCRIPTORS } from "./overlays/registry.js";
-import { mountCardGallery } from "./preview-cards.js";
+import { mountCardGallery, mountVulnSwatches } from "./preview-cards.js";
 import { ALL_GLYPH_TYPES } from "./node-glyphs.js";
 import { iceStrikeCage } from "./ice-glyphs.js";
 
@@ -305,3 +305,7 @@ document.getElementById("btn-reset-all").addEventListener("click", () => {
 // ── Card gallery ─────────────────────────────────────────────
 
 mountCardGallery(document.getElementById("card-gallery"));
+
+// ── Vuln glyph swatches ──────────────────────────────────────
+
+mountVulnSwatches(document.getElementById("vuln-swatches"));

--- a/js/ui/vuln-glyphs.js
+++ b/js/ui/vuln-glyphs.js
@@ -1,0 +1,83 @@
+// @ts-check
+// Vulnerability-type glyph vocabulary — pure data + SVG generation, mirroring
+// node-glyphs.js. One ideographic, no-curves mark per vuln type (issue #117),
+// shown on exploit cards and in the node panel so card↔node matching reads as a
+// shared glyph (a visual lock-and-key).
+//
+// First-stab alchemical/iconographic marks: color encodes the vuln's rarity tier
+// (common = teal, uncommon = amber, rare = magenta) and shape complexity climbs
+// with tier, so rarity reads in the glyph family. Tune shapes in the preview
+// swatch sheet. This module is pure (no DOM) so it is unit-testable.
+
+/**
+ * @typedef {{ color: string, body: string }} Glyph
+ * `body` is stroke-only inner SVG (polygon/line/rect/polyline), authored on a
+ * 0 0 64 64 viewBox. `color` is applied as the stroke by vulnGlyphSvg().
+ */
+
+const COMMON = "#3fd9c9"; // teal
+const UNCOMMON = "#ffb020"; // amber
+const RARE = "#ff5cc8"; // magenta
+
+/** @type {Record<string, Glyph>} */
+export const VULN_GLYPHS = {
+  // ── common (simple single marks — classical elements + salt/cross) ──
+  "unpatched-ssh":   { color: COMMON, body: `<polygon points="32,18 46,44 18,44"/>` }, // fire △
+  "weak-auth":       { color: COMMON, body: `<polygon points="18,20 46,20 32,46"/>` }, // water ▽
+  "stale-firmware":  { color: COMMON, body: `<polygon points="18,20 46,20 32,46"/><line x1="24" y1="30" x2="40" y2="30"/>` }, // earth ▽+bar
+  "open-telnet":     { color: COMMON, body: `<polygon points="32,18 46,44 18,44"/><line x1="24" y1="36" x2="40" y2="36"/>` }, // air △+bar
+  "buffer-overflow": { color: COMMON, body: `<rect x="20" y="20" width="24" height="24"/><line x1="20" y1="32" x2="44" y2="32"/>` }, // salt ▢⊖
+  "snmp-public":     { color: COMMON, body: `<line x1="32" y1="16" x2="32" y2="48"/><line x1="16" y1="32" x2="48" y2="32"/>` }, // cross +
+
+  // ── uncommon (paired/crossed 2–3 element marks) ──
+  "path-traversal":  { color: UNCOMMON, body: `<line x1="18" y1="44" x2="46" y2="44"/><polyline points="22,40 40,22"/><polyline points="31,22 40,22 40,31"/>` }, // escape arrow over a floor
+  "deserialization": { color: UNCOMMON, body: `<rect x="18" y="18" width="28" height="28"/><rect x="26" y="26" width="12" height="12"/>` }, // nested squares
+  "side-channel":    { color: UNCOMMON, body: `<line x1="32" y1="19" x2="32" y2="32"/><line x1="32" y1="32" x2="40" y2="38"/><line x1="44" y1="20" x2="20" y2="44" stroke-dasharray="3 3"/>` }, // clock hands + dashed leak
+  "race-condition":  { color: UNCOMMON, body: `<line x1="20" y1="27" x2="42" y2="27"/><polyline points="38,23 42,27 38,31"/><line x1="44" y1="39" x2="22" y2="39"/><polyline points="26,35 22,39 26,43"/>` }, // opposing arrows (TOCTOU)
+  "kernel-exploit":  { color: UNCOMMON, body: `<polygon points="32,18 45,25 45,39 32,46 19,39 19,25"/><line x1="28" y1="32" x2="36" y2="32"/><line x1="32" y1="28" x2="32" y2="36"/>` }, // ring-0 hexagon + core cross
+
+  // ── rare (3-element composites) ──
+  "zero-day-rce":           { color: RARE, body: `<polygon points="32,16 43,33 21,33"/><line x1="32" y1="33" x2="32" y2="48"/><line x1="25" y1="41" x2="39" y2="41"/>` }, // sulfur (△ over cross)
+  "supply-chain":           { color: RARE, body: `<polygon points="16,32 22,28 28,32 22,36"/><polygon points="26,32 32,28 38,32 32,36"/><polygon points="36,32 42,28 48,32 42,36"/>` }, // three linked diamonds (chain)
+  "hardware-backdoor":      { color: RARE, body: `<rect x="22" y="22" width="20" height="20"/><line x1="27" y1="18" x2="27" y2="22"/><line x1="37" y1="18" x2="37" y2="22"/><line x1="42" y1="42" x2="48" y2="48"/>` }, // chip + pins + hidden tail
+  "cryptographic-weakness": { color: RARE, body: `<polygon points="32,17 45,24 45,40 32,47 19,40 19,24"/><polyline points="33,19 28,32 36,32 31,45"/>` }, // cipher hexagon + lightning crack
+};
+
+/**
+ * Generic fallback for any unmapped id — a square with a diagonal slash, neutral teal.
+ * @type {Glyph}
+ */
+export const FALLBACK_VULN_GLYPH = {
+  color: "#7fd9c9",
+  body: `<polygon points="22,22 42,22 42,42 22,42"/><line x1="22" y1="22" x2="42" y2="42"/>`,
+};
+
+/** All explicitly-mapped vuln ids (excludes the fallback). */
+export const ALL_VULN_GLYPH_IDS = Object.keys(VULN_GLYPHS);
+
+/**
+ * @param {string} id vuln type id
+ * @returns {Glyph} the type's glyph, or the fallback.
+ */
+export function vulnGlyphFor(id) {
+  return VULN_GLYPHS[id] || FALLBACK_VULN_GLYPH;
+}
+
+/**
+ * Full standalone SVG markup for a vuln glyph (stroke = tier color).
+ * @param {string} id
+ * @returns {string}
+ */
+export function vulnGlyphSvg(id) {
+  const { color, body } = vulnGlyphFor(id);
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" fill="none" stroke="${color}" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round">${body}</svg>`;
+}
+
+/**
+ * Glyph as an <img>-ready `src` data URI (# percent-encoded).
+ * @param {string} id
+ * @returns {string}
+ */
+export function vulnGlyphDataUri(id) {
+  return "data:image/svg+xml," + encodeURIComponent(vulnGlyphSvg(id));
+}

--- a/js/ui/vuln-glyphs.test.js
+++ b/js/ui/vuln-glyphs.test.js
@@ -1,0 +1,57 @@
+// @ts-check
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  VULN_GLYPHS,
+  FALLBACK_VULN_GLYPH,
+  ALL_VULN_GLYPH_IDS,
+  vulnGlyphFor,
+  vulnGlyphSvg,
+  vulnGlyphDataUri,
+} from "./vuln-glyphs.js";
+import { VULNERABILITY_TYPES } from "../core/exploits.js";
+
+describe("vuln glyph vocabulary", () => {
+  const ids = VULNERABILITY_TYPES.map((v) => v.id);
+
+  test("covers every vulnerability type exactly (no extras, no gaps)", () => {
+    assert.equal(Object.keys(VULN_GLYPHS).length, ids.length);
+    for (const id of ids) {
+      assert.ok(VULN_GLYPHS[id], `missing glyph for ${id}`);
+    }
+  });
+
+  test("every glyph has a color and a non-empty stroke body", () => {
+    for (const id of ids) {
+      const g = VULN_GLYPHS[id];
+      assert.ok(g.color && /^#[0-9a-fA-F]{3,8}$/.test(g.color), `${id} color`);
+      assert.ok(g.body && g.body.length > 0, `${id} body`);
+    }
+  });
+
+  test("no real vuln type resolves to the fallback glyph", () => {
+    for (const id of ids) {
+      assert.notEqual(vulnGlyphFor(id), FALLBACK_VULN_GLYPH, `${id} should not be the fallback`);
+    }
+  });
+
+  test("unknown id falls back", () => {
+    assert.equal(vulnGlyphFor("does-not-exist"), FALLBACK_VULN_GLYPH);
+  });
+
+  test("ALL_VULN_GLYPH_IDS lists the mapped ids", () => {
+    assert.deepEqual(new Set(ALL_VULN_GLYPH_IDS), new Set(ids));
+  });
+
+  test("vulnGlyphSvg embeds the type color as stroke", () => {
+    const svg = vulnGlyphSvg("unpatched-ssh");
+    assert.match(svg, /^<svg[^>]*viewBox="0 0 64 64"/);
+    assert.ok(svg.includes(`stroke="${VULN_GLYPHS["unpatched-ssh"].color}"`));
+  });
+
+  test("vulnGlyphDataUri is a percent-encoded svg data uri", () => {
+    const uri = vulnGlyphDataUri("unpatched-ssh");
+    assert.ok(uri.startsWith("data:image/svg+xml,"));
+    assert.ok(!uri.includes("#"), "raw # must be percent-encoded");
+  });
+});

--- a/preview.html
+++ b/preview.html
@@ -210,6 +210,13 @@
         <div id="card-gallery"></div>
       </div>
 
+      <!-- Vuln Glyph Swatches — all 15 vuln-type glyphs (js/ui/vuln-glyphs.js),
+           grouped by rarity tier, for legibility tuning at small size. -->
+      <div class="section">
+        <h2>Vuln Glyphs</h2>
+        <div id="vuln-swatches"></div>
+      </div>
+
       <!-- Node Shapes (display only) -->
       <div class="section">
         <h2>Node Shape Gallery</h2>


### PR DESCRIPTION
## Summary
- Makes exploit-card↔node matching, card quality, and card wear readable **at a glance** — a visual lock-and-key — so matching becomes a glance, not a reading task.
- Addresses playtest feedback that cards/nodes were mostly text + monochrome pips, with match conveyed only by sort order.

## Design Decisions
Several signals (vuln identity, match, quality, rarity, wear) competed for limited visual channels; the encoding keeps them from fighting:

| Signal | Channel |
|---|---|
| Vuln identity | SVG stroke glyph per type (new `vuln-glyphs.js`), on card + node panel |
| Match | Card glow/lift + the specific shared glyph lights up; non-matches recede |
| Quality | Vivid color ramp on the pip bar (pip count kept for color-blind safety) |
| Rarity | Frame border color (unchanged) |
| Wear | Continuous desaturation + `worn` cracks + `disclosed` burnt strike |

- **No game-logic changes.** The match predicate was duplicated (`exploitSortKey` + the hand); this consolidates it into `matchingVulnIds`/`cardMatchesNode` so the view can light up the *specific* shared glyph, guarded by a structural-invariant test. `exploitSortKey` semantics are byte-for-byte preserved.
- **Glyphs are additive.** `status` / console text representation is unchanged (LLM-legibility requirement); zero diff in `js/core/console-commands/`.
- **First-stab glyph art.** Alchemical/iconographic marks, color-grouped by rarity tier — meant to be iterated in the preview swatch, not final.
- Match emphasis is card-side only (no bidirectional node→hand wiring); no glyphs on the Cytoscape graph node face.

## Changes
- **`js/core/exploits.js`** — `matchingVulnIds`, `cardMatchesNode`, `qualityTier`, `wearFraction` (all pure, unit-tested); `exploitSortKey` routed through the shared predicate.
- **`js/ui/vuln-glyphs.js`** (new) — 15 stroke-only SVG glyphs + accessors, mirroring `node-glyphs.js`.
- **`exploit-card-view.js` / `starnet-hand.js` / `starnet-action-choices.js` / `starnet-node-panel.js`** — render glyphs, match highlight, quality color, wear.
- **`css/style.css`** — quality ramp, match glow + glyph lock, wear desaturation/cracks/burnt, swatch grid.
- **Preview harness** — all-15 glyph swatch sheet; existing card gallery exercises quality/wear/match.
- **`MANUAL.md`** — Exploit Cards section updated (glyphs, color ramp, wear, match); corrects the stale "highlight in cyan" line.

## Test Plan
- [x] `make check` — 794 tests pass, lint clean (incl. structural-invariant, glyph-coverage, qualityTier, wearFraction)
- [x] Preview harness (`preview.html`) — verified via Playwright: 15 distinct tiered glyphs; quality ramp; worn cracks; disclosed burnt; match glow + glyph lock
- [x] Live game (`index.html`) — probed a node: panel shows glyphs, hand renders glyphs, match/no-match fires correctly, 0 console errors
- [x] `status` text unchanged (zero diff in `js/core/console-commands/`)
- [x] Bot runs cleanly (`make census SEEDS=10`)

## References
- Spec: `docs/dev-sessions/2026-06-10-1549-exploit-legibility/spec.md`
- Plan: `docs/dev-sessions/2026-06-10-1549-exploit-legibility/plan.md`
- Note: CLAUDE.md's bot-census references are stale (`scripts/bot-census.js` + `--time/--money` flags) — actual is `make census` / `scripts/bot/census.js`. Worth a follow-up doc fix.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)
