### PR TITLE
EXEC submenu/verb for non-core node actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,13 +264,15 @@ node scripts/playtest.js "status ice"
 
 ## Bot Player and Census
 
-`scripts/bot-player.js` is an automated game-playing agent for balance testing.
-`scripts/bot-census.js` runs it across many seeds and produces LLM-readable reports.
-See `docs/BOT-PLAYER.md` for full documentation.
+`scripts/bot/cli.js` runs an automated game-playing agent for balance testing
+(the bot logic lives across `scripts/bot/*.js`). `scripts/bot/census.js` runs it
+across many seeds and produces LLM-readable reports. See `docs/BOT-PLAYER.md` for
+full documentation.
 
-**`scripts/bot-player.js`, `scripts/playtest.js`, and `js/main.js` are three parallel
-entry points** into the same game engine. All three share timer wiring, action dispatch,
-and event handling. When changing game mechanics, check all three.
+**The bot (`scripts/bot/`, entry `scripts/bot/cli.js`), `scripts/playtest.js`, and
+`js/main.js` are three parallel entry points** into the same game engine. All three
+share timer wiring, action dispatch, and event handling. When changing game mechanics,
+check all three.
 
 **Keep the bot working when changing game mechanics.** The bot reads game state directly
 (`accessLevel`, `visibility`, `vulnerabilities`, `macguffins`) and dispatches actions
@@ -288,9 +290,11 @@ via `emitEvent("starnet:action", ...)`. Changes that affect the bot:
 - **Timer handler changes** → the bot's init block must register the same handlers as
   `playtest.js`. If a new TIMER type is added, add it to both.
 
-**Run `make bot-census` after balance changes** to verify the difficulty curve hasn't
-regressed. A quick smoke test: `node scripts/bot-census.js --time F --money F --seeds 10`
-should show ~80% success.
+**Run `make census` after balance changes** to verify the difficulty curve hasn't
+regressed. A quick smoke test: `make census SEEDS=10` (override grades with
+`THREAT=` / `WEALTH=` / `COMPLEXITY=` / `DEPTH=`). There's no fixed pass threshold —
+compare `successRate` / `traceFiredRate` against a same-seed run on `main` rather than
+an absolute number.
 
 ---
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -116,7 +116,7 @@ LOCKED  →  COMPROMISED  →  OWNED
 **Compromised** — Partial access. You can read contents and attempt to escalate.
 An IDS at this level can be corrupted to stop forwarding alerts.
 
-**Owned** — Full control. You can fetch macguffins, reboot the node, or eject ICE.
+**Owned** — Full control. You can fetch macguffins, reboot the node, or kick ICE.
 
 ---
 
@@ -338,8 +338,8 @@ point. A darknet broker operates through it, selling exploit cards mid-run.
 
 ### Accessing the Store
 
-Select the WAN node and use the `access-darknet` action (or click the button in the
-sidebar). **The LAN pauses while you shop** — ICE stops moving, timers freeze. You
+Select the WAN node and run `exec access-darknet` (or choose it from the EXEC submenu /
+sidebar button). **The LAN pauses while you shop** — ICE stops moving, timers freeze. You
 can browse without the clock running.
 
 ```
@@ -455,8 +455,8 @@ When global alert hits red and security monitors confirm active intrusion, a **T
 countdown** begins (30–90 seconds depending on network threat grade). The countdown shows in the HUD and sidebar. If it reaches zero,
 your tether is traced back to your home node — run over, score lost.
 
-To stop it: **jack out** before zero, or **own the security monitor** and use the
-`cancel-trace` action.
+To stop it: **jack out** before zero, or **own the security monitor** and run
+`exec cancel-trace`.
 
 ### HEALTH and DECK INTEGRITY
 
@@ -484,7 +484,7 @@ being a factor.
 If you can compromise and then **corrupt** an IDS node:
 
 ```
