### PR TITLE
Health + deck loss clocks: damaging ICE made real (#133)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -413,7 +413,8 @@ In addition to the trace, you have two resource pools that start each run at 100
   Fiction: the deck's OS is corrupted past recovery.
 
 Both are shown in the HUD as color-ramping meters (green → yellow → red). They appear in
-`status` and `status full`. Damage events are logged: e.g. `neural feedback: −20 HEALTH (80 left)`.
+`status` and `status full`. Damage events are logged with the offending node, e.g.
+`[ICE] gateway neural feedback: −20 HEALTH (80 left)` or `[ICE] router-2 deck corruption: −20 DECK (80 left)`.
 
 These are **parallel loss conditions** alongside the trace. A successful jack-out ends in
 `success`; a trace that hits zero ends in `caught`; HEALTH depletion ends in `burned`; DECK
@@ -521,7 +522,8 @@ The practical implication: **which ICE you face determines which clock you're ra
 network with patrol ICE puts pressure on your trace timer. A network with a Sentinel puts
 pressure on your HEALTH. A Spike pursues your deck. A run can end without the trace ever
 reaching red — if Sentinel or Spike detects you enough times. (There is one ICE entity per
-run; its type is set at spawn.)
+run; its type is rolled at spawn. At B+ that roll is weighted — a patrol ICE can still turn
+up — so a high-threat run doesn't guarantee a damaging type.)
 
 Counters are the same regardless of ICE type: untarget, eject, or reboot.
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -61,7 +61,7 @@ every ICE movement that crosses into your territory appears here.
 **Console** — Type commands directly. Tab-complete node names. Full command reference
 at the end of this manual.
 
-**HUD** — Top bar shows global alert level and your current cash balance.
+**HUD** — Top bar shows global alert level, your current cash balance, and your two resource meters: **HEALTH** and **DECK INTEGRITY**. Both ramp from green through yellow to red as they deplete.
 
 **Seed** — Each run is generated from a seed string, shown in the status display.
 Sharing a seed lets someone else play the same network layout, vulnerabilities,
@@ -400,6 +400,26 @@ your tether is traced back to your home node — run over, score lost.
 To stop it: **jack out** before zero, or **own the security monitor** and use the
 `cancel-trace` action.
 
+### HEALTH and DECK INTEGRITY
+
+In addition to the trace, you have two resource pools that start each run at 100:
+
+- **HEALTH** — Your neural integrity. Certain ICE deal direct damage here instead of raising the
+  alert. Depleting HEALTH to zero ends the run immediately — outcome: **burned** (end screen:
+  "FLATLINED"). Fiction: neural feedback, brain injury.
+
+- **DECK INTEGRITY** — Your hardware's operating condition. Other ICE target this pool directly.
+  Depleting DECK INTEGRITY to zero ends the run — outcome: **bricked** (end screen: "DECK FRIED").
+  Fiction: the deck's OS is corrupted past recovery.
+
+Both are shown in the HUD as color-ramping meters (green → yellow → red). They appear in
+`status` and `status full`. Damage events are logged: e.g. `neural feedback: −20 HEALTH (80 left)`.
+
+These are **parallel loss conditions** alongside the trace. A successful jack-out ends in
+`success`; a trace that hits zero ends in `caught`; HEALTH depletion ends in `burned`; DECK
+INTEGRITY depletion ends in `bricked`. You can lose any of the three ways without the others
+being a factor.
+
 ### Subverting the IDS
 
 If you can compromise and then **corrupt** an IDS node:
@@ -484,6 +504,27 @@ your node and returns, the dwell timer resets and another detection cycle begins
 ICE on a node you've untargeted continues its movement pattern but cannot detect you
 unless you target that node again.
 
+### ICE Types
+
+All ICE share the same grade-based movement and detection mechanics, but their **effect on
+detection** varies. Classic patrol ICE raises the global alert when it locks your signal —
+advancing the trace. Two additional ICE types appear at threat grade B or better, and they
+attack a different clock entirely:
+
+| Type        | Available at | Detection effect                                      |
+|-------------|--------------|-------------------------------------------------------|
+| **Patrol**  | All grades   | Detection raises global alert → advances the trace    |
+| **Sentinel**| B and above  | Detection deals **−20 HEALTH**; does NOT raise alert  |
+| **Spike**   | B and above  | Detection deals **−20 DECK INTEGRITY**; does NOT raise alert |
+
+The practical implication: **which ICE you face determines which clock you're racing.** A
+network with patrol ICE puts pressure on your trace timer. A network with a Sentinel puts
+pressure on your HEALTH. A Spike pursues your deck. A run can end without the trace ever
+reaching red — if Sentinel or Spike detects you enough times. (There is one ICE entity per
+run; its type is set at spawn.)
+
+Counters are the same regardless of ICE type: untarget, eject, or reboot.
+
 ---
 
 ## MISSION
@@ -544,8 +585,8 @@ jackout                End run.
 darknet                List darknet broker catalog (requires WAN targeted).
 buy <index>            Purchase exploit card from broker (requires WAN targeted).
 
-status                 Summary status (alias: status summary)
-status full            Complete state dump
+status                 Summary status — alert, wallet, HEALTH, DECK INTEGRITY, ICE, hand (alias: status summary)
+status full            Complete state dump — includes HEALTH and DECK INTEGRITY
 status ice             ICE grade, position (if visible), detection timer
 status hand            Exploit hand with match indicators
 status alert           Global alert, trace countdown, security node states

--- a/css/style.css
+++ b/css/style.css
@@ -1266,8 +1266,9 @@ html, body {
 /* Preview-harness toggle: disable the menace pulse. */
 #ice-overlay.ice-pulse-off .ice-cage { animation: none; }
 
-/* HUD resource meters (health / deck integrity) */
-.hud-meter {
+/* HUD resource meters (health / deck integrity) — scoped to #hud to match the
+   other HUD rules. */
+#hud .hud-meter {
   position: relative;
   display: inline-block;
   width: 64px;
@@ -1276,13 +1277,13 @@ html, body {
   vertical-align: middle;
   overflow: hidden;
 }
-.hud-meter-fill {
+#hud .hud-meter-fill {
   position: absolute;
   inset: 0 auto 0 0;
   opacity: 0.35;
   transition: width 0.3s ease;
 }
-.hud-meter-text {
+#hud .hud-meter-text {
   position: absolute;
   inset: 0;
   display: flex;

--- a/css/style.css
+++ b/css/style.css
@@ -1271,6 +1271,7 @@ html, body {
 #hud .hud-meter {
   position: relative;
   display: inline-block;
+  flex: 0 0 auto; /* the HUD is a flex row — don't let the meter shrink below 64px */
   width: 64px;
   height: 12px;
   border: 1px solid var(--cyan);

--- a/css/style.css
+++ b/css/style.css
@@ -1265,3 +1265,28 @@ html, body {
 }
 /* Preview-harness toggle: disable the menace pulse. */
 #ice-overlay.ice-pulse-off .ice-cage { animation: none; }
+
+/* HUD resource meters (health / deck integrity) */
+.hud-meter {
+  position: relative;
+  display: inline-block;
+  width: 64px;
+  height: 12px;
+  border: 1px solid var(--cyan);
+  vertical-align: middle;
+  overflow: hidden;
+}
+.hud-meter-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  opacity: 0.35;
+  transition: width 0.3s ease;
+}
+.hud-meter-text {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7em;
+}

--- a/docs/dev-sessions/2026-06-10-1626-health-deck-damage/notes.md
+++ b/docs/dev-sessions/2026-06-10-1626-health-deck-damage/notes.md
@@ -83,4 +83,10 @@ serving the *main* checkout — had to serve the worktree on :3101 to see the re
   for MVP).
 - **Bloom-driven-by-deck-integrity** (the `setBloomIntensity` seam on `main`) belongs to
   the #134 plasma visual pass, not #133.
+- **`status ice` reports `detections: 0` for damaging ICE.** `detectionCount` is only
+  incremented inside `recordIceDetection`, which Sentinel/Spike never call (they don't
+  raise alert). It's really the *trace* counter, so 0 is arguably correct — but a Sentinel
+  that has hit the player several times still shows 0 detections, which reads oddly. The
+  HEALTH/DECK pools + damage log carry the real signal. Tiny fix if it bothers anyone:
+  increment a separate per-instance hit counter in `applyIceEffects`.
 - **#134 (plasma overlay)** reads the now-live `health` pool — unblocked.

--- a/docs/dev-sessions/2026-06-10-1626-health-deck-damage/notes.md
+++ b/docs/dev-sessions/2026-06-10-1626-health-deck-damage/notes.md
@@ -1,0 +1,86 @@
+# Notes — Health + Deck loss clocks (#133)
+
+## Summary
+
+Made the player **HEALTH** and **DECK INTEGRITY** pools real in play. ICE-reinvention
+session 1 had already shipped the data layer (the pools, clamped mutators, the
+`burned`/`bricked` run-end wrappers, and the `damage-health`/`damage-deck` effect atoms)
+— but nothing fired the atoms in a live tick, no ICE dealt damage, and the pools were
+invisible. This session wired the effect dispatch at the detection trigger, added two
+damaging ICE presets, made the pools spawn-selectable, and surfaced them in the HUD,
+`status`, the log, and the end screen.
+
+Branch `worktree-health-deck-damage` off `main`, in a worktree. `make check` green
+throughout (793 tests, lint clean).
+
+## What shipped (10 tasks, TDD, subagent-driven)
+
+1. **Atoms register in the live app** — `ice/effects.js`/`triggers.js` were imported only
+   by tests; added side-effect imports to `ice/index.js`. (Prerequisite discovered during
+   planning — without it the registry is empty at runtime.)
+2. **Sentinel + Spike presets** + pure `pickIceTypeId(grade, roll)` (reuses canonical
+   `GRADE_INDEX`). Sentinel = `damage-health 20`, Spike = `damage-deck 20`, **neither
+   raises alert**.
+3. **Effect dispatch at detection** — `triggerDetection` now sets the detection lock and
+   calls `applyIceEffects`, which applies the instance type's `effects[]` via a ctx
+   (`raise-alert` → `recordIceDetection`; `damage-*` → `player-orchestration` wrappers),
+   emits `ICE_ACTIVATED`/`ICE_EFFECT_APPLIED`, and logs damage readouts. Classic ICE
+   behavior is provably unchanged (regression test + existing snapshot test green).
+4. **Registry-driven typed spawn** — replaced hardcoded `standard-ice`; the single ICE's
+   type is rolled at spawn (weighted, B+). Spawn also derives `behaviorPattern`/`focus`
+   from the registry type so the serialized instance is honest.
+5. **HUD meters** — HEALTH/DECK color-ramping meters (green→yellow→red).
+6. **`status` lines** — HEALTH/DECK in `status` summary + full.
+7. **End-screen** — `burned` → "FLATLINED", `bricked` → "DECK FRIED" (cash zeroed).
+8. **Harness** — `ICE_EFFECT_APPLIED` surfaced in `scripts/playtest.js`.
+9. **MANUAL.md** — loss clocks, Sentinel/Spike, outcomes, `status`.
+10. **Verification** — `make check`, bot census, browser smoke.
+
+## Key design decision: alert-raise is an orthogonal effect type
+
+At Les's call, alert-raising is **not** auto-bundled onto damaging ICE. The three loss
+vectors are independent: classic ICE pursue the **trace**, Sentinel pursues **health**,
+Spike pursues the **deck**. Consequence (intentional): on a Sentinel/Spike run, ICE no
+longer feeds the trace clock — trace pressure there comes only from exploit-failure IDS
+detections. Which ICE you face changes which clock you're racing.
+
+## Tuning values (as shipped — all easily adjustable)
+
+- Pools: **100 / 100**. Damage per detection: **20** (≈5 detections to deplete).
+- Sentinel/Spike gated to threat **B+**; at B+ the roll is classic 50% / sentinel 25% /
+  spike 25%. Below B, always classic.
+
+## Census finding — the mechanic is currently very gentle under bot play
+
+`node scripts/bot/census.js --seeds 20 --threat B`: 30% success, **all 14 failures are
+trace-driven, zero burned/bricked**, avg **0.4** ICE detections/run. The bot evades
+detection so well that damaging ICE almost never lands a hit, and 5 hits are needed to
+deplete a pool. At threat D (no ICE spawns at all — provably identical to baseline) the
+no-ICE path is unchanged.
+
+**No difficulty regression** (classic path test-proven identical; damaging path only
+*removes* alert pressure + adds rare damage). But the mechanic barely bites in automated
+play. Follow-up tuning options if we want it to matter: lower pools, higher per-hit
+damage, or repeat/cooldown damage on sustained dwell. Deferred — #133 was "make it real,"
+and it is; balancing its teeth is a separate pass (do it by hand or extend the bot to
+react to health, per the mine-balance precedent).
+
+## Browser smoke caught a real bug
+
+The HUD meters collapsed to **2px** because the header is a flex row and the
+`inline-block` meter had default `flex-shrink:1`. Fixed with `flex: 0 0 auto`. Verified
+afterward: 64px width, HEALTH 12 → red @12%, DECK 50 → yellow @50%; end-screen titles
+correct for all four outcomes. (Gotcha for next time: a stale `make serve` on :3000 was
+serving the *main* checkout — had to serve the worktree on :3101 to see the real build.)
+
+## Follow-ups / known caveats
+
+- **Stale `state` to multi-effect atoms**: `applyIceEffects` passes the pre-effect `state`
+  snapshot to every atom in a list; the loop's phase-break guard re-reads live state, and
+  current damage atoms ignore `state`, so it's harmless today. A future atom that reads
+  `state.player.*` to compute a value would see stale data — re-read inside the loop then.
+- **Biome-biasing** the type roll is a deferred seam in `pickIceTypeId` (grade-gating only
+  for MVP).
+- **Bloom-driven-by-deck-integrity** (the `setBloomIntensity` seam on `main`) belongs to
+  the #134 plasma visual pass, not #133.
+- **#134 (plasma overlay)** reads the now-live `health` pool — unblocked.

--- a/docs/dev-sessions/2026-06-10-1626-health-deck-damage/plan.md
+++ b/docs/dev-sessions/2026-06-10-1626-health-deck-damage/plan.md
@@ -1,0 +1,927 @@
+# Health + Deck Loss Clocks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the already-built `health` / `deckIntegrity` pools real in play — ICE
+effects fire on detection, two damaging presets (Sentinel/Spike) can spawn, and the
+pools are visible in HUD, `status`, and the log.
+
+**Architecture:** Wire a bounded slice of the ICE-reinvention §8 dispatcher at the
+*detection trigger*: `triggerDetection()` resolves the detecting instance's type and
+applies its `effects[]` via atoms, with a ctx that routes `raise-alert` to the existing
+alert path and `damage-*` to the `player-orchestration` wrappers (which already end the
+run on depletion). Alert-raise is one orthogonal effect type among three (alert / health
+/ deck); damaging presets carry no `raise-alert`, so they attack their own clock.
+
+**Tech Stack:** Vanilla ES modules, `node:test`, JSDoc `@ts-check`, Lit components.
+Run tests with `make test`; lint with `make lint`; both with `make check`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `js/core/ice/index.js` | ICE module public surface | **Modify** — side-effect import of `effects.js` + `triggers.js` so atoms register in the live app |
+| `js/core/ice/registry.js` | ICE type catalog | **Modify** — add `sentinel` + `spike` presets and a pure `pickIceTypeId(grade, roll)` |
+| `js/core/ice/runtime.js` | per-tick movement + detection | **Modify** — dispatch effects in `triggerDetection`; new `applyIceEffects()` |
+| `js/core/state/index.js` | initial state + ICE spawn | **Modify** — typed spawn via `pickIceTypeId` |
+| `js/ui/components/starnet-hud.js` | header bar | **Modify** — health/deck meters |
+| `js/ui/visual-renderer.js` | state→component bridge | **Modify** — push health/deck props to HUD |
+| `js/ui/components/starnet-end-screen.js` | game-over overlay | **Modify** — `burned`/`bricked` outcomes |
+| `js/core/console-commands/cmd-status.js` | `status` text | **Modify** — HEALTH/DECK lines |
+| `css/style.css` | styles | **Modify** — meter styles |
+| `scripts/playtest.js` | headless harness | **Modify** — log `ICE_EFFECT_APPLIED` |
+| `MANUAL.md` | canonical behavior | **Modify** — document the new mechanic |
+| `js/core/ice/registry.test.js` | (new) | **Create** — preset + picker tests |
+| `js/core/ice/dispatch.test.js` | (new) | **Create** — detection→effect integration tests |
+
+---
+
+## Task 1: Register ICE atoms in the live path
+
+The atom bodies live in `ice/effects.js` / `ice/triggers.js`, which are imported **only**
+by `atoms.test.js`. In the running app `EFFECT_ATOMS` is empty, so dispatch would always
+hit the fallback. Importing them from `ice/index.js` (the public surface) fixes this for
+every live consumer.
+
+**Files:**
+- Modify: `js/core/ice/index.js`
+- Test: `js/core/ice/index.test.js` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `js/core/ice/index.test.js`:
+
+```js
+// @ts-check
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// Importing the public surface MUST register the atom bodies as a side effect.
+import { getEffect, getTrigger, getType } from "./index.js";
+
+describe("ice/index registers atoms + types on import", () => {
+  it("damage-health / damage-deck / raise-alert atoms are live", () => {
+    assert.ok(getEffect("damage-health"), "damage-health must be registered");
+    assert.ok(getEffect("damage-deck"), "damage-deck must be registered");
+    assert.ok(getEffect("raise-alert"), "raise-alert must be registered");
+  });
+
+  it("on-dwell-grade trigger is live", () => {
+    assert.ok(getTrigger("on-dwell-grade"));
+  });
+
+  it("classic presets are registered", () => {
+    assert.ok(getType("patrol-classic-B"));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test js/core/ice/index.test.js`
+Expected: FAIL — `getEffect("damage-health")` is `null` (atoms never imported).
+
+- [ ] **Step 3: Add side-effect imports to `ice/index.js`**
+
+At the top of `js/core/ice/index.js`, immediately under the header comment, add:
+
+```js
+// Register atom bodies + trigger bodies as a side effect of loading the ICE
+// module. Without these imports EFFECT_ATOMS / TRIGGER_ATOMS are empty in the
+// live app (only the test suite imported them before).
+import "./effects.js";
+import "./triggers.js";
+```
+
+(Leave the existing `export { ... } from "./atoms.js"` / `"./registry.js"` re-exports as-is.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test js/core/ice/index.test.js`
+Expected: PASS (5 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/core/ice/index.js js/core/ice/index.test.js
+git commit -m 'feat(ice): register effect/trigger atoms in the live ICE module'
+```
+
+---
+
+## Task 2: Sentinel + Spike presets and a type picker
+
+**Files:**
+- Modify: `js/core/ice/registry.js`
+- Test: `js/core/ice/registry.test.js` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `js/core/ice/registry.test.js`:
+
+```js
+// @ts-check
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { getType, pickIceTypeId } from "./registry.js";
+
+describe("damaging presets", () => {
+  it("sentinel carries a damage-health effect and no raise-alert", () => {
+    const t = getType("sentinel");
+    assert.ok(t);
+    const atoms = t.effects.map((e) => e.atom);
+    assert.ok(atoms.includes("damage-health"));
+    assert.ok(!atoms.includes("raise-alert"));
+    const dmg = t.effects.find((e) => e.atom === "damage-health");
+    assert.equal(dmg.params.amount, 20);
+  });
+
+  it("spike carries a damage-deck effect and no raise-alert", () => {
+    const t = getType("spike");
+    assert.ok(t);
+    const atoms = t.effects.map((e) => e.atom);
+    assert.ok(atoms.includes("damage-deck"));
+    assert.ok(!atoms.includes("raise-alert"));
+    assert.equal(t.effects.find((e) => e.atom === "damage-deck").params.amount, 20);
+  });
+});
+
+describe("pickIceTypeId", () => {
+  it("below B: always classic, regardless of roll", () => {
+    assert.equal(pickIceTypeId("C", 0.0), "patrol-classic-C");
+    assert.equal(pickIceTypeId("D", 0.99), "patrol-classic-D");
+    assert.equal(pickIceTypeId("F", 0.6), "patrol-classic-F");
+  });
+
+  it("B+: roll partitions classic / sentinel / spike", () => {
+    assert.equal(pickIceTypeId("B", 0.10), "patrol-classic-B"); // < 0.5 → classic
+    assert.equal(pickIceTypeId("A", 0.60), "sentinel");          // [0.5, 0.75) → sentinel
+    assert.equal(pickIceTypeId("S", 0.90), "spike");             // >= 0.75 → spike
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test js/core/ice/registry.test.js`
+Expected: FAIL — `getType("sentinel")` is `null`, `pickIceTypeId` is not exported.
+
+- [ ] **Step 3: Add presets + picker to `registry.js`**
+
+Append to `js/core/ice/registry.js` (after the `for (const grade ...)` classic loop):
+
+```js
+// Session: health-deck-damage. Damaging presets — grade-agnostic (instance
+// grade is set at spawn). Alert-raise is intentionally NOT bundled: these ICE
+// attack the health / deck clocks, not the trace clock.
+registerType({
+  typeId: "sentinel",
+  focus: "roaming",
+  behaviorPattern: "disturbance-tracker",
+  triggers: ["on-dwell-grade"],
+  effects: [{ atom: "damage-health", params: { amount: 20 } }],
+});
+
+registerType({
+  typeId: "spike",
+  focus: "roaming",
+  behaviorPattern: "disturbance-tracker",
+  triggers: ["on-dwell-grade"],
+  effects: [{ atom: "damage-deck", params: { amount: 20 } }],
+});
+
+const GRADE_NUM = { F: 1, D: 2, C: 3, B: 4, A: 5, S: 6 };
+
+/**
+ * Pick the ICE type id for a spawned instance. Damaging presets only appear at
+ * threat B+; below that the network's single ICE stays classic (alert-only).
+ * Pure: `roll` is a float in [0, 1) supplied by the caller's seeded stream.
+ * (Biome-biasing is a deferred tuning seam — grade gating only for the MVP.)
+ * @param {string} grade
+ * @param {number} roll
+ * @returns {string}
+ */
+export function pickIceTypeId(grade, roll) {
+  if ((GRADE_NUM[grade] ?? 1) < 4) return `patrol-classic-${grade}`;
+  if (roll < 0.5) return `patrol-classic-${grade}`;
+  if (roll < 0.75) return "sentinel";
+  return "spike";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test js/core/ice/registry.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/core/ice/registry.js js/core/ice/registry.test.js
+git commit -m 'feat(ice): sentinel + spike damaging presets and pickIceTypeId'
+```
+
+---
+
+## Task 3: Wire effect dispatch at the detection trigger
+
+`triggerDetection()` currently calls `recordIceDetection()` directly. Replace that with:
+always set the detection lock, then apply the instance type's `effects[]`. `raise-alert`
+routes back to `recordIceDetection` (so classic ICE step alert / start trace exactly as
+today); `damage-*` route to the orchestration wrappers; each damage application logs and
+emits `ICE_EFFECT_APPLIED`.
+
+**Files:**
+- Modify: `js/core/ice/runtime.js`
+- Test: `js/core/ice/dispatch.test.js` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `js/core/ice/dispatch.test.js`:
+
+```js
+// @ts-check
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// corporate-exchange spawns an ICE instance (meta.ice grade "B").
+import { buildNetwork as buildCorporateExchange } from "../../../data/networks/corporate-exchange.js";
+import { initGame, getState } from "../state.js";
+import { setSelectedNode } from "../state/game.js";
+import { clearAll } from "../timers.js";
+import { on, off, E } from "../events.js";
+import { handleIceDetect } from "./runtime.js";
+
+function withEvents(type, fn) {
+  const captured = [];
+  const h = (p) => captured.push(p);
+  on(type, h);
+  fn();
+  off(type, h);
+  return captured;
+}
+
+beforeEach(() => {
+  clearAll();
+  // initGame(buildNetworkFn, seedString, opts). meta.ice comes from the builder.
+  initGame(() => buildCorporateExchange(), "dispatch-test");
+});
+
+// Helper: force the single spawned ICE instance to a given type, co-located with
+// the player. (Overriding typeId directly bypasses the spawn roll — this test is
+// about dispatch, independent of Task 4. State mutation here is test setup only.)
+function placeIce(typeId) {
+  const s = getState();
+  const ice = Object.values(s.ice.instances)[0];
+  ice.typeId = typeId;
+  const node = ice.attentionNodeId;
+  setSelectedNode(node);
+  return { ice, node };
+}
+
+describe("detection effect dispatch", () => {
+  it("sentinel detection reduces health and emits ICE_EFFECT_APPLIED", () => {
+    const { node } = placeIce("sentinel");
+    const before = getState().player.health.current;
+    const applied = withEvents(E.ICE_EFFECT_APPLIED, () => handleIceDetect({ nodeId: node }));
+    assert.equal(getState().player.health.current, before - 20);
+    assert.ok(applied.some((p) => p.effect === "damage-health"));
+  });
+
+  it("spike detection reduces deck integrity", () => {
+    const { node } = placeIce("spike");
+    const before = getState().player.deckIntegrity.current;
+    handleIceDetect({ nodeId: node });
+    assert.equal(getState().player.deckIntegrity.current, before - 20);
+  });
+
+  it("sentinel detection does NOT step the global alert (no raise-alert)", () => {
+    const { node } = placeIce("sentinel");
+    const alertBefore = getState().globalAlert;
+    handleIceDetect({ nodeId: node });
+    assert.equal(getState().globalAlert, alertBefore);
+  });
+
+  it("classic detection still raises the global alert (regression)", () => {
+    const { node } = placeIce("patrol-classic-B");
+    const raised = withEvents(E.ALERT_GLOBAL_RAISED, () => handleIceDetect({ nodeId: node }));
+    assert.ok(raised.length >= 1, "classic ICE must still step alert");
+    assert.equal(getState().player.health.current, 100, "classic ICE deals no damage");
+  });
+
+  it("damage emits a LOG_ENTRY readout", () => {
+    const { node } = placeIce("sentinel");
+    const logged = withEvents(E.LOG_ENTRY, () => handleIceDetect({ nodeId: node }));
+    assert.ok(logged.some((p) => /HEALTH/.test(p.text)));
+  });
+});
+```
+
+> Verified: `setSelectedNode` is exported from `js/core/state/game.js`; `initGame` is
+> `(buildNetworkFn, seedString, opts)`; `corporate-exchange` yields `meta.ice` at grade B.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test js/core/ice/dispatch.test.js`
+Expected: FAIL — sentinel currently steps alert and deals no damage (dispatch not wired).
+
+- [ ] **Step 3: Implement dispatch in `runtime.js`**
+
+Add imports near the top of `js/core/ice/runtime.js` (with the existing imports):
+
+```js
+import { getType, getEffect } from "./index.js";
+import { damagePlayerHealth, damagePlayerDeck } from "../player-orchestration.js";
+```
+
+Replace the existing `triggerDetection` function (lines ~233-241) with:
+
+```js
+function triggerDetection(nodeId) {
+  const s = getState();
+  const ice = getPrimaryIce();
+  emitEvent(E.ICE_DETECTED, { iceId: ice?.id ?? null, nodeId, label: s.nodes[nodeId]?.label ?? nodeId });
+  if (!ice) return;
+  // Detection lock — applies to ALL ICE regardless of effects, so the same node
+  // doesn't re-detect until the player moves. (recordIceDetection also sets this
+  // for classic ICE; idempotent.)
+  setIceDetectedAt(nodeId);
+  applyIceEffects(ice, s, nodeId);
+}
+
+/**
+ * Apply the detecting instance type's effect atoms. raise-alert routes through
+ * the existing alert/trace path (recordIceDetection); damage atoms route through
+ * the player-orchestration wrappers (which end the run on depletion) and log a
+ * readout. Untyped/legacy instances fall back to raise-alert — preserving
+ * pre-dispatch behavior for fixtures like 'standard-ice'.
+ */
+function applyIceEffects(ice, state, nodeId) {
+  const type = getType(ice.typeId);
+  const effects = type?.effects ?? [{ atom: "raise-alert", params: {} }];
+  const ctx = {
+    propagateAlertEvent: (nid) => recordIceDetection(nid),
+    damagePlayerHealth,
+    damagePlayerDeck,
+  };
+  emitEvent(E.ICE_ACTIVATED, { iceId: ice.id, trigger: "on-dwell-grade", hostNodeId: ice.attentionNodeId });
+  for (const eff of effects) {
+    const atom = getEffect(eff.atom);
+    if (!atom) continue;
+    atom.apply(ice, state, ctx, eff.params ?? {});
+    logIceEffect(ice, eff, nodeId);
+    emitEvent(E.ICE_EFFECT_APPLIED, { iceId: ice.id, effect: eff.atom, result: { ...(eff.params ?? {}) } });
+    // Stop if a depletion ended the run mid-list (single-effect presets won't hit this).
+    if (getState().phase !== "playing") break;
+  }
+}
+
+/** Emit a log readout for damage effects (raise-alert is logged by the alert layer). */
+function logIceEffect(ice, eff, nodeId) {
+  const s = getState();
+  const label = (s.nodes[nodeId]?.label ?? nodeId);
+  if (eff.atom === "damage-health") {
+    const h = s.player.health;
+    const dead = h.current === 0;
+    emitEvent(E.LOG_ENTRY, {
+      text: `${dead ? "!! " : ""}[ICE] ${label} neural feedback: −${eff.params.amount} HEALTH (${h.current} left)`,
+      type: dead ? "error" : "warning",
+    });
+  } else if (eff.atom === "damage-deck") {
+    const d = s.player.deckIntegrity;
+    const dead = d.current === 0;
+    emitEvent(E.LOG_ENTRY, {
+      text: `${dead ? "!! " : ""}[ICE] ${label} deck corruption: −${eff.params.amount} DECK (${d.current} left)`,
+      type: dead ? "error" : "warning",
+    });
+  }
+}
+```
+
+(Leave `recordIceDetection` in `alert.js` unchanged — `raise-alert` calls it via the ctx.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test js/core/ice/dispatch.test.js`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run the full suite to catch regressions**
+
+Run: `make test`
+Expected: all pass, including the existing `Snapshot: ICE detection at player node`
+(the `standard-ice` fixture exercises the raise-alert fallback).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add js/core/ice/runtime.js js/core/ice/dispatch.test.js
+git commit -m 'feat(ice): apply effect atoms on detection — health/deck damage live'
+```
+
+---
+
+## Task 4: Typed ICE spawn
+
+Replace the hardcoded `typeId: 'standard-ice'` with a registry pick so damaging presets
+can spawn. The weighted roll uses the seeded WORLD stream; an explicit `meta.ice.typeId`
+(tests / cheats) overrides it.
+
+**Files:**
+- Modify: `js/core/state/index.js`
+- Test: `js/core/state/index.test.js` (add a case if the file exists; otherwise create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `js/core/state/spawn.test.js`:
+
+```js
+// @ts-check
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildNetwork as buildCorporateExchange } from "../../../data/networks/corporate-exchange.js"; // meta.ice grade B
+import { buildNetwork as buildCorporateFoothold } from "../../../data/networks/corporate-foothold.js"; // meta.ice grade C
+import { initGame, getState } from "../state.js";
+import { getType } from "../ice/index.js";
+import { clearAll } from "../timers.js";
+
+beforeEach(() => clearAll());
+
+describe("typed ICE spawn", () => {
+  it("spawned ICE has a registry-resolvable typeId (not legacy 'standard-ice')", () => {
+    initGame(() => buildCorporateExchange(), "spawn-1");
+    const ice = Object.values(getState().ice.instances)[0];
+    assert.notEqual(ice.typeId, "standard-ice");
+    assert.ok(getType(ice.typeId), `typeId ${ice.typeId} must resolve in the registry`);
+    assert.match(ice.typeId, /^(patrol-classic-B|sentinel|spike)$/);
+  });
+
+  it("below B, the spawn stays classic", () => {
+    initGame(() => buildCorporateFoothold(), "spawn-2"); // grade C
+    const ice = Object.values(getState().ice.instances)[0];
+    assert.equal(ice.typeId, "patrol-classic-C");
+  });
+});
+```
+
+> The explicit-override branch (`meta.ice.typeId ?? pickIceTypeId(...)`) is covered by
+> reading + Task 2's picker unit tests; no network builder sets `meta.ice.typeId`, and
+> `initGame` doesn't accept it (it comes from the builder), so there's no integration
+> path to assert it without a bespoke fixture — not worth one for a trivial `??`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test js/core/state/spawn.test.js`
+Expected: FAIL — `ice.typeId === "standard-ice"`.
+
+- [ ] **Step 3: Implement typed spawn**
+
+In `js/core/state/index.js`, add the import (with the other imports at the top):
+
+```js
+import { pickIceTypeId } from "../ice/registry.js";
+import { random } from "../rng.js";
+```
+
+Replace the ICE spawn block (lines ~187-210). Change the `typeId` and `behaviorPattern`
+lines so:
+
+```js
+  // Spawn ICE if defined in meta
+  if (meta.ice) {
+    const nodeIds = Object.keys(nodes);
+    const hostNodeId = meta.ice.startNode ?? randomPick(RNG.WORLD, nodeIds);
+    const id = 'ice-1';
+    const grade = meta.ice.grade;
+    // Registry-driven type: damaging presets (sentinel/spike) appear at B+.
+    // An explicit meta.ice.typeId (cheats/tests) overrides the seeded roll.
+    const typeId = meta.ice.typeId ?? pickIceTypeId(grade, random(RNG.WORLD));
+    /** @type {import('../types.js').IceInstance} */
+    const primary = {
+      id,
+      typeId,
+      hostNodeId,
+      residentNodeId: hostNodeId, // deprecated, kept for migration; remove when callers stop reading it
+      attentionNodeId: hostNodeId,
+      active: true,
+      enabled: true,
+      grade,
+      focus: 'roaming',
+      behaviorPattern: 'standard',
+      dwellTimerId: null,
+      detectedAtNode: null,
+      detectionCount: 0,
+    };
+    state.ice = { instances: { [id]: primary } };
+  } else {
+    state.ice = { instances: {} };
+  }
+```
+
+(`behaviorPattern: 'standard'` is retained — movement keys off `grade`, not the pattern,
+so it's cosmetic this session. Movement-by-pattern is a later reinvention task.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test js/core/state/spawn.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Run full suite**
+
+Run: `make test`
+Expected: all pass. (The `standard-ice` fixture is a saved snapshot, not a fresh spawn,
+so it is unaffected.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add js/core/state/index.js js/core/state/spawn.test.js
+git commit -m 'feat(ice): registry-driven typed ICE spawn (sentinel/spike at B+)'
+```
+
+---
+
+## Task 5: HUD health + deck meters
+
+No Lit component unit-test harness exists, so this task is **verified in the browser**.
+
+**Files:**
+- Modify: `js/ui/components/starnet-hud.js`
+- Modify: `js/ui/visual-renderer.js`
+- Modify: `css/style.css`
+
+- [ ] **Step 1: Add properties + defaults to `starnet-hud.js`**
+
+In `static properties`, after `paused`:
+
+```js
+    health: { type: Number },
+    healthMax: { type: Number },
+    deck: { type: Number },
+    deckMax: { type: Number },
+```
+
+In the constructor, after `this.paused = false;`:
+
+```js
+    this.health = 100;
+    this.healthMax = 100;
+    this.deck = 100;
+    this.deckMax = 100;
+```
+
+- [ ] **Step 2: Render the meters**
+
+In `render()`, immediately after the WALLET `<span>` block (after line ~69) and before
+the trace block, insert:
+
+```js
+      ${this._meter("HEALTH", this.health, this.healthMax)}
+      ${this._meter("DECK", this.deck, this.deckMax)}
+```
+
+Add this method to the class (above `render()`):
+
+```js
+  _meter(label, current, max) {
+    const frac = max > 0 ? current / max : 0;
+    const color = frac > 0.6 ? "var(--green)" : frac > 0.3 ? "var(--yellow)" : "var(--red)";
+    return html`
+      <span class="hud-label">${label}:</span>
+      <span class="hud-meter" title="${current}/${max}">
+        <span class="hud-meter-fill" style="width:${Math.round(frac * 100)}%;background:${color}"></span>
+        <span class="hud-meter-text" style="color:${color}">${current}</span>
+      </span>
+    `;
+  }
+```
+
+- [ ] **Step 3: Push props from `visual-renderer.js`**
+
+In `syncHud(state)` (after `hudEl.phase = state.phase;`, ~line 350):
+
+```js
+    hudEl.health = state.player.health.current;
+    hudEl.healthMax = state.player.health.max;
+    hudEl.deck = state.player.deckIntegrity.current;
+    hudEl.deckMax = state.player.deckIntegrity.max;
+```
+
+- [ ] **Step 4: Add meter styles to `css/style.css`**
+
+Append:
+
+```css
+/* HUD resource meters (health / deck integrity) */
+.hud-meter {
+  position: relative;
+  display: inline-block;
+  width: 64px;
+  height: 12px;
+  border: 1px solid var(--cyan);
+  vertical-align: middle;
+  overflow: hidden;
+}
+.hud-meter-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  opacity: 0.35;
+  transition: width 0.3s ease;
+}
+.hud-meter-text {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7em;
+}
+```
+
+- [ ] **Step 5: Verify in the browser**
+
+Run: `make bundle-vendor` (if `dist/` is stale), then `make serve`.
+Open `http://localhost:3000`, start a run, and confirm HEALTH/DECK meters render in the
+header at 100. Then (fastest path) drive damage from the harness or a cheat and reload to
+confirm the meter shrinks and recolors. Screenshot for the notes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add js/ui/components/starnet-hud.js js/ui/visual-renderer.js css/style.css
+git commit -m 'feat(ui): HUD health + deck meters'
+```
+
+---
+
+## Task 6: `status` health/deck lines (HUD-parity for the console)
+
+**Files:**
+- Modify: `js/core/console-commands/cmd-status.js`
+- Test: `js/core/console-commands/cmd-status.test.js` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `js/core/console-commands/cmd-status.test.js`:
+
+```js
+// @ts-check
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildNetwork as buildCorporateFoothold } from "../../../data/networks/corporate-foothold.js";
+import { initGame } from "../state.js";
+import { clearAll } from "../timers.js";
+import { on, off, E } from "../events.js";
+import { cmdStatusSummary, cmdStatusFull } from "./cmd-status.js";
+
+function logs(fn) {
+  const captured = [];
+  const h = (p) => captured.push(p);
+  on(E.LOG_ENTRY, h);
+  fn();
+  off(E.LOG_ENTRY, h);
+  return captured;
+}
+
+beforeEach(() => {
+  clearAll();
+  initGame(() => buildCorporateFoothold(), "status-test");
+});
+
+describe("status shows resource pools", () => {
+  it("summary includes HEALTH and DECK", () => {
+    const out = logs(() => cmdStatusSummary()).map((p) => p.text).join("\n");
+    assert.match(out, /HEALTH/);
+    assert.match(out, /DECK/);
+    assert.match(out, /100/);
+  });
+
+  it("full includes health and deck", () => {
+    const out = logs(() => cmdStatusFull()).map((p) => p.text).join("\n");
+    assert.match(out, /health/i);
+    assert.match(out, /deck/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test js/core/console-commands/cmd-status.test.js`
+Expected: FAIL — no HEALTH/DECK in output.
+
+- [ ] **Step 3: Add the summary line**
+
+In `cmd-status.js` `cmdStatusSummary()`, after the Seed/Alert/Cash/Trace push (line ~19):
+
+```js
+  const h = s.player.health, d = s.player.deckIntegrity;
+  lines.push(`  HEALTH: ${h.current}/${h.max}  |  DECK: ${d.current}/${d.max}`);
+```
+
+- [ ] **Step 4: Add the full-status lines**
+
+In `cmdStatusFull()`, under `### PLAYER`, after the `- cash:` push (line ~94):
+
+```js
+  lines.push(`- health: ${s.player.health.current}/${s.player.health.max}`);
+  lines.push(`- deck integrity: ${s.player.deckIntegrity.current}/${s.player.deckIntegrity.max}`);
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `node --test js/core/console-commands/cmd-status.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add js/core/console-commands/cmd-status.js js/core/console-commands/cmd-status.test.js
+git commit -m 'feat(console): show health + deck integrity in status'
+```
+
+---
+
+## Task 7: End-screen `burned` / `bricked` outcomes
+
+`burned`/`bricked` currently fall through to the "RUN COMPLETE" branch. Treat them as
+failures (distinct title, zeroed-style cash) alongside `caught`.
+
+**Files:**
+- Modify: `js/ui/components/starnet-end-screen.js`
+
+- [ ] **Step 1: Replace the outcome-derived constants in `render()`**
+
+Replace `const caught = this.outcome === "caught";` (line ~52) with:
+
+```js
+    const failed = this.outcome === "caught"
+      || this.outcome === "burned"
+      || this.outcome === "bricked";
+    const title =
+      this.outcome === "caught"  ? "▶ TRACED ◀" :
+      this.outcome === "burned"  ? "▶ FLATLINED ◀" :
+      this.outcome === "bricked" ? "▶ DECK FRIED ◀" :
+                                   "▶ RUN COMPLETE ◀";
+```
+
+- [ ] **Step 2: Use `title` / `failed` in the template**
+
+Change the title line:
+
+```js
+        <div class="end-title">${title}</div>
+```
+
+Change the cash row's class binding from `${caught ? "end-zero" : ""}` to:
+
+```js
+          <span class="end-val ${failed ? "end-zero" : ""}">¥${this.cash.toLocaleString()}</span>
+```
+
+- [ ] **Step 3: Verify in the browser**
+
+Run a run to depletion (cheat or harness drives health/deck to 0), confirm the overlay
+shows FLATLINED / DECK FRIED with the cash styled as zero. (No unit-test harness for Lit
+components — verify visually; screenshot for notes.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add js/ui/components/starnet-end-screen.js
+git commit -m 'feat(ui): end-screen copy for burned / bricked outcomes'
+```
+
+---
+
+## Task 8: Headless-harness legibility for `ICE_EFFECT_APPLIED`
+
+The damage `LOG_ENTRY` already shows in the harness (it captures all log entries). Add the
+semantic `ICE_EFFECT_APPLIED` to the harness's printed event stream for completeness.
+
+**Files:**
+- Modify: `scripts/playtest.js`
+
+- [ ] **Step 1: Subscribe + format**
+
+In the event-subscription block of `scripts/playtest.js` (near the other `on(E.*)`
+handlers, ~line 214), add:
+
+```js
+  on(E.ICE_EFFECT_APPLIED, ({ iceId, effect, result }) =>
+    out(`[ICE] ${iceId} effect: ${effect}${result?.amount != null ? ` (${result.amount})` : ""}`));
+```
+
+If `E.ICE_EFFECT_APPLIED` is not already in the events-of-interest array (~lines 165-170),
+add it there too so JSON mode captures it.
+
+- [ ] **Step 2: Verify manually**
+
+```bash
+node scripts/playtest.js --seed dispatch-test reset
+node scripts/playtest.js "status"   # confirm HEALTH/DECK line prints
+```
+
+Expected: `status` prints a `HEALTH: 100/100 | DECK: 100/100` line.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/playtest.js
+git commit -m 'chore(playtest): surface ICE_EFFECT_APPLIED in the harness'
+```
+
+---
+
+## Task 9: Update MANUAL.md
+
+**Files:**
+- Modify: `MANUAL.md`
+
+- [ ] **Step 1: Document the mechanic**
+
+Add/extend the relevant sections:
+- **ICE types**: add **Sentinel** (burns HEALTH on detection, raises no alert) and
+  **Spike** (corrupts DECK integrity, raises no alert). Note they appear at threat B+.
+- **Loss clocks**: alongside the trace, the player now has **HEALTH** and **DECK
+  INTEGRITY** pools (start 100). Depleting HEALTH ends the run *flatlined* (`burned`);
+  depleting DECK ends it *bricked*. Note the orthogonality: classic ICE pursue the trace;
+  Sentinel/Spike pursue the health/deck clocks.
+- **Console**: `status` / `status full` now report HEALTH and DECK.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add MANUAL.md
+git commit -m 'docs(manual): health/deck loss clocks + Sentinel/Spike ICE'
+```
+
+---
+
+## Task 10: Full verification + balance check + notes
+
+- [ ] **Step 1: `make check` (lint + full test suite)**
+
+Run: `make check`
+Expected: 0 lint errors; all tests pass (baseline was 775 + new tests).
+
+- [ ] **Step 2: Bot census — confirm no difficulty regression**
+
+Run: `node scripts/bot-census.js --time F --money F --seeds 10`
+Expected: ~80% success (the smoke-test target from CLAUDE.md). Investigate if damaging
+ICE on B+ networks tanks the rate unexpectedly; record the numbers in notes. The bot does
+not track health/deck, so a modest dip on B+ runs is expected and acceptable — note it
+rather than papering over it.
+
+- [ ] **Step 3: End-to-end browser smoke**
+
+`make serve` → start a B+ run, get detected by a Sentinel/Spike (or drive damage), confirm:
+HUD meter drops + recolors, a log line appears, and depletion shows the right end screen.
+
+- [ ] **Step 4: Write the session summary in `notes.md`**
+
+Capture: what shipped, the alert-orthogonality decision, tuning values as shipped, census
+numbers, and any follow-ups (e.g., biome-biasing the type roll; bloom-driven-by-deck in
+#134).
+
+- [ ] **Step 5: Final commit (notes)**
+
+```bash
+git add docs/dev-sessions/2026-06-10-1626-health-deck-damage/notes.md
+git commit -m 'docs: session notes — health/deck loss clocks'
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 dispatch at detection → Task 3 ✓
+- §2 Sentinel/Spike presets + typed spawn → Tasks 2, 4 ✓
+- §2 alert as orthogonal effect (no bundling) → Task 2 presets (no raise-alert) + Task 3
+  dispatch (raise-alert only via classic) ✓; regression asserted in Task 3
+- §3 HUD / status / log visibility → Tasks 5, 6, 3 (log) ✓
+- §4 run-end copy (burned/bricked) → Task 7 ✓
+- atom-registration gap (live import) → Task 1 ✓ (prerequisite discovered during planning)
+- verification (make check, census, MANUAL) → Tasks 9, 10 ✓
+
+**Placeholder scan:** none — every code step shows the code. The signatures the test
+snippets depend on (`initGame(buildNetworkFn, seedString, opts)`, `meta.ice` from the
+builder, `setSelectedNode` in `state/game.js`, `corporate-exchange` = grade B,
+`corporate-foothold` = grade C) were verified against the repo during planning.
+
+**Type consistency:** `pickIceTypeId(grade, roll)` defined in Task 2, called in Task 4 with
+`random(RNG.WORLD)`. ctx methods `propagateAlertEvent` / `damagePlayerHealth` /
+`damagePlayerDeck` (Task 3) match the atom bodies in `ice/effects.js`. HUD props
+`health/healthMax/deck/deckMax` defined in Task 5 and pushed in the same task. Events
+`ICE_ACTIVATED` / `ICE_EFFECT_APPLIED` already exist in `js/core/events.js`.
+
+**Known soft spots (call out, don't hide):**
+- Tasks 5/7 (HUD meters, end-screen) have no unit tests — there is no Lit component test
+  harness in the repo. They are verified in-browser with screenshots saved to notes.
+- Task 4's spawn roll consumes one `RNG.WORLD` draw; its *position* in the WORLD stream
+  relative to other consumers isn't asserted (the test checks resolvability + the grade
+  gate, not an exact rolled type), so it won't go flaky if unrelated WORLD draws shift.

--- a/docs/dev-sessions/2026-06-10-1626-health-deck-damage/spec.md
+++ b/docs/dev-sessions/2026-06-10-1626-health-deck-damage/spec.md
@@ -1,0 +1,120 @@
+# Spec — Health + Deck loss clocks (foundation)
+
+**Issue:** #133 — Player health + deck-integrity pools + damage atoms (loss-clock foundation)
+**Branch:** `worktree-health-deck-damage` (worktree off `main`)
+**Companion follow-on this session:** #134 (plasma hallucination overlay) — designed separately after this lands.
+
+## Problem
+
+ICE-reinvention session 1 (merged in #108) shipped the **data layer** for player
+resource pools, but nothing makes them real in play:
+
+- ✅ `player.health` / `player.deckIntegrity` pools (`{current, max}`, default 100)
+- ✅ Clamped mutators + `player-orchestration` wrappers that end the run:
+  `burned` (health→0) / `bricked` (deck→0). `RunOutcome` already includes both.
+- ✅ `damage-health` / `damage-deck` effect atoms calling `ctx.damagePlayerHealth/Deck`
+- ✅ Unit + orchestration test coverage
+
+What's missing — the half that makes it a real mechanic:
+
+1. **Effects never fire in a live tick.** `triggerDetection()` in `ice/runtime.js`
+   calls `recordIceDetection()` directly and never reads the instance's declared
+   `effects[]` list. The trigger→effect dispatch is unwired; the atoms are decorative.
+2. **No ICE deals damage.** Only the classic per-grade presets exist, all
+   `raise-alert`. Generation spawns exactly one hardcoded `standard-ice` and does
+   not consult the type registry.
+3. **Zero player visibility.** HUD doesn't show the pools, `status` doesn't print
+   them, no log entry on damage. Invisible loss clocks violate the legibility
+   requirements (every event gets a log entry; console must be LLM-legible).
+
+## Scope (this session)
+
+A bounded slice of the reinvention's §8 dispatcher — enough to make health/deck
+real, without building the full pattern-driven movement engine (a later session).
+
+### 1. Effect dispatch at the detection trigger
+
+In `ice/runtime.js` `triggerDetection(nodeId)`:
+
+- Resolve the detecting instance's type via `getType(instance.typeId)`.
+- For each entry in the type's `effects[]`, call
+  `getEffect(atom).apply(instance, state, ctx, params)`.
+- `ctx` exposes:
+  - `propagateAlertEvent(nodeId)` → routes to the existing `recordIceDetection`
+    / IDS path (so `raise-alert` flows through the atom, not a hardcoded call)
+  - `damagePlayerHealth(n)` / `damagePlayerDeck(n)` → the `player-orchestration`
+    wrappers (which already handle burned/bricked run-end)
+- Emit `ICE_ACTIVATED` once and `ICE_EFFECT_APPLIED { iceId, effect, result }`
+  per atom (events already specced in §8).
+- `ICE_DETECTED` (reveal/flavor) still fires **unconditionally** — only the alert
+  *stepping* is gated behind the `raise-alert` atom.
+
+**Behavioral invariant:** classic-preset runs play identically to today (alert
+stepping + trace start unchanged), because their only effect is `raise-alert`
+routed through `propagateAlertEvent`. Bot census on carried-over networks should
+show near-zero regression.
+
+### 2. Two damaging presets + registry-driven typed spawn
+
+Alert-raise is treated as **one orthogonal effect type among three** (alert /
+health / deck) — not auto-bundled onto damaging ICE.
+
+| Preset | `effects` | Fiction | Clock it attacks |
+|---|---|---|---|
+| `patrol-classic-*` (existing) | `[raise-alert]` | surveillance | trace |
+| **Sentinel** | `[damage-health {amount: 20}]` | neural feedback spike — burns the decker | health |
+| **Spike** | `[damage-deck {amount: 20}]` | corrupts deck integrity | deck |
+
+- **Spawn**: replace the hardcoded `typeId: 'standard-ice'` with a registry pick.
+  The single ICE a network spawns is typed by a grade/biome-weighted roll:
+  mostly classic, with Sentinel/Spike appearing at threat **B+** (where ICE
+  already spawns today). The chosen type's `effects` and `grade` flow into the
+  spawned `IceInstance`.
+- **Flat damage amounts.** Grade already controls detection *frequency* via dwell
+  times; no second grade-scaling on amount (avoids double-scaling).
+
+**Consequence (intentional, made conscious):** on a Sentinel/Spike run, ICE no
+longer feeds the trace clock — trace pressure there comes only from
+exploit-failure IDS detections. The typed-ICE roll therefore changes *which clock
+the player is racing*: classic = trace, Sentinel = health, Spike = deck. This is
+a feature; it makes the three loss vectors legible and gives runs distinct texture.
+
+### 3. Visibility (legibility requirements)
+
+- **HUD**: two compact meters in the header alongside trace — `HEALTH` and
+  `DECK` — color-ramping green→yellow→red as they drop. Match the existing
+  trace/alert treatment unless a browser mock surfaces something better.
+- **`status`**: add a `HEALTH n/100  DECK n/100` line to `status summary`; full
+  breakdown in `status full`.
+- **Log**: every `ICE_EFFECT_APPLIED` damage event logs a line, e.g.
+  `SENTINEL — neural feedback: −20 HEALTH (60 left)`. Prominent formatting on the
+  killing blow (the burned/bricked event).
+
+### 4. Run-end
+
+`burned` / `bricked` outcomes already exist in the type + orchestration. Add
+end-screen copy for each, parallel to `caught`.
+
+## Defaults (all tunable; verify via bot census after)
+
+- Pools: **100 / 100**
+- Damage per detection: **20** (≈5 detections to deplete a pool)
+- Sentinel/Spike gated to threat **B+**; classic remains the common case
+- Bloom seam (`setBloomIntensity`, already on `main`): **deferred** — it should be
+  driven by deck integrity, but that wiring is part of #134's visual pass, not #133.
+
+## Non-goals (explicitly deferred)
+
+- Pattern-driven `onTick` / `onTriggerFired` movement engine (later reinvention session)
+- Multi-ICE placement / budgeting (#133 keeps one ICE per network)
+- Textured wounds/debuffs (#103, Layer 2)
+- Deck subsystem inventory + named glitches (#102, Layer 3)
+- The plasma overlay itself (#134 — designed next, same session, separate PR)
+
+## Out-of-scope verification
+
+- `make check` green throughout (start baseline: 775 tests, 0 fail).
+- Bot census after balance changes (`make census`) to confirm the difficulty
+  curve hasn't regressed.
+- MANUAL.md updated: new node/ICE behavior (Sentinel/Spike), the two new loss
+  clocks, the `burned`/`bricked` outcomes, and `status` additions.

--- a/js/core/console-commands/cmd-status.js
+++ b/js/core/console-commands/cmd-status.js
@@ -18,6 +18,9 @@ export function cmdStatusSummary() {
   const traceStr = s.traceSecondsRemaining !== null ? `${s.traceSecondsRemaining}s` : "—";
   lines.push(`  Seed: "${s.seed}"  |  Alert: ${s.globalAlert.toUpperCase()}  |  Cash: ¥${s.player.cash.toLocaleString()}  |  Trace: ${traceStr}`);
 
+  const h = s.player.health, d = s.player.deckIntegrity;
+  lines.push(`  HEALTH: ${h.current}/${h.max}  |  DECK: ${d.current}/${d.max}`);
+
   let iceStr;
   const ice = getPrimaryIce();
   if (!ice) iceStr = "NONE";
@@ -92,6 +95,8 @@ export function cmdStatusFull() {
   lines.push(`### PLAYER`);
   lines.push(`- seed: "${s.seed}"`);
   lines.push(`- cash: ¥${s.player.cash.toLocaleString()}`);
+  lines.push(`- health: ${s.player.health.current}/${s.player.health.max}`);
+  lines.push(`- deck integrity: ${s.player.deckIntegrity.current}/${s.player.deckIntegrity.max}`);
   lines.push(`- ${handDesc}`);
 
   lines.push(`### ALERT`);

--- a/js/core/console-commands/cmd-status.test.js
+++ b/js/core/console-commands/cmd-status.test.js
@@ -25,9 +25,9 @@ beforeEach(() => {
 describe("status shows resource pools", () => {
   it("summary includes HEALTH and DECK", () => {
     const out = logs(() => cmdStatusSummary()).map((p) => p.text).join("\n");
-    assert.match(out, /HEALTH/);
-    assert.match(out, /DECK/);
-    assert.match(out, /100/);
+    // Pin format + value together so the assertion can't pass on a stray "100".
+    assert.match(out, /HEALTH: 100\/100/);
+    assert.match(out, /DECK: 100\/100/);
   });
 
   it("full includes health and deck", () => {

--- a/js/core/console-commands/cmd-status.test.js
+++ b/js/core/console-commands/cmd-status.test.js
@@ -1,0 +1,38 @@
+// @ts-check
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildNetwork as buildCorporateFoothold } from "../../../data/networks/corporate-foothold.js";
+import { initGame } from "../state.js";
+import { clearAll } from "../timers.js";
+import { on, off, E } from "../events.js";
+import { cmdStatusSummary, cmdStatusFull } from "./cmd-status.js";
+
+function logs(fn) {
+  const captured = [];
+  const h = (p) => captured.push(p);
+  on(E.LOG_ENTRY, h);
+  fn();
+  off(E.LOG_ENTRY, h);
+  return captured;
+}
+
+beforeEach(() => {
+  clearAll();
+  initGame(() => buildCorporateFoothold(), "status-test");
+});
+
+describe("status shows resource pools", () => {
+  it("summary includes HEALTH and DECK", () => {
+    const out = logs(() => cmdStatusSummary()).map((p) => p.text).join("\n");
+    assert.match(out, /HEALTH/);
+    assert.match(out, /DECK/);
+    assert.match(out, /100/);
+  });
+
+  it("full includes health and deck", () => {
+    const out = logs(() => cmdStatusFull()).map((p) => p.text).join("\n");
+    assert.match(out, /health/i);
+    assert.match(out, /deck/i);
+  });
+});

--- a/js/core/ice/dispatch.test.js
+++ b/js/core/ice/dispatch.test.js
@@ -1,0 +1,78 @@
+// @ts-check
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// corporate-exchange spawns an ICE instance (meta.ice grade "B").
+import { buildNetwork as buildCorporateExchange } from "../../../data/networks/corporate-exchange.js";
+import { initGame, getState } from "../state.js";
+import { setSelectedNode } from "../state/game.js";
+import { clearAll } from "../timers.js";
+import { on, off, E } from "../events.js";
+import { handleIceDetect } from "./runtime.js";
+
+function withEvents(type, fn) {
+  const captured = [];
+  const h = (p) => captured.push(p);
+  on(type, h);
+  fn();
+  off(type, h);
+  return captured;
+}
+
+beforeEach(() => {
+  clearAll();
+  // initGame(buildNetworkFn, seedString, opts). meta.ice comes from the builder.
+  initGame(() => buildCorporateExchange(), "dispatch-test");
+});
+
+// Helper: force the single spawned ICE instance to a given type, co-located with
+// the player. (Overriding typeId directly bypasses the spawn roll — this test is
+// about dispatch, independent of Task 4. State mutation here is test setup only.)
+function placeIce(typeId) {
+  const s = getState();
+  const ice = Object.values(s.ice.instances)[0];
+  ice.typeId = typeId;
+  const node = ice.attentionNodeId;
+  setSelectedNode(node);
+  return { ice, node };
+}
+
+describe("detection effect dispatch", () => {
+  it("sentinel detection reduces health and emits ICE_EFFECT_APPLIED", () => {
+    const { node } = placeIce("sentinel");
+    const before = getState().player.health.current;
+    const applied = withEvents(E.ICE_EFFECT_APPLIED, () => handleIceDetect({ nodeId: node }));
+    assert.equal(getState().player.health.current, before - 20);
+    assert.ok(applied.some((p) => p.effect === "damage-health"));
+  });
+
+  it("spike detection reduces deck integrity", () => {
+    const { node } = placeIce("spike");
+    const before = getState().player.deckIntegrity.current;
+    handleIceDetect({ nodeId: node });
+    assert.equal(getState().player.deckIntegrity.current, before - 20);
+  });
+
+  it("sentinel detection does NOT step the global alert (no raise-alert)", () => {
+    const { node } = placeIce("sentinel");
+    const alertBefore = getState().globalAlert;
+    handleIceDetect({ nodeId: node });
+    assert.equal(getState().globalAlert, alertBefore);
+  });
+
+  it("classic detection still raises the global alert (regression)", () => {
+    const { node } = placeIce("patrol-classic-B");
+    const raised = withEvents(E.ALERT_GLOBAL_RAISED, () => handleIceDetect({ nodeId: node }));
+    const traceStarted = withEvents(E.ALERT_TRACE_STARTED, () => {});
+    // Accept either ALERT_GLOBAL_RAISED or ALERT_TRACE_STARTED as proof the alert path ran.
+    const alertRan = raised.length >= 1 || traceStarted.length >= 1;
+    assert.ok(alertRan, "classic ICE must still step alert");
+    assert.equal(getState().player.health.current, 100, "classic ICE deals no damage");
+  });
+
+  it("damage emits a LOG_ENTRY readout", () => {
+    const { node } = placeIce("sentinel");
+    const logged = withEvents(E.LOG_ENTRY, () => handleIceDetect({ nodeId: node }));
+    assert.ok(logged.some((p) => /HEALTH/.test(p.text)));
+  });
+});

--- a/js/core/ice/dispatch.test.js
+++ b/js/core/ice/dispatch.test.js
@@ -60,13 +60,19 @@ describe("detection effect dispatch", () => {
     assert.equal(getState().globalAlert, alertBefore);
   });
 
-  it("classic detection still raises the global alert (regression)", () => {
+  it("classic detection still runs the alert path (regression)", () => {
     const { node } = placeIce("patrol-classic-B");
-    const raised = withEvents(E.ALERT_GLOBAL_RAISED, () => handleIceDetect({ nodeId: node }));
-    const traceStarted = withEvents(E.ALERT_TRACE_STARTED, () => {});
-    // Accept either ALERT_GLOBAL_RAISED or ALERT_TRACE_STARTED as proof the alert path ran.
-    const alertRan = raised.length >= 1 || traceStarted.length >= 1;
-    assert.ok(alertRan, "classic ICE must still step alert");
+    // Capture both alert-path signals around the SAME detection: depending on
+    // grade threshold, a fresh detection either steps the alert or starts the trace.
+    const alertEvents = [];
+    const onRaised = (p) => alertEvents.push(["raised", p]);
+    const onTrace = (p) => alertEvents.push(["trace", p]);
+    on(E.ALERT_GLOBAL_RAISED, onRaised);
+    on(E.ALERT_TRACE_STARTED, onTrace);
+    handleIceDetect({ nodeId: node });
+    off(E.ALERT_GLOBAL_RAISED, onRaised);
+    off(E.ALERT_TRACE_STARTED, onTrace);
+    assert.ok(alertEvents.length >= 1, "classic ICE must still step alert or start trace");
     assert.equal(getState().player.health.current, 100, "classic ICE deals no damage");
   });
 

--- a/js/core/ice/index.js
+++ b/js/core/ice/index.js
@@ -18,5 +18,5 @@ export {
 // registry.js self-registers the classic ICE presets in its module body, so this
 // re-export also runs that registration at load (no separate side-effect import needed).
 export {
-  ICE_TYPES, registerType, getType,
+  ICE_TYPES, registerType, getType, pickIceTypeId,
 } from "./registry.js";

--- a/js/core/ice/index.js
+++ b/js/core/ice/index.js
@@ -15,6 +15,8 @@ export {
   getEffect, getTrigger,
 } from "./atoms.js";
 
+// registry.js self-registers the classic ICE presets in its module body, so this
+// re-export also runs that registration at load (no separate side-effect import needed).
 export {
   ICE_TYPES, registerType, getType,
 } from "./registry.js";

--- a/js/core/ice/index.js
+++ b/js/core/ice/index.js
@@ -3,6 +3,12 @@
 // Callers outside this directory should import from here, not from submodules,
 // so internal restructuring is non-breaking.
 
+// Register atom bodies + trigger bodies as a side effect of loading the ICE
+// module. Without these imports EFFECT_ATOMS / TRIGGER_ATOMS are empty in the
+// live app (only the test suite imported them before).
+import "./effects.js";
+import "./triggers.js";
+
 export {
   EFFECT_ATOMS, TRIGGER_ATOMS,
   registerEffect, registerTrigger,

--- a/js/core/ice/index.test.js
+++ b/js/core/ice/index.test.js
@@ -13,10 +13,11 @@ describe("ice/index registers atoms + types on import", () => {
   });
 
   it("on-dwell-grade trigger is live", () => {
-    assert.ok(getTrigger("on-dwell-grade"));
+    assert.ok(getTrigger("on-dwell-grade"), "on-dwell-grade must be registered");
   });
 
   it("classic presets are registered", () => {
-    assert.ok(getType("patrol-classic-B"));
+    // Spot-check: registry.js self-registers a classic preset per grade on import.
+    assert.ok(getType("patrol-classic-B"), "patrol-classic-B must be registered");
   });
 });

--- a/js/core/ice/index.test.js
+++ b/js/core/ice/index.test.js
@@ -1,0 +1,22 @@
+// @ts-check
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// Importing the public surface MUST register the atom bodies as a side effect.
+import { getEffect, getTrigger, getType } from "./index.js";
+
+describe("ice/index registers atoms + types on import", () => {
+  it("damage-health / damage-deck / raise-alert atoms are live", () => {
+    assert.ok(getEffect("damage-health"), "damage-health must be registered");
+    assert.ok(getEffect("damage-deck"), "damage-deck must be registered");
+    assert.ok(getEffect("raise-alert"), "raise-alert must be registered");
+  });
+
+  it("on-dwell-grade trigger is live", () => {
+    assert.ok(getTrigger("on-dwell-grade"));
+  });
+
+  it("classic presets are registered", () => {
+    assert.ok(getType("patrol-classic-B"));
+  });
+});

--- a/js/core/ice/registry.js
+++ b/js/core/ice/registry.js
@@ -3,6 +3,8 @@
 // pattern, a trigger list, and an effect list into a named type that
 // procgen and network meta can reference.
 
+import { GRADE_INDEX } from "../grades.js";
+
 /** @type {Object<string, any>} */
 export const ICE_TYPES = {};
 
@@ -57,19 +59,19 @@ registerType({
   effects: [{ atom: "damage-deck", params: { amount: 20 } }],
 });
 
-const GRADE_NUM = { F: 1, D: 2, C: 3, B: 4, A: 5, S: 6 };
-
 /**
  * Pick the ICE type id for a spawned instance. Damaging presets only appear at
  * threat B+; below that the network's single ICE stays classic (alert-only).
  * Pure: `roll` is a float in [0, 1) supplied by the caller's seeded stream.
  * (Biome-biasing is a deferred tuning seam — grade gating only for the MVP.)
+ * Grade ordering reuses the canonical GRADE_INDEX (F=0 … S=5) so there's a
+ * single source of truth.
  * @param {string} grade
  * @param {number} roll
  * @returns {string}
  */
 export function pickIceTypeId(grade, roll) {
-  if ((GRADE_NUM[grade] ?? 1) < 4) return `patrol-classic-${grade}`;
+  if ((GRADE_INDEX[grade] ?? 0) < GRADE_INDEX.B) return `patrol-classic-${grade}`;
   if (roll < 0.5) return `patrol-classic-${grade}`;
   if (roll < 0.75) return "sentinel";
   return "spike";

--- a/js/core/ice/registry.js
+++ b/js/core/ice/registry.js
@@ -37,3 +37,40 @@ function classicFor(grade) {
 for (const grade of ["S", "A", "B", "C", "D", "F"]) {
   registerType(classicFor(grade));
 }
+
+// Session: health-deck-damage. Damaging presets — grade-agnostic (instance
+// grade is set at spawn). Alert-raise is intentionally NOT bundled: these ICE
+// attack the health / deck clocks, not the trace clock.
+registerType({
+  typeId: "sentinel",
+  focus: "roaming",
+  behaviorPattern: "disturbance-tracker",
+  triggers: ["on-dwell-grade"],
+  effects: [{ atom: "damage-health", params: { amount: 20 } }],
+});
+
+registerType({
+  typeId: "spike",
+  focus: "roaming",
+  behaviorPattern: "disturbance-tracker",
+  triggers: ["on-dwell-grade"],
+  effects: [{ atom: "damage-deck", params: { amount: 20 } }],
+});
+
+const GRADE_NUM = { F: 1, D: 2, C: 3, B: 4, A: 5, S: 6 };
+
+/**
+ * Pick the ICE type id for a spawned instance. Damaging presets only appear at
+ * threat B+; below that the network's single ICE stays classic (alert-only).
+ * Pure: `roll` is a float in [0, 1) supplied by the caller's seeded stream.
+ * (Biome-biasing is a deferred tuning seam — grade gating only for the MVP.)
+ * @param {string} grade
+ * @param {number} roll
+ * @returns {string}
+ */
+export function pickIceTypeId(grade, roll) {
+  if ((GRADE_NUM[grade] ?? 1) < 4) return `patrol-classic-${grade}`;
+  if (roll < 0.5) return `patrol-classic-${grade}`;
+  if (roll < 0.75) return "sentinel";
+  return "spike";
+}

--- a/js/core/ice/registry.test.js
+++ b/js/core/ice/registry.test.js
@@ -23,6 +23,11 @@ describe("damaging presets", () => {
     assert.ok(!atoms.includes("raise-alert"));
     assert.equal(t.effects.find((e) => e.atom === "damage-deck").params.amount, 20);
   });
+
+  it("damaging presets are grade-agnostic (no grade field — set at spawn)", () => {
+    assert.equal(getType("sentinel").grade, undefined);
+    assert.equal(getType("spike").grade, undefined);
+  });
 });
 
 describe("pickIceTypeId", () => {
@@ -36,5 +41,10 @@ describe("pickIceTypeId", () => {
     assert.equal(pickIceTypeId("B", 0.10), "patrol-classic-B"); // < 0.5 -> classic
     assert.equal(pickIceTypeId("A", 0.60), "sentinel");          // [0.5, 0.75) -> sentinel
     assert.equal(pickIceTypeId("S", 0.90), "spike");             // >= 0.75 -> spike
+  });
+
+  it("B+: exact boundary values fall into the upper bucket", () => {
+    assert.equal(pickIceTypeId("B", 0.5), "sentinel");  // 0.5 is first sentinel
+    assert.equal(pickIceTypeId("B", 0.75), "spike");    // 0.75 is first spike
   });
 });

--- a/js/core/ice/registry.test.js
+++ b/js/core/ice/registry.test.js
@@ -1,0 +1,40 @@
+// @ts-check
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { getType, pickIceTypeId } from "./registry.js";
+
+describe("damaging presets", () => {
+  it("sentinel carries a damage-health effect and no raise-alert", () => {
+    const t = getType("sentinel");
+    assert.ok(t);
+    const atoms = t.effects.map((e) => e.atom);
+    assert.ok(atoms.includes("damage-health"));
+    assert.ok(!atoms.includes("raise-alert"));
+    const dmg = t.effects.find((e) => e.atom === "damage-health");
+    assert.equal(dmg.params.amount, 20);
+  });
+
+  it("spike carries a damage-deck effect and no raise-alert", () => {
+    const t = getType("spike");
+    assert.ok(t);
+    const atoms = t.effects.map((e) => e.atom);
+    assert.ok(atoms.includes("damage-deck"));
+    assert.ok(!atoms.includes("raise-alert"));
+    assert.equal(t.effects.find((e) => e.atom === "damage-deck").params.amount, 20);
+  });
+});
+
+describe("pickIceTypeId", () => {
+  it("below B: always classic, regardless of roll", () => {
+    assert.equal(pickIceTypeId("C", 0.0), "patrol-classic-C");
+    assert.equal(pickIceTypeId("D", 0.99), "patrol-classic-D");
+    assert.equal(pickIceTypeId("F", 0.6), "patrol-classic-F");
+  });
+
+  it("B+: roll partitions classic / sentinel / spike", () => {
+    assert.equal(pickIceTypeId("B", 0.10), "patrol-classic-B"); // < 0.5 -> classic
+    assert.equal(pickIceTypeId("A", 0.60), "sentinel");          // [0.5, 0.75) -> sentinel
+    assert.equal(pickIceTypeId("S", 0.90), "spike");             // >= 0.75 -> spike
+  });
+});

--- a/js/core/ice/runtime.js
+++ b/js/core/ice/runtime.js
@@ -13,6 +13,8 @@ import { scheduleEvent, scheduleRepeating, cancelAllByType, TIMER } from "../tim
 import { emitEvent, on, E } from "../events.js";
 import { A } from "../action-ids.js";
 import { RNG, randomPick } from "../rng.js";
+import { getType, getEffect } from "./index.js";
+import { damagePlayerHealth, damagePlayerDeck } from "../player-orchestration.js";
 
 // Called whenever ICE vacates a node for any reason: normal movement, eject, or reboot.
 // Cancels any pending detection dwell and releases the detection lock so ICE can
@@ -234,10 +236,63 @@ function triggerDetection(nodeId) {
   const s = getState();
   const ice = getPrimaryIce();
   emitEvent(E.ICE_DETECTED, { iceId: ice?.id ?? null, nodeId, label: s.nodes[nodeId]?.label ?? nodeId });
-  // ICE detection drives the global alert directly (count/grade-gated) inside
-  // recordIceDetection. It does NOT route through the exploit-failure IDS→monitor
-  // propagation path (that's the separate puzzle layer) — see MANUAL.md.
-  recordIceDetection(nodeId); // steps alert; starts trace at the grade threshold
+  if (!ice) return;
+  // Detection lock — applies to ALL ICE regardless of effects, so the same node
+  // doesn't re-detect until the player moves. (recordIceDetection also sets this
+  // for classic ICE; idempotent.)
+  setIceDetectedAt(nodeId);
+  applyIceEffects(ice, s, nodeId);
+}
+
+/**
+ * Apply the detecting instance type's effect atoms. raise-alert routes through
+ * the existing alert/trace path (recordIceDetection); damage atoms route through
+ * the player-orchestration wrappers (which end the run on depletion) and log a
+ * readout. Untyped/legacy instances fall back to raise-alert — preserving
+ * pre-dispatch behavior for fixtures like 'standard-ice'.
+ * @param {import('../types.js').IceInstance} ice
+ * @param {import('../types.js').GameState} state
+ * @param {string} nodeId
+ */
+function applyIceEffects(ice, state, nodeId) {
+  const type = getType(ice.typeId);
+  const effects = type?.effects ?? [{ atom: "raise-alert", params: {} }];
+  const ctx = {
+    propagateAlertEvent: (nid) => recordIceDetection(nid),
+    damagePlayerHealth,
+    damagePlayerDeck,
+  };
+  emitEvent(E.ICE_ACTIVATED, { iceId: ice.id, trigger: "on-dwell-grade", hostNodeId: ice.attentionNodeId });
+  for (const eff of effects) {
+    const atom = getEffect(eff.atom);
+    if (!atom) continue;
+    atom.apply(ice, state, ctx, eff.params ?? {});
+    logIceEffect(ice, eff, nodeId);
+    emitEvent(E.ICE_EFFECT_APPLIED, { iceId: ice.id, effect: eff.atom, result: { ...(eff.params ?? {}) } });
+    // Stop if a depletion ended the run mid-list (single-effect presets won't hit this).
+    if (getState().phase !== "playing") break;
+  }
+}
+
+/** Emit a log readout for damage effects (raise-alert is logged by the alert layer). */
+function logIceEffect(ice, eff, nodeId) {
+  const s = getState();
+  const label = (s.nodes[nodeId]?.label ?? nodeId);
+  if (eff.atom === "damage-health") {
+    const h = s.player.health;
+    const dead = h.current === 0;
+    emitEvent(E.LOG_ENTRY, {
+      text: `${dead ? "!! " : ""}[ICE] ${label} neural feedback: −${eff.params.amount} HEALTH (${h.current} left)`,
+      type: dead ? "error" : "warning",
+    });
+  } else if (eff.atom === "damage-deck") {
+    const d = s.player.deckIntegrity;
+    const dead = d.current === 0;
+    emitEvent(E.LOG_ENTRY, {
+      text: `${dead ? "!! " : ""}[ICE] ${label} deck corruption: −${eff.params.amount} DECK (${d.current} left)`,
+      type: dead ? "error" : "warning",
+    });
+  }
 }
 
 export function cancelIceDwell() {

--- a/js/core/ice/runtime.js
+++ b/js/core/ice/runtime.js
@@ -262,7 +262,9 @@ function applyIceEffects(ice, state, nodeId) {
     damagePlayerHealth,
     damagePlayerDeck,
   };
-  emitEvent(E.ICE_ACTIVATED, { iceId: ice.id, trigger: "on-dwell-grade", hostNodeId: ice.attentionNodeId });
+  // hostNodeId = the ICE's install node (real instance field); nodeId = where it
+  // activated (the detection node, == attentionNodeId at detection time).
+  emitEvent(E.ICE_ACTIVATED, { iceId: ice.id, trigger: "on-dwell-grade", hostNodeId: ice.hostNodeId, nodeId });
   for (const eff of effects) {
     const atom = getEffect(eff.atom);
     if (!atom) continue;

--- a/js/core/state/index.js
+++ b/js/core/state/index.js
@@ -23,7 +23,8 @@
 /** @typedef {import('../types.js').NodeAlertLevel} NodeAlertLevel */
 /** @typedef {import('../types.js').GlobalAlertLevel} GlobalAlertLevel */
 
-import { RNG, initRng, getSeed, serializeRng, deserializeRng, randomPick, randomInt } from "../rng.js";
+import { RNG, initRng, getSeed, serializeRng, deserializeRng, randomPick, randomInt, random } from "../rng.js";
+import { pickIceTypeId } from "../ice/registry.js";
 import { generateStartingHand, generateVulnerabilities, _exploitIdCounter, setExploitIdCounter } from "../exploits.js";
 import { generateMacguffin, flagMissionMacguffin } from "../loot.js";
 import { clearAll as clearAllTimers, serializeTimers, deserializeTimers, setGraphForTick } from "../timers.js";
@@ -188,16 +189,20 @@ export function initGame(buildNetworkFn, seedString, opts = {}) {
     const nodeIds = Object.keys(nodes);
     const hostNodeId = meta.ice.startNode ?? randomPick(RNG.WORLD, nodeIds);
     const id = 'ice-1';
+    const grade = meta.ice.grade;
+    // Registry-driven type: damaging presets (sentinel/spike) appear at B+.
+    // An explicit meta.ice.typeId (cheats/tests) overrides the seeded roll.
+    const typeId = meta.ice.typeId ?? pickIceTypeId(grade, random(RNG.WORLD));
     /** @type {import('../types.js').IceInstance} */
     const primary = {
       id,
-      typeId: 'standard-ice',
+      typeId,
       hostNodeId,
       residentNodeId: hostNodeId, // deprecated, kept for migration; remove when callers stop reading it
       attentionNodeId: hostNodeId,
       active: true,
       enabled: true,
-      grade: meta.ice.grade,
+      grade,
       focus: 'roaming',
       behaviorPattern: 'standard',
       dwellTimerId: null,

--- a/js/core/state/index.js
+++ b/js/core/state/index.js
@@ -24,7 +24,7 @@
 /** @typedef {import('../types.js').GlobalAlertLevel} GlobalAlertLevel */
 
 import { RNG, initRng, getSeed, serializeRng, deserializeRng, randomPick, randomInt, random } from "../rng.js";
-import { pickIceTypeId } from "../ice/registry.js";
+import { pickIceTypeId, getType } from "../ice/registry.js";
 import { generateStartingHand, generateVulnerabilities, _exploitIdCounter, setExploitIdCounter } from "../exploits.js";
 import { generateMacguffin, flagMissionMacguffin } from "../loot.js";
 import { clearAll as clearAllTimers, serializeTimers, deserializeTimers, setGraphForTick } from "../timers.js";
@@ -192,7 +192,11 @@ export function initGame(buildNetworkFn, seedString, opts = {}) {
     const grade = meta.ice.grade;
     // Registry-driven type: damaging presets (sentinel/spike) appear at B+.
     // An explicit meta.ice.typeId (cheats/tests) overrides the seeded roll.
+    // NOTE: the hostNodeId draw above is conditional (skipped when startNode is
+    // pinned), so the WORLD-stream position entering this roll differs between
+    // networks that pin startNode and those that don't — same seed, different type.
     const typeId = meta.ice.typeId ?? pickIceTypeId(grade, random(RNG.WORLD));
+    const typeDef = getType(typeId);
     /** @type {import('../types.js').IceInstance} */
     const primary = {
       id,
@@ -203,8 +207,10 @@ export function initGame(buildNetworkFn, seedString, opts = {}) {
       active: true,
       enabled: true,
       grade,
-      focus: 'roaming',
-      behaviorPattern: 'standard',
+      focus: typeDef?.focus ?? 'roaming',
+      // Derive from the registry type so the serialized instance stays honest
+      // (sentinel/spike are 'disturbance-tracker', not the old 'standard' default).
+      behaviorPattern: typeDef?.behaviorPattern ?? 'standard',
       dwellTimerId: null,
       detectedAtNode: null,
       detectionCount: 0,

--- a/js/core/state/index.js
+++ b/js/core/state/index.js
@@ -24,7 +24,7 @@
 /** @typedef {import('../types.js').GlobalAlertLevel} GlobalAlertLevel */
 
 import { RNG, initRng, getSeed, serializeRng, deserializeRng, randomPick, randomInt, random } from "../rng.js";
-import { pickIceTypeId, getType } from "../ice/registry.js";
+import { pickIceTypeId, getType } from "../ice/index.js";
 import { generateStartingHand, generateVulnerabilities, _exploitIdCounter, setExploitIdCounter } from "../exploits.js";
 import { generateMacguffin, flagMissionMacguffin } from "../loot.js";
 import { clearAll as clearAllTimers, serializeTimers, deserializeTimers, setGraphForTick } from "../timers.js";

--- a/js/core/state/spawn.test.js
+++ b/js/core/state/spawn.test.js
@@ -1,0 +1,27 @@
+// @ts-check
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildNetwork as buildCorporateExchange } from "../../../data/networks/corporate-exchange.js"; // meta.ice grade B
+import { buildNetwork as buildCorporateFoothold } from "../../../data/networks/corporate-foothold.js"; // meta.ice grade C
+import { initGame, getState } from "../state.js";
+import { getType } from "../ice/index.js";
+import { clearAll } from "../timers.js";
+
+beforeEach(() => clearAll());
+
+describe("typed ICE spawn", () => {
+  it("spawned ICE has a registry-resolvable typeId (not legacy 'standard-ice')", () => {
+    initGame(() => buildCorporateExchange(), "spawn-1");
+    const ice = Object.values(getState().ice.instances)[0];
+    assert.notEqual(ice.typeId, "standard-ice");
+    assert.ok(getType(ice.typeId), `typeId ${ice.typeId} must resolve in the registry`);
+    assert.match(ice.typeId, /^(patrol-classic-B|sentinel|spike)$/);
+  });
+
+  it("below B, the spawn stays classic", () => {
+    initGame(() => buildCorporateFoothold(), "spawn-2"); // grade C
+    const ice = Object.values(getState().ice.instances)[0];
+    assert.equal(ice.typeId, "patrol-classic-C");
+  });
+});

--- a/js/ui/components/starnet-end-screen.js
+++ b/js/ui/components/starnet-end-screen.js
@@ -49,15 +49,22 @@ class StarnetEndScreen extends StarnetElement {
   render() {
     if (!this.open) return nothing;
 
-    const caught = this.outcome === "caught";
+    const failed = this.outcome === "caught"
+      || this.outcome === "burned"
+      || this.outcome === "bricked";
+    const title =
+      this.outcome === "caught"  ? "▶ TRACED ◀" :
+      this.outcome === "burned"  ? "▶ FLATLINED ◀" :
+      this.outcome === "bricked" ? "▶ DECK FRIED ◀" :
+                                   "▶ RUN COMPLETE ◀";
 
     return html`
       <div class="end-box">
-        <div class="end-title">${caught ? "▶ TRACED ◀" : "▶ RUN COMPLETE ◀"}</div>
+        <div class="end-title">${title}</div>
         <div class="end-divider">════════════════════════</div>
         <div class="end-row">
           <span class="end-key">CASH EXTRACTED</span>
-          <span class="end-val ${caught ? "end-zero" : ""}">¥${this.cash.toLocaleString()}</span>
+          <span class="end-val ${failed ? "end-zero" : ""}">¥${this.cash.toLocaleString()}</span>
         </div>
         ${this.hasMission ? html`
           <div class="end-row">

--- a/js/ui/components/starnet-hud.js
+++ b/js/ui/components/starnet-hud.js
@@ -14,6 +14,10 @@ class StarnetHud extends StarnetElement {
     isCheating: { type: Boolean },
     phase: { type: String },
     paused: { type: Boolean },
+    health: { type: Number },
+    healthMax: { type: Number },
+    deck: { type: Number },
+    deckMax: { type: Number },
   };
 
   constructor() {
@@ -26,6 +30,10 @@ class StarnetHud extends StarnetElement {
     this.isCheating = false;
     this.phase = "";
     this.paused = false;
+    this.health = 100;
+    this.healthMax = 100;
+    this.deck = 100;
+    this.deckMax = 100;
   }
 
   _emit(action, detail = {}) {
@@ -39,6 +47,18 @@ class StarnetHud extends StarnetElement {
     if (!file) return;
     this._emit("load", { file });
     e.target.value = "";
+  }
+
+  _meter(label, current, max) {
+    const frac = max > 0 ? current / max : 0;
+    const color = frac > 0.6 ? "var(--green)" : frac > 0.3 ? "var(--yellow)" : "var(--red)";
+    return html`
+      <span class="hud-label">${label}:</span>
+      <span class="hud-meter" title="${current}/${max}">
+        <span class="hud-meter-fill" style="width:${Math.round(frac * 100)}%;background:${color}"></span>
+        <span class="hud-meter-text" style="color:${color}">${current}</span>
+      </span>
+    `;
   }
 
   render() {
@@ -67,6 +87,9 @@ class StarnetHud extends StarnetElement {
 
       <span class="hud-label">WALLET:</span>
       <span class="hud-value" id="wallet">¥${this.cash.toLocaleString()}</span>
+
+      ${this._meter("HEALTH", this.health, this.healthMax)}
+      ${this._meter("DECK", this.deck, this.deckMax)}
 
       ${this.traceSeconds !== null && this.phase === "playing" ? html`
         <span id="trace-countdown" class="hud-value trace-countdown">TRACE: ${this.traceSeconds}s</span>

--- a/js/ui/components/starnet-hud.js
+++ b/js/ui/components/starnet-hud.js
@@ -16,8 +16,8 @@ class StarnetHud extends StarnetElement {
     paused: { type: Boolean },
     health: { type: Number },
     healthMax: { type: Number },
-    deck: { type: Number },
-    deckMax: { type: Number },
+    deckIntegrity: { type: Number },
+    deckIntegrityMax: { type: Number },
   };
 
   constructor() {
@@ -32,8 +32,8 @@ class StarnetHud extends StarnetElement {
     this.paused = false;
     this.health = 100;
     this.healthMax = 100;
-    this.deck = 100;
-    this.deckMax = 100;
+    this.deckIntegrity = 100;
+    this.deckIntegrityMax = 100;
   }
 
   _emit(action, detail = {}) {
@@ -54,7 +54,7 @@ class StarnetHud extends StarnetElement {
     const color = frac > 0.6 ? "var(--green)" : frac > 0.3 ? "var(--yellow)" : "var(--red)";
     return html`
       <span class="hud-label">${label}:</span>
-      <span class="hud-meter" title="${current}/${max}">
+      <span class="hud-meter" title="${label}: ${current}/${max}">
         <span class="hud-meter-fill" style="width:${Math.round(frac * 100)}%;background:${color}"></span>
         <span class="hud-meter-text" style="color:${color}">${current}</span>
       </span>
@@ -89,7 +89,7 @@ class StarnetHud extends StarnetElement {
       <span class="hud-value" id="wallet">¥${this.cash.toLocaleString()}</span>
 
       ${this._meter("HEALTH", this.health, this.healthMax)}
-      ${this._meter("DECK", this.deck, this.deckMax)}
+      ${this._meter("DECK", this.deckIntegrity, this.deckIntegrityMax)}
 
       ${this.traceSeconds !== null && this.phase === "playing" ? html`
         <span id="trace-countdown" class="hud-value trace-countdown">TRACE: ${this.traceSeconds}s</span>

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -348,6 +348,10 @@ function syncHud(state) {
     hudEl.traceSeconds = state.traceSecondsRemaining;
     hudEl.isCheating = state.isCheating;
     hudEl.phase = state.phase;
+    hudEl.health = state.player.health.current;
+    hudEl.healthMax = state.player.health.max;
+    hudEl.deck = state.player.deckIntegrity.current;
+    hudEl.deckMax = state.player.deckIntegrity.max;
 
     // Connection status
     const detecting = getVisibleTimers().some((t) => t.label === "ICE DETECTION");

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -350,8 +350,8 @@ function syncHud(state) {
     hudEl.phase = state.phase;
     hudEl.health = state.player.health.current;
     hudEl.healthMax = state.player.health.max;
-    hudEl.deck = state.player.deckIntegrity.current;
-    hudEl.deckMax = state.player.deckIntegrity.max;
+    hudEl.deckIntegrity = state.player.deckIntegrity.current;
+    hudEl.deckIntegrityMax = state.player.deckIntegrity.max;
 
     // Connection status
     const detecting = getVisibleTimers().some((t) => t.label === "ICE DETECTION");

--- a/scripts/playtest.js
+++ b/scripts/playtest.js
@@ -166,7 +166,7 @@ if (jsonMode) {
     E.EXPLOIT_DISCLOSED, E.EXPLOIT_PARTIAL_BURN, E.EXPLOIT_SURFACE,
     E.ALERT_GLOBAL_RAISED, E.ALERT_TRACE_STARTED, E.ALERT_TRACE_CANCELLED, E.ALERT_PROPAGATED,
     E.PLAYER_NAVIGATED,
-    E.ICE_MOVED, E.ICE_DETECT_PENDING, E.ICE_DETECTED, E.ICE_EJECTED, E.ICE_REBOOTED, E.ICE_DISABLED,
+    E.ICE_MOVED, E.ICE_DETECT_PENDING, E.ICE_DETECTED, E.ICE_EJECTED, E.ICE_REBOOTED, E.ICE_DISABLED, E.ICE_EFFECT_APPLIED,
     E.MISSION_STARTED, E.MISSION_COMPLETE,
     E.ACTION_FEEDBACK, E.ACTION_RESOLVED,
     E.RUN_STARTED, E.RUN_ENDED,
@@ -222,6 +222,8 @@ if (jsonMode) {
   on(E.ICE_EJECTED,          ({ fromId, toId })          => out(`[ICE] Ejected: ${fromId} → ${toId}.`));
   on(E.ICE_REBOOTED,         ({ residentLabel })         => out(`[ICE] Rebooted to ${residentLabel}.`));
   on(E.ICE_DISABLED,         ()                          => out(`[ICE] Disabled.`));
+  on(E.ICE_EFFECT_APPLIED,   ({ iceId, effect, result }) =>
+    out(`[ICE] ${iceId} effect: ${effect}${result?.amount != null ? ` (${result.amount})` : ""}`));
   on(E.MISSION_STARTED,      ({ targetName })            => out(`[MISSION] Target: ${targetName}`));
   on(E.MISSION_COMPLETE,     ({ targetName })            => out(`[MISSION] ★ Complete: ${targetName}`));
   on(E.RUN_ENDED,            ({ outcome })               => out(`[RUN] ${outcome.toUpperCase()}`));


### PR DESCRIPTION
Closes #133.

## Summary

ICE-reinvention session 1 shipped the **data layer** for player HEALTH / DECK INTEGRITY (the pools, clamped mutators, the `burned`/`bricked` run-end wrappers, and the `damage-health`/`damage-deck` atoms) — but nothing fired the atoms in a live tick, no ICE dealt damage, and the pools were invisible. This makes the mechanic real:

- **Effect dispatch at the detection trigger** — `triggerDetection` applies the detecting ICE type's `effects[]` via a ctx (`raise-alert` → existing alert/trace path; `damage-*` → `player-orchestration` wrappers that end the run). Emits `ICE_ACTIVATED`/`ICE_EFFECT_APPLIED` + damage log lines. Classic ICE behavior is provably unchanged.
- **Two damaging presets** — **Sentinel** (`damage-health 20`) and **Spike** (`damage-deck 20`), **neither raising alert**. Alert-raise is now one orthogonal effect type of three: classic ICE pursue the trace, Sentinel your health, Spike your deck — so which ICE you face changes which clock you're racing.
- **Registry-driven typed spawn** — the network's single ICE is rolled at spawn (weighted; damaging types at threat B+), replacing the hardcoded `standard-ice`.
- **Visibility** — HUD meters (green→yellow→red), `status`/`status full` lines, per-hit damage log, and end-screen copy (`burned`→FLATLINED, `bricked`→DECK FRIED).
- Also registers the ICE atoms in the live module (they were imported only by tests), and updates MANUAL.md.

## Test plan

- [x] `make check` green (793 tests, lint clean)
- [x] New unit/integration tests: atom registration, sentinel/spike presets + `pickIceTypeId` boundaries, detection→damage dispatch (health/deck reduce; sentinel raises no alert; classic still alerts and deals no damage; damage logs), typed spawn, `status` HEALTH/DECK
- [x] Browser smoke: HUD meters render + color-ramp (caught & fixed a flex-shrink collapse), end-screen FLATLINED/DECK FRIED for all four outcomes
- [x] Bot census (threat B, 20 seeds): no difficulty regression — see notes on the mechanic being gentle under bot play (tuning is a deliberate follow-up)

## Notes / follow-ups

- The damage barely bites under bot play (~0.4 detections/run; 5 hits to deplete) — balancing its teeth is a separate pass, per the spec.
- Unblocks #134 (plasma overlay reads the now-live `health` pool).
- Session docs: `docs/dev-sessions/2026-06-10-1626-health-deck-damage/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)