### PR TITLE
feat: overworld meta-state — persistent profile + hub (v1)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -120,6 +120,50 @@ An IDS at this level can be corrupted to stop forwarding alerts.
 
 ---
 
+## THE OVERWORLD HUB
+
+Between runs you sit in the **overworld hub** — your home base. The game opens
+here, and you return here after every run.
+
+The hub holds your **persistent state**. A single run is self-contained, but two
+things carry across runs:
+
+- **Bank** — your cash. Loot you extract is deposited here when you jack out clean.
+- **Exploit inventory** — the exploit cards you own. The darknet broker and mining
+  add to it, and it persists between runs.
+
+### Outfitting a run
+
+From the hub you:
+
+1. **Equip a loadout** — choose up to **5 exploits** from your inventory to take
+   into the run; these become your hand. (Click a card, or `equip <#>`.)
+2. **Carry cash** — decide how much of your bank to bring along, e.g. to shop the
+   darknet broker mid-run. (`carry <amount>`.)
+3. **Pick a target** — the hub offers a short list of targets at varying
+   difficulty. Selecting one launches the run. (`launch <id>`.)
+
+From the hub you can also **discard disclosed exploits** (burned-out cards
+cluttering your inventory) and **visit the darknet broker** — opened from the
+hub, the broker spends your **bank** and delivers purchases straight to your
+**inventory** (rather than in-run cash and your hand).
+
+### Stakes
+
+What you bring is what you risk:
+
+- **Clean jack-out** — your carried cash plus any loot is banked, and your loadout
+  returns to inventory (worn by use, but yours). Cards you bought or mined mid-run
+  are added to your inventory too.
+- **Traced (caught)** — you lose the run's cash **and your carried loadout is
+  burned** — those exploits are seized, gone from your inventory. Your bank and the
+  exploits you *didn't* bring are safe.
+
+A loadout is an ante: bring your best cards against a hard target and a trace costs
+you dearly; bring cheap cards and you risk less but crack less.
+
+---
+
 ## THE CORE LOOP
 
 ### 1. Select a Node
@@ -557,6 +601,17 @@ jackout                End run.
 
 darknet                List darknet broker catalog (requires WAN targeted).
 buy <index>            Purchase exploit card from broker (requires WAN targeted).
+
+hub                    Open the overworld hub (between runs).
+inventory              List your bank balance and persistent exploit inventory.
+equip <#|id>           Add an inventory exploit to your loadout (max 5).
+unequip <#|id>         Remove an exploit from your loadout.
+carry <amount>         Set how much cash to carry into the next run.
+discard-disclosed      Discard all disclosed (burned) exploits from inventory.
+targets                List available targets to launch.
+launch <targetId>      Start a run against a target with your loadout + carried cash.
+                       (At the hub, `darknet` lists the broker catalog and `buy <index>`
+                        purchases into your inventory, spending bank.)
 
 status                 Summary status (alias: status summary)
 status full            Complete state dump

--- a/css/style.css
+++ b/css/style.css
@@ -1080,6 +1080,97 @@ html, body {
   background: rgba(0, 255, 255, 0.1);
 }
 
