### PR TITLE
fix: scatteredLock vault Crack Vault repeatable for infinite cash

### DIFF
--- a/data/biomes/corporate-pieces.js
+++ b/data/biomes/corporate-pieces.js
@@ -1576,7 +1576,7 @@ function makeScatteredLock(n, cost) {
         id: "vault",
         type: "cryptovault",
         traits: ["graded", "hackable", "rebootable"],
-        attributes: { accessLevel: "locked", concealed: true },
+        attributes: { accessLevel: "locked", concealed: true, cracked: false },
         operators: [],
         actions: [
           {
@@ -1585,9 +1585,14 @@ function makeScatteredLock(n, cost) {
             requires: [
               /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
               /** @type {const} */ ({ type: "quality-gte", name: "locks-opened", value: n }),
+              // One-shot guard: the vault pays out exactly once. The other requires
+              // (owned + locks-opened>=n) are monotonic and never revert, so without
+              // this the action stays available forever and farms cash on every click.
+              /** @type {const} */ ({ type: "node-attr", attr: "cracked", eq: false }),
             ],
             effects: [
               /** @type {const} */ ({ effect: "ctx-call", method: "giveReward", args: [1500] }),
+              /** @type {const} */ ({ effect: "set-attr", attr: "cracked", value: true }),
               /** @type {const} */ ({ effect: "ctx-call", method: "log", args: ["Vault cracked — ¥1,500 extracted"] }),
             ],
           },

--- a/js/core/network/set-pieces.test.js
+++ b/js/core/network/set-pieces.test.js
@@ -851,6 +851,30 @@ describe("scatteredLock3: crack-vault requires all switches + owned", () => {
     assert.equal(ctx.calls.giveReward?.length, 1);
     assert.deepEqual(ctx.calls.giveReward[0], [1500]);
   });
+
+  it("crack-vault is one-shot — spent after the first crack", () => {
+    const ctx = mockCtx();
+    const inst = instantiate(scatteredLock3, "sl");
+    const graph = new NodeGraph(inst, ctx);
+
+    for (const sw of ["sl/switch-a", "sl/switch-b", "sl/switch-c"]) {
+      graph._nodes.get(sw).attributes.accessLevel = "owned";
+    }
+    graph.executeAction("sl/switch-a", "activate");
+    graph.executeAction("sl/switch-b", "activate");
+    graph.executeAction("sl/switch-c", "activate");
+    graph._nodes.get("sl/vault").attributes.accessLevel = "owned";
+
+    // First crack pays out.
+    graph.executeAction("sl/vault", "crack-vault");
+    assert.equal(ctx.calls.giveReward?.length, 1);
+
+    // The vault is now spent: crack-vault is no longer offered, so the player
+    // cannot keep cracking it for cash. (Without a one-shot guard, the monotonic
+    // requires — owned + locks-opened>=n — stay true forever and it repeats.)
+    const available = graph.getAvailableActions("sl/vault").map((a) => a.id);
+    assert.ok(!available.includes("crack-vault"), "crack-vault should be spent after one crack");
+  });
 });
 
 describe("scatteredLock variants: correct switch counts and thresholds", () => {


### PR DESCRIPTION
## Problem

Found during playtesting: a `scatteredLock` vault's **Crack Vault** action could be run repeatedly, paying ¥1,500 every time — infinite cash.

## Root cause

The `scatteredLock` `crack-vault` action (`data/biomes/corporate-pieces.js`, used by `scatteredLock1/3/5`) had **no one-shot guard**:

- Its `requires` are both **monotonic** — `accessLevel === "owned"` (never reverts) and `quality-gte: locks-opened >= n` (the quality only ever increases).
- Its `effects` just called `giveReward(1500)` — nothing disabled the action.

So once the vault was owned and its locks were open, Crack Vault stayed available forever.

The other two vault types were already correctly one-shot, which is what made this an outlier:
- **combination-lock vault** flips its `opened` flag back to `false` on crack.
- **key-vault** (`unlock-vault`) resets `keys-collected` to `0` on unlock.

`makeScatteredLock` simply omitted the equivalent consume step.

## Fix

Mirror the guarded pattern with a dedicated `cracked` attribute (chosen over resetting `locks-opened`, which the reveal trigger and the scan-lock readout both depend on):

- attribute `cracked: false`
- `requires`: add `cracked === false`
- `effects`: add `set-attr cracked = true`

## Tests

Added a failing-first test (`set-pieces.test.js`) that cracks the vault once and asserts the action is then **spent** (no longer offered) — it caught the bug, and passes with the fix. The pre-existing test only cracked once and asserted the reward fired, so it never noticed the repeat.

`make check` passes (lint + full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