-> corrupt
+> exec corrupt
 ```
 
 Event forwarding from that IDS to its connected security monitor is severed. Subsequent
@@ -556,7 +556,7 @@ your node and returns, the dwell timer resets and another detection cycle begins
 **Counters:**
 
 - **Untarget** the node or target a different one — drops back to passive, cancels the dwell timer
-- **Eject** (owned nodes) — boots ICE to a random adjacent node: `> eject`
+- **Kick** (owned nodes) — boots ICE to a random adjacent node: `> kick`
 - **Reboot** (owned nodes) — forces ICE back to its resident node and takes your node
   offline briefly: `> reboot`
 
@@ -604,18 +604,19 @@ Actions depend on the selected node's type and access level:
 
 | Action            | Available when...                              | Effect |
 |-------------------|------------------------------------------------|--------|
-| `access-darknet`  | WAN node is targeted                           | Opens the darknet broker store; pauses the LAN while shopping |
+| `exec access-darknet` | WAN node is targeted                       | Opens the darknet broker store; pauses the LAN while shopping (run via `exec`) |
 | `probe`           | Node is locked and unprobed                   | Timed scan — reveals vulnerabilities, raises local alert |
 | `abort`           | Timed action in progress on targeted node      | Aborts the current action (probe, xploit, dump, or fetch) |
 | `xploit` (menu) / `xploit <n>` (console) | Node is accessible and not currently exploiting | Opens a node-anchored card picker. Unprobed → all usable cards (blind); probed → only cards matching revealed vulns; disabled with a reason when no card applies or the node is already owned. The hand strip and `xploit <n>` console command stay full-agency (play any usable card). Raises access level on success. |
 | `dump`         | Node is compromised or owned, unread           | Timed scan — reveals macguffins |
 | `fetch`        | Node is owned + has uncollected macguffins     | Timed extraction — collects macguffins for cash |
 | `mine`         | Node is owned and not exhausted                | Timed data-mining — rolls a yield chance for one exploit card targeting the node's own vuln classes; yield decays per attempt; disappears when the node is exhausted |
-| `corrupt`      | IDS node is compromised or owned               | Severs event forwarding to security monitor |
-| `spoof`        | Security-monitor node, compromised or owned    | Recalibrates security monitor |
-| `eject`        | Owned node + ICE is present here               | Boots ICE to adjacent node |
+| `exec <script>` | A compromised/owned node exposes node scripts | Lists/runs the node's scripts (corrupt, spoof, unlock-vault, cancel-trace, access-darknet, …) |
+| `corrupt`      | IDS node is compromised or owned               | Severs event forwarding to security monitor (run via `exec`) |
+| `spoof`        | Security-monitor node, compromised or owned    | Recalibrates security monitor (run via `exec`) |
+| `kick`         | Owned node + ICE is present here               | Boots ICE to adjacent node |
 | `reboot`       | Owned node, not currently rebooting            | Forces ICE home, node offline briefly |
-| `cancel-trace` | Owned security-monitor + trace active          | Cancels the trace countdown |
+| `cancel-trace` | Owned security-monitor + trace active          | Cancels the trace countdown (run via `exec`) |
 | `jackout`      | Any time during run                            | End run, collect score |
 
 ---
@@ -635,11 +636,9 @@ xploit <#|name>        Use exploit card by number or name on targeted node.
 dump [node]            Dump contents of targeted/specified node.
 fetch [node]           Extract macguffins from owned node.
 mine [node]            Data-mine owned node for an exploit card (timed; diminishing returns).
-corrupt [node]         Disable IDS event forwarding.
-spoof [node]           Recalibrate security monitor.
-eject                  Push ICE off current node to adjacent node.
+exec [<script>]        Run a node script (corrupt, spoof, unlock-vault, …). No arg lists scripts.
+kick                   Push ICE off current node to adjacent node.
 reboot [node]          Force ICE home; node goes briefly offline.
-cancel-trace           Abort trace (requires owned security-monitor).
 jackout                End run.
 
 darknet                List darknet broker catalog (requires WAN targeted).
@@ -687,7 +686,7 @@ compromise and corrupt the IDS first, you can work quietly behind it.
 
 **ICE is predictable once you understand its grade.** A grade-C ICE is drawn to
 disturbances — it will come to where the action is. If you're making noise in one
-part of the network, expect it to show up. Plan an escape route or have an eject
+part of the network, expect it to show up. Plan an escape route or have a kick
 ready.
 
 **Decay is real.** Don't burn your best card on a soft target. Save rare cards for

--- a/css/style.css
+++ b/css/style.css
@@ -597,6 +597,19 @@ html, body {
   overflow-y: auto;
 }
 
+/* EXEC-style action choices are list rows, not cards: the 2-col grid above is
+   sized for exploit cards, which left script titles too narrow and wrapping.
+   Give them the full panel width and keep the title on one line (the longer
+   description below it still wraps). */
+#action-choices .ac-choices .ctx-item {
+  grid-column: 1 / -1;
+  white-space: nowrap;
+}
+
+#action-choices .ac-choices .ctx-item .ctx-item-desc {
+  white-space: normal;
+}
+
 /* ── Action Buttons ─────────────────────────────────────── */
 
 .action-btn {

--- a/docs/dev-sessions/2026-06-10-1628-exec-submenu-node-scripts/notes.md
+++ b/docs/dev-sessions/2026-06-10-1628-exec-submenu-node-scripts/notes.md
@@ -1,0 +1,80 @@
+# Session Notes — EXEC submenu / verb for non-core node actions
+
+**Issue:** #135 · **Branch:** `exec-submenu-node-scripts`
+
+## Summary
+
+Grouped all non-core node actions ("scripts") behind a single `EXEC` affordance —
+an `EXEC ▸` context-menu submenu and an `exec` console verb — separating them from
+the core deck command namespace and top-level tab-completion. New set-piece-authored
+node actions become scripts automatically (allowlist partition). Renamed the player
+verb `eject` → `kick` to free the letter `e` for `exec`.
+
+Executed via subagent-driven development: one implementer + spec review + code-quality
+review per task, plus a final whole-branch review.
+
+## What shipped
+
+- **`js/core/actions/scripts.js`** (new, pure) — `CORE_NODE_VERBS` allowlist +
+  `isScriptAction(id)`. A node-contextual action is a script iff its id is not core.
+- **`js/core/actions/node-actions.js`** — injects a synthetic `EXEC` follow-up action
+  when a node has ≥1 script; exports `getScriptActions`. `buildExecAction` closes over
+  the wrapped scripts (no import cycle); `EXEC.execute` runs the chosen script directly.
+- **`js/core/actions/action-context.js`** — dispatcher echo special-case: a GUI EXEC
+  pick logs `exec <script>` (one echo), mirroring the `xploit <card>` pattern.
+- **`js/core/console-commands/dynamic-actions.js`** — skips scripts + synthetic EXEC
+  when registering dynamic verbs (scripts leave the top-level namespace).
+- **`js/core/console-commands/commands.js`** — static `exec` command (list / run /
+  complete); `actions` listing groups scripts under `exec`; `help` advertises `exec`.
+- **`js/ui/visual-renderer.js`** — context menu filters out raw scripts; `EXEC ▸` stands in.
+- **`js/ui/components/starnet-action-choices.js`** — new `render: "action"` branch so
+  script choices render as labeled buttons in the existing picker.
+- **`eject` → `kick`** across action-ids, game-types, traits, console, log text, bot,
+  and harness. Internal mechanism unchanged: `ejectIce()` and `E.ICE_EJECTED` keep their names.
+- **MANUAL.md** — node-actions table, console commands, ICE/trace/darknet/IDS sections,
+  tips. `access-darknet` and `cancel-trace` reframed as exec scripts.
+
+## Key decisions
+
+- **Naming:** `run`/`shell`/`exec` all collided on first letters of existing core verbs
+  (r=reboot, s=status, e=eject). Resolved by renaming `eject`→`kick` (frees `e`) and
+  using `exec`. First-letter uniqueness matters for tab-completion ergonomics.
+- **Approach A (synthetic EXEC follow-up action):** reuses the existing exploit-card
+  choice picker rather than building new menu UI. Action/dispatch layer untouched —
+  scripts stay dispatchable by id; only presentation changed.
+- **Module boundary:** `scripts.js` stays pure (predicate only); `getScriptActions` +
+  `buildExecAction` live in `node-actions.js` to avoid a `node-actions ↔ scripts` cycle.
+- **`cancel-trace` under EXEC:** accepted despite being time-critical; UX-friction
+  mitigation deferred to a future iteration (per #135).
+- **Plan deviation (better):** picker choices use `render: "action"` + `data:{label,desc}`
+  (a render-type discriminator) instead of the plan's `render: s.label`. The original
+  would have rendered blank — the picker component only renders known render types.
+  Caught in Task 3 code review and fixed.
+
+## Verification
+
+- `make check`: 792 tests pass, lint clean.
+- Playtest harness `help`: shows `exec` + `kick`, no `eject`.
+- Bot census (`make census SEEDS=10`): branch == main (0.2 success, identical) — no
+  gameplay regression. The bot dispatches action ids directly (bypassing exec/menu),
+  so its behavior is unaffected; it runs cleanly with `kick`.
+- EXEC menu/picker data path confirmed via a node one-off: owned IDS menu = `mine,
+  reboot, exec` (raw `corrupt` hidden), picker choice = `{id:"corrupt",
+  render:"action", label:"Corrupt IDS"}`.
+
+## Carried forward / follow-ups
+
+- **Live browser click-through NOT run.** The Playwright Firefox build fails to launch
+  in this environment, and there's no DOM/jsdom test infra. The picker render branch +
+  menu filter were verified via the node data-path check + code review, not a live paint.
+  **Recommend a one-line manual smoke before/after merge:** own an IDS, click
+  `EXEC ▸ corrupt`, confirm `> exec corrupt` in the log and forwarding disabled.
+- **`cancel-trace` UX friction** under EXEC (time-critical, two interactions deep) —
+  revisit if it bites in play (#135).
+- **`docs/BACKLOG.md`** line ~129 ("bot never uses eject") is doubly stale — bot uses
+  `kick` now, and has used it since the evasion heuristics. Pre-existing; fix on a backlog pass.
+- **Latent test hazard:** `initActionDispatcher` registers a persistent `starnet:action`
+  listener (no cleanup); registered once in `tests/integration.test.js`. Fine today;
+  add a guard flag if that suite grows more dispatcher-based tests.
+- **`actions` listing** nested ternary in the dispatcher echo is at 3 branches — if a
+  4th submenu (e.g. a `buy` picker) ever appears, refactor to a small helper.

--- a/docs/dev-sessions/2026-06-10-1628-exec-submenu-node-scripts/plan.md
+++ b/docs/dev-sessions/2026-06-10-1628-exec-submenu-node-scripts/plan.md
@@ -1,0 +1,873 @@
+# EXEC Submenu / Verb Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Group all non-core node actions (set-piece scripts + security subversion) behind a single `EXEC` context-menu entry and `exec` console verb, separating them from the core deck command namespace and top-level tab-completion.
+
+**Architecture:** Approach A — the action/dispatch layer is unchanged; scripts stay in `getAvailableActions()` and stay dispatchable by id. We add a pure partition predicate (`isScriptAction`), inject one synthetic `EXEC` follow-up action when a node has ≥1 script (reusing the existing exploit-card choice picker for the GUI), drop scripts from the dynamic console verb registry, and add a static `exec` command. We rename `eject` → `kick` to free the letter `e` for `exec`.
+
+**Tech Stack:** Vanilla ES modules, JSDoc `@ts-check`, `node:test` + `node:assert/strict`. Run tests via `make test`; lint via `make lint`; both via `make check`.
+
+**Spec:** `docs/dev-sessions/2026-06-10-1628-exec-submenu-node-scripts/spec.md` · **Issue:** #135
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `js/core/action-ids.js` | canonical action id constants | rename `EJECT`→`KICK`; add `EXEC` |
+| `js/core/actions/scripts.js` | **new** — pure core/script partition | `CORE_NODE_VERBS`, `isScriptAction` |
+| `js/core/actions/scripts.test.js` | **new** — predicate unit tests | — |
+| `js/core/actions/node-actions.js` | merge global + graph actions | inject synthetic EXEC; export `getScriptActions` |
+| `js/core/actions/action-context.js` | unified dispatcher | EXEC log-echo special-case |
+| `js/core/node-graph/game-types.js` | node-type/action templates | `EJECT_ACTION`→`KICK_ACTION` |
+| `js/core/node-graph/traits.js` | composable trait defs | `ACTION_TEMPLATES.EJECT`→`.KICK` |
+| `js/core/node-graph/traits.test.js` | trait tests | `"eject"`→`"kick"` assertions |
+| `js/core/console-commands/dynamic-actions.js` | per-selection dynamic verbs | skip scripts + synthetic EXEC |
+| `js/core/console-commands/commands.js` | static console commands | add `exec`; regroup `actions`; help text; kick |
+| `js/core/console-commands/commands.test.js` | console command tests | `exec` tests |
+| `js/ui/visual-renderer.js` | graph context-menu sync | filter raw scripts from menu |
+| `js/ui/log-renderer.js` | log text | "eject"→"kick" in ICE warning |
+| `scripts/bot/execute.js`, `scripts/bot/heuristics/{puzzles,evasion}.js`, `scripts/playtest.js` | bot/harness | `A.EJECT`→`A.KICK`; help text |
+| `MANUAL.md` | player-facing reference | EXEC section, kick rename, console list |
+
+**Note on module boundaries (avoids a circular import):** `scripts.js` stays *pure* — it imports only `action-ids.js` and exports `CORE_NODE_VERBS` + `isScriptAction`. `getScriptActions` and `buildExecAction` live in `node-actions.js` (which already owns `getAvailableActions`). `buildExecAction` closes over the already-wrapped script ActionDefs, so `EXEC.execute` never needs to re-query `getAvailableActions` — no import cycle.
+
+---
+
+## Task 1: Rename `eject` → `kick`
+
+Frees the first letter `e` for `exec`. Only the **player-facing** verb/label/id changes. The internal mechanism keeps its names: `ejectIce()` ctx method and `E.ICE_EJECTED` event are NOT renamed.
+
+**Files:**
+- Modify: `js/core/action-ids.js:24`
+- Modify: `js/core/node-graph/game-types.js:156-166, 409`
+- Modify: `js/core/node-graph/traits.js:244`
+- Modify: `js/core/actions/node-actions.js:5, 36`
+- Modify: `js/core/console-commands/commands.js:52, 85, 156, 162, 284`
+- Modify: `js/ui/log-renderer.js:159`
+- Modify: `scripts/bot/execute.js:18, 117, 127`
+- Modify: `scripts/bot/heuristics/puzzles.js:19`
+- Modify: `scripts/bot/heuristics/evasion.js:24, 31, 34` (rename the verb usages; the internal const `ICE_ON_NODE_EJECT` may stay — it's not player-facing)
+- Modify: `scripts/playtest.js:123`
+- Test: `js/core/node-graph/traits.test.js:229, 305` (existing assertions flip eject→kick — they go red on rename, green after)
+- Test: `tests/integration.test.js` (new behavior test)
+
+- [ ] **Step 1: Flip the existing trait test assertions (red first)**
+
+In `js/core/node-graph/traits.test.js`, change both occurrences:
+
+```js
+assert.ok(actionIds.includes("eject"));
+```
+to
+```js
+assert.ok(actionIds.includes("kick"));
+```
+
+- [ ] **Step 2: Run them — verify they fail**
+
+Run: `node --test js/core/node-graph/traits.test.js`
+Expected: FAIL — the action id is still `"eject"`.
+
+- [ ] **Step 3: Rename the constant**
+
+`js/core/action-ids.js:24` — replace:
+```js
+  EJECT: "eject",
+```
+with:
+```js
+  KICK: "kick",
+```
+
+- [ ] **Step 4: Rename the action template**
+
+`js/core/node-graph/game-types.js` lines 155-166 — replace the `EJECT_ACTION` block:
+```js
+/** @type {ActionDef} */
+const KICK_ACTION = {
+  id: A.KICK,
+  label: "KICK",
+  desc: "Boot ICE attention to a random adjacent node.",
+  requires: [
+    { type: "node-attr", attr: "accessLevel", eq: "owned" },
+  ],
+  effects: [
+    { effect: "ctx-call", method: "ejectIce", args: [] },
+  ],
+};
+```
+And line 409 — replace `EJECT: EJECT_ACTION,` in the `ACTION_TEMPLATES` map with:
+```js
+  KICK: KICK_ACTION,
+```
+
+- [ ] **Step 5: Update the trait reference and the ICE filter**
+
+`js/core/node-graph/traits.js:244` — replace `ACTION_TEMPLATES.EJECT,` with `ACTION_TEMPLATES.KICK,`.
+
+`js/core/actions/node-actions.js:36` — replace `if (action.id === A.EJECT) {` with `if (action.id === A.KICK) {`. Also update the doc comment at line 5 (`...cancel-*, eject,` → `...cancel-*, kick,`).
+
+- [ ] **Step 6: Update console command text + ids**
+
+`js/core/console-commands/commands.js`:
+- Line 156: `if (has.has(A.EJECT))  lines.push(\`  eject ...\`)` → `if (has.has(A.KICK))   lines.push(\`  kick                     — push ICE to adjacent node\`)`
+- Line 162: in the `standardIds` array, replace `A.EJECT` with `A.KICK`.
+- Line 284 (help): `"  eject                     Push ICE attention to adjacent node.",` → `"  kick                      Push ICE attention to adjacent node.",`
+- Lines 52, 85 comments: `eject` → `kick`.
+
+- [ ] **Step 7: Update player-facing log text**
+
+`js/ui/log-renderer.js:159` — change `disengage or eject` to `disengage or kick`.
+
+- [ ] **Step 8: Update bot + harness references**
+
+- `scripts/bot/execute.js:18` and `scripts/bot/heuristics/puzzles.js:19`: in the KNOWN-actions set, `A.EJECT` → `A.KICK`.
+- `scripts/bot/execute.js:127`: `actionId: A.EJECT` → `actionId: A.KICK` (comment at 117 optional).
+- `scripts/bot/heuristics/evasion.js:31`: `action: A.EJECT,` → `action: A.KICK,` (reason string + const name may stay).
+- `scripts/playtest.js:123`: help string `eject` → `kick`.
+
+- [ ] **Step 9: Add a behavior test (kick == former eject)**
+
+In `tests/integration.test.js`, add to the ICE area (reuse `buildAlertLAN`, `startIce`, `getAvailableActions`, `A`, `withEvents`-style capture):
+
+```js
+describe("kick action (renamed from eject)", () => {
+  it("kick is the verb on an owned node with ICE present, and ejects ICE", () => {
+    clearAll();
+    initGame(() => buildAlertLAN({ ice: { grade: "C" } }), "itest-kick");
+    const s = getState();
+    s.nodeGraph.setNodeAttr("ids-1", "accessLevel", "owned");
+    startIce();
+    // Force ICE attention to ids-1 so the kick availability filter passes.
+    const ice = Object.values(s.ice.instances).find((i) => i?.active);
+    ice.attentionNodeId = "ids-1";
+    const ids = getAvailableActions(s.nodes["ids-1"], s).map((a) => a.id);
+    assert.ok(ids.includes("kick"), "kick should be available");
+    assert.ok(!ids.includes("eject"), "eject must be gone");
+
+    let ejected = false;
+    const h = () => { ejected = true; };
+    on(E.ICE_EJECTED, h);
+    s.nodeGraph.executeAction("ids-1", "kick");
+    off(E.ICE_EJECTED, h);
+    assert.ok(ejected, "kick must fire ICE_EJECTED (internal mechanism unchanged)");
+  });
+});
+```
+
+> If `buildAlertLAN`'s ICE option shape differs, mirror an existing ICE test in the file for the exact `startIce`/instance setup. The key assertions are: `kick` present, `eject` absent, `ICE_EJECTED` fires.
+
+- [ ] **Step 10: Run the full suite**
+
+Run: `make test`
+Expected: PASS (traits tests now green; new kick test green; no `eject` references remain except `ejectIce`/`ICE_EJECTED`).
+
+- [ ] **Step 11: Lint**
+
+Run: `make lint`
+Expected: no type errors.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add -A
+git commit -m 'refactor: rename player verb eject -> kick (frees e for exec) (#135)'
+```
+
+---
+
+## Task 2: Partition module (`scripts.js`) + `EXEC` id
+
+**Files:**
+- Modify: `js/core/action-ids.js`
+- Create: `js/core/actions/scripts.js`
+- Test: `js/core/actions/scripts.test.js`
+
+- [ ] **Step 1: Write the failing predicate test**
+
+Create `js/core/actions/scripts.test.js`:
+
+```js
+// @ts-check
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { CORE_NODE_VERBS, isScriptAction } from "./scripts.js";
+import { A } from "../action-ids.js";
+
+describe("isScriptAction — core/script partition", () => {
+  test("core node verbs are NOT scripts", () => {
+    for (const id of [A.PROBE, A.XPLOIT, A.DUMP, A.FETCH, A.MINE, A.KICK,
+                       A.REBOOT, A.ABORT, A.TARGET, A.UNTARGET, A.JACKOUT, A.EXEC]) {
+      assert.equal(isScriptAction(id), false, `${id} should be core`);
+    }
+  });
+
+  test("set-piece + subversion actions ARE scripts", () => {
+    for (const id of ["corrupt", "spoof", "disarm", "unlock-vault",
+                      "extract-token", "extract-key", "decrypt-loot",
+                      "scan-vault", "cancel-trace", "access-darknet"]) {
+      assert.equal(isScriptAction(id), true, `${id} should be a script`);
+    }
+  });
+
+  test("EXEC is in the core set so it is never treated as a script", () => {
+    assert.ok(CORE_NODE_VERBS.has(A.EXEC));
+  });
+});
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `node --test js/core/actions/scripts.test.js`
+Expected: FAIL — `scripts.js` and `A.EXEC` don't exist.
+
+- [ ] **Step 3: Add the `EXEC` id**
+
+In `js/core/action-ids.js`, in the `// Node-specific actions` group, add:
+```js
+  EXEC: "exec",
+```
+
+- [ ] **Step 4: Create the partition module**
+
+Create `js/core/actions/scripts.js`:
+```js
+// @ts-check
+/**
+ * Core/script partition. A node-contextual action is a "script" (grouped under
+ * the EXEC submenu/verb) iff its id is NOT in the core deck-verb allowlist.
+ * New set-piece-authored node actions become scripts automatically.
+ */
+import { A } from "../action-ids.js";
+
+/** Core node verbs that stay top-level (never grouped under EXEC). */
+export const CORE_NODE_VERBS = new Set([
+  A.PROBE, A.XPLOIT, A.DUMP, A.FETCH, A.MINE, A.KICK,
+  A.REBOOT, A.ABORT, A.TARGET, A.UNTARGET, A.JACKOUT,
+  A.EXEC, // synthetic submenu action — not itself a script
+]);
+
+/** @param {string} id @returns {boolean} */
+export function isScriptAction(id) {
+  return !CORE_NODE_VERBS.has(id);
+}
+```
+
+- [ ] **Step 5: Run it — verify it passes**
+
+Run: `node --test js/core/actions/scripts.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add js/core/action-ids.js js/core/actions/scripts.js js/core/actions/scripts.test.js
+git commit -m 'feat: add core/script partition predicate + EXEC action id (#135)'
+```
+
+---
+
+## Task 3: Inject the synthetic `EXEC` action
+
+**Files:**
+- Modify: `js/core/actions/node-actions.js`
+- Test: `tests/integration.test.js`
+
+- [ ] **Step 1: Write the failing integration test**
+
+In `tests/integration.test.js`, add (reusing `buildAlertLAN`, `getAvailableActions`, `A`):
+
+```js
+describe("EXEC synthetic action injection", () => {
+  beforeEach(() => { clearAll(); initGame(() => buildAlertLAN(), "itest-exec"); });
+
+  it("a node with a script (owned IDS → corrupt) gains an EXEC action whose followup lists the script", () => {
+    const s = getState();
+    s.nodeGraph.setNodeAttr("ids-1", "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr("ids-1", "forwardingEnabled", true);
+    const actions = getAvailableActions(s.nodes["ids-1"], s);
+    const exec = actions.find((a) => a.id === A.EXEC);
+    assert.ok(exec, "EXEC should be present");
+    assert.ok(exec.followup, "EXEC should carry a followup");
+    const choiceIds = exec.followup.choices(s.nodes["ids-1"], s).map((c) => c.id);
+    assert.ok(choiceIds.includes("corrupt"), "corrupt should be an EXEC choice");
+  });
+
+  it("a node with no scripts gets no EXEC action", () => {
+    const s = getState();
+    // gateway has only core verbs (probe/xploit), no scripts
+    const actions = getAvailableActions(s.nodes["gateway"], s);
+    assert.ok(!actions.some((a) => a.id === A.EXEC), "no EXEC when no scripts");
+  });
+
+  it("EXEC.execute runs the chosen script (forwarding disabled), same as dispatching it directly", () => {
+    const s = getState();
+    s.nodeGraph.setNodeAttr("ids-1", "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr("ids-1", "forwardingEnabled", true);
+    const exec = getAvailableActions(s.nodes["ids-1"], s).find((a) => a.id === A.EXEC);
+    exec.execute(s.nodes["ids-1"], s, {}, { scriptId: "corrupt", nodeId: "ids-1" });
+    assert.equal(s.nodes["ids-1"].forwardingEnabled, false);
+  });
+});
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `node --test tests/integration.test.js`
+Expected: FAIL — no `EXEC` action exists.
+
+- [ ] **Step 3: Inject EXEC in `getAvailableActions` + export `getScriptActions`**
+
+In `js/core/actions/node-actions.js`:
+
+Add import at top:
+```js
+import { isScriptAction } from "./scripts.js";
+```
+
+Replace the end of `getAvailableActions` (current lines 43-46) so it appends EXEC:
+```js
+  // Wrap each graph ActionDef into a game-compatible ActionDef
+  const wrapped = filtered.map(ga => wrapGraphAction(ga));
+
+  // Group non-core node actions (scripts) under a synthetic EXEC follow-up action.
+  const scripts = wrapped.filter(a => isScriptAction(a.id));
+  const result = [...global, ...wrapped];
+  if (scripts.length > 0) result.push(buildExecAction(scripts));
+  return result;
+}
+
+/**
+ * Node-contextual scripts available on this node (non-core actions only),
+ * without the synthetic EXEC wrapper. Used by the console (`exec`, `actions`).
+ * @param {NodeState | null} node @param {GameState} state @returns {ActionDef[]}
+ */
+export function getScriptActions(node, state) {
+  return getAvailableActions(node, state).filter(a => isScriptAction(a.id));
+}
+
+/**
+ * Build the synthetic EXEC action from already-wrapped script ActionDefs.
+ * Closes over `scripts` so execute() needs no re-query (avoids an import cycle).
+ * @param {ActionDef[]} scripts @returns {ActionDef}
+ */
+function buildExecAction(scripts) {
+  const byId = new Map(scripts.map(s => [s.id, s]));
+  return {
+    id: A.EXEC,
+    label: "EXEC",
+    available: () => true,
+    desc: () => "run a script on this node",
+    followup: {
+      title: () => "EXEC",
+      choices: () => scripts.map(s => ({
+        id: s.id, payloadKey: "scriptId", render: s.label, data: {},
+      })),
+      empty: () => "no scripts available",
+    },
+    execute: (node, state, ctx, payload) => {
+      const script = byId.get(payload?.scriptId);
+      script?.execute?.(node, state, ctx, { nodeId: node.id });
+    },
+  };
+}
+```
+
+> `A` is already imported in `node-actions.js`. `isScriptAction(A.EXEC)` is `false`, so `getScriptActions` excludes the synthetic action and only returns real scripts.
+
+- [ ] **Step 4: Run it — verify it passes**
+
+Run: `node --test tests/integration.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Lint**
+
+Run: `make lint`
+Expected: no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add js/core/actions/node-actions.js tests/integration.test.js
+git commit -m 'feat: inject synthetic EXEC follow-up action for node scripts (#135)'
+```
+
+---
+
+## Task 4: Dispatcher log-echo special-case
+
+So the GUI EXEC pick echoes `exec corrupt`, not `exec`, with exactly one echo — mirroring how `xploit <card>` already reads.
+
+**Files:**
+- Modify: `js/core/actions/action-context.js:74-78`
+- Test: `tests/integration.test.js`
+
+- [ ] **Step 1: Write the failing dispatcher test**
+
+In `tests/integration.test.js`, add (uses `initActionDispatcher`, `buildActionContext` — import them at the top of the file from `../js/core/actions/action-context.js`):
+
+```js
+describe("EXEC dispatch echo", () => {
+  let dispatcherReady = false;
+  before(() => {
+    initActionDispatcher(buildActionContext());
+    dispatcherReady = true;
+  });
+
+  it("dispatching exec with a scriptId echoes 'exec <script>' once and runs the script", () => {
+    clearAll();
+    initGame(() => buildAlertLAN(), "itest-exec-echo");
+    const s = getState();
+    s.nodeGraph.setNodeAttr("ids-1", "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr("ids-1", "forwardingEnabled", true);
+
+    const echoes = [];
+    const h = ({ cmd }) => echoes.push(cmd);
+    on(E.COMMAND_ISSUED, h);
+    emitEvent("starnet:action", { actionId: "exec", nodeId: "ids-1", scriptId: "corrupt" });
+    off(E.COMMAND_ISSUED, h);
+
+    assert.deepEqual(echoes, ["exec corrupt"], "exactly one echo reading 'exec corrupt'");
+    assert.equal(getState().nodes["ids-1"].forwardingEnabled, false, "script ran");
+  });
+});
+```
+
+> `initActionDispatcher` registers a persistent `starnet:action` listener — register it once in `before()` for this describe only. If another describe in the file later relies on no dispatcher being present, keep this block last, or guard with the `dispatcherReady` flag pattern shown.
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `node --test tests/integration.test.js`
+Expected: FAIL — echo reads `exec`, not `exec corrupt`.
+
+- [ ] **Step 3: Add the echo special-case**
+
+In `js/core/actions/action-context.js`, replace the `logStr` block (lines 74-78):
+```js
+    if (!fromConsole) {
+      // For exploit, log the card reference; for exec, log the chosen script —
+      // both match the console output rather than the raw actionId.
+      const logStr =
+        (actionId === A.XPLOIT && (payload.cardIndex ?? payload.exploitId))
+          ? `xploit ${payload.cardIndex ?? payload.exploitId}`
+          : (actionId === A.EXEC && payload.scriptId)
+            ? `exec ${payload.scriptId}`
+            : actionId + (nodeId ? ` ${nodeId}` : "");
+      emitEvent(E.COMMAND_ISSUED, { cmd: logStr });
+    }
+```
+
+> `A` is already imported in `action-context.js`.
+
+- [ ] **Step 4: Run it — verify it passes**
+
+Run: `node --test tests/integration.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/core/actions/action-context.js tests/integration.test.js
+git commit -m 'feat: dispatcher echoes "exec <script>" for the EXEC menu pick (#135)'
+```
+
+---
+
+## Task 5: Console — drop scripts from verb namespace, add `exec`
+
+**Files:**
+- Modify: `js/core/console-commands/dynamic-actions.js`
+- Modify: `js/core/console-commands/commands.js`
+- Test: `js/core/console-commands/commands.test.js`
+
+- [ ] **Step 1: Write failing `exec` command tests**
+
+In `js/core/console-commands/commands.test.js`, add a describe block. Owning the IDS for these tests uses the same `setNodeAccessLevel` import already present, plus a `forwardingEnabled` graph attr:
+
+```js
+describe("exec", () => {
+  /** Own ids-1, enable forwarding, select it — so `corrupt` is an available script. */
+  function selectOwnedIds() {
+    const s = getState();
+    s.nodeGraph.setNodeAttr("ids-1", "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr("ids-1", "forwardingEnabled", true);
+    navigateTo("ids-1");
+  }
+
+  it("`exec` with no arg lists the node's scripts", () => {
+    selectOwnedIds();
+    const ls = logs(() => getCommand("exec").execute([]));
+    const text = ls.map((l) => l.text).join("\n");
+    assert.ok(text.includes("corrupt"), "should list corrupt");
+  });
+
+  it("`exec corrupt` dispatches the corrupt action on the selected node", () => {
+    selectOwnedIds();
+    const evts = actions(() => getCommand("exec").execute(["corrupt"]));
+    assert.equal(evts.length, 1);
+    assert.equal(evts[0].actionId, "corrupt");
+    assert.equal(evts[0].nodeId, "ids-1");
+    assert.equal(evts[0].fromConsole, true);
+  });
+
+  it("`exec bogus` logs an error and dispatches nothing", () => {
+    selectOwnedIds();
+    let evts;
+    const ls = logs(() => { evts = actions(() => getCommand("exec").execute(["bogus"])); });
+    assert.ok(ls.some((l) => l.type === "error"));
+    assert.equal(evts.length, 0);
+  });
+
+  it("tab-completion returns script ids", () => {
+    selectOwnedIds();
+    const res = getCommand("exec").complete([], "", getState());
+    assert.ok(res.insertTexts.includes("corrupt"));
+  });
+
+  it("`exec` with no node selected logs an error", () => {
+    const ls = logs(() => getCommand("exec").execute([]));
+    assert.ok(ls.some((l) => l.type === "error"));
+  });
+});
+```
+
+> If `ids-1` is `hidden`/`obscured` after init so `navigateTo` won't select it, set `s.nodes["ids-1"].visibility = "accessible"` before `navigateTo`, mirroring how other tests in this file prepare a node. The assertions that matter are the dispatch payload and the listing.
+
+- [ ] **Step 2: Run them — verify they fail**
+
+Run: `node --test js/core/console-commands/commands.test.js`
+Expected: FAIL — there is no `exec` command.
+
+- [ ] **Step 3: Add the `exec` command**
+
+In `js/core/console-commands/commands.js`:
+
+Extend the import from `node-actions.js` (line 7):
+```js
+import { getAvailableActions, getScriptActions } from "../actions/node-actions.js";
+```
+
+Add this CommandDef to the `COMMANDS` array (place it after the `xploit` block, near the other node-arg commands):
+```js
+  // ── exec — run a node script (grouped non-core node actions) ─────────────────
+  { verb: "exec",
+    complete(args, partial, state) {
+      if (args.length > 0) return null;
+      const sel = state.selectedNodeId ? state.nodes[state.selectedNodeId] : null;
+      if (!sel) return null;
+      return fromList(getScriptActions(sel, state).map((a) => a.id), partial);
+    },
+    execute(args) {
+      const s = getState();
+      const sel = s.selectedNodeId ? s.nodes[s.selectedNodeId] : null;
+      if (!sel) { addLogEntry("exec: no node selected.", "error"); return; }
+      const scripts = getScriptActions(sel, s);
+      if (args.length === 0) {
+        if (scripts.length === 0) { addLogEntry(`no scripts on ${sel.id}.`, "meta"); return; }
+        addLogEntry(`scripts on ${sel.id}: ${scripts.map((a) => a.id).join("  ")}`, "meta");
+        return;
+      }
+      const id = args[0].toLowerCase();
+      if (!scripts.some((a) => a.id === id)) {
+        addLogEntry(`exec: no script "${id}" on ${sel.id}.`, "error");
+        return;
+      }
+      dispatch(id, { nodeId: sel.id });
+    },
+  },
+```
+
+> `fromList`, `dispatch`, `addLogEntry`, `getState` are all already imported in this file.
+
+- [ ] **Step 4: Drop scripts (and synthetic EXEC) from the dynamic verb registry**
+
+In `js/core/console-commands/dynamic-actions.js`:
+
+Add import:
+```js
+import { isScriptAction } from "../actions/scripts.js";
+```
+
+Add `A.EXEC` to the `STATIC_ACTION_IDS` set (so the synthetic EXEC is never registered as a dynamic verb):
+```js
+const STATIC_ACTION_IDS = new Set([
+  A.XPLOIT,
+  A.TARGET, A.UNTARGET, A.JACKOUT,
+  A.EXEC, // synthetic submenu action — `exec` is a static command
+]);
+```
+
+In `syncDynamicActions`, inside the `for (const action of graphActions)` loop, after the `STATIC_ACTION_IDS` skip, add:
+```js
+    if (isScriptAction(action.id)) continue; // scripts live under `exec`
+```
+
+- [ ] **Step 5: Run the command tests — verify they pass**
+
+Run: `node --test js/core/console-commands/commands.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Add a namespace-separation test**
+
+Create `js/core/console-commands/dynamic-actions.test.js`:
+```js
+// @ts-check
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { buildNetwork as buildCorporateFoothold } from "../../../data/networks/corporate-foothold.js";
+import { initGame, getState } from "../state.js";
+import { navigateTo } from "../navigation.js";
+import { clearAll } from "../timers.js";
+import { emitEvent, E } from "../events.js";
+import { registry } from "./registry.js";
+import { initDynamicActions } from "./dynamic-actions.js";
+
+describe("dynamic-actions namespace separation", () => {
+  beforeEach(() => { clearAll(); initGame(() => buildCorporateFoothold()); });
+
+  test("a node with scripts registers no script verbs (only core verbs + static exec)", () => {
+    initDynamicActions();
+    const s = getState();
+    const ids = Object.values(s.nodes).find((n) => n.type === "ids");
+    assert.ok(ids, "expected an IDS node");
+    s.nodeGraph.setNodeAttr(ids.id, "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr(ids.id, "forwardingEnabled", true);
+    s.nodes[ids.id].visibility = "accessible";
+    navigateTo(ids.id);
+    emitEvent(E.STATE_CHANGED, s); // trigger syncDynamicActions
+
+    assert.equal(registry.has("corrupt"), false, "script verb must not be top-level");
+    assert.equal(registry.has("exec"), true, "static exec command stays");
+  });
+});
+```
+
+> `initDynamicActions` adds persistent listeners; this test file runs in its own process so stacking is not a concern. If `registry`/`initDynamicActions` exports differ, check `dynamic-actions.js` and `registry.js` for the exact names (they are `registry` and `initDynamicActions`). `exec` is registered when `COMMANDS` is loaded via `index.js`; if this test imports neither, register it explicitly or import `./index.js` for its side effects.
+
+- [ ] **Step 7: Run it — confirm pass (after registering `exec`)**
+
+Run: `node --test js/core/console-commands/dynamic-actions.test.js`
+Expected: PASS. If `registry.has("exec")` is false, add `import "./index.js";` at the top of the test to load the static command set.
+
+- [ ] **Step 8: Lint + commit**
+
+```bash
+make lint
+git add js/core/console-commands/
+git commit -m 'feat: exec console verb + drop node scripts from top-level namespace (#135)'
+```
+
+---
+
+## Task 6: `actions` listing grouping + `help` text
+
+Show scripts grouped under `exec` in `actions` (so players discover them without extra commands), and update `help`.
+
+**Files:**
+- Modify: `js/core/console-commands/commands.js` (`actions` block ~159-169, `help` ~277-286)
+- Test: `js/core/console-commands/commands.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `commands.test.js`:
+```js
+describe("actions listing groups scripts under exec", () => {
+  it("lists `exec` and an indented `corrupt` for an owned IDS", () => {
+    const s = getState();
+    s.nodeGraph.setNodeAttr("ids-1", "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr("ids-1", "forwardingEnabled", true);
+    s.nodes["ids-1"].visibility = "accessible";
+    navigateTo("ids-1");
+    const text = logs(() => getCommand("actions").execute([])).map((l) => l.text).join("\n");
+    assert.ok(/exec <script>/.test(text), "should advertise exec");
+    assert.ok(/^\s+corrupt/m.test(text), "corrupt should be indented under exec");
+  });
+});
+
+// extend the existing help test's verb list:
+//   for (const verb of ["target", "probe", "xploit", "jackout", "status", "cheat", "exec"]) {
+```
+
+- [ ] **Step 2: Run — verify fail**
+
+Run: `node --test js/core/console-commands/commands.test.js`
+Expected: FAIL — no `exec <script>` grouping; help lacks `exec`.
+
+- [ ] **Step 3: Regroup the `actions` block**
+
+In `js/core/console-commands/commands.js`, replace the type-specific block (current lines 159-169, the `standardIds`/`typeSpecific` computation and its `forEach`) with:
+```js
+        // Non-core node actions are grouped under `exec` (see scripts.js).
+        const scripts = getScriptActions(sel, s);
+        if (scripts.length > 0) {
+          lines.push(`  exec <script>            — run a script on ${sel.id}:`);
+          scripts.forEach((a) => {
+            const desc = typeof a.desc === "function" ? a.desc(sel, s) : (a.desc || a.label);
+            lines.push(`    ${a.id.padEnd(22)} — ${desc}`);
+          });
+        }
+```
+
+> This removes the `standardIds` array and the bare type-specific listing entirely. The core verbs (probe/xploit/dump/fetch/kick/reboot) keep their existing explicit `lines.push` entries above this block.
+
+- [ ] **Step 4: Update `help`**
+
+In the `help` command's `lines` array: remove the standalone `corrupt [node]` entry (line ~281) and add an `exec` entry near the node verbs:
+```js
+        "  exec [<script>]           Run a node script (corrupt, unlock-vault, …). No arg lists scripts.",
+```
+(The `eject`→`kick` help line was already changed in Task 1.)
+
+- [ ] **Step 5: Run — verify pass**
+
+Run: `node --test js/core/console-commands/commands.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+make lint
+git add js/core/console-commands/commands.js js/core/console-commands/commands.test.js
+git commit -m 'feat: actions listing + help group node scripts under exec (#135)'
+```
+
+---
+
+## Task 7: Context menu — hide raw scripts behind EXEC
+
+The synthetic EXEC already arrives via `getAvailableActions`; we just stop rendering the raw script buttons so only `EXEC ▸` shows.
+
+**Files:**
+- Modify: `js/ui/visual-renderer.js:223-224` (`syncContextMenu`)
+
+> `js/ui/components/starnet-node-panel.js` was audited — it does not render the action list (only vulns/macguffins/ice-timers + an untarget button), so no change is needed there. The graph context menu is the only button surface.
+
+- [ ] **Step 1: Filter raw scripts from the menu**
+
+In `js/ui/visual-renderer.js`, add the import (top of file, with the other action imports):
+```js
+import { isScriptAction } from "../core/actions/scripts.js";
+```
+
+In `syncContextMenu`, extend the filter (line ~224):
+```js
+  const actions = getAvailableActions(node, state)
+    .filter((a) => !a.noSidebar && a.id !== A.TARGET && a.id !== A.JACKOUT
+      && a.id !== A.UNTARGET && a.id !== A.ABORT
+      && !isScriptAction(a.id)); // scripts are reached via the EXEC ▸ entry
+```
+
+> `isScriptAction(A.EXEC)` is `false`, so the synthetic `EXEC` entry (which has a `followup`) survives the filter and renders with the `▸` indicator via the existing `hasFollowup` path. No component change needed — clicking it opens the existing `starnet:open-choices` picker.
+
+- [ ] **Step 2: Lint**
+
+Run: `make lint`
+Expected: no type errors. (This is DOM/`@ts-nocheck`-adjacent UI code; verify it loads.)
+
+- [ ] **Step 3: Manual smoke in the browser**
+
+Run: `make bundle-vendor` (if not already built), then `make serve`. Open the game, navigate to and own an IDS node. Confirm:
+- The context menu shows core verbs + `EXEC ▸` (no bare `CORRUPT` button).
+- Clicking `EXEC ▸` opens the picker listing `corrupt`.
+- Picking `corrupt` runs it; the log shows `> exec corrupt` followed by the corrupt effect line.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add js/ui/visual-renderer.js
+git commit -m 'feat: hide raw node scripts behind the EXEC submenu in the context menu (#135)'
+```
+
+---
+
+## Task 8: MANUAL.md
+
+**Files:**
+- Modify: `MANUAL.md`
+
+- [ ] **Step 1: Node Actions Reference table (line ~504)**
+
+Add an `exec` row and fold the scripts under it. Concretely: keep core rows; change the `corrupt`/`spoof`/`cancel-trace`/`access-darknet` rows to note they're run via `exec`, and add a heading row. Replace the `eject` row with `kick`. Minimal edit:
+
+- Add above the script rows:
+  `| \`exec <script>\` | A compromised/owned node has node scripts | Lists/runs the node's scripts (corrupt, spoof, unlock-vault, cancel-trace, access-darknet, …) |`
+- Change `| \`eject\`        | Owned node + ICE is present here               | Boots ICE to adjacent node |` to `| \`kick\`         | Owned node + ICE is present here               | Boots ICE to adjacent node |`
+- Append " (run via `exec`)" to the Effect cell of `corrupt`, `spoof`, `cancel-trace`, and the `access-darknet` row.
+
+- [ ] **Step 2: ICE section (line ~480)**
+
+Change `**Eject** (owned nodes) — boots ICE to a random adjacent node: \`> eject\`` to `**Kick** (owned nodes) — boots ICE to a random adjacent node: \`> kick\``. Update the TIPS reference (line ~578, "have an eject") to "have a kick".
+
+- [ ] **Step 3: Access Levels (line ~119)**
+
+`...reboot the node, or eject ICE.` → `...reboot the node, or kick ICE.`
+
+- [ ] **Step 4: Console Commands block (lines ~537-541)**
+
+Replace:
+```
+corrupt [node]         Disable IDS event forwarding.
+spoof [node]           Recalibrate security monitor.
+eject                  Push ICE off current node to adjacent node.
+```
+with:
+```
+exec [<script>]        Run a node script (corrupt, spoof, unlock-vault, …). No arg lists scripts.
+kick                   Push ICE off current node to adjacent node.
+```
+(Leave `reboot`, `cancel-trace`, `jackout` lines; `cancel-trace` and `access-darknet` are now reached via `exec` — note that inline if desired.)
+
+- [ ] **Step 5: Subverting the IDS (line ~405-408)**
+
+The example shows `> corrupt`. Update to `> exec corrupt` to match the new console flow.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add MANUAL.md
+git commit -m 'docs: MANUAL — EXEC submenu, exec verb, eject→kick rename (#135)'
+```
+
+---
+
+## Task 9: Full verification
+
+- [ ] **Step 1: Lint + test**
+
+Run: `make check`
+Expected: lint clean, all tests PASS.
+
+- [ ] **Step 2: Playtest harness smoke (parallel entry point)**
+
+```bash
+node scripts/playtest.js reset
+node scripts/playtest.js "target ids-1"   # or any node id from status
+node scripts/playtest.js "status full"
+```
+Expected: no crash; `kick`/`exec` referenced correctly in help/actions output. (Cheat-own a node if needed to surface a script, then confirm `exec` lists it — note: cheat commands aren't supported in the harness, so verify via the browser smoke in Task 7 instead if needed.)
+
+- [ ] **Step 3: Bot census smoke (verify difficulty curve didn't regress)**
+
+Run: `node scripts/bot-census.js --time F --money F --seeds 10`
+Expected: ~80% success. The bot uses `A.KICK` after the rename; confirm no errors about unknown actions.
+
+- [ ] **Step 4: Open PR**
+
+```bash
+git push -u origin exec-submenu-node-scripts
+gh pr create --title "EXEC submenu/verb for non-core node actions" \
+  --body "Closes #135. Groups set-piece + subversion node actions under a single EXEC menu entry and \`exec\` console verb; renames eject→kick to free \`e\`. See docs/dev-sessions/2026-06-10-1628-exec-submenu-node-scripts/." \
+  --base main
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** partition (Task 2), EXEC injection (Task 3), dispatcher symmetry/echo (Task 4), console namespace + `exec` (Task 5), `actions`/`help` grouping (Task 6), context menu (Task 7), `eject`→`kick` (Task 1), MANUAL (Task 8), bot/harness parity + verification (Tasks 1, 9). All spec sections map to a task.
+- **Module-boundary correction vs spec:** spec placed `getScriptActions`/`buildExecAction` in `scripts.js`; the plan keeps `scripts.js` pure and puts those two in `node-actions.js` to avoid a `node-actions ↔ scripts` import cycle. Net behavior identical.
+- **Type/name consistency:** `A.KICK` (value `"kick"`), `A.EXEC` (value `"exec"`), `isScriptAction`, `getScriptActions`, `buildExecAction`, payloadKey `"scriptId"` — used identically across all tasks.
+- **cancel-trace** intentionally lands under EXEC (spec non-goal: UX-friction mitigation deferred).

--- a/docs/dev-sessions/2026-06-10-1628-exec-submenu-node-scripts/spec.md
+++ b/docs/dev-sessions/2026-06-10-1628-exec-submenu-node-scripts/spec.md
@@ -1,0 +1,238 @@
+# EXEC submenu / verb for non-core node actions
+
+**Issue:** [#135](https://github.com/lmorchard/starnet/issues/135)
+**Branch:** `exec-submenu-node-scripts`
+
+## Problem
+
+Set-piece node actions (`unlock-vault`, `extract-token`, `extract-key`,
+`decrypt-loot`, `scan-vault`) and security-subversion actions (`corrupt`,
+`spoof`, `disarm`) are registered as both top-level context-menu buttons and
+**flat console verbs** — indistinguishable from core deck commands like `probe`,
+`xploit`, `dump`, `fetch`. They crowd the context menu and pollute the top-level
+tab-completion namespace.
+
+Conceptually these are **scripts run on a compromised node**, not core deck
+operations. They should be grouped behind a single `EXEC` affordance — a menu
+entry and a console verb — so the core deck namespace stays clean and new
+set-piece actions don't leak into it.
+
+## Goals
+
+- Group all non-core node actions under one `EXEC` entry in the graph context menu.
+- Provide an `exec` console verb: `exec` lists the selected node's scripts;
+  `exec <script>` runs one; tab-completion completes script ids after `exec `.
+- Remove script actions from the top-level console verb namespace and
+  top-level tab-completion.
+- Future set-piece-authored node actions become scripts **by default** — no
+  per-action tagging required.
+- Preserve the **GUI/console symmetry invariant**: picking a script in the menu
+  and typing `exec <script>` produce identical state changes and log output.
+
+## Non-goals
+
+- No change to *what* any script does — only how it's presented and dispatched.
+- No new menu-rendering paradigm (flyouts, nested panels). We reuse the existing
+  follow-up choice picker.
+- `cancel-trace` lands under EXEC despite being time-critical. UX-friction
+  mitigation is explicitly deferred to a future iteration (noted in #135).
+- Scripts that themselves declare a `followup` are out of scope (none exist
+  today). If one is added later, nesting EXEC → script-followup needs design.
+
+## Scope: the core/script partition
+
+**Core top-level verbs (stay flat, unchanged):**
+`probe`, `xploit`, `dump`, `fetch`, `mine`, `kick` (renamed from `eject`),
+`reboot`, `abort`, `target`, `untarget`, `jackout`.
+
+Meta console commands (`status`, `actions`, `darknet`, `buy`, `log`, `help`,
+`cheat`) are not node actions and are untouched.
+
+**EXEC scripts (grouped under `exec`):**
+`corrupt`, `spoof`, `disarm`, `unlock-vault`, `extract-token`, `extract-key`,
+`decrypt-loot`, `scan-vault`, `cancel-trace`, `access-darknet`, **and every
+future set-piece-authored node action by default.**
+
+**Partition rule:** a node-contextual action is a *script* iff its id is **not**
+in the core allowlist `CORE_NODE_VERBS`. This is an allowlist (everything else is
+a script), so new set-piece actions are scripts automatically.
+
+```
+CORE_NODE_VERBS = { probe, xploit, dump, fetch, mine, kick,
+                    reboot, abort, target, untarget, jackout, exec }
+```
+
+(`exec` itself is in the set so the synthetic action is never treated as a script.)
+
+## Naming and the `eject` → `kick` rename
+
+`run`, `shell`, and `exec` all collide on first letters already taken by core
+verbs (`r`=reboot, `s`=status, `e`=eject). To use **`exec`** with a unique first
+letter, **rename `eject` → `kick`** (the letter `k` is unused).
+
+- Change the **player-facing** verb/label/id: `A.EJECT` constant becomes `A.KICK`
+  with value `"kick"`, label `"KICK"`, and all help/console text.
+- **Do not** rename the internal mechanism: the `ejectIce()` ctx method and the
+  `E.ICE_EJECTED` event keep their names — they describe the mechanic (pushing
+  ICE to an adjacent node), not the player verb.
+
+## Design (Approach A — synthetic EXEC follow-up action)
+
+The action/dispatch layer stays intact: **all** node actions (core *and*
+scripts) remain in `getAvailableActions()` and remain dispatchable by id. We add
+one synthetic action and change only the *presentation* layers.
+
+### 1. Partition module — `js/core/actions/scripts.js` (new)
+
+- `CORE_NODE_VERBS` set (above).
+- `isScriptAction(id)` → `!CORE_NODE_VERBS.has(id)`.
+- `getScriptActions(node, state)` → the node's available actions filtered by
+  `isScriptAction`.
+- `buildExecAction(scripts)` → the synthetic `EXEC` ActionDef (below).
+
+### 2. Synthetic EXEC action — injected in `getAvailableActions()` (`node-actions.js`)
+
+After assembling global + graph actions, if the node has ≥1 script, append:
+
+```
+{
+  id: A.EXEC,                       // "exec"
+  label: "EXEC",
+  desc: () => "run a script on this node",
+  followup: {
+    title: () => "EXEC",
+    choices: (node, state) =>
+      getScriptActions(node, state).map(s => ({
+        id: s.id, payloadKey: "scriptId", render: s.label, data: {},
+      })),
+    empty: () => "no scripts available",
+  },
+  execute: (node, state, ctx, payload) => {
+    const script = getAvailableActions(node, state).find(a => a.id === payload.scriptId);
+    script?.execute?.(node, state, ctx, { nodeId: node.id });
+  },
+}
+```
+
+The raw script actions stay in the returned array (so the dispatcher and EXEC
+can find them by id); presentation layers hide them.
+
+### 3. Dispatcher echo — `action-context.js`
+
+Mirror the existing `xploit` special-case so the GUI EXEC pick echoes the script
+name, not `exec`:
+
+```
+const logStr =
+  (actionId === A.XPLOIT && ...) ? `xploit ${...}`
+  : (actionId === A.EXEC && payload.scriptId) ? `exec ${payload.scriptId}`
+  : actionId + (nodeId ? ` ${nodeId}` : "");
+```
+
+Because EXEC.execute invokes the script's `execute` **directly** (not a
+re-dispatch), there is exactly one `COMMAND_ISSUED` echo and the script's own
+effect logs follow — identical to how `xploit <card>` reads today.
+
+### 4. Context menu — `visual-renderer.js#syncContextMenu`
+
+Filter the raw script actions out of the menu list (`!isScriptAction(a.id)`).
+The synthetic EXEC action remains and, having a `followup`, renders with the
+existing `hasFollowup` ▸ indicator. Clicking it opens the existing
+`starnet:open-choices` picker, populated with the node's scripts. Picking a
+script dispatches `starnet:action { actionId: "exec", scriptId }` — handled by
+EXEC.execute. **No new component or rendering path.**
+
+The same filter must be applied anywhere else raw node actions are rendered as
+buttons (e.g. `starnet-node-panel` sidebar) — audit during implementation.
+
+### 5. Console — drop scripts from the verb namespace, add `exec`
+
+- **`dynamic-actions.js`:** skip script actions when registering dynamic verbs
+  (`if (isScriptAction(action.id)) continue;`). Core node verbs
+  (`probe`/`dump`/`fetch`/`mine`/`kick`/`reboot`/`abort`) keep registering as
+  today.
+- **`commands.js`:** add a static `exec` command:
+  - `complete(args, partial, state)` → script ids for the selected node
+    (`getScriptActions`), formatted as `{ insertTexts, displayTexts }`.
+  - `execute(args)`:
+    - no arg → print `scripts on <nodeId>: <id> <id> …` (or "no scripts" / "no
+      node selected").
+    - `exec <id>` → `emitEvent("starnet:action", { actionId: <id>,
+      nodeId: selected, fromConsole: true })`. The dispatcher finds and runs the
+      script; an unknown/unavailable id falls through to the existing
+      `"<id>: not available."` error.
+
+### 6. `actions` console command + help text
+
+Update the `actions` listing and `help` text so scripts are shown grouped under
+`exec` rather than as bare verbs, and so `kick` replaces `eject`.
+
+## Data flow
+
+```
+GUI:   click node ▸ EXEC ▸ pick "corrupt"
+       → starnet:action { actionId:"exec", scriptId:"corrupt", nodeId }
+       → dispatcher echoes "exec corrupt"
+       → EXEC.execute → corrupt.execute(node,state,ctx)         → effects + logs
+
+Console: > exec corrupt
+       → console echoes raw "> exec corrupt"
+       → starnet:action { actionId:"corrupt", nodeId, fromConsole:true }
+       → corrupt.execute(node,state,ctx)                        → effects + logs
+```
+
+Both paths converge on the same script `execute`, same state mutation, same
+effect log lines. Symmetry preserved.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `js/core/action-ids.js` | `EJECT`→`KICK`; add `EXEC: "exec"` |
+| `js/core/actions/scripts.js` | **new** — `CORE_NODE_VERBS`, `isScriptAction`, `getScriptActions`, `buildExecAction` |
+| `js/core/actions/node-actions.js` | inject synthetic EXEC when node has scripts |
+| `js/core/actions/action-context.js` | EXEC echo special-case |
+| `js/core/node-graph/game-types.js` | `EJECT_ACTION` label/id → KICK |
+| `js/core/node-graph/traits.js` | EJECT template ref → KICK |
+| `js/ui/visual-renderer.js` | filter raw scripts from context menu |
+| `js/ui/components/starnet-node-panel.js` | filter raw scripts (if it lists actions) — audit |
+| `js/core/console-commands/dynamic-actions.js` | skip scripts |
+| `js/core/console-commands/commands.js` | add `exec` command; update `actions`/`help`; `eject`→`kick` text |
+| `MANUAL.md` | node-actions reference, console commands, new EXEC section, kick rename |
+
+## Testing
+
+Bugs/behaviors pinned with tests before/alongside implementation:
+
+- **Partition predicate:** `isScriptAction` returns false for every core verb,
+  true for known scripts; `getScriptActions` returns exactly the scripts for a
+  representative set-piece node.
+- **EXEC injection:** a node with scripts gains an `EXEC` action with a
+  non-empty followup; a node with no scripts does not.
+- **EXEC dispatch (GUI path):** dispatching `starnet:action { actionId:"exec",
+  scriptId:"corrupt" }` produces the same state change as dispatching
+  `corrupt` directly (assert observable consequence, e.g. forwarding disabled),
+  and exactly one `COMMAND_ISSUED` echo reading `exec corrupt`.
+- **Console `exec`:** `exec corrupt` runs the script; `exec` with no arg lists
+  scripts; tab-completion returns script ids; an unknown id errors cleanly.
+- **Namespace separation:** after selecting a node with scripts, the dynamic
+  console registry contains no script verbs (only core verbs + `exec`).
+- **`kick` rename:** `kick` dispatches the former `eject` behavior end-to-end;
+  `E.ICE_EJECTED` still fires; no `eject` verb remains registered.
+
+Run `make check` (lint + test). Bot harness reads action ids directly — the
+`eject`→`kick` rename and any code that referenced `A.EJECT` must be updated so
+`scripts/bot-player.js` and `scripts/playtest.js` stay green; smoke-test with the
+playtest harness.
+
+## Acceptance criteria
+
+- Core verbs remain top-level in both menu and console.
+- Scripts no longer appear as top-level verbs or top-level tab-completions.
+- `EXEC ▸` appears in the context menu exactly when the node has ≥1 script and
+  opens the existing picker.
+- `exec` lists / runs / tab-completes the selected node's scripts.
+- `eject` is renamed to `kick` end-to-end; internal `ejectIce`/`ICE_EJECTED`
+  names unchanged.
+- MANUAL.md reflects EXEC and the `kick` rename.
+- `make check` passes; playtest harness smoke test passes.

--- a/js/core/action-ids.js
+++ b/js/core/action-ids.js
@@ -21,10 +21,11 @@ export const A = Object.freeze({
   TARGET: "target",
   UNTARGET: "untarget",
   JACKOUT: "jackout",
-  EJECT: "eject",
+  KICK: "kick",
   REBOOT: "reboot",
 
   // Node-specific actions
+  EXEC: "exec",
   CORRUPT: "corrupt",
   SPOOF: "spoof",
   CANCEL_TRACE: "cancel-trace",

--- a/js/core/actions/action-context.js
+++ b/js/core/actions/action-context.js
@@ -71,10 +71,14 @@ export function initActionDispatcher(ctx) {
       return;
     }
     if (!fromConsole) {
-      // For exploit, log the card reference rather than the nodeId (matches console output)
-      const logStr = (actionId === A.XPLOIT && (payload.cardIndex ?? payload.exploitId))
-        ? `xploit ${payload.cardIndex ?? payload.exploitId}`
-        : actionId + (nodeId ? ` ${nodeId}` : "");
+      // For exploit, log the card reference; for exec, log the chosen script —
+      // both match the console output rather than the raw actionId.
+      const logStr =
+        (actionId === A.XPLOIT && (payload.cardIndex ?? payload.exploitId))
+          ? `xploit ${payload.cardIndex ?? payload.exploitId}`
+          : (actionId === A.EXEC && payload.scriptId)
+            ? `exec ${payload.scriptId}`
+            : actionId + (nodeId ? ` ${nodeId}` : "");
       emitEvent(E.COMMAND_ISSUED, { cmd: logStr });
     }
     const versionBefore = getVersion();

--- a/js/core/actions/node-actions.js
+++ b/js/core/actions/node-actions.js
@@ -2,7 +2,7 @@
 /**
  * Unified action query — merges global actions with NodeGraph actions.
  *
- * All node-contextual actions (probe, exploit, read, loot, cancel-*, eject,
+ * All node-contextual actions (probe, exploit, read, loot, cancel-*, kick,
  * reboot, reconfigure, cancel-trace, access-darknet, etc.) are defined as
  * NodeDef actions on each node in the graph. This module wraps them into
  * game-compatible ActionDefs for the dispatcher and UI.
@@ -15,6 +15,7 @@
 import { getGlobalActions } from "./global-actions.js";
 import { A } from "../action-ids.js";
 import { getPrimaryIceFromState } from "../state/ice.js";
+import { isScriptAction } from "./scripts.js";
 
 /**
  * Returns all available actions for the given node and game state.
@@ -32,8 +33,8 @@ export function getAvailableActions(node, state) {
 
   // Apply global state filters the graph can't check
   const filtered = graphActions.filter(action => {
-    // Eject requires ICE attention at this specific node
-    if (action.id === A.EJECT) {
+    // Kick requires ICE attention at this specific node
+    if (action.id === A.KICK) {
       const ice = getPrimaryIceFromState(state);
       return !!(ice?.active && ice.attentionNodeId === node.id);
     }
@@ -42,7 +43,50 @@ export function getAvailableActions(node, state) {
 
   // Wrap each graph ActionDef into a game-compatible ActionDef
   const wrapped = filtered.map(ga => wrapGraphAction(ga));
-  return [...global, ...wrapped];
+
+  // Group non-core node actions (scripts) under a synthetic EXEC follow-up action.
+  const scripts = wrapped.filter(a => isScriptAction(a.id));
+  const result = [...global, ...wrapped];
+  if (scripts.length > 0) result.push(buildExecAction(scripts));
+  return result;
+}
+
+/**
+ * Node-contextual scripts available on this node (non-core actions only),
+ * without the synthetic EXEC wrapper. Used by the console (`exec`, `actions`).
+ * @param {NodeState | null} node @param {GameState} state @returns {ActionDef[]}
+ */
+export function getScriptActions(node, state) {
+  return getAvailableActions(node, state).filter(a => isScriptAction(a.id));
+}
+
+/**
+ * Build the synthetic EXEC action from already-wrapped script ActionDefs.
+ * Closes over `scripts` so execute() needs no re-query (avoids an import cycle).
+ * @param {ActionDef[]} scripts @returns {ActionDef}
+ */
+function buildExecAction(scripts) {
+  const byId = new Map(scripts.map(s => [s.id, s]));
+  return {
+    id: A.EXEC,
+    label: "EXEC",
+    available: () => true,
+    desc: () => "run a script on this node",
+    followup: {
+      title: () => "EXEC",
+      choices: (node, state) => scripts.map(s => ({
+        id: s.id,
+        payloadKey: "scriptId",
+        render: "action",
+        data: { label: s.label, desc: s.desc(node, state) },
+      })),
+      empty: () => "no scripts available",
+    },
+    execute: (node, state, ctx, payload) => {
+      const script = byId.get(payload?.scriptId);
+      script?.execute?.(node, state, ctx, { nodeId: node.id });
+    },
+  };
 }
 
 /**

--- a/js/core/actions/scripts.js
+++ b/js/core/actions/scripts.js
@@ -1,0 +1,19 @@
+// @ts-check
+/**
+ * Core/script partition. A node-contextual action is a "script" (grouped under
+ * the EXEC submenu/verb) iff its id is NOT in the core deck-verb allowlist.
+ * New set-piece-authored node actions become scripts automatically.
+ */
+import { A } from "../action-ids.js";
+
+/** @type {Set<string>} Core node verbs that stay top-level (never grouped under EXEC). */
+export const CORE_NODE_VERBS = new Set([
+  A.PROBE, A.XPLOIT, A.DUMP, A.FETCH, A.MINE, A.KICK,
+  A.REBOOT, A.ABORT, A.TARGET, A.UNTARGET, A.JACKOUT,
+  A.EXEC, // synthetic submenu action — not itself a script
+]);
+
+/** @param {string} id @returns {boolean} */
+export function isScriptAction(id) {
+  return !CORE_NODE_VERBS.has(id);
+}

--- a/js/core/actions/scripts.test.js
+++ b/js/core/actions/scripts.test.js
@@ -1,0 +1,30 @@
+// @ts-check
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { CORE_NODE_VERBS, isScriptAction } from "./scripts.js";
+import { A } from "../action-ids.js";
+
+describe("isScriptAction — core/script partition", () => {
+  test("core node verbs are NOT scripts", () => {
+    for (const id of [A.PROBE, A.XPLOIT, A.DUMP, A.FETCH, A.MINE, A.KICK,
+                       A.REBOOT, A.ABORT, A.TARGET, A.UNTARGET, A.JACKOUT, A.EXEC]) {
+      assert.equal(isScriptAction(id), false, `${id} should be core`);
+    }
+  });
+
+  test("set-piece + subversion actions ARE scripts", () => {
+    for (const id of ["corrupt", "spoof", "disarm", "unlock-vault",
+                      "extract-token", "extract-key", "decrypt-loot",
+                      "scan-vault", "cancel-trace", "access-darknet"]) {
+      assert.equal(isScriptAction(id), true, `${id} should be a script`);
+    }
+  });
+
+  test("EXEC is in the core set so it is never treated as a script", () => {
+    assert.ok(CORE_NODE_VERBS.has(A.EXEC));
+  });
+
+  test("an unknown id is treated as a script (open-world default)", () => {
+    assert.equal(isScriptAction("zzz-not-a-real-action"), true);
+  });
+});

--- a/js/core/console-commands/commands.js
+++ b/js/core/console-commands/commands.js
@@ -4,7 +4,7 @@
 import { getState } from "../state.js";
 import { addLogEntry, getRecentLog } from "../log.js";
 import { exploitSortKey, getStoreCatalog } from "../exploits.js";
-import { getAvailableActions } from "../actions/node-actions.js";
+import { getAvailableActions, getScriptActions } from "../actions/node-actions.js";
 import { buyFromStore } from "../store-logic.js";
 import {
   fromList, fromNodes, fromCards, fromVulnIds, completeNodeArg, getObscuredAliases,
@@ -49,9 +49,10 @@ export const COMMANDS = [
     execute() { dispatch(A.UNTARGET); },
   },
 
-  // probe, read, loot, reconfigure, reboot, cancel-*, eject, cancel-trace,
-  // access-darknet — all dynamically discovered from graph available actions.
-  // See dynamic-actions.js.
+  // Core node verbs (probe, dump, fetch, mine, kick, reboot, abort) are
+  // dynamically discovered from graph available actions. Non-core node actions
+  // (corrupt, cancel-trace, access-darknet, etc.) are scripts grouped under the
+  // static `exec` command, not registered as top-level verbs. See dynamic-actions.js.
 
   // ── exploit ────────────────────────────────────────────────────────────────
 
@@ -82,7 +83,34 @@ export const COMMANDS = [
     },
   },
 
-  // eject — dynamically discovered from graph available actions
+  // kick — dynamically discovered from graph available actions
+
+  // ── exec — run a node script (grouped non-core node actions) ─────────────────
+  { verb: "exec",
+    complete(args, partial, state) {
+      if (args.length > 0) return null;
+      const sel = state.selectedNodeId ? state.nodes[state.selectedNodeId] : null;
+      if (!sel) return null;
+      return fromList(getScriptActions(sel, state).map((a) => a.id), partial);
+    },
+    execute(args) {
+      const s = getState();
+      const sel = s.selectedNodeId ? s.nodes[s.selectedNodeId] : null;
+      if (!sel) { addLogEntry("exec: no node selected.", "error"); return; }
+      const scripts = getScriptActions(sel, s);
+      if (args.length === 0) {
+        if (scripts.length === 0) { addLogEntry(`no scripts on ${sel.id}.`, "meta"); return; }
+        addLogEntry(`scripts on ${sel.id}: ${scripts.map((a) => a.id).join("  ")}`, "meta");
+        return;
+      }
+      const id = args[0].toLowerCase();
+      if (!scripts.some((a) => a.id === id)) {
+        addLogEntry(`exec: no script "${id}" on ${sel.id}.`, "error");
+        return;
+      }
+      dispatch(id, { nodeId: sel.id });
+    },
+  },
 
   // ── jackout ────────────────────────────────────────────────────────────────
 
@@ -153,20 +181,18 @@ export const COMMANDS = [
         if (has.has(A.FETCH)) {
           lines.push(`  fetch                    — extract items from ${sel.id}`);
         }
-        if (has.has(A.EJECT))  lines.push(`  eject                    — push ICE to adjacent node`);
+        if (has.has(A.KICK))   lines.push(`  kick                     — push ICE to adjacent node`);
         if (has.has(A.REBOOT)) lines.push(`  reboot                   — send ICE home, take ${sel.id} offline briefly`);
 
-        // Type-specific actions (reconfigure, cancel-trace, access-darknet)
-        // are now included in getAvailableActions via graph path
-        const standardIds = /** @type {string[]} */ ([A.PROBE, A.ABORT, A.XPLOIT, A.DUMP,
-            A.FETCH, A.EJECT, A.REBOOT, A.JACKOUT, A.TARGET, A.UNTARGET]);
-        const typeSpecific = getAvailableActions(sel, s).filter(a =>
-          !standardIds.includes(a.id)
-        );
-        typeSpecific.forEach((a) => {
-          const desc = typeof a.desc === "function" ? a.desc(sel, s) : (a.desc || a.label);
-          lines.push(`  ${a.id.padEnd(24)} — ${desc}`);
-        });
+        // Non-core node actions are grouped under `exec` (see scripts.js).
+        const scripts = getScriptActions(sel, s);
+        if (scripts.length > 0) {
+          lines.push(`  exec <script>            — run a script on ${sel.id}:`);
+          scripts.forEach((a) => {
+            const desc = typeof a.desc === "function" ? a.desc(sel, s) : (a.desc || a.label);
+            lines.push(`    ${a.id.padEnd(22)} — ${desc}`);
+          });
+        }
 
         if (sel.type === "wan") {
           lines.push(`  darknet                  — list darknet broker catalog`);
@@ -278,10 +304,9 @@ export const COMMANDS = [
         "  xploit [node] <card>      Launch exploit. Card by index, id, or name prefix.",
         "  dump [node]               Scan node contents.",
         "  fetch [node]              Collect macguffins from owned node.",
-        "  corrupt [node]            Disable IDS event forwarding.",
+        "  exec [<script>]           Run a node script (corrupt, cancel-trace, unlock-vault, …). No arg lists scripts.",
         "  abort                     Cancel the current timed action (probe, xploit, dump, fetch).",
-        "  cancel-trace              Abort trace countdown (requires owned security-monitor selected).",
-        "  eject                     Push ICE attention to adjacent node.",
+        "  kick                      Push ICE attention to adjacent node.",
         "  reboot [node]             Send ICE home. Node offline briefly.",
         "  jackout                   Disconnect and end run.",
         "  actions                   List all currently valid actions with context.",

--- a/js/core/console-commands/commands.test.js
+++ b/js/core/console-commands/commands.test.js
@@ -260,7 +260,7 @@ describe("help", () => {
   it("produces a listing that includes key verbs", () => {
     const ls = logs(() => getCommand("help").execute([]));
     const text = ls.map((l) => l.text).join("\n");
-    for (const verb of ["target", "probe", "xploit", "jackout", "status", "cheat"]) {
+    for (const verb of ["target", "probe", "xploit", "jackout", "status", "cheat", "exec"]) {
       assert.ok(text.includes(verb), `expected help to mention "${verb}"`);
     }
   });
@@ -285,6 +285,84 @@ describe("darknet / buy — WAN access guard", () => {
     navigateTo(wanId);
     const ls = logs(() => getCommand("darknet").execute([]));
     assert.ok(ls.some((l) => l.text.includes("DARKNET BROKER")));
+  });
+});
+
+// ── exec ──────────────────────────────────────────────────────────────────────
+
+describe("exec", () => {
+  /** Own an IDS node, enable forwarding, select it — so `corrupt` is a script. */
+  function selectOwnedIds() {
+    const s = getState();
+    const ids = Object.values(s.nodes).find((n) => n.type === "ids");
+    assert.ok(ids, "fixture should have an IDS node");
+    s.nodeGraph.setNodeAttr(ids.id, "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr(ids.id, "forwardingEnabled", true);
+    s.nodes[ids.id].visibility = "accessible";
+    navigateTo(ids.id);
+    return ids.id;
+  }
+
+  it("`exec` with no arg lists the node's scripts", () => {
+    selectOwnedIds();
+    const ls = logs(() => getCommand("exec").execute([]));
+    assert.ok(ls.map((l) => l.text).join("\n").includes("corrupt"));
+  });
+
+  it("`exec corrupt` dispatches the corrupt action on the selected node", () => {
+    const id = selectOwnedIds();
+    const evts = actions(() => getCommand("exec").execute(["corrupt"]));
+    assert.equal(evts.length, 1);
+    assert.equal(evts[0].actionId, "corrupt");
+    assert.equal(evts[0].nodeId, id);
+    assert.equal(evts[0].fromConsole, true);
+  });
+
+  it("`exec bogus` logs an error and dispatches nothing", () => {
+    selectOwnedIds();
+    let evts;
+    const ls = logs(() => { evts = actions(() => getCommand("exec").execute(["bogus"])); });
+    assert.ok(ls.some((l) => l.type === "error"));
+    assert.equal(evts.length, 0);
+  });
+
+  it("tab-completion returns script ids", () => {
+    selectOwnedIds();
+    const res = getCommand("exec").complete([], "", getState());
+    assert.ok(res.insertTexts.includes("corrupt"));
+  });
+
+  it("`exec` with no node selected logs an error", () => {
+    const ls = logs(() => getCommand("exec").execute([]));
+    assert.ok(ls.some((l) => l.type === "error"));
+  });
+});
+
+// ── actions listing groups scripts under exec ─────────────────────────────────
+
+describe("actions listing groups scripts under exec", () => {
+  it("lists `exec` and an indented `corrupt` for an owned IDS", () => {
+    const s = getState();
+    const ids = Object.values(s.nodes).find((n) => n.type === "ids");
+    s.nodeGraph.setNodeAttr(ids.id, "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr(ids.id, "forwardingEnabled", true);
+    s.nodes[ids.id].visibility = "accessible";
+    navigateTo(ids.id);
+    const text = logs(() => getCommand("actions").execute([])).map((l) => l.text).join("\n");
+    assert.ok(/exec <script>/.test(text), "should advertise exec");
+    assert.ok(/^\s+corrupt/m.test(text), "corrupt should be indented under exec");
+  });
+
+  it("does NOT print a bare top-level `exec` synthetic-action line", () => {
+    const s = getState();
+    const ids = Object.values(s.nodes).find((n) => n.type === "ids");
+    s.nodeGraph.setNodeAttr(ids.id, "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr(ids.id, "forwardingEnabled", true);
+    s.nodes[ids.id].visibility = "accessible";
+    navigateTo(ids.id);
+    const text = logs(() => getCommand("actions").execute([])).map((l) => l.text).join("\n");
+    // the synthetic EXEC action's desc is "run a script on this node" — it must NOT appear as its own bare line
+    assert.ok(!/run a script on this node/.test(text), "synthetic EXEC desc should not be printed as a bare action");
   });
 });
 

--- a/js/core/console-commands/completions.test.js
+++ b/js/core/console-commands/completions.test.js
@@ -41,7 +41,7 @@ describe("tabComplete: verb completion", () => {
   });
 
   it("multi-match verb prefix returns LCP and all suggestions", () => {
-    // "ch" matches cheat; "e" matches exploit and eject (once both exist)
+    // "ch" matches cheat; "e" matches exec (scripts run via the exec verb)
     // For now "ex" uniquely matches exploit, so use empty prefix filtered
     // "he" matches help — single. Use a known multi: "s" matches status + store? No, store is darknet.
     // Actually: just test that empty prefix returns all verbs (already tested below).

--- a/js/core/console-commands/dynamic-actions.js
+++ b/js/core/console-commands/dynamic-actions.js
@@ -18,12 +18,14 @@ import { A } from "../action-ids.js";
 import { on, E, emitEvent } from "../events.js";
 import { registry, registerCommand } from "./registry.js";
 import { completeNodeArg } from "./completions.js";
+import { isScriptAction } from "../actions/scripts.js";
 
 // Action IDs with custom argument handling that stay as static console commands.
 // Everything else is dynamically discovered from the graph's available actions.
 const STATIC_ACTION_IDS = new Set([
   A.XPLOIT,  // needs card argument from payload
   A.TARGET, A.UNTARGET, A.JACKOUT,  // global actions, not node-specific
+  A.EXEC,    // synthetic submenu verb — never a dynamic registration
 ]);
 
 /** Track which dynamic commands we've registered so we can remove them. */
@@ -54,6 +56,7 @@ function syncDynamicActions() {
 
   for (const action of graphActions) {
     if (STATIC_ACTION_IDS.has(action.id)) continue;
+    if (isScriptAction(action.id)) continue; // scripts live under `exec`
 
     const actionId = action.id;
     const label = action.label || actionId;

--- a/js/core/console-commands/dynamic-actions.test.js
+++ b/js/core/console-commands/dynamic-actions.test.js
@@ -1,0 +1,29 @@
+// @ts-check
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import "./index.js"; // load static commands (registers `exec`)
+import { buildNetwork as buildCorporateFoothold } from "../../../data/networks/corporate-foothold.js";
+import { initGame, getState } from "../state.js";
+import { navigateTo } from "../navigation.js";
+import { clearAll } from "../timers.js";
+import { emitEvent, E } from "../events.js";
+import { registry } from "./registry.js";
+import { initDynamicActions } from "./dynamic-actions.js";
+
+describe("dynamic-actions namespace separation", () => {
+  beforeEach(() => { clearAll(); initGame(() => buildCorporateFoothold()); });
+
+  test("a node with scripts registers no script verbs (only core verbs + static exec)", () => {
+    initDynamicActions();
+    const s = getState();
+    const ids = Object.values(s.nodes).find((n) => n.type === "ids");
+    assert.ok(ids);
+    s.nodeGraph.setNodeAttr(ids.id, "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr(ids.id, "forwardingEnabled", true);
+    s.nodes[ids.id].visibility = "accessible";
+    navigateTo(ids.id);
+    emitEvent(E.STATE_CHANGED, s);
+    assert.equal(registry.has("corrupt"), false, "script verb must not be top-level");
+    assert.equal(registry.has("exec"), true, "static exec command stays");
+  });
+});

--- a/js/core/node-graph/game-types.js
+++ b/js/core/node-graph/game-types.js
@@ -153,9 +153,9 @@ const MINE_ACTION = {
 };
 
 /** @type {ActionDef} */
-const EJECT_ACTION = {
-  id: A.EJECT,
-  label: "EJECT",
+const KICK_ACTION = {
+  id: A.KICK,
+  label: "KICK",
   desc: "Boot ICE attention to a random adjacent node.",
   requires: [
     { type: "node-attr", attr: "accessLevel", eq: "owned" },
@@ -406,7 +406,7 @@ export const ACTION_TEMPLATES = {
   DUMP: DUMP_ACTION,
   FETCH: FETCH_ACTION,
   MINE: MINE_ACTION,
-  EJECT: EJECT_ACTION,
+  KICK: KICK_ACTION,
   REBOOT: REBOOT_ACTION,
   RECONFIGURE: RECONFIGURE_ACTION,
   CANCEL_TRACE: CANCEL_TRACE_ACTION,

--- a/js/core/node-graph/traits.js
+++ b/js/core/node-graph/traits.js
@@ -241,7 +241,7 @@ registerTrait("rebootable", {
     },
   ],
   actions: [
-    ACTION_TEMPLATES.EJECT,
+    ACTION_TEMPLATES.KICK,
     ACTION_TEMPLATES.REBOOT,
   ],
 });

--- a/js/core/node-graph/traits.test.js
+++ b/js/core/node-graph/traits.test.js
@@ -222,11 +222,11 @@ describe("Built-in traits", () => {
     assert.ok(actionIds.includes("fetch"));
   });
 
-  it("rebootable provides rebooting and eject/reboot actions", () => {
+  it("rebootable provides rebooting and kick/reboot actions", () => {
     const t = getTrait("rebootable");
     assert.equal(t.attributes.rebooting, false);
     const actionIds = t.actions.map(a => a.id);
-    assert.ok(actionIds.includes("eject"));
+    assert.ok(actionIds.includes("kick"));
     assert.ok(actionIds.includes("reboot"));
   });
 
@@ -302,7 +302,7 @@ describe("Built-in traits", () => {
     assert.ok(actionIds.includes("xploit"));
     assert.ok(actionIds.includes("dump"));
     assert.ok(actionIds.includes("fetch"));
-    assert.ok(actionIds.includes("eject"));
+    assert.ok(actionIds.includes("kick"));
     assert.ok(actionIds.includes("reboot"));
   });
 

--- a/js/ui/components/starnet-action-choices.js
+++ b/js/ui/components/starnet-action-choices.js
@@ -76,6 +76,14 @@ class StarnetActionChoices extends StarnetElement {
           ${exploitCardBody(choice.data, undefined, matched)}
         </div>`;
     }
+    if (choice.render === "action") {
+      return html`
+        <button class="ctx-item" @click=${() => this._pick(choice)}>
+          [ ${choice.data.label} ]${choice.data.desc
+            ? html`<span class="ctx-item-desc">${choice.data.desc}</span>`
+            : nothing}
+        </button>`;
+    }
     return nothing;
   }
 

--- a/js/ui/log-renderer.js
+++ b/js/ui/log-renderer.js
@@ -156,7 +156,7 @@ export function initLogRenderer() {
     }
   });
   on(E.ICE_DETECT_PENDING, (/** @type {IceDetectPendingPayload} */ { label, dwellMs }) =>
-    add(`[ICE] ⚠ ${label} — disengage or eject (${Math.round(dwellMs / 1000)}s)`, "error"));
+    add(`[ICE] ⚠ ${label} — disengage or kick (${Math.round(dwellMs / 1000)}s)`, "error"));
   on(E.ICE_DETECTED,    (/** @type {IceDetectedPayload} */  { label }) => add(`[ICE] ⚠ Detected at ${label} — signal locked.`, "error"));
   on(E.ICE_EJECTED,     () => add(`[ICE] Ejected to adjacent node.`, "success"));
   on(E.ICE_REBOOTED,    (/** @type {IceRebootedPayload} */ { residentLabel }) => add(`[ICE] Sent home: ${residentLabel}.`, "info"));

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -11,6 +11,7 @@ import { on, E } from "../core/events.js";
 import { A } from "../core/action-ids.js";
 import { getState as _getState } from "../core/state.js";
 import { getAvailableActions } from "../core/actions/node-actions.js";
+import { isScriptAction } from "../core/actions/scripts.js";
 import { updateNodeStyle, getCy, flashNode, addIceNode, syncIceGraph, syncSelection, relayout, onViewport, setReticleOverlay } from "./graph.js";
 import { mountOverlays } from "./overlays/index.js";
 import { mountReticle } from "./overlays/selection-reticle.js";
@@ -221,7 +222,9 @@ function syncContextMenu(node, state) {
   contextMenuNodeId = node.id;
 
   const actions = getAvailableActions(node, state)
-    .filter((a) => !a.noSidebar && a.id !== A.TARGET && a.id !== A.JACKOUT && a.id !== A.UNTARGET && a.id !== A.ABORT);
+    .filter((a) => !a.noSidebar && a.id !== A.TARGET && a.id !== A.JACKOUT
+      && a.id !== A.UNTARGET && a.id !== A.ABORT
+      && !isScriptAction(a.id)); // scripts are reached via the EXEC ▸ entry
 
   if (!actions.length) {
     clearContextMenu();

--- a/scripts/bot/execute.js
+++ b/scripts/bot/execute.js
@@ -15,7 +15,7 @@ const TIMED_ACTIONS = new Set([A.PROBE, A.XPLOIT, A.DUMP, A.FETCH, A.REBOOT, A.M
 /** Actions that are instant (no ticking needed) */
 const INSTANT_ACTIONS = new Set([
   A.TARGET, A.UNTARGET, A.JACKOUT, A.CORRUPT, A.CANCEL_TRACE,
-  A.ABORT, A.EJECT, A.ACCESS_DARKNET,
+  A.ABORT, A.KICK, A.ACCESS_DARKNET,
   // Set-piece puzzle actions
   "activate", "scan-lock", "scan-vault", "crack-vault",
   "unlock-vault", "extract-token", "extract-key", "decrypt-loot",
@@ -114,7 +114,7 @@ function tickUntilResolved(choice, budget) {
   // ICE arriving on our node does NOT auto-abort the action. Detection requires
   // ICE to dwell (grade-scaled), so the hack and the dwell race — a focused
   // decker keeps working and only bails if the trace actually lands. On an OWNED
-  // node, eject is free, so push ICE off and keep going. (Previously the bot
+  // node, kick is free, so push ICE off and keep going. (Previously the bot
   // panic-aborted on mere arrival: ICE never actually detected — so it was
   // toothless — yet the bot abandoned and restarted actions, the source of the
   // evasion thrash and exchange tick-cap. #114 WS2.)
@@ -124,7 +124,7 @@ function tickUntilResolved(choice, budget) {
     const node = s.nodes[targetNodeId];
     const primaryIce = getPrimaryIce();
     if (node && node.accessLevel === "owned" && primaryIce?.active && primaryIce.attentionNodeId === targetNodeId) {
-      emitEvent("starnet:action", { actionId: A.EJECT, nodeId: targetNodeId });
+      emitEvent("starnet:action", { actionId: A.KICK, nodeId: targetNodeId });
     }
   };
 

--- a/scripts/bot/heuristics/evasion.js
+++ b/scripts/bot/heuristics/evasion.js
@@ -21,17 +21,17 @@ export function evasionStrategy(world) {
   const proposals = [];
 
   // If ICE is on the currently selected node:
-  // - If we own the node, eject ICE (keeps us in position)
+  // - If we own the node, kick ICE (keeps us in position)
   // - Otherwise, untarget to hide
   if (world.ice.isOnSelectedNode && world.player.selectedNodeId) {
     const nodeId = world.player.selectedNodeId;
     const node = world.nodes.get(nodeId);
     if (node && node.accessLevel === "owned") {
       proposals.push({
-        action: A.EJECT,
+        action: A.KICK,
         nodeId,
         score: ICE_ON_NODE_EJECT,
-        reason: "ICE on owned node — eject to stay in position",
+        reason: "ICE on owned node — kick to stay in position",
         strategy: STRATEGY,
       });
     }

--- a/scripts/bot/heuristics/puzzles.js
+++ b/scripts/bot/heuristics/puzzles.js
@@ -16,7 +16,7 @@ const BASE_PUZZLE = 60;
 const KNOWN_ACTIONS = new Set([
   A.PROBE, A.XPLOIT, A.DUMP, A.FETCH, A.REBOOT,
   A.TARGET, A.UNTARGET, A.JACKOUT, A.CORRUPT, A.CANCEL_TRACE,
-  A.ABORT, A.EJECT, A.ACCESS_DARKNET,
+  A.ABORT, A.KICK, A.ACCESS_DARKNET,
   A.MINE, // handled by mineStrategy (card-blocked fallback) — not a proactive puzzle action
 ]);
 

--- a/scripts/playtest.js
+++ b/scripts/playtest.js
@@ -119,8 +119,8 @@ if (!cmdStr) {
   console.error("Usage: node scripts/playtest.js [--state <file>] [--seed <s>] [--time <grade>] [--money <grade>] [--force-piece <id>] <command>");
   console.error("Commands: reset  tick <n>  target <node>  untarget");
   console.error("          probe [node]  xploit <node> <card>  dump [node]");
-  console.error("          fetch [node]  corrupt [node]  jackout");
-  console.error("          abort  eject  reboot [node]  cancel-trace");
+  console.error("          fetch [node]  exec [<script>]  jackout");
+  console.error("          abort  kick   reboot [node]");
   console.error("          status [summary|full|ice|hand|node|alert|mission]");
   console.error("          actions  log [n]  help  cheat ...");
   process.exit(1);

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -45,6 +45,7 @@ import { setGlobalAlert } from "../js/core/state/alert.js";
 // Old executor imports removed — timed actions now graph-native
 import { RNG, _forceNext } from "../js/core/rng.js";
 import { getPrimaryIce } from "../js/core/state/ice.js";
+import { initActionDispatcher, buildActionContext } from "../js/core/actions/action-context.js";
 
 // Register the node lifecycle dispatcher once for this test file.
 
@@ -1218,5 +1219,87 @@ describe("ice events: iceId in payload", () => {
     });
     assert.ok(payloads.length > 0, "expected at least one ICE_EJECTED");
     assert.equal(payloads[0].iceId, "ice-1");
+  });
+});
+
+// ── EXEC synthetic action injection ──────────────────────────────────────────
+
+describe("EXEC synthetic action injection", () => {
+  beforeEach(() => { clearAll(); initGame(() => buildAlertLAN(), "itest-exec"); });
+
+  it("a node with a script (owned IDS → corrupt) gains an EXEC action whose followup lists the script", () => {
+    const s = getState();
+    s.nodeGraph.setNodeAttr("ids-1", "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr("ids-1", "forwardingEnabled", true);
+    const actions = getAvailableActions(s.nodes["ids-1"], s);
+    const exec = actions.find((a) => a.id === A.EXEC);
+    assert.ok(exec, "EXEC should be present");
+    assert.ok(exec.followup, "EXEC should carry a followup");
+    const choiceIds = exec.followup.choices(s.nodes["ids-1"], s).map((c) => c.id);
+    assert.ok(choiceIds.includes("corrupt"), "corrupt should be an EXEC choice");
+    const corruptChoice = exec.followup.choices(s.nodes["ids-1"], s).find((c) => c.id === "corrupt");
+    assert.equal(corruptChoice.render, "action", "script choices use the 'action' render type");
+    assert.equal(corruptChoice.payloadKey, "scriptId");
+    assert.ok(corruptChoice.data.label, "choice carries a display label");
+  });
+
+  it("a node with no scripts gets no EXEC action", () => {
+    const s = getState();
+    const actions = getAvailableActions(s.nodes["gateway"], s);
+    assert.ok(!actions.some((a) => a.id === A.EXEC), "no EXEC when no scripts");
+  });
+
+  it("EXEC.execute runs the chosen script (forwarding disabled), same as dispatching it directly", () => {
+    const s = getState();
+    s.nodeGraph.setNodeAttr("ids-1", "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr("ids-1", "forwardingEnabled", true);
+    const exec = getAvailableActions(s.nodes["ids-1"], s).find((a) => a.id === A.EXEC);
+    exec.execute(s.nodes["ids-1"], s, {}, { scriptId: "corrupt", nodeId: "ids-1" });
+    assert.equal(s.nodes["ids-1"].forwardingEnabled, false);
+  });
+});
+
+// ── kick action (renamed from eject) ─────────────────────────────────────────
+
+describe("kick action (renamed from eject)", () => {
+  it("kick is the verb on an owned node with ICE present, and ejects ICE", () => {
+    clearAll();
+    initGame(() => buildAlertLAN({ ice: { grade: "C", startNode: "ids-1" } }), "itest-kick");
+    const s = getState();
+    s.nodeGraph.setNodeAttr("ids-1", "accessLevel", "owned");
+    startIce();
+    getPrimaryIce().attentionNodeId = "ids-1";
+
+    const ids = getAvailableActions(s.nodes["ids-1"], s).map((a) => a.id);
+    assert.ok(ids.includes("kick"), "kick should be available on owned node with ICE present");
+    assert.ok(!ids.includes("eject"), "eject must be gone — rename is complete");
+
+    const fired = withEvents(E.ICE_EJECTED, () => {
+      s.nodeGraph.executeAction("ids-1", "kick");
+    });
+    assert.ok(fired.length > 0, "kick must fire ICE_EJECTED (internal mechanism unchanged)");
+  });
+});
+
+// ── EXEC dispatch echo ────────────────────────────────────────────────────────
+
+describe("EXEC dispatch echo", () => {
+  before(() => { initActionDispatcher(buildActionContext()); });
+
+  it("dispatching exec with a scriptId echoes 'exec <script>' once and runs the script", () => {
+    clearAll();
+    initGame(() => buildAlertLAN(), "itest-exec-echo");
+    const s = getState();
+    s.nodeGraph.setNodeAttr("ids-1", "accessLevel", "owned");
+    s.nodeGraph.setNodeAttr("ids-1", "forwardingEnabled", true);
+
+    const echoes = [];
+    const h = ({ cmd }) => echoes.push(cmd);
+    on(E.COMMAND_ISSUED, h);
+    emitEvent("starnet:action", { actionId: "exec", nodeId: "ids-1", scriptId: "corrupt" });
+    off(E.COMMAND_ISSUED, h);
+
+    assert.deepEqual(echoes, ["exec corrupt"], "exactly one echo reading 'exec corrupt'");
+    assert.equal(getState().nodes["ids-1"].forwardingEnabled, false, "script ran");
   });
 });


### PR DESCRIPTION
Closes #135.

## Summary

Groups all non-core node actions ("scripts") behind a single **EXEC** affordance — an `EXEC ▸` context-menu submenu and an `exec` console verb — separating them from the core deck command namespace and top-level tab-completion. New set-piece-authored node actions become scripts automatically (allowlist partition). Renames the player verb `eject` → `kick` to free the letter `e` for `exec`.

**Scripts now under EXEC:** `corrupt`, `spoof`, `disarm`, `unlock-vault`, `extract-token`, `extract-key`, `decrypt-loot`, `scan-vault`, `cancel-trace`, `access-darknet`, + future set-piece actions.
**Core verbs (stay top-level):** `probe`, `xploit`, `dump`, `fetch`, `mine`, `kick`, `reboot`, `abort`, `target`, `untarget`, `jackout`.

### How it works (Approach A — synthetic follow-up action)

- `js/core/actions/scripts.js` (new, pure): `CORE_NODE_VERBS` + `isScriptAction`.
- `getAvailableActions` injects a synthetic `EXEC` follow-up action when a node has ≥1 script — reusing the existing exploit-card choice picker. The action/dispatch layer is untouched; scripts stay dispatchable by id.
- Dispatcher echoes `exec <script>` for the GUI pick (one log line, like `xploit <card>`).
- Console: `exec` lists / runs / tab-completes a node's scripts; scripts dropped from the top-level verb namespace; `actions`/`help` group them under `exec`.
- Context menu hides raw scripts behind `EXEC ▸`; picker renders script choices via a new `render: "action"` branch.
- `eject` → `kick` across core/console/bot/harness; internal `ejectIce()` / `E.ICE_EJECTED` unchanged.
- MANUAL.md updated (node-actions table, console commands, ICE/trace/darknet/IDS, tips).

`cancel-trace` lands under EXEC despite being time-critical; UX-friction mitigation deferred (see #135).

## Test Plan

- [x] `make check` — 792 tests pass, lint clean
- [x] New tests: partition predicate, EXEC injection + choice shape, dispatcher echo (`exec corrupt`, exactly one), console `exec` (list/run/complete/error), namespace separation, `actions` grouping, `kick` rename behavior
- [x] Bot census (`make census SEEDS=10`) — identical to `main` (no gameplay regression); bot runs cleanly with `kick`
- [x] EXEC menu/picker data path verified via node one-off (owned IDS → menu `mine, reboot, exec`; picker choice `{id:"corrupt", render:"action", label:"Corrupt IDS"}`)
- [ ] **Manual browser smoke (not run — Playwright Firefox failed to launch in dev env):** own an IDS, click `EXEC ▸ corrupt`, confirm `> exec corrupt` in the log and forwarding disabled

Session docs: `docs/dev-sessions/2026-06-10-1628-exec-submenu-node-scripts/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