+/* ── Overworld Hub ──────────────────────────────────────── */
+
+#overworld-hub {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.hub-box {
+  background: var(--bg-panel);
+  border: 1px solid var(--cyan);
+  box-shadow: 0 0 24px rgba(0, 255, 255, 0.2);
+  padding: 1.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 440px;
+  max-height: 85vh;
+  overflow-y: auto;
+}
+
+.hub-title {
+  font-size: 1.1rem;
+  color: var(--cyan);
+  text-shadow: 0 0 10px var(--cyan);
+  letter-spacing: 0.2em;
+  text-align: center;
+}
+
+.hub-divider { color: var(--border); font-size: 0.8rem; text-align: center; }
+
+.hub-row { display: flex; justify-content: space-between; gap: 2rem; font-size: 0.85rem; }
+.hub-key { color: var(--text-dim); letter-spacing: 0.08em; }
+.hub-val { color: var(--green); text-shadow: var(--glow-sm) var(--green); }
+
+.hub-section {
+  color: var(--text-dim);
+  letter-spacing: 0.12em;
+  font-size: 0.72rem;
+  margin-top: 0.7rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.2rem;
+}
+
+.hub-empty { color: var(--text-dim); font-size: 0.78rem; font-style: italic; }
+
+.hub-card, .hub-target {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.8rem;
+  padding: 0.3rem 0.5rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.hub-card:hover, .hub-target:hover { background: rgba(0, 255, 255, 0.07); border-color: var(--border); }
+.hub-card.equipped { border-color: var(--cyan); color: var(--cyan); text-shadow: var(--glow-sm) var(--cyan); }
+.hub-card.burned { color: var(--red); opacity: 0.6; }
+.hub-card-meta, .hub-target-grade { color: var(--text-dim); font-size: 0.72rem; }
+.hub-target-label { color: var(--cyan); }
+
+.hub-carry {
+  background: var(--bg-dark, #0a0a0f);
+  border: 1px solid var(--border);
+  color: var(--green);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  padding: 0.3rem 0.5rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.hub-actions { display: flex; gap: 0.5rem; margin: 0.3rem 0; }
+.hub-btn {
+  background: transparent;
+  border: 1px solid var(--cyan);
+  color: var(--cyan);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  padding: 0.35rem 0.7rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.hub-btn:hover:not(:disabled) { background: rgba(0, 255, 255, 0.1); }
+.hub-btn:disabled { color: var(--text-dim); border-color: var(--border); cursor: default; opacity: 0.5; }
+
 /* ── Cheat mode ─────────────────────────────────────────── */
 
 .hud-cheat-label {
@@ -1157,6 +1248,28 @@ html, body {
   color: var(--green);
   font-size: 0.7rem;
 }
+
+.store-subtitle {
+  color: var(--green);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  padding: 0.2rem 0.75rem 0;
+  opacity: 0.85;
+}
+
+/* Darknet broker opened from the overworld hub: pop OVER the hub (left visible
+   behind, dimmed) with a distinct green accent, rather than reading like an
+   in-run LAN session. */
+#darknet-store.from-hub {
+  position: fixed;
+  z-index: 110;                      /* above the hub overlay (z-index 100) */
+  background: rgba(2, 8, 12, 0.55);  /* lighter so the hub shows through, dimmed */
+}
+#darknet-store.from-hub .store-box {
+  border-color: var(--green);
+  box-shadow: 0 0 24px rgba(0, 255, 65, 0.28);
+}
+#darknet-store.from-hub .store-title { color: var(--green); }
 
 .store-card-list {
   overflow-y: auto;

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -126,6 +126,7 @@ speed, stealth) would directly address the exploit-duration vs ICE-dwell race.
 
 ### Adversarial / ICE
 - **Defender ICE** — instead of detecting and triggering alert, this ICE variant reverses access levels (owned → compromised → locked) as it dwells on a node; creates territory-holding pressure that complements the existing detection model. Would need new ICE behavior type, reverse-access state mutation, and visual feedback distinct from current ICE presence indicator.
+- **ICE reaches into the deck — burns exploits mid-run** — an ICE variant that, on detection/dwell, doesn't just raise alert but attacks the player's *loadout*: it disables or "burns" an exploit card mid-run (the graduated, in-run cousin of capture-burns-loadout). Extends the existing failure-driven `disclose` mechanic in `combat.js`, but ICE-driven rather than player-failure-driven. Pairs with the persistent exploit inventory (see `docs/dev-sessions/2026-06-10-1516-overworld-meta-state/`): once cards are durable inventory instances with stable ids, burning a specific card has lasting cost. Fits the multi-instance / variant-ICE direction in `docs/ICE.md`. _Raised 2026-06-10; future iteration, depends on the meta-state inventory landing first._
 - **Bot player: eject and reboot** — the bot currently never uses eject (push
   ICE to adjacent node) or reboot (force ICE to resident, node goes offline).
   Eject is a simple reflex ("ICE is here, push it away") and worth adding —

--- a/docs/dev-sessions/2026-06-10-1516-overworld-meta-state/notes.md
+++ b/docs/dev-sessions/2026-06-10-1516-overworld-meta-state/notes.md
@@ -1,0 +1,68 @@
+# Notes — Overworld Meta-State (v1)
+
+## Session start (2026-06-10)
+
+- Branched `overworld-meta-state` off `origin/main` (`8667e72`) in a worktree at
+  `.worktrees/overworld-meta-state/`. The main checkout stays on
+  `vector-crt-rendering` (unrelated CRT work) — untouched.
+- Brainstorm was done conversationally before `start`; spec written directly from
+  the agreed design. Codebase grounding captured in `research.md` (Explore sweep).
+- Baseline `npm install` + `make test` deferred to the execute boundary (spec phase
+  needs no deps). **Run a clean baseline before writing any code.**
+
+## Observations to follow up (out of scope this session)
+
+- **CLAUDE.md File-Structure drift.** The project `CLAUDE.md` still documents the
+  pre-reorg layout (`js/main.js`, `js/state/`, `js/combat.js`) while the code is
+  split into `js/core/` + `js/ui/` (per `MEMORY.md`, confirmed by the sweep). Worth
+  a separate doc-fix PR. Not touched here.
+
+## Decisions locked in brainstorm
+
+- v1 = persistent profile (bank + card inventory) outside `GameState`, surfaced via
+  a textual hub (a generalization of the darknet store).
+- **Medium stakes**: capture forfeits run cash and burns the carried loadout.
+- Bank ↔ in-run cash = withdraw/deposit.
+- Browser-first; headless entry points synthesize a loadout.
+- Filed the "ICE burns exploits mid-run" idea to `docs/BACKLOG.md` (Adversarial/ICE).
+
+## Phase 3a — restart bug (debugged in-browser)
+
+- **Bug:** "run again" reset core state but not the graph view; the prior run's
+  revealed nodes persisted on the board. Reproduced with Playwright against the
+  worktree server.
+- **Deeper root cause:** `initGame` emits `NODE_STATE_CHANGED` during NodeGraph
+  *construction* (vuln/macguffin `setNodeAttr` loop, before the new `state` object
+  is assigned). On a re-init the global `state` still references the prior run, so
+  `visual-renderer`'s NODE_STATE_CHANGED handler re-adds the prior run's revealed
+  nodes. Fixed by ordering `startRun` as initGame → resetGraph → syncInitialNodes.
+- **LATENT ISSUE for a future session (out of scope):** `initGame` emitting node
+  events against the stale global `state` during construction is fragile. Candidate
+  cleanups: null/sentinel the global `state` at the top of `initGame`, or suppress
+  graph→state→event sync until the new `state` is assigned. Only known symptom so
+  far is the graph re-add (now handled by reset ordering); not fixing now to avoid
+  touching the shared `initGame` used by playtest/bot entry points.
+
+## Session summary (v1 complete)
+
+Delivered the overworld meta-state v1 across five commits:
+- **Phase 1** — persistent profile model (`js/core/profile`) + localStorage store + bootstrap.
+- **Phase 2** — loadout launch (`meta.startHandCards`) + `commitRun` (deposit/decay-writeback/absorb mid-run cards on success; burn loadout on capture).
+- **Phase 3a** — fixed the broken run-again: unified `startRun` (`run-control.js`) + `resetGraph`; root cause was initGame emitting node events against stale state during construction.
+- **Phase 3b** — the overworld hub: `starnet-hub` Lit modal, target list, console parity, boot→hub flow.
+- **Phase 4** — MANUAL.md + regression sweep.
+
+Verified end-to-end in-browser (Playwright): boot→hub→equip→carry→launch→run with exact loadout+cash→jackout→commit→return-to-hub. 722 tests green; bot census + playtest headless unaffected.
+
+**Known v1 wart / follow-ups:**
+- CLAUDE.md is stale in two places (file-structure section; bot census flags `--time/--money` vs actual `--threat/--wealth/--complexity/--depth`). Worth a doc-fix PR.
+- Latent: `initGame` emits node events against stale global `state` during NodeGraph construction (see Phase 3a). Handled for the graph by reset-ordering; consider nulling `state` at the top of `initGame` in a future cleanup.
+- Capture-burn was verified by unit test, not in-browser (hard to force a trace via script).
+
+## Gotcha: dev-server port collision
+
+- `make serve` (`npx serve .`) **silently fell back to a random port (49826)**
+  because something else already held :3000. Curl/Playwright against :3000 hit a
+  *different* server (the main checkout, stale code) — wasted a verify cycle. Always
+  confirm the actual port from the serve output, and verify a worktree-only file
+  (e.g. `/js/ui/profile-store.js`) returns 200 on the port you're testing.

--- a/docs/dev-sessions/2026-06-10-1516-overworld-meta-state/plan.md
+++ b/docs/dev-sessions/2026-06-10-1516-overworld-meta-state/plan.md
@@ -1,0 +1,522 @@
+# Overworld Meta-State (v1) Implementation Plan
+
+**Goal:** A persistent player profile (cash bank + exploit-card inventory) that
+survives between runs, with runs launched and resolved through a textual hub.
+
+**Approach:** Profile lives outside `GameState` in localStorage (a pure core model
++ a UI localStorage binding). Runs launch from a chosen loadout via a new
+`meta.startHandCards` path; on `RUN_ENDED` the result commits back — success
+deposits cash and writes card decay back, capture (Medium stakes) forfeits run
+cash and burns the carried loadout. The hub is a Lit modal mirroring the darknet
+store, with symmetric console commands.
+
+**Tech stack:** Vanilla ES modules, Lit (light-DOM components), Node `node:test`,
+browser `localStorage`. No new dependencies.
+
+---
+
+## Phase 1: Persistent profile foundation (model + store + bootstrap)
+
+Pure profile data model in core, a localStorage binding in UI, and a
+new-profile bootstrap. Not user-visible yet; establishes the spine everything
+else reads/writes.
+
+**Files:**
+- Modify: `js/core/types.js` — add `instanceId` to `ExploitCard`; add `StarnetProfile` typedef.
+- Create: `js/core/profile/index.js` — pure profile model + mutations.
+- Create: `js/ui/profile-store.js` — localStorage load/save + bootstrap.
+- Test: `js/core/profile/profile.test.js`
+
+**Key changes:**
+
+`js/core/types.js` — extend `ExploitCard`, add profile type:
+```javascript
+/**
+ * @typedef {{
+ *   id: string,
+ *   name: string,
+ *   rarity: Rarity,
+ *   quality: number,
+ *   targetVulnTypes: string[],
+ *   decayState: DecayState,
+ *   usesRemaining: number,
+ *   instanceId?: string,   // profile-scoped unique id; assigned on inventory entry
+ * }} ExploitCard
+ */
+
+/**
+ * Persistent cross-run player profile. Lives OUTSIDE GameState (localStorage).
+ * @typedef {{
+ *   version: number,
+ *   bank: number,
+ *   inventory: ExploitCard[],
+ *   _instanceSeq: number,   // monotonic source of instanceIds (persisted)
+ *   _hubVisits: number,      // drives deterministic target generation
+ * }} StarnetProfile
+ */
+```
+
+`js/core/profile/index.js` — pure functions, mutate-and-return a passed profile:
+```javascript
+// @ts-check
+/** @typedef {import('../types.js').StarnetProfile} StarnetProfile */
+/** @typedef {import('../types.js').ExploitCard} ExploitCard */
+
+export const PROFILE_VERSION = 1;
+
+/** @returns {StarnetProfile} */
+export function createProfile({ bank = 0, inventory = [] } = {}) {
+  const p = { version: PROFILE_VERSION, bank, inventory: [], _instanceSeq: 0, _hubVisits: 0 };
+  inventory.forEach((c) => addCardToInventory(p, c));
+  return p;
+}
+
+/** Assigns an instanceId if absent and pushes the card into inventory. @returns {ExploitCard} */
+export function addCardToInventory(profile, card) {
+  if (!card.instanceId) card.instanceId = `inv-${profile._instanceSeq++}`;
+  profile.inventory.push(card);
+  return card;
+}
+
+/** @returns {ExploitCard|undefined} */
+export function findCard(profile, instanceId) {
+  return profile.inventory.find((c) => c.instanceId === instanceId);
+}
+
+/** Removes inventory cards whose instanceId is in the set. @returns {ExploitCard[]} removed */
+export function removeCardsByInstanceId(profile, instanceIds) {
+  const set = new Set(instanceIds);
+  const removed = profile.inventory.filter((c) => set.has(c.instanceId));
+  profile.inventory = profile.inventory.filter((c) => !set.has(c.instanceId));
+  return removed;
+}
+
+export function deposit(profile, amount) { profile.bank += amount; return profile; }
+
+/** Debits bank if sufficient. @returns {boolean} success */
+export function withdraw(profile, amount) {
+  if (amount < 0 || profile.bank < amount) return false;
+  profile.bank -= amount;
+  return true;
+}
+```
+
+`js/ui/profile-store.js` — localStorage binding + bootstrap (mirror `save-load.js` JSON):
+```javascript
+// @ts-check
+import { createProfile, addCardToInventory } from "../core/profile/index.js";
+import { generateStartingHand } from "../core/exploits.js";
+
+const PROFILE_KEY = "starnet:profile";
+const DEFAULT_BANK = 1000; // matches initGame's startCash fallback
+
+/** Load the profile from localStorage, or bootstrap a new one. @returns {import('../core/types.js').StarnetProfile} */
+export function loadProfile() {
+  const raw = localStorage.getItem(PROFILE_KEY);
+  if (raw) { try { return JSON.parse(raw); } catch { /* fall through to bootstrap */ } }
+  return bootstrapProfile();
+}
+
+export function saveProfile(profile) {
+  localStorage.setItem(PROFILE_KEY, JSON.stringify(profile));
+}
+
+function bootstrapProfile() {
+  const p = createProfile({ bank: DEFAULT_BANK });
+  generateStartingHand().forEach((c) => addCardToInventory(p, c)); // ~5 starter cards
+  saveProfile(p);
+  return p;
+}
+```
+
+**Verification — automated:**
+- [x] `make test` passes (new `js/core/profile/profile.test.js`: instanceId assigned & unique; `removeCardsByInstanceId` removes only matches; `withdraw` guards on insufficient bank; `createProfile` bootstraps inventory with instanceIds)
+- [x] `make lint` passes (JSDoc types for new typedefs resolve)
+
+**Verification — manual:**
+- [x] Browser (Phase 3b): on boot the hub calls `loadProfile()`, bootstrapping `starnet:profile` with `bank: 1000` and 6 starter cards each carrying an `instanceId`. Verified via Playwright.
+
+---
+
+## Phase 2: Launch from a loadout + commit results on run end
+
+A run can be launched with real loadout cards, and on `RUN_ENDED` the outcome
+commits back to the profile. After this phase, persistence is real end-to-end
+(verifiable via tests and a manual play-through), even before the hub UI exists.
+
+**Files:**
+- Modify: `js/core/state/index.js` — `initGame` accepts `meta.startHandCards`.
+- Modify: `js/core/profile/index.js` — add `buildRunHand` + `commitRun`.
+- Modify: `js/ui/profile-store.js` — `launchRun`, an `activeRun` record, and an `E.RUN_ENDED` subscriber that commits.
+- Test: `js/core/profile/profile.test.js` (extend) and `tests/profile-commit.test.js`
+
+**Key changes:**
+
+`js/core/state/index.js` (~line 156) — backwards-compatible hand source:
+```javascript
+player: {
+  cash: meta.startCash ?? 1000,
+  hand: meta.startHandCards ?? generateStartingHand(meta.startHand),
+},
+```
+(Headless entry points pass no `startHandCards`, so they keep generating from the rarity spec — unchanged.)
+
+`js/core/profile/index.js` — loadout cloning + commit:
+```javascript
+/**
+ * Clone loadout cards for use as a run hand. Clones so in-run decay mutates the
+ * run copy, not the inventory object; instanceId is preserved for write-back.
+ * @param {ExploitCard[]} loadoutCards
+ * @returns {ExploitCard[]}
+ */
+export function buildRunHand(loadoutCards) {
+  return loadoutCards.map((c) => ({ ...c, targetVulnTypes: [...c.targetVulnTypes] }));
+}
+
+/**
+ * Commit a finished run back into the profile.
+ * @param {StarnetProfile} profile
+ * @param {{ outcome: "success"|"caught", finalCash: number, finalHand: ExploitCard[], carriedInstanceIds: string[] }} run
+ * @returns {StarnetProfile}
+ */
+export function commitRun(profile, { outcome, finalCash, finalHand, carriedInstanceIds }) {
+  if (outcome === "caught") {
+    // Medium stakes: carried loadout burned; run cash already forfeit (finalCash 0).
+    removeCardsByInstanceId(profile, carriedInstanceIds);
+    return profile;
+  }
+  // success: deposit run cash (carried leftover + loot), then reconcile the hand.
+  deposit(profile, finalCash);
+  for (const card of finalHand) {
+    const existing = card.instanceId ? findCard(profile, card.instanceId) : null;
+    if (existing) {
+      existing.usesRemaining = card.usesRemaining;  // write back decay
+      existing.decayState = card.decayState;
+    } else {
+      addCardToInventory(profile, card);  // bought/mined mid-run → new inventory card
+    }
+  }
+  return profile;
+}
+```
+
+`js/ui/profile-store.js` — launch + commit wiring:
+```javascript
+import { on } from "../core/events.js";
+import { E } from "../core/events.js";
+import { getState, initGame } from "../core/state/index.js";
+import { buildRunHand, commitRun, withdraw, findCard } from "../core/profile/index.js";
+
+let activeRun = null; // { carriedInstanceIds: string[] } for the in-flight run
+
+/**
+ * Launch a run from the profile. buildNetworkResult() returns { graphDef, meta }.
+ * @param {{ buildNetworkResult: () => any, loadoutInstanceIds: string[], withdrawAmount: number, opts?: object }} args
+ */
+export function launchRun({ buildNetworkResult, loadoutInstanceIds, withdrawAmount, opts = {} }) {
+  const profile = loadProfile();
+  if (!withdraw(profile, withdrawAmount)) return false;
+  const loadout = loadoutInstanceIds.map((id) => findCard(profile, id)).filter(Boolean);
+  saveProfile(profile); // bank debited at launch
+  activeRun = { carriedInstanceIds: loadout.map((c) => c.instanceId) };
+  const base = buildNetworkResult();
+  const meta = { ...base.meta, startHandCards: buildRunHand(loadout), startCash: withdrawAmount };
+  initGame(() => ({ graphDef: base.graphDef, meta }), undefined, opts);
+  return true;
+}
+
+// Commit on run end (subscribe once at module init).
+on(E.RUN_ENDED, ({ outcome }) => {
+  if (!activeRun) return;
+  const s = getState();
+  const profile = loadProfile();
+  commitRun(profile, {
+    outcome,
+    finalCash: s.player.cash,        // already 0 on "caught" (endRun zeroes it)
+    finalHand: s.player.hand,
+    carriedInstanceIds: activeRun.carriedInstanceIds,
+  });
+  saveProfile(profile);
+  activeRun = null;
+});
+```
+
+**Verification — automated:**
+- [x] `make test` passes. New tests in `tests/profile-commit.test.js` (use explicit seeds per the seed convention):
+  - success deposits `finalCash` to bank
+  - a carried card whose `usesRemaining`/`decayState` changed writes back to the same inventory instance (matched by `instanceId`)
+  - a `finalHand` card with no `instanceId` (simulating a mid-run store/mine acquisition) is added to inventory with a fresh `instanceId`
+  - "caught" removes exactly the carried `instanceId`s and deposits nothing; bank unchanged from post-withdraw value
+  - `initGame` with `meta.startHandCards` produces a `player.hand` equal to those cards (by `instanceId`); with only `meta.startHand` it still generates from the rarity spec
+- [x] `make lint` passes
+
+> **Adaptation:** the run-end commit is wired via an exported `initProfileRunCommit()`
+> (called from `main.js` in Phase 3) rather than a bare import side-effect — avoids
+> registering the handler just by importing `launchRun`.
+
+**Verification — manual:**
+- [x] Browser (Phase 3b): launched from the hub with loadout `[inv-0, inv-1]` + ¥200 carried → bank debited 1000→800; jacked out → `commitRun` deposited the ¥200 back (bank 1000) and the loadout returned to inventory (not duplicated, not burned on success). Capture-burn path covered by the `commitRun` "caught" unit test.
+
+---
+
+## Phase 3a: Rework restart into a unified `startRun` + graph reset
+
+Fixes the broken "run again" (discovered mid-execute) and builds the foundation
+the hub needs. **Root cause:** `runAgainHandler` calls `initGame` (core state
+resets) but never resets the view — `graph.js` has no `RUN_STARTED`/`STATE_CHANGED`
+hook, `ensureNodeInGraph` is add-only/idempotent, and there is no element-removal
+path. The prior run's nodes/ICE persist, so the game appears not to reset. Today's
+"run again" only worked at all because it reused the same topology.
+
+**Files:**
+- Modify: `js/ui/graph.js` — add `resetGraph(networkData)`.
+- Modify: `js/ui/main.js` — extract `startRun(networkResult)`; use it from `init()` and `runAgainHandler`.
+
+**Key changes:**
+```javascript
+// graph.js — clear the board and re-point topology, reusing the same cy instance
+// (no cytoscape teardown → sidesteps the destroy/leak risk of Option A).
+export function resetGraph(networkData) {
+  if (!cy) return;
+  cy.elements().remove();
+  _networkNodes = new Map();
+  for (const n of networkData.nodes) {
+    _networkNodes.set(n.id, { id: n.id, label: n.label, type: n.type, grade: n.grade });
+  }
+  _networkEdges = networkData.edges;
+}
+
+// main.js — the one path all three callers share (first boot, run-again, hub)
+function startRun(networkResult) {
+  resetGraph(toCytoscapeFormat(networkResult)); // no-op first time (cy empty)
+  initGame(() => networkResult, undefined, { openDarknetsStore });
+  syncInitialNodes(getState().nodes);
+  const cy = getCy();
+  if (cy) fitGraph(cy);
+  addIceNode();
+  startIce();
+}
+```
+`init()` keeps its one-time setup (initGraph to create cy, console, visual-renderer
+— which must subscribe before the first `initGame` STATE_CHANGED — graph-bridge,
+dynamic-actions), then calls `startRun(networkResult)`. `runAgainHandler` becomes
+`() => startRun(buildNetworkFn())`. (`startRun` is exported/closured so the hub can
+call it in Phase 3b.)
+
+**Deeper root cause found during execute (Playwright):** the bug wasn't just a
+missing reset. `initGame` fires `NODE_STATE_CHANGED` events while *constructing*
+the NodeGraph (setting vulns/macguffins), and on a re-init the global `state` still
+points at the prior run during that window — so `visual-renderer` re-adds the prior
+run's revealed nodes from stale state. Resetting *before* `initGame` got immediately
+re-populated. **Fix:** `startRun` does `initGame` → `resetGraph` → `syncInitialNodes`
+(reset after the event storm, rebuild from authoritative new state). The latent
+"initGame emits against stale state during construction" fragility is noted in
+`notes.md` for a future cleanup (out of scope here; no other known symptom).
+
+**Verification — automated:**
+- [x] `make lint` + `make test` still pass (719 tests; refactor + ordering fix, no core-logic change)
+
+**Verification — manual (browser via Playwright):**
+- [x] Reproduce-before: start a run, probe to reveal `router-1`, run-again → board still showed `router-1` while core state had reset (bug confirmed).
+- [x] After fix: run-again → board resets to `[gateway, wan]` (matches state exactly, `router-1` gone); re-probing the restarted run reveals `router-1` again — new run fully playable; no console errors.
+
+---
+
+## Phase 3b: The hub (UI + target list + console parity + end-screen wiring)
+
+The user-facing slice: a textual hub modal to manage bank/inventory/loadout and
+launch a target (via `startRun` from Phase 3a), symmetric console commands, and the
+end-screen returning to the hub instead of an instant re-run.
+
+**Files:**
+- Create: `js/core/profile/targets.js` — deterministic target-list generation.
+- Create: `js/ui/components/starnet-hub.js` — Lit modal (mirror `starnet-store.js`).
+- Create: `js/ui/hub.js` — controller: open/close, wire component events to `launchRun`.
+- Create: `js/ui/hub-commands.js` — console commands (registered from UI; profile is a browser concern).
+- Modify: `js/ui/main.js` — open the hub on load and after `RUN_ENDED`; replace the `run-again` handler with a return-to-hub flow.
+- Modify: `index.html` — add the `<starnet-hub>` element next to `<starnet-store>`.
+- Modify: `js/ui/console.js` — import `./hub-commands.js` so its `registerCommand` calls run.
+- Test: `js/core/profile/targets.test.js`
+
+**Key changes:**
+
+`js/core/profile/targets.js` — 3 targets at varying grades, deterministic per visit:
+```javascript
+// @ts-check
+const TIERS = [
+  { id: "soft",   label: "Soft target",   spec: { threat: "F", wealth: "D", complexity: "F", depth: "F" } },
+  { id: "median", label: "Standard job",  spec: { threat: "C", wealth: "B", complexity: "C", depth: "C" } },
+  { id: "hard",   label: "Hard mark",     spec: { threat: "A", wealth: "S", complexity: "B", depth: "B" } },
+];
+
+/**
+ * Build the hub's target list. Seeds are derived from the profile's hub-visit
+ * counter so the list is deterministic for a given profile state.
+ * @param {import('../types.js').StarnetProfile} profile
+ * @returns {{ id: string, label: string, seed: string, spec: object }[]}
+ */
+export function generateTargets(profile) {
+  const visit = profile._hubVisits;
+  return TIERS.map((t) => ({ ...t, seed: `target-${visit}-${t.id}` }));
+}
+```
+
+`js/ui/components/starnet-hub.js` — Lit, light-DOM, mirrors `starnet-store.js`:
+```javascript
+import { html, nothing } from "/dist/lit.js";
+import { StarnetElement } from "./starnet-element.js";
+
+class StarnetHub extends StarnetElement {
+  static properties = {
+    open: { type: Boolean },
+    bank: { type: Number },
+    inventory: { type: Array },
+    loadout: { type: Array },      // selected instanceIds
+    withdrawAmount: { type: Number },
+    targets: { type: Array },
+  };
+  constructor() {
+    super();
+    this.open = false; this.bank = 0; this.inventory = []; this.loadout = [];
+    this.withdrawAmount = 0; this.targets = [];
+  }
+  updated(c) { if (c.has("open")) this.style.display = this.open ? "" : "none"; }
+  connectedCallback() { super.connectedCallback(); this.style.display = this.open ? "" : "none"; }
+
+  _toggleCard(id) {
+    const next = this.loadout.includes(id)
+      ? this.loadout.filter((x) => x !== id)
+      : (this.loadout.length < 5 ? [...this.loadout, id] : this.loadout);
+    this.dispatchEvent(new CustomEvent("loadout-change", { bubbles: true, detail: { loadout: next } }));
+  }
+  _launch(target) {
+    this.dispatchEvent(new CustomEvent("launch", { bubbles: true,
+      detail: { targetId: target.id, loadout: this.loadout, withdrawAmount: this.withdrawAmount } }));
+  }
+  render() {
+    if (!this.open) return nothing;
+    return html`
+      <div class="hub-box">
+        <h2>OVERWORLD HUB</h2>
+        <div>Bank: ¥${this.bank.toLocaleString()}</div>
+        <h3>Inventory (loadout ${this.loadout.length}/5)</h3>
+        ${this.inventory.map((c) => html`
+          <div class="hub-card ${this.loadout.includes(c.instanceId) ? "equipped" : ""}"
+               @click=${() => this._toggleCard(c.instanceId)}>
+            ${c.name} [${c.rarity}] ${c.decayState} ×${c.usesRemaining}
+          </div>`)}
+        <h3>Carry cash</h3>
+        <input type="number" .value=${String(this.withdrawAmount)} min="0" max=${this.bank}
+          @input=${(e) => this.dispatchEvent(new CustomEvent("withdraw-change",
+            { bubbles: true, detail: { amount: Number(e.target.value) } }))} />
+        <h3>Targets</h3>
+        ${this.targets.map((t) => html`
+          <div class="hub-target" @click=${() => this._launch(t)}>${t.label} — ${t.spec.threat}/${t.spec.wealth}</div>`)}
+      </div>`;
+  }
+}
+customElements.define("starnet-hub", StarnetHub);
+```
+
+`js/ui/hub.js` — controller binds component ↔ profile-store:
+```javascript
+// @ts-check
+import { loadProfile, saveProfile, launchRun } from "./profile-store.js";
+import { generateTargets } from "../core/profile/index.js"; // re-exported from targets.js via index
+import { buildGenerated } from "../core/network/...";        // same builder getSelectedNetwork() uses
+
+export function openHub() {
+  const el = /** @type {any} */ (document.getElementById("overworld-hub"));
+  const profile = loadProfile();
+  profile._hubVisits++; saveProfile(profile);
+  el.bank = profile.bank; el.inventory = profile.inventory; el.loadout = [];
+  el.withdrawAmount = 0; el.targets = generateTargets(profile); el.open = true;
+
+  el.addEventListener("loadout-change", (e) => { el.loadout = e.detail.loadout; });
+  el.addEventListener("withdraw-change", (e) => { el.withdrawAmount = e.detail.amount; });
+  el.addEventListener("launch", (e) => {
+    const target = el.targets.find((t) => t.id === e.detail.targetId);
+    el.open = false;
+    launchRun({
+      buildNetworkResult: () => buildGenerated({ seed: target.seed, spec: target.spec }),
+      loadoutInstanceIds: e.detail.loadout,
+      withdrawAmount: e.detail.withdrawAmount,
+      opts: { openDarknetsStore },   // imported as today
+    });
+  }, { once: true });
+}
+```
+
+`js/ui/hub-commands.js` — console parity (registered from UI):
+```javascript
+// @ts-check
+import { registerCommand } from "../core/console-commands/index.js";
+import { addLogEntry } from "./log-util.js"; // same logger the store command uses
+import { loadProfile } from "./profile-store.js";
+import { openHub } from "./hub.js";
+
+registerCommand({ verb: "hub", execute() { openHub(); addLogEntry("[HUB] Overworld hub opened.", "meta"); } });
+registerCommand({ verb: "inventory", execute() {
+  const p = loadProfile();
+  addLogEntry(`Bank: ¥${p.bank.toLocaleString()}`, "meta");
+  p.inventory.forEach((c, i) => addLogEntry(`  [${i + 1}] ${c.name} [${c.rarity}] ${c.decayState} ×${c.usesRemaining} (${c.instanceId})`, "meta"));
+} });
+// `equip <instanceId>`, `unequip <instanceId>`, `carry <amount>`, `targets`, `launch <targetId>`
+// follow the same shape, reading/mutating an in-progress hub selection held in hub.js.
+```
+
+`js/ui/main.js` — open hub on boot and after a run; retire instant run-again:
+```javascript
+// boot: instead of initGame() directly, open the hub
+init();           // keep graph/console/renderer init
+openHub();        // player launches the first run from the hub
+
+// replace runAgainHandler:
+const returnToHubHandler = () => { openHub(); };
+on("starnet:action:run-again", returnToHubHandler);
+document.getElementById("end-screen")?.addEventListener("run-again", returnToHubHandler);
+```
+(The `RUN_ENDED` subscriber in `profile-store.js` commits before the end-screen's button fires; opening the hub reloads the freshly-committed profile.)
+
+**Verification — automated:**
+- [x] `make test` passes (new `js/core/profile/targets.test.js`: `generateTargets` returns 3 targets with distinct seeds that change when `_hubVisits` changes; specs match the tier table) — 722 tests total
+- [x] `make lint` passes
+
+**Verification — manual (browser via Playwright):**
+- [x] Boot → the hub opens showing bank ¥1000, 6 starter cards, and 3 targets; no console errors (after fixing a boot-order bug: the profile bootstrap needed the RNG initialized — added `initRng()` at app startup).
+- [x] Equip a loadout (console `equip`/GUI click — verified both produce the same result), set carry ¥200, launch "soft" → a run starts with the hand = exactly the equipped loadout (`[inv-0, inv-1]`) and wallet = ¥200, on the target's generated topology; hub closes.
+- [x] Jack out → end-screen → "RETURN TO HUB" reopens the hub with the committed bank and re-rolled targets; selection reset.
+- [~] Capture path: the carried-loadout burn on "caught" is covered by the `commitRun` unit test (forcing a trace in-browser is impractical to script quickly).
+- [x] Console parity: `hub`, `inventory`, `equip`, `carry`, `launch` route through the same `hub.js` operations as the GUI — a clicked card and `equip <n>` produce identical state + log.
+
+---
+
+## Phase 4: Manual update + regression sweep
+
+Bring `MANUAL.md` current and confirm nothing regressed — especially the headless
+entry points, since `initGame` changed.
+
+**Files:**
+- Modify: `MANUAL.md` — document the overworld hub, persistent bank + inventory, loadout selection, Medium capture stakes, and the new console commands.
+- Modify: `docs/dev-sessions/2026-06-10-1516-overworld-meta-state/notes.md` — session retro notes.
+
+This phase is a TDD opt-out (docs + verification only — no behavior change).
+
+**Verification — automated:**
+- [x] `make check` passes (lint + test, 722 tests)
+- [x] Bot census smoke unaffected by the `initGame` change: `node scripts/bot/census.js --seeds 10 --threat F --wealth F --complexity F --depth F` ran all 10 seeds cleanly (avg cash ¥11.7k, all-green alerts, no crashes). _(Note: census is `scripts/bot/census.js` with `--threat/--wealth/--complexity/--depth`, not the CLAUDE.md `--time/--money` flags — CLAUDE.md is stale here too.)_
+- [x] `node scripts/playtest.js reset && … "status hand"` still deals a generated hand (headless path uses `meta.startHand`, unchanged by `startHandCards`).
+
+**Verification — manual:**
+- [x] `MANUAL.md` updated: new "THE OVERWORLD HUB" section (persistent bank/inventory, loadout, carry-cash, Medium stakes) + the hub console commands in the reference.
+- [x] Re-read the spec's "What we're NOT doing": scope held — no standings, storylets, installations, navigation map, economy depth, headless-profile, or multiple profiles crept in. (`run-control.js` extraction and boot→hub were necessary integration + the Phase 3a bug fix, not deferred subsystems.)
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** persistent profile (P1) ✓; bank+inventory (P1) ✓; loadout selection (P3 UI, P2 launch) ✓; run read/write contract (P2) ✓; Medium stakes (P2 `commitRun`) ✓; withdraw/deposit bank↔run cash (P2 `launchRun`/`commitRun`) ✓; hub as textual menu (P3) ✓; target list seam (P3) ✓; store/mining feed inventory (P2 `commitRun` new-card rule) ✓; browser-first / headless synthesize loadout (P2 backwards-compat + P4 regression) ✓; instanceId scheme (P1) ✓; new-profile bootstrap (P1) ✓; console parity (P3) ✓; MANUAL update (P4) ✓.
+- **Placeholder scan:** the `hub-commands.js` equip/unequip/carry/targets/launch verbs are described by shape, not fully written — they are mechanical mirrors of the two shown commands operating on `hub.js` selection state; flagged here so `execute` writes them out in full rather than stubbing.
+- **Type consistency:** `instanceId`, `carriedInstanceIds`, `StarnetProfile` fields (`bank`, `inventory`, `_instanceSeq`, `_hubVisits`), and `commitRun`/`buildRunHand`/`launchRun` signatures are consistent across phases.
+
+**One import to confirm at execute time:** `js/ui/hub.js` needs the same generated-network builder `getSelectedNetwork()` uses (`buildGenerated`) — verify its exact import path in `js/ui/main.js` before wiring (path elided above as `../core/network/...`).

--- a/docs/dev-sessions/2026-06-10-1516-overworld-meta-state/research.md
+++ b/docs/dev-sessions/2026-06-10-1516-overworld-meta-state/research.md
@@ -1,0 +1,71 @@
+# Research — Overworld Meta-State (codebase sweep)
+
+Findings from an `Explore` sweep of the run lifecycle, persistence, and meta
+surfaces. Line numbers reflect the codebase at session start and may drift —
+re-verify in `plan` / `execute`.
+
+> **Doc drift caught:** the project `CLAUDE.md` "File Structure" section still
+> documents the *pre-reorg* layout (`js/main.js`, `js/state/`, `js/combat.js`).
+> The actual code is split into `js/core/` (pure) and `js/ui/` (DOM), per
+> `MEMORY.md` and confirmed by this sweep. Use the `js/core/` // `js/ui/` paths
+> below, not CLAUDE.md's. (CLAUDE.md fix is out of scope — noted in `notes.md`.)
+
+## Run lifecycle
+
+- **Three parallel entry points, one shared run engine:** browser `js/ui/main.js`;
+  headless `scripts/playtest.js`; bot `scripts/bot/run.js` → `scripts/lib/headless-engine.js`.
+- **Run config:** `getSelectedNetwork()` in `js/ui/main.js` parses URL params
+  (`?network=`, `?seed=`, `?threat=`, `?wealth=`, `?complexity=`, `?depth=`,
+  `?lanGrade=`, `?recipe=`). Network builders return `{ graphDef, meta }`; `meta`
+  carries `startNode`, `startCash`, `moneyCost`, `spec`, `ice`, **`startHand`**.
+- **Startup:** `initGame(buildNetworkFn, seedString, opts)` builds state, generates
+  per-node vulns + macguffins (seeded), flags one macguffin as mission target,
+  spawns ICE, emits `RUN_STARTED`.
+- **End:** `jackOut()` → `endRun("success")` (`js/core/actions/action-context.js:28`).
+  Trace capture → `endRun("caught")`, which **zeroes cash** (`js/core/state/index.js:251`).
+  `endRun(outcome)` clears timers, sets `phase="ended"`, emits `RUN_ENDED`, shows
+  the end-screen.
+- **"Run again"** re-invokes `initGame()` with the same builder (`js/ui/main.js:149-157`)
+  — fully fresh state, zero carry-over. **This is the seam the hub replaces.**
+
+## Persistence
+
+- **Save/load exists but is single-run:** `js/ui/save-load.js` (downloads a JSON
+  snapshot; `restoreFromFile(file, opts)` rehydrates).
+- **`GameState` is strictly single-run** (`js/core/types.js:200-274`): `seed`, `spec`,
+  `moneyCost`, `nodes`, `adjacency`, `nodeGraph`, `player{cash,hand}`, `phase`,
+  `runOutcome`, `mission`, `ice`, `globalAlert`. **No cross-run fields** — no bank,
+  inventory, reputation, or unlocks.
+- `player.hand` is regenerated each run via `generateStartingHand()`.
+- `resetGame()` (`scripts/lib/headless-engine.js:77-88`) wipes the event bus + timers,
+  guaranteeing run isolation.
+- **Implication:** meta-state MUST live OUTSIDE `GameState`, in a separate
+  player-scoped store. Adding cross-run fields to `GameState` would fight
+  run-isolation and the save-load snapshot semantics.
+
+## Existing meta surfaces / what to reuse
+
+- **Darknet store:** `js/ui/store.js` + component `js/ui/components/starnet-store.js`,
+  reached via the WAN node `access-darknet` action. Pauses the LAN, spends **in-run
+  cash** on cards **into the current hand**. The pattern to generalize for the hub;
+  today its purchases evaporate at run end.
+- **Mining** yields exploit cards into the current hand (per `MANUAL.md`) — another
+  inventory feed to redirect at the profile.
+- **In-network qualities** `js/core/node-graph/qualities.js` are per-run set-piece
+  state — **do NOT reuse** for player standings; player qualities need their own store.
+- **Biomes:** only `data/biomes/corporate.js` exists.
+- **State mutation pattern:** `GameState` mutations route through a versioned
+  `mutate()` wrapper in `js/core/state/index.js` (submodule setters call it). The
+  profile model should follow an analogous pure-setter pattern.
+
+## Node hierarchy
+
+- SPEC's Universe→…→Device hierarchy is **aspirational only** — no code represents
+  it. Generation stops at a single seeded LAN. (Confirms: the hub's target list is a
+  flat menu, not a hierarchy traversal, in v1.)
+
+## Architecture note
+
+- `js/` is split: `js/core/` (pure JS, no DOM) and `js/ui/` (DOM/Cytoscape/Lit). The
+  profile **data model + mutations belong in `js/core/`**; the localStorage binding
+  and the hub component belong in `js/ui/`.

--- a/docs/dev-sessions/2026-06-10-1516-overworld-meta-state/spec.md
+++ b/docs/dev-sessions/2026-06-10-1516-overworld-meta-state/spec.md
@@ -1,0 +1,160 @@
+# Overworld Meta-State (v1) Spec
+
+**Goal:** Give the game a persistent layer *between* hack-sessions — a player
+profile holding a cash bank and an exploit-card inventory — so runs stop being
+isolated islands and become a campaign, launched and resolved through a textual
+"overworld hub."
+
+**Source:** User request, 2026-06-10. First buildable slice of the overworld
+decomposition; see `docs/VISION-dual-mode-and-standings.md` for the larger arc.
+
+## Current state
+
+Every run is fully independent (`research.md`). `GameState`
+(`js/core/types.js:200-274`) is strictly single-run; `resetGame()`
+(`scripts/lib/headless-engine.js:77-88`) wipes everything between runs, and
+"run again" just re-invokes `initGame()` with the same builder
+(`js/ui/main.js:149-157`). Cash and the 5-card hand are regenerated each run;
+nothing carries over. Save/load (`js/ui/save-load.js`) is snapshot-of-one-run
+only. The darknet store (`js/ui/store.js`) spends in-run cash on cards into the
+current hand, but those purchases evaporate at run end.
+
+## Desired end state
+
+A **persistent profile** lives outside `GameState`, in browser localStorage:
+
+```
+StarnetProfile {
+  version: number,
+  bank: number,                 // persistent cash
+  inventory: ExploitCard[],     // persistent card collection; each card carries a
+                                 // stable, profile-unique instanceId (distinct from
+                                 // its vuln-type display id)
+  // RESERVED (schema room, not implemented in v1): standings, installations, unlocks
+}
+```
+
+The browser flow becomes:
+
+1. **Hub** (textual menu, a generalization of the darknet store) shows: bank
+   balance, inventory (cards + their worn/disclosed/uses state), and a short list
+   of **available targets**.
+2. Player **composes a loadout** (≤5 cards from inventory) and **withdraws** an
+   amount of cash to carry in.
+3. Player **picks a target** → a run launches with `meta.startHand = loadout` and
+   `meta.startCash = withdrawn cash`. The run itself plays exactly as today
+   (darknet store still spends the carried in-run cash).
+4. **On `endRun`, results commit back to the profile:**
+   - **success (`jackout`):** run cash (carried leftover + loot) **deposits** to
+     bank; the loadout cards return to inventory with their updated
+     uses/worn/disclosed state.
+   - **caught (trace):** run cash is **forfeit** (extends today's cash-zeroing,
+     `js/core/state/index.js:251`) AND the **carried loadout cards are burned** —
+     removed from inventory (Medium stakes). Bank and un-carried inventory survive.
+5. The **darknet store** and **mining** now feed the persistent inventory:
+   purchases/yields land in the profile, not a throwaway hand.
+
+The console keeps parity (per the symmetric-input + LLM-legible principles): the
+hub is inspectable/operable via commands, not GUI-only.
+
+## Design decisions
+
+- **Decision:** Meta-state lives in a separate player-scoped profile store, outside
+  `GameState`.
+  - **Why:** `GameState` is strictly single-run and `resetGame()` wipes it; the
+    save-load snapshot is one-run. Cross-run data needs its own home.
+  - **Rejected:** adding `bank`/`inventory` fields to `GameState` — fights
+    run-isolation and corrupts save/load snapshot semantics.
+
+- **Decision:** v1 profile = **bank + card inventory only**.
+  - **Why:** persistent cash is meaningless without a persistent thing to buy;
+    together they flip cash from pure score into investment. Smallest slice that
+    makes a campaign.
+  - **Rejected:** cash-only (no stakes, no meaning); standings/storylets/
+    installations (separate subsystems — would be two-specs-in-a-trenchcoat).
+
+- **Decision:** **Medium stakes** — capture forfeits run cash AND burns the carried
+  loadout; bank + un-carried inventory survive.
+  - **Why:** lightest model that makes the persistent inventory *matter* and gives
+    capture teeth now that "run again" isn't free. Makes "which cards / how much
+    cash do I risk bringing" the core decision.
+  - **Rejected:** Soft (loot-only, no inventory stakes — tensionless); Hard
+    (persistent Heat/standings/installation loss — pulls in deferred subsystems).
+
+- **Decision:** Bank ↔ in-run cash = **withdraw/deposit**. You carry cash *into* a
+  run; leftover + loot deposits on success.
+  - **Why:** keeps the darknet store working unchanged (it spends in-run cash) and
+    adds a "how much to risk carrying" decision.
+  - **Rejected:** store spends bank directly (changes the store; removes the
+    carry-risk decision).
+
+- **Decision:** Persistent inventory + per-run **loadout (≤5)** replaces the random
+  `startHand`. Each inventory card gets a **stable, profile-unique `instanceId`**.
+  - **Why:** Medium stakes needs to remove *specific carried cards*; stable ids
+    enable that. Also turns store/mining into long-term investment, and is the
+    cheap door-opener for the future "ICE burns exploits mid-run" idea (same
+    targeted-removal operation, triggered earlier).
+  - **Rejected:** keep random per-run hands (no persistence = no campaign).
+
+- **Decision:** Hub is a **textual menu**; target selection is a **minimal
+  generated list** (the seam where navigation will later grow into a map).
+  - **Why:** deliver continuity now; the map is the most design-open + visual piece
+    and isn't needed for the spine.
+  - **Rejected:** building a graphical navigation map / world hierarchy now.
+
+- **Decision:** **Browser-first.** Headless entry points (`playtest.js`, the bot)
+  bypass the profile and synthesize a loadout (current `generateStartingHand`
+  behavior).
+  - **Why:** the profile is a browser/localStorage concern; headless runs operate
+    at the run level and shouldn't depend on a profile.
+  - **Rejected:** threading the profile through all three entry points in v1 (scope).
+
+## Patterns to follow
+
+- **core/ui split:** profile **data model + pure mutations in `js/core/`** (e.g.
+  `js/core/profile/`); **localStorage binding + hub component in `js/ui/`**.
+- **Versioned setter pattern:** mirror `mutate()` in `js/core/state/index.js` —
+  pure setters that bump a version, no event emission inside the data layer.
+- **Hub component:** mirror the Lit, light-DOM modal pattern of
+  `js/ui/components/starnet-store.js` (and its `js/ui/store.js` controller).
+- **Run config surface:** populate `meta.startHand` / `meta.startCash` the way
+  network builders do today (`js/ui/main.js` `getSelectedNetwork()` + builder meta).
+- **Reuse the `ExploitCard` typedef** (`js/core/types.js`) for inventory entries;
+  add `instanceId` there.
+- **JSON persist/restore:** follow `js/ui/save-load.js` for profile export/import.
+- **Console parity:** add hub commands alongside the GUI (symmetric-input principle).
+
+## What we're NOT doing
+
+- **Standings / reputation / the constellation** — deferred subsystem.
+- **Storylet engine / player qualities** — deferred; and NOT the in-network
+  `js/core/node-graph/qualities.js` (per-run set-piece state, left untouched).
+- **Persistent installations / tether-redirect nodes.**
+- **Graphical navigation map / world hierarchy** (Universe→…→Device) — target list
+  stays a flat menu.
+- **Economy depth** beyond bank+inventory — no deck-hardware/script/upgrade shop.
+- **Profile in headless entry points** (`playtest.js`, bot) — they synthesize a
+  loadout.
+- **Multiple profiles / save slots** — single profile for v1.
+- **Mid-run ICE burning exploits** — filed to `docs/BACKLOG.md`; future. (v1 only
+  leaves the door open via stable card `instanceId`s.)
+- **Fixing CLAUDE.md's stale File-Structure section** — noted in `notes.md`, out of
+  scope here.
+
+## Open questions
+
+All carry a default so planning can proceed:
+
+- **Target-list generation & refresh.** *Default:* regenerate 3 targets at varying
+  grade tiers on each hub visit, seeded deterministically from profile + a visit
+  counter; selecting one launches it. Refinement deferred.
+- **New-profile bootstrap.** *Default:* on an empty profile, seed an initial bank
+  (reuse the current per-network `startCash` value) and an initial inventory (reuse
+  `generateStartingHand`, ~5 cards).
+- **Carried cash on capture.** *Default:* forfeit along with loot (consistent with
+  today's full cash-zeroing on capture).
+- **Loadout minimum.** *Default:* no minimum — launching with <5 (even 0, a blind
+  run) is allowed.
+- **Inventory cap.** *Default:* unbounded in v1.
+- **`instanceId` scheme.** *Default:* assign a profile-scoped unique id when a card
+  enters inventory (counter or UUID), independent of the vuln-type+counter display id.

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
     </main>
 
     <starnet-end-screen id="end-screen"></starnet-end-screen>
+    <starnet-hub id="overworld-hub"></starnet-hub>
 
   </div>
 
@@ -68,6 +69,7 @@
   <script type="module" src="js/ui/components/starnet-end-screen.js"></script>
   <script type="module" src="js/ui/components/starnet-store.js"></script>
   <script type="module" src="js/ui/components/starnet-level-select.js"></script>
+  <script type="module" src="js/ui/components/starnet-hub.js"></script>
   <script type="module" src="js/ui/main.js"></script>
 </body>
 </html>

--- a/js/core/profile/index.js
+++ b/js/core/profile/index.js
@@ -1,0 +1,149 @@
+// @ts-check
+// Persistent cross-run player profile — pure data model.
+//
+// This lives OUTSIDE GameState (which is strictly single-run and wiped by
+// resetGame between runs). The profile holds what carries across runs: a cash
+// bank and an exploit-card inventory. Functions here are pure in the sense that
+// they operate on a profile object passed in — no module-level singleton, no
+// event emission, no DOM. The localStorage binding lives in js/ui/profile-store.js.
+
+/** @typedef {import('../types.js').StarnetProfile} StarnetProfile */
+/** @typedef {import('../types.js').ExploitCard} ExploitCard */
+
+export const PROFILE_VERSION = 1;
+
+export { generateTargets } from "./targets.js";
+
+/**
+ * Create a fresh profile. Any seed `inventory` cards are added via
+ * addCardToInventory so they receive stable instanceIds.
+ * @param {{ bank?: number, inventory?: ExploitCard[] }} [opts]
+ * @returns {StarnetProfile}
+ */
+export function createProfile({ bank = 0, inventory = [] } = {}) {
+  /** @type {StarnetProfile} */
+  const p = { version: PROFILE_VERSION, bank, inventory: [], _instanceSeq: 0, _hubVisits: 0 };
+  inventory.forEach((c) => addCardToInventory(p, c));
+  return p;
+}
+
+/**
+ * Push a card into inventory, assigning a profile-unique instanceId if it lacks
+ * one. The instanceId is what lets specific cards be written back or burned.
+ * @param {StarnetProfile} profile
+ * @param {ExploitCard} card
+ * @returns {ExploitCard}
+ */
+export function addCardToInventory(profile, card) {
+  if (!card.instanceId) {
+    card.instanceId = `inv-${profile._instanceSeq++}`;
+  } else {
+    // Preserve an explicit id, but keep _instanceSeq above any inv-N so a future
+    // auto-assigned id can't collide with it.
+    const m = /^inv-(\d+)$/.exec(card.instanceId);
+    if (m) profile._instanceSeq = Math.max(profile._instanceSeq, Number(m[1]) + 1);
+  }
+  profile.inventory.push(card);
+  return card;
+}
+
+/**
+ * @param {StarnetProfile} profile
+ * @param {string} instanceId
+ * @returns {ExploitCard|undefined}
+ */
+export function findCard(profile, instanceId) {
+  return profile.inventory.find((c) => c.instanceId === instanceId);
+}
+
+/**
+ * Remove inventory cards whose instanceId is in the given list.
+ * @param {StarnetProfile} profile
+ * @param {string[]} instanceIds
+ * @returns {ExploitCard[]} the removed cards
+ */
+export function removeCardsByInstanceId(profile, instanceIds) {
+  const set = new Set(instanceIds);
+  const removed = profile.inventory.filter((c) => set.has(c.instanceId));
+  profile.inventory = profile.inventory.filter((c) => !set.has(c.instanceId));
+  return removed;
+}
+
+/**
+ * Discard all disclosed (burned-out, unplayable) exploits from inventory.
+ * @param {StarnetProfile} profile
+ * @returns {ExploitCard[]} the removed cards
+ */
+export function removeDisclosedCards(profile) {
+  const removed = profile.inventory.filter((c) => c.decayState === "disclosed");
+  profile.inventory = profile.inventory.filter((c) => c.decayState !== "disclosed");
+  return removed;
+}
+
+/**
+ * Credit the bank.
+ * @param {StarnetProfile} profile
+ * @param {number} amount
+ * @returns {StarnetProfile}
+ */
+export function deposit(profile, amount) {
+  profile.bank += amount;
+  return profile;
+}
+
+/**
+ * Debit the bank if sufficient funds. Refuses negative amounts.
+ * @param {StarnetProfile} profile
+ * @param {number} amount
+ * @returns {boolean} true if the debit succeeded
+ */
+export function withdraw(profile, amount) {
+  if (amount < 0 || profile.bank < amount) return false;
+  profile.bank -= amount;
+  return true;
+}
+
+/**
+ * Clone loadout cards for use as a run hand. Cloning means in-run decay mutates
+ * the run copy, not the inventory object; the instanceId is preserved so the
+ * decayed state can be written back on commit.
+ * @param {ExploitCard[]} loadoutCards
+ * @returns {ExploitCard[]}
+ */
+export function buildRunHand(loadoutCards) {
+  return loadoutCards.map((c) => ({ ...c, targetVulnTypes: [...c.targetVulnTypes] }));
+}
+
+/**
+ * Commit a finished run back into the profile.
+ * - success: deposit run cash (carried leftover + loot); for each final-hand card,
+ *   write decay back to its inventory instance (matched by instanceId), or — if it
+ *   has no instanceId (a card bought/mined mid-run) — add it to inventory.
+ * - caught (Medium stakes): burn the carried loadout (remove by instanceId). Run
+ *   cash is already forfeit upstream (endRun zeroes it), so nothing is deposited.
+ * @param {StarnetProfile} profile
+ * @param {{
+ *   outcome: import('../types.js').RunOutcome,
+ *   finalCash: number,
+ *   finalHand: ExploitCard[],
+ *   carriedInstanceIds: string[],
+ * }} run
+ * @returns {StarnetProfile}
+ */
+export function commitRun(profile, { outcome, finalCash, finalHand, carriedInstanceIds }) {
+  if (outcome === "caught") {
+    removeCardsByInstanceId(profile, carriedInstanceIds);
+    return profile;
+  }
+  deposit(profile, finalCash);
+  for (const card of finalHand) {
+    const existing = card.instanceId ? findCard(profile, card.instanceId) : null;
+    if (existing) {
+      existing.usesRemaining = card.usesRemaining;
+      existing.decayState = card.decayState;
+    } else {
+      addCardToInventory(profile, card);
+    }
+  }
+  return profile;
+}

--- a/js/core/profile/profile.test.js
+++ b/js/core/profile/profile.test.js
@@ -1,0 +1,127 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createProfile,
+  addCardToInventory,
+  findCard,
+  removeCardsByInstanceId,
+  removeDisclosedCards,
+  deposit,
+  withdraw,
+  PROFILE_VERSION,
+} from "./index.js";
+
+/** Minimal ExploitCard-shaped object for profile tests (seed-independent). */
+function card(id, over = {}) {
+  return {
+    id,
+    name: `card-${id}`,
+    rarity: "common",
+    quality: 1,
+    targetVulnTypes: ["card"],
+    decayState: "fresh",
+    usesRemaining: 3,
+    ...over,
+  };
+}
+
+describe("createProfile", () => {
+  it("sets version and bank, and bootstraps inventory with instanceIds", () => {
+    const p = createProfile({ bank: 1000, inventory: [card("a"), card("b")] });
+    assert.equal(p.version, PROFILE_VERSION);
+    assert.equal(p.bank, 1000);
+    assert.equal(p.inventory.length, 2);
+    assert.ok(p.inventory.every((c) => typeof c.instanceId === "string"));
+    const ids = new Set(p.inventory.map((c) => c.instanceId));
+    assert.equal(ids.size, 2, "instanceIds are unique");
+  });
+
+  it("defaults to empty bank and inventory", () => {
+    const p = createProfile();
+    assert.equal(p.bank, 0);
+    assert.deepEqual(p.inventory, []);
+  });
+});
+
+describe("addCardToInventory", () => {
+  it("assigns a unique instanceId when absent", () => {
+    const p = createProfile();
+    const a = addCardToInventory(p, card("a"));
+    const b = addCardToInventory(p, card("b"));
+    assert.ok(a.instanceId && b.instanceId);
+    assert.notEqual(a.instanceId, b.instanceId);
+    assert.equal(p.inventory.length, 2);
+  });
+
+  it("preserves an existing instanceId", () => {
+    const p = createProfile();
+    const c = addCardToInventory(p, card("a", { instanceId: "keep-me" }));
+    assert.equal(c.instanceId, "keep-me");
+  });
+
+  it("keeps _instanceSeq ahead of an explicit inv-N id (no collision)", () => {
+    const p = createProfile();
+    addCardToInventory(p, card("a", { instanceId: "inv-5" }));
+    const auto = addCardToInventory(p, card("b"));
+    assert.equal(auto.instanceId, "inv-6");
+  });
+});
+
+describe("findCard / removeCardsByInstanceId", () => {
+  it("finds by instanceId", () => {
+    const p = createProfile({ inventory: [card("a"), card("b")] });
+    const target = p.inventory[1];
+    assert.equal(findCard(p, target.instanceId), target);
+    assert.equal(findCard(p, "nope"), undefined);
+  });
+
+  it("removes only matching instanceIds and returns the removed cards", () => {
+    const p = createProfile({ inventory: [card("a"), card("b"), card("c")] });
+    const burn = [p.inventory[0].instanceId, p.inventory[2].instanceId];
+    const removed = removeCardsByInstanceId(p, burn);
+    assert.equal(removed.length, 2);
+    assert.equal(p.inventory.length, 1);
+    assert.equal(p.inventory[0].id, "b");
+  });
+});
+
+describe("deposit / withdraw", () => {
+  it("deposit increases the bank", () => {
+    const p = createProfile({ bank: 100 });
+    deposit(p, 50);
+    assert.equal(p.bank, 150);
+  });
+
+  it("withdraw debits on success and refuses when insufficient or negative", () => {
+    const p = createProfile({ bank: 100 });
+    assert.equal(withdraw(p, 40), true);
+    assert.equal(p.bank, 60);
+    assert.equal(withdraw(p, 1000), false, "refuses insufficient");
+    assert.equal(p.bank, 60, "bank unchanged on failed withdraw");
+    assert.equal(withdraw(p, -5), false, "refuses negative");
+    assert.equal(p.bank, 60);
+  });
+});
+
+describe("removeDisclosedCards", () => {
+  it("removes only disclosed cards and returns them", () => {
+    const p = createProfile({
+      inventory: [
+        card("a", { decayState: "fresh" }),
+        card("b", { decayState: "disclosed" }),
+        card("c", { decayState: "worn" }),
+        card("d", { decayState: "disclosed" }),
+      ],
+    });
+    const removed = removeDisclosedCards(p);
+    assert.equal(removed.length, 2);
+    assert.deepEqual(p.inventory.map((c) => c.id).sort(), ["a", "c"]);
+  });
+
+  it("is a no-op when nothing is disclosed", () => {
+    const p = createProfile({ inventory: [card("a"), card("b")] });
+    const removed = removeDisclosedCards(p);
+    assert.equal(removed.length, 0);
+    assert.equal(p.inventory.length, 2);
+  });
+});

--- a/js/core/profile/targets.js
+++ b/js/core/profile/targets.js
@@ -1,0 +1,36 @@
+// @ts-check
+// Hub target-list generation. v1: a small fixed set of difficulty tiers, with
+// seeds derived from the profile's hub-visit counter so the list is deterministic
+// for a given profile state and rotates as the player returns to the hub.
+//
+// This is deliberately minimal — the flat list is the seam where richer
+// navigation (a map / world hierarchy) will grow later.
+
+/** @typedef {import('../types.js').StarnetProfile} StarnetProfile */
+
+/**
+ * @typedef {{
+ *   id: string,
+ *   label: string,
+ *   seed: string,
+ *   spec: { threat: string, wealth: string, complexity: string, depth: string },
+ * }} HubTarget
+ */
+
+/** @type {{ id: string, label: string, spec: HubTarget["spec"] }[]} */
+const TIERS = [
+  { id: "soft",     label: "Soft target — residential edge", spec: { threat: "F", wealth: "D", complexity: "F", depth: "F" } },
+  { id: "standard", label: "Standard job — corporate LAN",   spec: { threat: "C", wealth: "B", complexity: "C", depth: "C" } },
+  { id: "hard",     label: "Hard mark — hardened vault",      spec: { threat: "A", wealth: "S", complexity: "B", depth: "B" } },
+];
+
+/**
+ * Build the hub's target list. Seeds incorporate the profile's hub-visit counter
+ * so each visit offers a fresh-but-deterministic set.
+ * @param {StarnetProfile} profile
+ * @returns {HubTarget[]}
+ */
+export function generateTargets(profile) {
+  const visit = profile._hubVisits ?? 0;
+  return TIERS.map((t) => ({ ...t, seed: `target-${visit}-${t.id}` }));
+}

--- a/js/core/profile/targets.test.js
+++ b/js/core/profile/targets.test.js
@@ -1,0 +1,32 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { generateTargets } from "./targets.js";
+import { createProfile } from "./index.js";
+
+describe("generateTargets", () => {
+  it("returns three well-formed targets", () => {
+    const targets = generateTargets(createProfile());
+    assert.equal(targets.length, 3);
+    for (const t of targets) {
+      assert.ok(typeof t.id === "string" && t.id.length > 0);
+      assert.ok(typeof t.label === "string" && t.label.length > 0);
+      assert.ok(typeof t.seed === "string" && t.seed.length > 0);
+      assert.ok(t.spec && t.spec.threat && t.spec.wealth && t.spec.complexity && t.spec.depth);
+    }
+  });
+
+  it("is deterministic for a given hub-visit count", () => {
+    const a = generateTargets({ ...createProfile(), _hubVisits: 5 });
+    const b = generateTargets({ ...createProfile(), _hubVisits: 5 });
+    assert.deepEqual(a, b);
+  });
+
+  it("produces different seeds as the hub-visit count changes", () => {
+    const v0 = generateTargets({ ...createProfile(), _hubVisits: 0 });
+    const v1 = generateTargets({ ...createProfile(), _hubVisits: 1 });
+    assert.notDeepEqual(
+      v0.map((t) => t.seed),
+      v1.map((t) => t.seed),
+    );
+  });
+});

--- a/js/core/state/index.js
+++ b/js/core/state/index.js
@@ -155,7 +155,12 @@ export function initGame(buildNetworkFn, seedString, opts = {}) {
     nodeGraph: graph,
     player: {
       cash: meta.startCash ?? 1000,
-      hand: generateStartingHand(meta.startHand),
+      // Clone startHandCards so in-run decay never mutates the caller's objects
+      // (e.g. profile inventory) — matches generateStartingHand's fresh-objects
+      // contract. instanceId is preserved for commit write-back.
+      hand: meta.startHandCards
+        ? meta.startHandCards.map((c) => ({ ...c, targetVulnTypes: [...c.targetVulnTypes] }))
+        : generateStartingHand(meta.startHand),
       health:        { current: meta.startHealth        ?? 100, max: meta.startHealth        ?? 100 },
       deckIntegrity: { current: meta.startDeckIntegrity ?? 100, max: meta.startDeckIntegrity ?? 100 },
     },

--- a/js/core/store-logic.js
+++ b/js/core/store-logic.js
@@ -5,38 +5,53 @@
 
 import { buyExploit } from "./state.js";
 import { generateExploitForVuln, getStoreCatalog } from "./exploits.js";
+import { withdraw, addCardToInventory } from "./profile/index.js";
 
 /**
- * Buy an exploit card from the darknet broker by catalog index (1-based)
- * or vulnerability ID string.
- *
+ * Resolve a catalog item from a 1-based index or a vuln ID string (exact match,
+ * then unique prefix). Returns null if unresolved/ambiguous.
+ * @param {number | string} indexOrVulnId
+ * @returns {{ vulnId: string, name: string, rarity: string, price: number } | null}
+ */
+function findCatalogItem(indexOrVulnId) {
+  const catalog = getStoreCatalog();
+  if (typeof indexOrVulnId === "number") {
+    return indexOrVulnId >= 1 && indexOrVulnId <= catalog.length ? catalog[indexOrVulnId - 1] : null;
+  }
+  const lower = String(indexOrVulnId).toLowerCase();
+  const exact = catalog.filter((c) => c.vulnId.toLowerCase() === lower);
+  if (exact.length === 1) return exact[0];
+  const prefix = catalog.filter((c) => c.vulnId.toLowerCase().startsWith(lower));
+  return prefix.length === 1 ? prefix[0] : null;
+}
+
+/**
+ * Buy an exploit from the broker into the in-run hand (spends in-run cash).
  * @param {number | string} indexOrVulnId — 1-based catalog index or vuln ID string
  * @returns {{ card: import('./types.js').ExploitCard, price: number, vulnId: string } | null}
  */
 export function buyFromStore(indexOrVulnId) {
-  const catalog = getStoreCatalog();
-  let item = null;
-
-  if (typeof indexOrVulnId === "number") {
-    if (indexOrVulnId >= 1 && indexOrVulnId <= catalog.length) {
-      item = catalog[indexOrVulnId - 1];
-    }
-  } else {
-    const lower = String(indexOrVulnId).toLowerCase();
-    const matches = catalog.filter((c) => c.vulnId.toLowerCase() === lower);
-    if (matches.length === 1) item = matches[0];
-    // If no exact match, try prefix
-    if (!item) {
-      const prefix = catalog.filter((c) => c.vulnId.toLowerCase().startsWith(lower));
-      if (prefix.length === 1) item = prefix[0];
-    }
-  }
-
+  const item = findCatalogItem(indexOrVulnId);
   if (!item) return null;
-
   const card = generateExploitForVuln(item.vulnId);
   const success = buyExploit(card, item.price);
   if (!success) return null;
+  return { card, price: item.price, vulnId: item.vulnId };
+}
 
+/**
+ * Buy an exploit from the broker into a persistent profile (spends bank cash,
+ * adds to the inventory). Used by the overworld hub's darknet store.
+ * @param {import('./types.js').StarnetProfile} profile
+ * @param {number | string} indexOrVulnId
+ * @returns {{ card: import('./types.js').ExploitCard, price: number, vulnId: string } | null}
+ */
+export function buyFromStoreToProfile(profile, indexOrVulnId) {
+  const item = findCatalogItem(indexOrVulnId);
+  if (!item) return null;
+  if (profile.bank < item.price) return null;
+  const card = generateExploitForVuln(item.vulnId);
+  withdraw(profile, item.price);
+  addCardToInventory(profile, card);
   return { card, price: item.price, vulnId: item.vulnId };
 }

--- a/js/core/store-logic.test.js
+++ b/js/core/store-logic.test.js
@@ -1,9 +1,11 @@
 // @ts-check
 import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { buyFromStore } from "./store-logic.js";
+import { buyFromStore, buyFromStoreToProfile } from "./store-logic.js";
 import { getStoreCatalog } from "./exploits.js";
 import { initGame, getState } from "./state.js";
+import { initRng } from "./rng.js";
+import { createProfile } from "./profile/index.js";
 import { createGateway, createRouter } from "./node-graph/game-types.js";
 
 function buildStoreLAN() {
@@ -67,5 +69,34 @@ describe("buyFromStore", () => {
     // Now should fail
     const result = buyFromStore(1);
     assert.equal(result, null);
+  });
+});
+
+describe("buyFromStoreToProfile (hub darknet)", () => {
+  beforeEach(() => initRng("store-logic-profile-test"));
+
+  it("spends bank and adds the card to inventory", () => {
+    const p = createProfile({ bank: 1000 });
+    const price = getStoreCatalog()[0].price;
+    const result = buyFromStoreToProfile(p, 1);
+    assert.ok(result, "expected successful purchase");
+    assert.equal(result.price, price);
+    assert.equal(p.bank, 1000 - price);
+    assert.equal(p.inventory.length, 1);
+    assert.ok(p.inventory[0].instanceId, "purchased card gets an instanceId");
+    assert.equal(p.inventory[0].id, result.card.id);
+  });
+
+  it("refuses when the bank can't cover the price (no debit, no card)", () => {
+    const p = createProfile({ bank: 0 });
+    assert.equal(buyFromStoreToProfile(p, 1), null);
+    assert.equal(p.bank, 0);
+    assert.equal(p.inventory.length, 0);
+  });
+
+  it("returns null for an out-of-range index", () => {
+    const p = createProfile({ bank: 1000 });
+    assert.equal(buyFromStoreToProfile(p, 999), null);
+    assert.equal(p.bank, 1000);
   });
 });

--- a/js/core/types.js
+++ b/js/core/types.js
@@ -47,6 +47,10 @@
 
 /**
  * An exploit card in the player's hand.
+ * `instanceId` is a profile-scoped unique id, assigned when the card enters the
+ * persistent inventory (js/core/profile). It is distinct from `id` (a per-run,
+ * vuln-type+counter display id) and is what lets a specific card be written back
+ * or burned across runs. Absent on freshly-generated, not-yet-banked cards.
  * @typedef {{
  *   id: string,
  *   name: string,
@@ -55,6 +59,7 @@
  *   targetVulnTypes: string[],
  *   decayState: DecayState,
  *   usesRemaining: number,
+ *   instanceId?: string,
  * }} ExploitCard
  */
 
@@ -134,6 +139,19 @@
  *   health: { current: number, max: number },
  *   deckIntegrity: { current: number, max: number },
  * }} PlayerState
+ */
+
+/**
+ * Persistent cross-run player profile. Lives OUTSIDE GameState (in localStorage
+ * via js/ui/profile-store.js), so it survives resetGame between runs. Model and
+ * mutations are in js/core/profile.
+ * @typedef {{
+ *   version: number,
+ *   bank: number,
+ *   inventory: ExploitCard[],
+ *   _instanceSeq: number,
+ *   _hubVisits: number,
+ * }} StarnetProfile
  */
 
 /**

--- a/js/ui/components/starnet-end-screen.js
+++ b/js/ui/components/starnet-end-screen.js
@@ -80,7 +80,7 @@ class StarnetEndScreen extends StarnetElement {
           <span class="end-val">${this.macguffinsLooted}</span>
         </div>
         <div class="end-divider">════════════════════════</div>
-        <button class="end-btn" @click=${this._onRunAgain}>[ RUN AGAIN ]</button>
+        <button class="end-btn" @click=${this._onRunAgain}>[ RETURN TO HUB ]</button>
       </div>`;
   }
 }

--- a/js/ui/components/starnet-hub.js
+++ b/js/ui/components/starnet-hub.js
@@ -1,0 +1,101 @@
+// <starnet-hub> — Overworld hub overlay: manage the persistent bank + exploit
+// inventory, pick a loadout and how much cash to carry, and launch a target.
+// Pure view: it renders props set by hub.js and dispatches intent events back.
+
+import { html, nothing } from "lit";
+import { repeat } from "lit/directives/repeat.js";
+import { StarnetElement } from "./starnet-element.js";
+
+class StarnetHub extends StarnetElement {
+  static properties = {
+    open: { type: Boolean },
+    bank: { type: Number },
+    inventory: { type: Array },
+    loadout: { type: Array },          // selected instanceIds
+    withdrawAmount: { type: Number },
+    targets: { type: Array },
+  };
+
+  constructor() {
+    super();
+    this.open = false;
+    this.bank = 0;
+    this.inventory = [];
+    this.loadout = [];
+    this.withdrawAmount = 0;
+    this.targets = [];
+  }
+
+  updated(changed) {
+    if (changed.has("open")) this.style.display = this.open ? "" : "none";
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.style.display = this.open ? "" : "none";
+  }
+
+  _toggle(instanceId) {
+    this.dispatchEvent(new CustomEvent("loadout-toggle", { bubbles: true, detail: { instanceId } }));
+  }
+
+  _withdraw(e) {
+    this.dispatchEvent(new CustomEvent("withdraw-change", { bubbles: true, detail: { amount: Number(e.target.value) } }));
+  }
+
+  _launch(targetId) {
+    this.dispatchEvent(new CustomEvent("launch", { bubbles: true, detail: { targetId } }));
+  }
+
+  _discardDisclosed() {
+    this.dispatchEvent(new CustomEvent("discard-disclosed", { bubbles: true }));
+  }
+
+  _visitDarknet() {
+    this.dispatchEvent(new CustomEvent("visit-darknet", { bubbles: true }));
+  }
+
+  render() {
+    if (!this.open) return nothing;
+    const loadout = this.loadout ?? [];
+    const disclosed = (this.inventory ?? []).filter((c) => c.decayState === "disclosed").length;
+    return html`
+      <div class="hub-box">
+        <div class="hub-title">▶ OVERWORLD HUB ◀</div>
+        <div class="hub-divider">════════════════════════</div>
+        <div class="hub-row"><span class="hub-key">BANK</span><span class="hub-val">¥${this.bank.toLocaleString()}</span></div>
+        <div class="hub-actions">
+          <button class="hub-btn" @click=${this._visitDarknet}>[ VISIT DARKNET ]</button>
+        </div>
+
+        <div class="hub-section">EXPLOIT INVENTORY — loadout ${loadout.length}/5</div>
+        ${this.inventory.length === 0
+          ? html`<div class="hub-empty">(inventory empty — mine or buy exploits)</div>`
+          : repeat(this.inventory, (c) => c.instanceId, (c) => html`
+              <div class="hub-card ${loadout.includes(c.instanceId) ? "equipped" : ""} ${c.decayState === "disclosed" ? "burned" : ""}"
+                   @click=${() => this._toggle(c.instanceId)}>
+                <span class="hub-card-name">${loadout.includes(c.instanceId) ? "▣" : "▢"} ${c.name}</span>
+                <span class="hub-card-meta">[${c.rarity}] ${c.decayState} ×${c.usesRemaining}</span>
+              </div>`)}
+
+        <div class="hub-actions">
+          <button class="hub-btn" ?disabled=${disclosed === 0} @click=${this._discardDisclosed}>
+            [ DISCARD DISCLOSED${disclosed ? ` (${disclosed})` : ""} ]
+          </button>
+        </div>
+
+        <div class="hub-section">CARRY CASH</div>
+        <input class="hub-carry" type="number" min="0" max=${this.bank}
+               .value=${String(this.withdrawAmount)} @input=${this._withdraw} />
+
+        <div class="hub-section">AVAILABLE TARGETS</div>
+        ${repeat(this.targets, (t) => t.id, (t) => html`
+          <div class="hub-target" @click=${() => this._launch(t.id)}>
+            <span class="hub-target-label">▸ ${t.label}</span>
+            <span class="hub-target-grade">threat ${t.spec.threat} · wealth ${t.spec.wealth}</span>
+          </div>`)}
+      </div>`;
+  }
+}
+
+customElements.define("starnet-hub", StarnetHub);

--- a/js/ui/components/starnet-store.js
+++ b/js/ui/components/starnet-store.js
@@ -10,6 +10,7 @@ class StarnetStore extends StarnetElement {
     open: { type: Boolean },
     catalog: { type: Array },
     cash: { type: Number },
+    subtitle: { type: String },
   };
 
   constructor() {
@@ -17,6 +18,7 @@ class StarnetStore extends StarnetElement {
     this.open = false;
     this.catalog = [];
     this.cash = 0;
+    this.subtitle = "";
   }
 
   updated(changed) {
@@ -55,6 +57,7 @@ class StarnetStore extends StarnetElement {
           <span class="store-title">// DARKNET BROKER</span>
           <span class="store-wallet">¥${this.cash.toLocaleString()}</span>
         </div>
+        ${this.subtitle ? html`<div class="store-subtitle">${this.subtitle}</div>` : nothing}
         <div class="store-card-list">
           ${(this.catalog || []).map((item, i) => {
             const canAfford = this.cash >= item.price;

--- a/js/ui/graph.js
+++ b/js/ui/graph.js
@@ -289,6 +289,23 @@ export function syncInitialNodes(nodes) {
 }
 
 /**
+ * Reset the graph to empty and re-point it at a (possibly different) topology.
+ * Reuses the existing cy instance — clears all elements rather than destroying
+ * cy, so there's no teardown/leak. Call before syncInitialNodes when starting a
+ * fresh run (first boot, run-again, hub launch); a no-op if cy isn't built yet.
+ * @param {{ nodes: {id:string,label:string,type:string,grade:string}[], edges: {source:string,target:string}[] }} networkData
+ */
+export function resetGraph(networkData) {
+  if (!cy) return;
+  cy.elements().remove();
+  _networkNodes = new Map();
+  for (const n of networkData.nodes) {
+    _networkNodes.set(n.id, { id: n.id, label: n.label, type: n.type, grade: n.grade });
+  }
+  _networkEdges = networkData.edges;
+}
+
+/**
  * Add a node to the Cytoscape graph when it becomes visible.
  * Also adds edges to any already-present neighbors.
  * @param {string} nodeId

--- a/js/ui/hub-commands.js
+++ b/js/ui/hub-commands.js
@@ -1,0 +1,103 @@
+// @ts-check
+// Console commands for the overworld hub. Registered from the UI layer (the
+// profile is a browser/localStorage concern). Each command routes through the
+// shared hub.js operations, so typing a command and clicking the GUI produce
+// identical state changes and log output (the GUI/console symmetry principle).
+
+import { registerCommand, getCommand } from "../core/console-commands/index.js";
+import { emitEvent, E } from "../core/events.js";
+import {
+  openHub, equipCard, unequipCard, setWithdraw, launchTarget, getHub,
+  discardDisclosed, isHubContext, hubBuy, listHubCatalog,
+} from "./hub.js";
+
+function log(text, type = "meta") {
+  emitEvent(E.LOG_ENTRY, { text, type });
+}
+
+/**
+ * Resolve an inventory reference (1-based index from `inventory` listing, or a
+ * literal instanceId) to an instanceId. Logs and returns null if unresolved.
+ */
+function resolveInstanceId(arg) {
+  if (!arg) { log("Usage: equip <#|instanceId>", "error"); return null; }
+  const { inventory } = getHub();
+  const n = parseInt(arg, 10);
+  if (!isNaN(n) && String(n) === arg) {
+    const card = inventory[n - 1];
+    if (!card) { log(`No inventory card #${arg}.`, "error"); return null; }
+    return card.instanceId;
+  }
+  const match = inventory.find((c) => c.instanceId === arg);
+  if (!match) { log(`No exploit with id ${arg}.`, "error"); return null; }
+  return match.instanceId;
+}
+
+registerCommand({ verb: "hub", execute() { openHub(); } });
+
+registerCommand({
+  verb: "inventory",
+  execute() {
+    const { bank, inventory, selection } = getHub();
+    log(`BANK: ¥${bank.toLocaleString()}  (loadout ${selection.loadoutIds.length}/5)`);
+    if (!inventory.length) { log("Inventory empty — mine or buy exploits."); return; }
+    inventory.forEach((c, i) => {
+      const eq = selection.loadoutIds.includes(c.instanceId) ? "  [EQUIPPED]" : "";
+      log(`  [${i + 1}] ${c.instanceId}  ${c.name} [${c.rarity}] ${c.decayState} ×${c.usesRemaining}${eq}`);
+    });
+  },
+});
+
+registerCommand({ verb: "equip", execute(args) { const id = resolveInstanceId(args[0]); if (id) equipCard(id); } });
+registerCommand({ verb: "unequip", execute(args) { const id = resolveInstanceId(args[0]); if (id) unequipCard(id); } });
+registerCommand({ verb: "carry", execute(args) { setWithdraw(parseInt(args[0], 10) || 0); } });
+
+registerCommand({
+  verb: "targets",
+  execute() {
+    const { targets } = getHub();
+    log("AVAILABLE TARGETS:");
+    targets.forEach((t) => log(`  ${t.id}  —  ${t.label}  (threat ${t.spec.threat} / wealth ${t.spec.wealth})`));
+    log("Use: launch <id>");
+  },
+});
+
+registerCommand({
+  verb: "launch",
+  execute(args) {
+    if (!args[0]) { log("Usage: launch <targetId>  (see: targets)", "error"); return; }
+    launchTarget(args[0]);
+  },
+});
+
+registerCommand({ verb: "discard-disclosed", execute() { discardDisclosed(); } });
+
+// Make darknet/buy context-aware: at the hub they spend bank into inventory; in a
+// run they keep their original WAN-gated behavior. Capture the core commands and
+// delegate to them when not at the hub (the documented registry-override hook).
+const coreDarknet = getCommand("darknet");
+const coreBuy = getCommand("buy");
+
+registerCommand({
+  verb: "darknet",
+  complete: coreDarknet?.complete ?? null,
+  execute(args) {
+    if (isHubContext()) { listHubCatalog(); return; }
+    coreDarknet?.execute?.(args);
+  },
+});
+
+registerCommand({
+  verb: "buy",
+  complete: coreBuy?.complete ?? null,
+  execute(args) {
+    if (isHubContext()) {
+      if (!args[0]) { log("Usage: buy <index>", "error"); return; }
+      const n = parseInt(args[0], 10);
+      const key = !isNaN(n) && String(n) === args[0] ? n : args[0];
+      hubBuy(key);
+      return;
+    }
+    coreBuy?.execute?.(args);
+  },
+});

--- a/js/ui/hub.js
+++ b/js/ui/hub.js
@@ -1,0 +1,213 @@
+// @ts-nocheck — DOM wiring.
+// Overworld hub controller. Holds the in-progress launch selection (loadout +
+// carried cash) in module scope so BOTH input channels — the <starnet-hub> GUI
+// component and the console hub commands — drive the same state and produce the
+// same log output (the GUI/console symmetry principle). The pure profile model is
+// in js/core/profile; the run-start path is run-control.js.
+
+import { loadProfile, saveProfile, prepareLaunch } from "./profile-store.js";
+import { generateTargets, removeDisclosedCards } from "../core/profile/index.js";
+import { buyFromStoreToProfile } from "../core/store-logic.js";
+import { getStoreCatalog } from "../core/exploits.js";
+import { startRun } from "./run-control.js";
+import { buildNetwork as buildGenerated } from "../../data/networks/generated.js";
+import { emitEvent, E } from "../core/events.js";
+
+const MAX_LOADOUT = 5;
+
+/** @type {{ loadoutIds: string[], withdrawAmount: number }} */
+let selection = { loadoutIds: [], withdrawAmount: 0 };
+/** @type {import('../core/profile/targets.js').HubTarget[]} */
+let targets = [];
+/** True while the darknet store modal is open from the hub (for console context). */
+let hubStoreOpen = false;
+
+function hubEl() {
+  return document.getElementById("overworld-hub");
+}
+
+function log(text, type = "meta") {
+  emitEvent(E.LOG_ENTRY, { text, type });
+}
+
+/** Push current profile + selection into the component for rendering. */
+function refresh() {
+  const el = hubEl();
+  if (!el) return;
+  const p = loadProfile();
+  el.bank = p.bank;
+  el.inventory = p.inventory;
+  el.loadout = [...selection.loadoutIds];
+  el.withdrawAmount = selection.withdrawAmount;
+  el.targets = targets;
+}
+
+/** Attach component → controller event wiring once, at app init. */
+export function initHub() {
+  const el = hubEl();
+  if (!el) return;
+  el.addEventListener("loadout-toggle", (e) => toggleCard(e.detail.instanceId));
+  el.addEventListener("withdraw-change", (e) => setWithdraw(e.detail.amount));
+  el.addEventListener("launch", (e) => launchTarget(e.detail.targetId));
+  el.addEventListener("discard-disclosed", () => discardDisclosed());
+  el.addEventListener("visit-darknet", () => openHubDarknet());
+  el.addEventListener("close", () => { el.open = false; });
+}
+
+/** Show the hub and sync it, without disturbing the in-progress selection or targets. */
+function showHub() {
+  const el = hubEl();
+  if (!el) return;
+  refresh();
+  el.open = true;
+}
+
+/** Enter the hub fresh: roll a new target list, reset the selection, show it. */
+export function openHub() {
+  const p = loadProfile();
+  p._hubVisits = (p._hubVisits ?? 0) + 1;
+  saveProfile(p);
+  targets = generateTargets(p);
+  selection = { loadoutIds: [], withdrawAmount: 0 };
+  showHub();
+  log(`[HUB] Overworld hub — bank ¥${p.bank.toLocaleString()}, ${p.inventory.length} exploits in inventory.`);
+}
+
+// ── Operations (shared by GUI events and console commands) ───────────────────
+
+export function equipCard(instanceId) {
+  const p = loadProfile();
+  const card = p.inventory.find((c) => c.instanceId === instanceId);
+  if (!card) { log(`[HUB] No such exploit: ${instanceId}`, "error"); return; }
+  if (selection.loadoutIds.includes(instanceId)) return;
+  if (selection.loadoutIds.length >= MAX_LOADOUT) {
+    log(`[HUB] Loadout full (${MAX_LOADOUT}). Unequip something first.`, "error");
+    return;
+  }
+  selection.loadoutIds.push(instanceId);
+  log(`[HUB] Equipped ${card.name} (${selection.loadoutIds.length}/${MAX_LOADOUT}).`);
+  refresh();
+}
+
+export function unequipCard(instanceId) {
+  const before = selection.loadoutIds.length;
+  selection.loadoutIds = selection.loadoutIds.filter((id) => id !== instanceId);
+  if (selection.loadoutIds.length !== before) {
+    log(`[HUB] Unequipped (${selection.loadoutIds.length}/${MAX_LOADOUT}).`);
+    refresh();
+  }
+}
+
+export function toggleCard(instanceId) {
+  if (selection.loadoutIds.includes(instanceId)) unequipCard(instanceId);
+  else equipCard(instanceId);
+}
+
+export function setWithdraw(amount) {
+  const p = loadProfile();
+  const clamped = Math.max(0, Math.min(Number(amount) || 0, p.bank));
+  selection.withdrawAmount = clamped;
+  log(`[HUB] Carrying ¥${clamped.toLocaleString()} into the run.`);
+  refresh();
+}
+
+/** Start a run against the given target with the current loadout + carried cash. */
+export function launchTarget(targetId) {
+  const target = targets.find((t) => t.id === targetId);
+  if (!target) { log(`[HUB] No such target: ${targetId}`, "error"); return; }
+  const launchMeta = prepareLaunch({
+    loadoutInstanceIds: selection.loadoutIds,
+    withdrawAmount: selection.withdrawAmount,
+  });
+  if (!launchMeta) { log("[HUB] Insufficient bank for that carry amount.", "error"); return; }
+  const result = buildGenerated({ seed: target.seed, spec: target.spec });
+  const el = hubEl();
+  if (el) el.open = false;
+  log(`[HUB] Jacking into ${target.label}…`, "success");
+  startRun({ graphDef: result.graphDef, meta: { ...result.meta, ...launchMeta } });
+}
+
+/** Read-only snapshot for console listing. */
+export function getHub() {
+  const p = loadProfile();
+  return { bank: p.bank, inventory: p.inventory, targets, selection };
+}
+
+/** Discard all disclosed (burned, unplayable) exploits from inventory. */
+export function discardDisclosed() {
+  const profile = loadProfile();
+  const removed = removeDisclosedCards(profile);
+  if (!removed.length) { log("[HUB] No disclosed exploits to discard."); return; }
+  const removedIds = new Set(removed.map((c) => c.instanceId));
+  selection.loadoutIds = selection.loadoutIds.filter((id) => !removedIds.has(id));
+  saveProfile(profile);
+  refresh();
+  log(`[HUB] Discarded ${removed.length} disclosed exploit${removed.length === 1 ? "" : "s"}.`);
+}
+
+/** True when the player is at the hub (or its darknet store) rather than in a run. */
+export function isHubContext() {
+  return Boolean(hubEl()?.open) || hubStoreOpen;
+}
+
+/**
+ * Open the darknet broker from the hub. Reuses the in-run store modal, but spends
+ * bank cash and delivers to the persistent inventory. Hides the hub while shopping.
+ */
+export function openHubDarknet() {
+  const storeEl = /** @type {any} */ (document.getElementById("darknet-store"));
+  if (!storeEl || storeEl.open) return;
+  hubStoreOpen = true;
+
+  // Pop over the hub (left visible behind) and mark it as the overworld broker so
+  // it reads distinctly from an in-run LAN session — see #darknet-store.from-hub.
+  const profile = loadProfile();
+  storeEl.classList.add("from-hub");
+  storeEl.subtitle = "OVERWORLD — spending bank, delivering to inventory";
+  storeEl.catalog = getStoreCatalog();
+  storeEl.cash = profile.bank;
+  storeEl.open = true;
+  log("[DARKNET] Broker online — spending bank, delivering to inventory.");
+
+  const onBuy = (evt) => {
+    if (hubBuy(evt.detail.index)) {
+      const p = loadProfile();
+      storeEl.cash = p.bank;
+      storeEl.catalog = getStoreCatalog();
+    }
+  };
+  const onClose = () => {
+    storeEl.open = false;
+    storeEl.classList.remove("from-hub");
+    storeEl.subtitle = "";
+    storeEl.removeEventListener("buy", onBuy);
+    storeEl.removeEventListener("close", onClose);
+    hubStoreOpen = false;
+    refresh(); // the hub stayed open behind; just sync the updated bank/inventory
+  };
+  storeEl.addEventListener("buy", onBuy);
+  storeEl.addEventListener("close", onClose);
+}
+
+/** Buy an exploit from the broker into the persistent inventory (spends bank). */
+export function hubBuy(indexOrVulnId) {
+  const profile = loadProfile();
+  const result = buyFromStoreToProfile(profile, indexOrVulnId);
+  if (!result) { log("[DARKNET] Purchase failed — insufficient bank or unknown item.", "error"); return null; }
+  saveProfile(profile);
+  log(`[DARKNET] Bought ${result.card.name} for ¥${result.price.toLocaleString()} → inventory.`, "success");
+  refresh();
+  return result;
+}
+
+/** Console: list the broker catalog and bank balance (hub context). */
+export function listHubCatalog() {
+  const p = loadProfile();
+  log("DARKNET BROKER (hub) — spending bank, buying to inventory");
+  log(`Bank: ¥${p.bank.toLocaleString()}`);
+  getStoreCatalog().forEach((item, i) => {
+    const afford = p.bank >= item.price ? "" : "  [INSUFFICIENT BANK]";
+    log(`  [${i + 1}] ${item.name}  [${item.rarity}]  ${item.vulnId}  ¥${item.price}${afford}`);
+  });
+  log("Use: buy <index>");
+}

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -1,7 +1,7 @@
 // @ts-nocheck — main.js is DOM event wiring; CustomEvent.detail typing noise outweighs benefit here.
-import { initGraph, getCy, addIceNode, fitGraph, syncInitialNodes } from "./graph.js";
-import { initGame, getState } from "../core/state.js";
-import { startIce, handleIceTick, handleIceDetect } from "../core/ice.js";
+import { initGraph } from "./graph.js";
+import { getState } from "../core/state.js";
+import { handleIceTick, handleIceDetect } from "../core/ice.js";
 import { initConsole, runCommand } from "./console.js";
 import { on, emitEvent, E } from "../core/events.js";
 import { tick, TICK_MS, TIMER, getVisibleTimers, pauseTimers, resumeTimers } from "../core/timers.js";
@@ -12,6 +12,11 @@ import { buildActionContext, initActionDispatcher, buildNodeClickHandler } from 
 import { openDarknetsStore } from "./store.js";
 import { initGraphBridge } from "../core/graph-bridge.js";
 import { initDynamicActions } from "../core/console-commands/dynamic-actions.js";
+import { initRng } from "../core/rng.js";
+import { toCytoscapeFormat } from "./run-control.js";
+import { openHub, initHub } from "./hub.js";
+import { initProfileRunCommit } from "./profile-store.js";
+import "./hub-commands.js";
 
 import { buildNetwork as buildCorporateFoothold } from "../../data/networks/corporate-foothold.js";
 import { buildNetwork as buildResearchStation } from "../../data/networks/research-station.js";
@@ -49,49 +54,35 @@ function getSelectedNetwork() {
   return NETWORKS[name] ?? buildCorporateFoothold;
 }
 
-/**
- * Convert a graph network definition to the format initGraph (Cytoscape) expects.
- * @param {{ graphDef: { nodes: any[], edges: [string,string][] }, meta: any }} result
- */
-function toCytoscapeFormat(result) {
-  const { graphDef, meta } = result;
-  return {
-    nodes: graphDef.nodes.map(n => ({
-      id: n.id,
-      type: n.type,
-      label: n.attributes?.label ?? n.id,
-      grade: n.attributes?.grade ?? "D",
-    })),
-    edges: graphDef.edges.map(([a, b]) => ({ source: a, target: b })),
-    startNode: meta.startNode,
-    startCash: meta.startCash,
-    moneyCost: meta.moneyCost,
-    ice: meta.ice,
-  };
-}
-
-/** Module-scope so run-again can reuse it. */
+/** Module-scope: the default network builder, used to seed the empty graph at boot. */
 const buildNetworkFn = getSelectedNetwork();
 
 function init() {
-  const networkResult = buildNetworkFn();
-  const cytoscapeNetwork = toCytoscapeFormat(networkResult);
+  // Initialize the RNG streams up front. Previously initGame did this at boot, but
+  // now boot opens the hub first, and the hub bootstraps a fresh profile (generating
+  // a starter exploit hand) before any run — so the RNG must be ready beforehand.
+  // Each run's initGame re-seeds per its own seed afterward.
+  initRng();
+
+  // Build the cytoscape instance once from a default topology. The board starts
+  // empty; the hub launches the first (and every) run via run-control's startRun,
+  // which resets the graph to the chosen target's topology.
+  const cytoscapeNetwork = toCytoscapeFormat(buildNetworkFn());
 
   initLogRenderer();
-  const cy = initGraph(cytoscapeNetwork, buildNodeClickHandler(), () => {
+  initGraph(cytoscapeNetwork, buildNodeClickHandler(), () => {
     emitEvent("starnet:action", { actionId: "untarget" });
   });
   initConsole();
   initVisualRenderer();  // must subscribe before initGame fires STATE_CHANGED
-  initGame(() => networkResult, undefined, { openDarknetsStore });
   initGraphBridge();
   initDynamicActions();
-  syncInitialNodes(getState().nodes);
-  fitGraph(cy);
-  addIceNode();  // after layout — ICE polygon shape crashes cola bounding box calc
-  startIce();
+  initProfileRunCommit();  // wire RUN_ENDED → commit results back to the profile
+  initHub();               // wire the hub component's events to the controller
+
   let prevVisibleCount = 0;
   setInterval(() => {
+    if (!getState()) return;  // no active run yet (player is in the hub at boot)
     tick(1);
     const count = getVisibleTimers().length;
     // Emit on the falling edge to zero too, so timer-driven UI (e.g. the sidebar
@@ -152,16 +143,15 @@ function init() {
   on(TIMER.TRACE_TICK,   () => handleTraceTick());
   // Probe, exploit, read, loot, reboot timers removed — timed-action operator drives these
 
-  // Run-again: from end screen component (custom event) or legacy event bus
-  const runAgainHandler = () => {
-    initGame(() => buildNetworkFn(), undefined, { openDarknetsStore });
-    const cy = getCy();
-    if (cy) fitGraph(cy);
-    addIceNode();
-    startIce();
-  };
-  on("starnet:action:run-again", runAgainHandler);
-  document.getElementById("end-screen")?.addEventListener("run-again", runAgainHandler);
+  // End-screen button / legacy run-again event → return to the hub, where the
+  // player re-equips and launches the next target. (The RUN_ENDED commit to the
+  // profile has already run by this point.)
+  const returnToHub = () => openHub();
+  on("starnet:action:run-again", returnToHub);
+  document.getElementById("end-screen")?.addEventListener("run-again", returnToHub);
+
+  // Boot into the hub — the player launches the first run from there.
+  openHub();
 }
 
 document.addEventListener("DOMContentLoaded", init);

--- a/js/ui/profile-store.js
+++ b/js/ui/profile-store.js
@@ -1,0 +1,132 @@
+// @ts-check
+// Browser binding for the persistent player profile: localStorage load/save and
+// new-profile bootstrap. The pure model lives in js/core/profile.
+//
+// (Phase 2 adds launchRun + the RUN_ENDED commit subscriber to this module.)
+
+import {
+  createProfile,
+  addCardToInventory,
+  buildRunHand,
+  commitRun,
+  withdraw,
+  findCard,
+  PROFILE_VERSION,
+} from "../core/profile/index.js";
+import { generateStartingHand } from "../core/exploits.js";
+import { on, E } from "../core/events.js";
+import { getState } from "../core/state.js";
+
+/** @typedef {import('../core/types.js').StarnetProfile} StarnetProfile */
+
+const PROFILE_KEY = "starnet:profile";
+const DEFAULT_BANK = 1000; // matches initGame's startCash fallback
+
+/**
+ * Load the profile from localStorage, or bootstrap a new one if absent/corrupt.
+ * @returns {StarnetProfile}
+ */
+export function loadProfile() {
+  const raw = localStorage.getItem(PROFILE_KEY);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") return normalizeProfile(parsed);
+    } catch {
+      // unparseable payload — fall through and re-bootstrap
+    }
+  }
+  return bootstrapProfile();
+}
+
+/**
+ * Repair a parsed profile to the current shape, filling missing/invalid fields so
+ * an older or partially-written payload can't crash the hub downstream. Mutates
+ * and returns the object.
+ * @param {any} p
+ * @returns {StarnetProfile}
+ */
+function normalizeProfile(p) {
+  if (typeof p.bank !== "number") p.bank = 0;
+  if (!Array.isArray(p.inventory)) p.inventory = [];
+  if (typeof p._hubVisits !== "number") p._hubVisits = 0;
+  if (typeof p.version !== "number") p.version = PROFILE_VERSION;
+  // Derive _instanceSeq above any existing inv-N id so future auto-ids don't collide.
+  let seq = typeof p._instanceSeq === "number" ? p._instanceSeq : 0;
+  for (const c of p.inventory) {
+    const m = c && typeof c.instanceId === "string" ? /^inv-(\d+)$/.exec(c.instanceId) : null;
+    if (m) seq = Math.max(seq, Number(m[1]) + 1);
+  }
+  p._instanceSeq = seq;
+  return p;
+}
+
+/**
+ * Persist the profile to localStorage.
+ * @param {StarnetProfile} profile
+ */
+export function saveProfile(profile) {
+  localStorage.setItem(PROFILE_KEY, JSON.stringify(profile));
+}
+
+/**
+ * Create and persist a starter profile: a default bank plus a generated starter
+ * inventory (each card banked so it gets an instanceId).
+ * @returns {StarnetProfile}
+ */
+function bootstrapProfile() {
+  const p = createProfile({ bank: DEFAULT_BANK });
+  generateStartingHand().forEach((c) => addCardToInventory(p, c));
+  saveProfile(p);
+  return p;
+}
+
+// ── Run launch + commit ──────────────────────────────────────────────────────
+
+/** @type {{ carriedInstanceIds: string[] } | null} Carried set for the in-flight run. */
+let activeRun = null;
+
+/**
+ * Prepare a run launch from the profile: withdraw the carried cash, clone the
+ * chosen loadout, and record the carried set so the run can be committed when it
+ * ends. Returns the meta additions (startHandCards + startCash) for the caller to
+ * merge into the network meta and start via startRun(); returns null if the bank
+ * can't cover the carried cash. The DOM/graph side stays in the UI layer (hub.js).
+ * @param {{ loadoutInstanceIds: string[], withdrawAmount: number }} args
+ * @returns {{ startHandCards: import('../core/types.js').ExploitCard[], startCash: number } | null}
+ */
+export function prepareLaunch({ loadoutInstanceIds, withdrawAmount }) {
+  const profile = loadProfile();
+  if (!withdraw(profile, withdrawAmount)) return null;
+  const loadout = loadoutInstanceIds
+    .map((id) => findCard(profile, id))
+    .filter(/** @returns {c is import('../core/types.js').ExploitCard} */ (c) => Boolean(c));
+  saveProfile(profile); // bank debited at launch
+  activeRun = { carriedInstanceIds: loadout.map((c) => /** @type {string} */ (c.instanceId)) };
+  return { startHandCards: buildRunHand(loadout), startCash: withdrawAmount };
+}
+
+let _commitWired = false;
+
+/**
+ * Wire the run-end → profile commit (call once at app init). On RUN_ENDED:
+ * success deposits run cash and writes card decay back; capture burns the carried
+ * loadout. Reads the final cash/hand from live game state.
+ */
+export function initProfileRunCommit() {
+  if (_commitWired) return;
+  _commitWired = true;
+  on(E.RUN_ENDED, ({ outcome }) => {
+    if (!activeRun) return;
+    const s = getState();
+    const profile = loadProfile();
+    commitRun(profile, {
+      outcome,
+      finalCash: s.player.cash, // already 0 on "caught" — endRun zeroes it
+      finalHand: s.player.hand,
+      carriedInstanceIds: activeRun.carriedInstanceIds,
+    });
+    saveProfile(profile);
+    activeRun = null;
+  });
+}

--- a/js/ui/run-control.js
+++ b/js/ui/run-control.js
@@ -1,0 +1,51 @@
+// @ts-nocheck — DOM/graph wiring; cy typing noise outweighs benefit here.
+// The single in-place run-start path, shared by first boot, run-again, and the
+// hub launch. Extracted from main.js so hub.js can start runs without a circular
+// import on main.js.
+
+import { resetGraph, syncInitialNodes, getCy, fitGraph, addIceNode } from "./graph.js";
+import { initGame, getState } from "../core/state.js";
+import { startIce } from "../core/ice.js";
+import { openDarknetsStore } from "./store.js";
+
+/**
+ * Convert a graph network definition to the format initGraph (Cytoscape) expects.
+ * @param {{ graphDef: { nodes: any[], edges: [string,string][] }, meta: any }} result
+ */
+export function toCytoscapeFormat(result) {
+  const { graphDef, meta } = result;
+  return {
+    nodes: graphDef.nodes.map((n) => ({
+      id: n.id,
+      type: n.type,
+      label: n.attributes?.label ?? n.id,
+      grade: n.attributes?.grade ?? "D",
+    })),
+    edges: graphDef.edges.map(([a, b]) => ({ source: a, target: b })),
+    startNode: meta.startNode,
+    startCash: meta.startCash,
+    moneyCost: meta.moneyCost,
+    ice: meta.ice,
+  };
+}
+
+/**
+ * Start (or restart) a run in place.
+ *
+ * Order matters. initGame fires NODE_STATE_CHANGED events while constructing the
+ * NodeGraph (setting vulns/macguffins on every node). On a re-init the global
+ * `state` still points at the *previous* run during that window, so visual-renderer
+ * would re-add the previous run's revealed nodes to the board. So: initGame first,
+ * THEN resetGraph (wipes both the old board and any stale re-adds), THEN rebuild
+ * the board from the authoritative new state via syncInitialNodes (Phase 3a root cause).
+ * @param {{ graphDef: any, meta: any }} networkResult
+ */
+export function startRun(networkResult) {
+  initGame(() => networkResult, undefined, { openDarknetsStore });
+  resetGraph(toCytoscapeFormat(networkResult));
+  syncInitialNodes(getState().nodes);
+  const cy = getCy();
+  if (cy) fitGraph(cy);
+  addIceNode();  // after layout — ICE polygon shape crashes cola bounding box calc
+  startIce();
+}

--- a/tests/profile-commit.test.js
+++ b/tests/profile-commit.test.js
@@ -1,0 +1,124 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { initGame, getState } from "../js/core/state.js";
+import { clearHandlers } from "../js/core/events.js";
+import { buildNetwork as buildCorporateFoothold } from "../data/networks/corporate-foothold.js";
+import {
+  createProfile,
+  buildRunHand,
+  commitRun,
+  findCard,
+} from "../js/core/profile/index.js";
+
+afterEach(() => clearHandlers());
+
+/** Minimal ExploitCard-shaped object (seed-independent). */
+function card(id, over = {}) {
+  return {
+    id,
+    name: `card-${id}`,
+    rarity: "common",
+    quality: 1,
+    targetVulnTypes: ["card"],
+    decayState: "fresh",
+    usesRemaining: 3,
+    ...over,
+  };
+}
+
+describe("buildRunHand", () => {
+  it("clones loadout cards (new objects) while preserving instanceId", () => {
+    const p = createProfile({ inventory: [card("a")] });
+    const [src] = p.inventory;
+    const [clone] = buildRunHand([src]);
+    assert.notEqual(clone, src, "is a distinct object");
+    assert.equal(clone.instanceId, src.instanceId, "keeps instanceId for write-back");
+    assert.notEqual(clone.targetVulnTypes, src.targetVulnTypes, "deep-copies the vuln array");
+    clone.usesRemaining = 0;
+    assert.equal(src.usesRemaining, 3, "mutating the clone does not touch the inventory card");
+  });
+});
+
+describe("commitRun — success", () => {
+  it("deposits run cash to the bank", () => {
+    const p = createProfile({ bank: 100, inventory: [card("a")] });
+    commitRun(p, { outcome: "success", finalCash: 500, finalHand: [], carriedInstanceIds: [] });
+    assert.equal(p.bank, 600);
+  });
+
+  it("writes a carried card's decay back to the same inventory instance", () => {
+    const p = createProfile({ bank: 0, inventory: [card("a")] });
+    const src = p.inventory[0];
+    const [run] = buildRunHand([src]);
+    run.usesRemaining = 1;
+    run.decayState = "worn";
+    commitRun(p, {
+      outcome: "success",
+      finalCash: 0,
+      finalHand: [run],
+      carriedInstanceIds: [src.instanceId],
+    });
+    const updated = findCard(p, src.instanceId);
+    assert.equal(updated.usesRemaining, 1);
+    assert.equal(updated.decayState, "worn");
+    assert.equal(p.inventory.length, 1, "no duplicate added");
+  });
+
+  it("adds a mid-run-acquired card (no instanceId) to inventory", () => {
+    const p = createProfile({ bank: 0, inventory: [card("a")] });
+    const carried = buildRunHand(p.inventory);
+    const bought = card("bought"); // no instanceId — simulates store/mine acquisition
+    commitRun(p, {
+      outcome: "success",
+      finalCash: 0,
+      finalHand: [...carried, bought],
+      carriedInstanceIds: p.inventory.map((c) => c.instanceId),
+    });
+    assert.equal(p.inventory.length, 2);
+    const added = p.inventory.find((c) => c.id === "bought");
+    assert.ok(added && added.instanceId, "new card got an instanceId");
+  });
+});
+
+describe("commitRun — caught (Medium stakes)", () => {
+  it("burns the carried loadout, deposits nothing, leaves un-carried inventory and bank intact", () => {
+    const p = createProfile({ bank: 250, inventory: [card("a"), card("b")] });
+    const carriedId = p.inventory[0].instanceId;
+    commitRun(p, {
+      outcome: "caught",
+      finalCash: 0,
+      finalHand: [],
+      carriedInstanceIds: [carriedId],
+    });
+    assert.equal(p.bank, 250, "bank unchanged on capture");
+    assert.equal(p.inventory.length, 1, "carried card burned");
+    assert.equal(p.inventory[0].id, "b", "un-carried card survives");
+  });
+});
+
+describe("initGame loadout path", () => {
+  it("uses meta.startHandCards (as fresh clones) when present", () => {
+    const loadout = [card("x", { instanceId: "inv-x" }), card("y", { instanceId: "inv-y" })];
+    initGame(() => {
+      const r = buildCorporateFoothold();
+      return { graphDef: r.graphDef, meta: { ...r.meta, startHandCards: loadout } };
+    }, "loadout-seed-1");
+    const hand = getState().player.hand;
+    assert.deepEqual(
+      hand.map((c) => c.instanceId),
+      ["inv-x", "inv-y"],
+      "hand carries the provided loadout (by instanceId)",
+    );
+    // Clones, not aliases: mutating the run hand must not touch the caller's cards.
+    assert.notEqual(hand[0], loadout[0], "hand card is a distinct object");
+    hand[0].usesRemaining = 0;
+    assert.notEqual(loadout[0].usesRemaining, 0, "loadout source is untouched by in-run mutation");
+  });
+
+  it("falls back to generating a hand when startHandCards is absent", () => {
+    initGame(() => buildCorporateFoothold(), "loadout-seed-2");
+    const hand = getState().player.hand;
+    assert.ok(hand.length > 0);
+    assert.ok(hand.every((c) => c.instanceId === undefined), "generated cards have no instanceId");
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first slice of the **overworld meta-state**: a persistent player profile (cash **bank** + exploit-card **inventory**) that lives outside the single-run `GameState`, and an **overworld hub** the game boots into and returns to between runs. Runs are launched from a chosen loadout + carried cash, and their results commit back to the profile when the run ends.

This is the foundation the larger overworld arc hangs off — see `docs/VISION-dual-mode-and-standings.md` for where it's headed (standings, storylets, an overworld map). Those are explicitly **out of scope** here.

## The loop

Boot → **hub** (bank, exploit inventory, a short target list) → equip a loadout (≤5) + set carried cash → **launch** a target → play the run → jack out → results **commit** → back to the hub.

**Medium stakes:** a clean jack-out banks your cash and returns the loadout (worn by use); getting **traced** forfeits the run's cash *and burns the carried loadout* — your bank and un-carried inventory are safe.

## What's included

- **Profile model** (`js/core/profile/`) + a localStorage binding (`js/ui/profile-store.js`) + new-profile bootstrap. Cards get a stable `instanceId` on entering inventory (also leaves the door open for a future "ICE burns an exploit mid-run" mechanic).
- **Run launch + commit:** `initGame` gains a backwards-compatible `meta.startHandCards` path (headless entry points are unaffected — they still generate from the rarity spec); `commitRun` deposits cash, writes card decay back, absorbs mid-run-acquired cards on success, and burns the carried loadout on capture.
- **Fixed "run again,"** which reset core state but never the graph view. Root cause ran deeper than a missing reset: `initGame` emits `NODE_STATE_CHANGED` *during* `NodeGraph` construction while the global `state` still points at the prior run, so `visual-renderer` re-added the prior run's nodes. Fixed with a unified `startRun` (`js/ui/run-control.js`) ordered `initGame → resetGraph → syncInitialNodes`, shared by first boot, run-again, and the hub launch.
- **The hub:** `<starnet-hub>` modal, deterministic target list, boot→hub flow, and full console parity (`hub`, `inventory`, `equip`, `unequip`, `carry`, `targets`, `launch`).
- **Hub tools:** discard disclosed (burned) exploits; visit the darknet broker from the hub — it spends **bank** and delivers to **inventory**, and pops over the hub with a distinct accent so it doesn't read like an in-run session. The `darknet`/`buy` console verbs are context-aware (hub vs. in-run) without breaking the in-run store.

## Verification

- `make check` green — **819 tests** (including new unit tests for the profile model, `commitRun`, target generation, and the profile-targeted store buy).
- Verified end-to-end in a browser (Playwright): boot → hub → equip (GUI + console) → launch → loadout/cash applied → jack out → commit → return to hub; the run-again fix; both hub tools; the darknet popover; and that in-run `darknet`/`buy` still delegate to the core WAN-gated path. No console errors.
- Rebased onto current `main` (atop the `ice-reinvention` and `exploit-legibility` merges) and re-verified.

## Notes / follow-ups

- Session artifacts: `docs/dev-sessions/2026-06-10-1516-overworld-meta-state/` (`spec.md`, `plan.md`, `research.md`, `notes.md`).
- `notes.md` logs two pre-existing items found along the way: `CLAUDE.md` is stale in spots (file-structure section; bot-census flags), and the latent "`initGame` emits against stale `state` during construction" fragility (handled for the graph here; worth a future cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
