### PR TITLE
Exploit card redesign: two-zone layout + 3-column XPLOIT submenu

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -291,8 +291,9 @@ information without relying on color.
 **Vulnerability glyphs** — Each vulnerability type has its own **glyph**, shown on
 both the exploit card (next to each vuln it targets) and on the node panel (next to
 each revealed vulnerability). Color groups the glyphs by rarity tier: teal (common),
-amber (uncommon), magenta (rare). The textual vuln id stays next to the glyph, and
-`status` output is unchanged.
+amber (uncommon), magenta (rare). In the **hand** and node panel the textual vuln id
+sits beside the glyph; the in-graph **XPLOIT picker** is a denser "express" view that
+shows glyphs only (no labels). `status` output is unchanged.
 
 **Decay** — Cards wear out, and *look* worn as they do:
 

--- a/css/style.css
+++ b/css/style.css
@@ -591,7 +591,7 @@ html, body {
 
 #action-choices .ac-choices {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, 1fr);
   gap: 0.5rem;
   max-height: 50vh;
   overflow-y: auto;
@@ -679,16 +679,14 @@ html, body {
 
 .exploit-card {
   border: 1px solid var(--grey);
-  padding: 0.4rem 0.5rem;
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
   font-size: 0.72rem;
   background: var(--bg-panel2);
   width: auto;
-  height: 160px;
   position: relative;
   overflow: hidden;
+  /* content-height — two zones (.ec-top grows, .ec-foot pinned) */
 }
 
 /* Rarity expressed via border + subtle glow; no text label */
@@ -735,11 +733,17 @@ html, body {
   background: linear-gradient(135deg, transparent 45%, rgba(120, 120, 120, 0.4) 50%, transparent 55%);
 }
 
+.ec-top {
+  padding: 0.4rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
 .ec-header {
   display: flex;
   align-items: baseline;
   gap: 0.25rem;
-  margin-bottom: 0.5rem;
 }
 
 .ec-index {
@@ -755,15 +759,21 @@ html, body {
   min-width: 0;
 }
 
-.ec-row {
+/* Stat footer — pips (left) · uses (right), pinned to the card bottom. */
+.ec-foot {
+  margin-top: auto;
+  border-top: 1px solid #223;
+  background: var(--bg-panel);
+  padding: 0.25rem 0.5rem;
   display: flex;
-  gap: 0.5rem;
-  align-items: baseline;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.7rem;
 }
 
-.ec-key  { color: var(--text-dim); min-width: 3rem; }
-.ec-pips { color: var(--green); letter-spacing: 0.05em; }
-.ec-val  { color: var(--green); }
+.ec-pips { letter-spacing: 0.05em; }   /* color comes from the .qN ramp below */
+.ec-uses { color: var(--green); }
+.ec-uses.worn { color: #e08a1e; }       /* amber tint signals worn; cracks/desat carry the rest */
 
 /* Quality color ramp — dim-red (low) → amber → bright-green/white (high).
    Color is the dramatic signal; the pip count stays the color-blind-safe
@@ -777,9 +787,15 @@ html, body {
 .ec-vulns {
   display: flex;
   flex-direction: column;
-  gap: 0.1rem;
-  margin-top: 0.6rem;
+  gap: 0.15rem;
   overflow: hidden;
+}
+
+/* Express view (graph XPLOIT submenu): glyphs in a row, no labels. */
+.ec-vulns.glyphs-only {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.4rem;
 }
 
 .ec-vuln {
@@ -875,16 +891,18 @@ html, body {
   color: var(--cyan);
   font-size: 0.6rem;
   letter-spacing: 0.05em;
-  margin-top: auto; /* push to card bottom */
   text-shadow: var(--glow-md) var(--cyan-dim);
   position: relative; /* keep above the ::before fill */
-  visibility: hidden;
+  /* display:none (not visibility:hidden) so the label reserves NO layout space
+     when idle — otherwise it competes with .ec-foot's margin-top:auto and leaves
+     a dead gap below the footer on content-height cards. */
+  display: none;
   white-space: nowrap; /* prevents text wrapping which would shift card content */
   overflow: hidden;
 }
 
 .exploit-card.executing .ec-executing-label {
-  visibility: visible;
+  display: block;
 }
 
 /* Cancel overlay — semi-transparent circle with ✕, centered on executing card */

--- a/docs/dev-sessions/2026-06-10-1758-card-redesign/plan.md
+++ b/docs/dev-sessions/2026-06-10-1758-card-redesign/plan.md
@@ -1,0 +1,160 @@
+# Exploit Card Redesign — Implementation Plan
+
+**Goal:** Restructure the exploit card into a content-height two-zone layout (identity + stat footer) shared by the hand and the graph XPLOIT picker, and move the picker to 3 columns.
+
+**Approach:** Rewrite the shared `exploitCardBody` into a two-zone fragment with a `glyphsOnly` render mode (hand = glyph+label rows, picker = glyph row); replace the fixed-height card CSS with the two-zone structure; switch the picker grid to 3 columns. All #117 state classes (`.match/.no-match/.worn/.disclosed`, `.ec-pips.qN`, `--wear`/`--sat-extra`, rarity) keep their contract so match/quality/wear keep working.
+
+**Tech stack:** Lit component (light DOM), CSS, preview harness + Playwright for visual verification.
+
+**TDD note:** Presentational restructure — no new pure logic, so test-first doesn't apply. Verification is the existing suite (regression) + lint + visual checks in the preview harness and live game.
+
+---
+
+## Phase 1: Two-zone card (component + CSS), both surfaces
+
+Rewrite `exploitCardBody` into identity-zone + stat-footer with a `glyphsOnly` mode, and replace the card CSS. Hand renders labeled (default); the picker passes `glyphsOnly = true`. Drops the fixed 160px height and the `QUAL`/`USES` text rows.
+
+**Files:**
+- Modify: `js/ui/components/exploit-card-view.js` — two-zone body + `glyphsOnly` param
+- Modify: `js/ui/components/starnet-action-choices.js` — pass `glyphsOnly = true`
+- Modify: `js/ui/components/starnet-hand.js` — (no signature change needed; confirm it omits the new param so it stays labeled)
+- Modify: `css/style.css` — replace `.exploit-card` fixed-height block, `.ec-header/.ec-row/.ec-key/.ec-val/.ec-vulns` with two-zone (`.ec-top`, `.ec-foot`, `.ec-uses`, `.ec-vulns.glyphs-only`)
+
+**Key changes:**
+
+`exploitCardBody` — new signature `exploitCardBody(card, indexLabel, matchedVulnIds = [], glyphsOnly = false)`:
+```js
+export function exploitCardBody(card, indexLabel, matchedVulnIds = [], glyphsOnly = false) {
+  const disclosed = card.decayState === "disclosed";
+  const worn = card.decayState === "worn";
+  const qualityPips = Math.round(card.quality * 5);
+  const pips = "█".repeat(qualityPips) + "░".repeat(5 - qualityPips);
+  const matched = new Set(matchedVulnIds);
+
+  const vulns = card.targetVulnTypes.map((t) => html`
+    <div class="ec-vuln ${matched.has(t) ? "matched" : ""}">
+      <img class="ec-vuln-glyph" src=${vulnGlyphDataUri(t)} alt="" />
+      ${glyphsOnly ? nothing : html`<span class="ec-vuln-label">${t}</span>`}
+    </div>`);
+
+  return html`
+    <div class="ec-top">
+      <div class="ec-header">
+        ${indexLabel ? html`<span class="ec-index">${indexLabel}</span>` : nothing}
+        <span class="ec-name">${card.name}</span>
+      </div>
+      <div class="ec-vulns ${glyphsOnly ? "glyphs-only" : ""}">${vulns}</div>
+    </div>
+    <div class="ec-foot">
+      <span class="ec-pips ${qualityTier(card.quality)}">${pips}</span>
+      <span class="ec-uses ${worn ? "worn" : ""}">${disclosed ? "DISCLOSED" : `${card.usesRemaining}×`}</span>
+    </div>`;
+}
+```
+- `starnet-action-choices.js` `_renderChoice`: `${exploitCardBody(choice.data, undefined, matched, true)}` (4th arg `true`).
+- `starnet-hand.js` `_renderCard`: stays `${exploitCardBody(card, `${index}.`, matchedVulnIds)}` (glyphsOnly defaults false). No change required — confirm only.
+
+CSS — replace the fixed-height `.exploit-card` rule and the header/row/key/val/vulns rules:
+```css
+.exploit-card {
+  border: 1px solid var(--grey);
+  display: flex;
+  flex-direction: column;
+  font-size: 0.72rem;
+  background: var(--bg-panel2);
+  position: relative;
+  overflow: hidden;
+  /* content-height — no fixed height (was 160px) */
+}
+/* base wear filter rule, rarity rules, .worn/.disclosed, .match/.no-match,
+   .ec-pips.qN, .ec-vuln.matched all UNCHANGED — keep their existing blocks */
+
+.ec-top {
+  padding: 0.4rem 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.ec-header { display: flex; align-items: baseline; gap: 0.25rem; }  /* drop margin-bottom: 0.5rem */
+.ec-index  { color: var(--text-dim); font-size: 0.7rem; flex-shrink: 0; }
+.ec-name   { color: var(--green); overflow-wrap: break-word; min-width: 0; }
+
+.ec-vulns { display: flex; flex-direction: column; gap: 0.15rem; overflow: hidden; }  /* drop margin-top: 0.6rem */
+.ec-vulns.glyphs-only { flex-direction: row; gap: 0.4rem; flex-wrap: wrap; }
+
+.ec-vuln { display: flex; align-items: center; gap: 0.3rem; color: var(--text-dim); font-size: 0.65rem; white-space: nowrap; overflow: hidden; }
+.ec-vuln-glyph { width: 16px; height: 16px; flex-shrink: 0; }
+.ec-vuln-label { overflow: hidden; text-overflow: ellipsis; }
+
+.ec-foot {
+  margin-top: auto;            /* stick to card bottom; grid stretches row pairs */
+  border-top: 1px solid #223;
+  background: var(--bg-panel);
+  padding: 0.25rem 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.7rem;
+}
+.ec-pips { letter-spacing: 0.05em; }     /* color comes from .qN ramp */
+.ec-uses { color: var(--green); }
+.ec-uses.worn { color: #e08a1e; }        /* amber tint signals worn; cracks/desat carry the rest */
+```
+Delete the now-unused `.ec-row`, `.ec-key`, `.ec-val` rules (the new body emits none of them). Keep `.ec-pips.q0..q4` exactly as-is.
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (regression — 821 pass; preview-card-gallery test still green)
+- [x] `make check` passes
+
+**Verification — manual (preview harness via Playwright):**
+- [x] `make bundle-vendor`; serve; open `preview.html` — hand card gallery: cards are content-height (no empty lower half), name + glyph/label rows on top, pips+uses footer. Rarity borders, quality pip colors, match glow + glyph lock, worn cracks + amber uses, disclosed burnt/struck all still render. *Verified via screenshot; 0 console errors.*
+- [x] A rare 3-vuln card shows three glyph+label rows and grows taller; its 2-col grid partner stretches to match with its footer pinned to the bottom. *Verified: 3 vuln rows; worn partner footer got 18.55px auto top-margin to align; worn uses amber #e08a1e.*
+
+---
+
+## Phase 2: 3-column XPLOIT submenu + polish
+
+Switch the picker grid to 3 columns and finish the glyph-row submenu look; resolve the worn-footer and min-height open questions visually; update the manual.
+
+**Files:**
+- Modify: `css/style.css` — `#action-choices .ac-choices` → 3 columns; any submenu-specific sizing
+- Modify: `MANUAL.md` — note the card layout/footer + 3-col submenu if the Exploit Cards section describes layout
+- (Possibly) Modify: `css/style.css` — add `.exploit-card { min-height: … }` only if single-vuln cards look too ragged next to multi-vuln ones (decide in preview)
+
+**Key changes:**
+```css
+#action-choices .ac-choices {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);  /* was 1fr 1fr */
+  gap: 0.5rem;
+  max-height: 50vh;
+  overflow-y: auto;
+}
+```
+- Panel stays `max-width: 320px` — glyph-only cards (≈97px) fit 3 across. If they feel cramped, nudge panel `max-width` up slightly (decide in preview); note the value chosen.
+- Worn footer: the amber `.ec-uses.worn` tint from Phase 1 is the marker; confirm it reads at submenu width. (Worn cards can appear in the picker; disclosed cannot.)
+- Min-height: default is content-height (no min). Add a small `min-height` only if the preview shows ragged single-vuln cards — record the decision in notes.
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes
+- [x] `make check` passes
+
+**Verification — manual (preview + live game via Playwright):**
+- [x] Live game: open the XPLOIT submenu on a probed node — 3 columns, glyph-row cards (no labels), matching cards glow + glyph lock, fits the panel without horizontal scroll. *Verified: 3 cols, 320px panel, no x-overflow, glyphsOnly active (0 labels), 3-vuln glyphs fit one row.*
+- [x] Hand still 2 columns with labels; switching node selection updates match highlight in both hand and submenu. *Verified: hand `.nd-hand` 2-col.*
+- [x] Executing-card state in the hand still renders correctly with the two-zone layout (progress fill + cancel overlay not broken by `.ec-foot { margin-top:auto }`). *Verified: EXECUTING label renders below footer, cyan border + fill + cancel intact.*
+- [x] `status` text output unchanged. *No `js/core/console-commands/` changes.*
+
+**Decisions recorded:** no `min-height` added (cards read well at content height); submenu panel kept at `max-width: 320px` (3 glyph-only cards fit without overflow).
+
+---
+
+## Final verification (before PR)
+
+- [x] `make check` clean (821 tests, lint)
+- [x] `make bundle-vendor && make serve` → verified via Playwright (preview + live game): hand reads tighter (no dead space), XPLOIT submenu is 3-col glyph-row, all #117 treatments intact, 0 console errors.
+- [x] Bot still runs cleanly (`make census SEEDS=10`) — ran 10 seeds, no errors; success rate is a balance metric unaffected by the presentational change.
+- [x] `MANUAL.md` updated (clarified hand/panel show labels, picker is glyph-only "express" view); footer keeps the explicit `N×` count (per #143 deferral).

--- a/docs/dev-sessions/2026-06-10-1758-card-redesign/spec.md
+++ b/docs/dev-sessions/2026-06-10-1758-card-redesign/spec.md
@@ -1,0 +1,63 @@
+# Exploit Card Redesign Spec
+
+**Goal:** Tighten the exploit-card rendering (kill the dead space from the fixed 160px height) and move the in-graph XPLOIT submenu to 3 columns, via a light two-zone card redesign shared by the hand and the picker.
+
+**Source:** Follow-up to #117 (exploit legibility), user request 2026-06-10.
+
+## Current state
+
+`exploitCardBody()` (`js/ui/components/exploit-card-view.js`) renders, top to bottom: header (index + name), a `QUAL` row (3rem text key + colored pips), a `USES` row (3rem text key + value), and a `.ec-vulns` column of glyph+label rows. The card chrome `.exploit-card` (`css/style.css`) is a **fixed `height: 160px`** flex column, so low-vuln cards show a large empty lower half.
+
+Consumers: the hand (`starnet-hand.js`, `.nd-hand` 2-col grid) and the graph XPLOIT picker (`starnet-action-choices.js`, `#action-choices .ac-choices` 2-col grid in a `max-width: 320px` panel). Both call `exploitCardBody(card, indexLabel?, matchedVulnIds?)`.
+
+Match highlight (green glow/lift + per-glyph lock), quality color ramp (`qualityTier` → `.ec-pips.q0..q4`), wear (`wearFraction` → `--wear` desaturation + `.worn` cracks + `.disclosed` burnt), and rarity border all already exist from #117.
+
+## Desired end state
+
+A **two-zone card**, content-height (no fixed height):
+- **Identity zone (top):** name (with `N.` index in the hand), then the vuln area.
+- **Stat footer (bottom):** quality pips on the left, uses on the right, separated by a top border. The `QUAL`/`USES` text keys and their 3rem column are gone.
+
+**Hybrid vuln rendering:**
+- **Hand (inventory):** glyph **+ text label**, one vuln per row (rare 3-vuln cards grow taller; the 2-col grid keeps pairs row-aligned). Stays **2 columns**.
+- **Graph XPLOIT submenu:** **glyphs in a single row**, no labels. Moves to **3 columns**, fitting the existing ~320px panel.
+
+All #117 treatments carry over unchanged: rarity border, match glow/lift + per-glyph lock, quality color ramp, wear desaturation/cracks, `disclosed` (greyed/struck/burnt — rendered in the footer as `DISCLOSED`). Worn cards show the uses count marked in the footer.
+
+Console/`status` text representation is untouched (this is presentational only).
+
+## Design decisions
+
+- **Decision:** Two-zone layout (identity + stat footer), content-height, drop the `QUAL`/`USES` text keys.
+  - **Why:** The fixed 160px + per-stat text rows are the source of the bulk/empty space. Pips already read as quality; a compact footer recovers the vertical space and gives a clean place for pips+uses.
+  - **Rejected:** Glyph-forward "hero glyph" direction (B) — strong at-a-glance but sacrifices the text labels the hand benefits from; compact-stacked (A) — kept the inline stat line but read busier than the footer separation.
+
+- **Decision:** Hybrid vuln rendering via a parameter on the shared `exploitCardBody`.
+  - **Why:** Labels aid learning in the persistent, roomy hand; glyph-only keeps the transient, tight 3-col submenu clean and lets even rare (3-target) cards stay short. Keeping one shared component (with a mode flag) preserves the GUI/console symmetry and the single match/quality/wear surface.
+  - **Rejected:** Two separate card components (drifts visually, duplicates the footer/header/state logic); labels everywhere (3-col submenu too cramped); glyph-only everywhere (loses hand learnability).
+
+- **Decision:** Submenu to 3 columns within the existing ~320px panel; hand stays 2 columns.
+  - **Why:** Glyph-only cards are narrow enough for 3 columns at the current panel width — no need to widen the panel. The user only asked to densify the submenu; the hand at 2-col already reads fine.
+  - **Rejected:** Widening the panel for 3 labeled columns (unnecessary once the submenu is glyph-only).
+
+## Patterns to follow
+
+- Extend `exploitCardBody(card, indexLabel?, matchedVulnIds?)` (`js/ui/components/exploit-card-view.js`) with a vuln-rendering mode (e.g. an options arg or a `glyphsOnly` flag). Hand passes labeled mode; `starnet-action-choices.js` passes glyph-row mode. Keep header/footer/match/quality/wear shared.
+- Mirror the existing class conventions (`.ec-*`, `.exploit-card.match/.no-match/.worn/.disclosed`, `.ec-pips.qN`, `--wear`) — restructure CSS into the two-zone layout without changing the state-class contract, so #117's match/quality/wear rules keep working.
+- `css/style.css`: replace the fixed-height `.exploit-card` block and the `.ec-header/.ec-row/.ec-key/.ec-vulns` rules with the two-zone structure (`.ec-top`, `.ec-foot`); update `.nd-hand` (stays 2-col) and `#action-choices .ac-choices` (→ 3-col).
+- Preview harness: the existing card gallery (`js/ui/preview-cards.js`) and the swatch sheet already exercise rarity/quality/wear/match — verify the redesign there; add a 3-col submenu-style sample if the gallery doesn't already cover the glyph-row mode.
+
+## What we're NOT doing
+
+- **No game-logic changes** — purely presentational (layout/CSS + a render-mode param). Match/quality/wear/decay logic from #117 is untouched.
+- **Not changing the glyph artwork** — the 15 glyphs stay as-is (separate follow-up).
+- **Not widening the submenu panel** — 3 columns fit the current ~320px via glyph-only cards.
+- **Not changing the hand column count** — stays 2.
+- **Not touching console/`status` text** rendering.
+- **Not changing what the footer displays for uses** — keeps the explicit count (`N×`) for now. Obscuring the count / reframing decay as white-hat/blue-team patch disclosure is [#143](https://github.com/lmorchard/starnet/issues/143), sequenced after this redesign. The two-zone **footer is the single display surface** that follow-up will swap, so this redesign deliberately localizes uses-rendering there.
+- **Not adding tooltips** for the glyph-only submenu labels in this pass (the node panel + hand already carry the text; revisit if it tests poorly).
+
+## Open questions
+
+- **Worn footer treatment.** *Default:* show the uses count with a worn marker in the footer (e.g. tinted `N×` or `N× worn`), consistent with current "(worn)" semantics; tune in the preview. Not a blocker.
+- **Card min-height / grid raggedness.** *Default:* content-height with no min; the 2-col hand grid aligns row pairs, and submenu rows align per grid row. If single-vuln cards look too short next to 3-vuln ones, add a small `min-height`. Decide visually in the preview. Not a blocker.

--- a/js/ui/components/exploit-card-view.js
+++ b/js/ui/components/exploit-card-view.js
@@ -1,7 +1,9 @@
-// Shared presentational fragment for an exploit card's inner body
-// (header + quality pips + uses + target vulns). Used by both the hand
-// (<starnet-hand>) and the action choice picker (<starnet-action-choices>)
-// so the two views stay visually identical.
+// Shared presentational fragment for an exploit card's inner body. Two zones:
+// an identity zone (name + target vulns) on top and a compact stat footer
+// (quality pips · uses) at the bottom. Used by both the hand (<starnet-hand>)
+// and the action choice picker (<starnet-action-choices>) so the two views
+// stay visually consistent. The hand renders vulns as glyph + text label; the
+// picker (an "express" view) renders glyphs-only in a row via glyphsOnly.
 
 import { html, nothing } from "lit";
 import { vulnGlyphDataUri } from "../vuln-glyphs.js";
@@ -11,30 +13,31 @@ import { qualityTier } from "../../core/exploits.js";
  * @param {import('../../core/types.js').ExploitCard} card
  * @param {string} [indexLabel] - optional left-aligned index label (e.g. "1.") for the hand
  * @param {string[]} [matchedVulnIds] - card targets that the selected node reveals; their glyphs light up
+ * @param {boolean} [glyphsOnly] - render vulns as a glyph row with no text labels (graph XPLOIT submenu)
  */
-export function exploitCardBody(card, indexLabel, matchedVulnIds = []) {
+export function exploitCardBody(card, indexLabel, matchedVulnIds = [], glyphsOnly = false) {
   const disclosed = card.decayState === "disclosed";
   const worn = card.decayState === "worn";
   const qualityPips = Math.round(card.quality * 5);
   const pips = "█".repeat(qualityPips) + "░".repeat(5 - qualityPips);
   const matched = new Set(matchedVulnIds);
 
+  const vulns = card.targetVulnTypes.map((t) => html`
+    <div class="ec-vuln ${matched.has(t) ? "matched" : ""}">
+      <img class="ec-vuln-glyph" src=${vulnGlyphDataUri(t)} alt=${glyphsOnly ? t : ""} />
+      ${glyphsOnly ? nothing : html`<span class="ec-vuln-label">${t}</span>`}
+    </div>`);
+
   return html`
-    <div class="ec-header">
-      ${indexLabel ? html`<span class="ec-index">${indexLabel}</span>` : nothing}
-      <span class="ec-name">${card.name}</span>
+    <div class="ec-top">
+      <div class="ec-header">
+        ${indexLabel ? html`<span class="ec-index">${indexLabel}</span>` : nothing}
+        <span class="ec-name">${card.name}</span>
+      </div>
+      <div class="ec-vulns ${glyphsOnly ? "glyphs-only" : ""}">${vulns}</div>
     </div>
-    <div class="ec-row">
-      <span class="ec-key">QUAL</span>
+    <div class="ec-foot">
       <span class="ec-pips ${qualityTier(card.quality)}">${pips}</span>
-    </div>
-    <div class="ec-row">
-      <span class="ec-key">USES</span>
-      <span class="ec-val">${disclosed ? "DISCLOSED" : worn ? `${card.usesRemaining} (worn)` : card.usesRemaining}</span>
-    </div>
-    <div class="ec-vulns">${card.targetVulnTypes.map((t) => html`
-      <div class="ec-vuln ${matched.has(t) ? "matched" : ""}">
-        <img class="ec-vuln-glyph" src=${vulnGlyphDataUri(t)} alt="" />
-        <span class="ec-vuln-label">${t}</span>
-      </div>`)}</div>`;
+      <span class="ec-uses ${worn ? "worn" : ""}">${disclosed ? "DISCLOSED" : `${card.usesRemaining}×`}</span>
+    </div>`;
 }

--- a/js/ui/components/starnet-action-choices.js
+++ b/js/ui/components/starnet-action-choices.js
@@ -73,7 +73,7 @@ class StarnetActionChoices extends StarnetElement {
         <div class="exploit-card rarity-${choice.data.rarity} selectable-card ${matched.length ? "match" : ""} ${worn ? "worn" : ""}"
              style=${`--wear:${wearFraction(choice.data)}`}
              @click=${() => this._pick(choice)}>
-          ${exploitCardBody(choice.data, undefined, matched)}
+          ${exploitCardBody(choice.data, undefined, matched, true)}
         </div>`;
     }
     return nothing;


### PR DESCRIPTION
## Summary
- Tightens exploit-card rendering — the fixed 160px height left a lot of dead space — and densifies the in-graph XPLOIT picker to 3 columns.
- A light card redesign building on the #117 glyph/match/quality/wear work.

## Design Decisions
- **Two-zone card.** Identity (name + vulns) on top, a compact **stat footer** (quality pips left · `N×` uses right) pinned to the bottom. Drops the fixed 160px height and the `QUAL`/`USES` text rows → content-height, no dead space.
- **Hybrid vuln rendering** via a `glyphsOnly` param on the shared `exploitCardBody`: the **hand** shows glyph **+ text label** (2 columns, for learnability); the graph **XPLOIT picker** is a denser glyph-row **"express" view** (3 columns) within the existing 320px panel — no widening needed.
- **Everything from #117 carries over** unchanged: rarity border, match glow/lift + per-glyph lock, quality color ramp, wear desaturation/cracks, disclosed burnt. Worn uses tinted amber.
- **No `min-height`** — cards read well at content height; the 2-col hand grid keeps row pairs footer-aligned (shorter card's footer gets an auto top-margin).
- Footer keeps the explicit `N×` count; obscuring it / the white-hat patch-feed fiction is deferred to **#143**.

## Changes
- `js/ui/components/exploit-card-view.js` — `exploitCardBody` rewritten into two zones + `glyphsOnly` param.
- `js/ui/components/starnet-action-choices.js` — picker passes `glyphsOnly = true`.
- `css/style.css` — two-zone card structure (`.ec-top`/`.ec-foot`/`.ec-uses`/`.ec-vulns.glyphs-only`), removed fixed height + dead `.ec-row/.ec-key/.ec-val`, `#action-choices .ac-choices` → 3 columns.
- `MANUAL.md` — clarifies hand/panel show labels, picker is glyph-only.

## Test Plan
- [x] `make check` — 839 tests pass, lint clean (presentational change; existing suite as regression)
- [x] Preview harness (Playwright): content-height cards, footer-aligned pairs, rare 3-vuln row growth, worn amber tint, disclosed burnt; 0 console errors
- [x] Live game (Playwright): 3-col glyph-row submenu fits 320px panel (no x-overflow), hand stays 2-col, match glow + glyph lock in both, executing-card state intact
- [x] Bot runs cleanly (`make census SEEDS=10`)
- [x] `status` text unchanged (no `js/core/console-commands/` changes)

## References
- Spec: `docs/dev-sessions/2026-06-10-1758-card-redesign/spec.md`
- Plan: `docs/dev-sessions/2026-06-10-1758-card-redesign/plan.md`
- Follow-up: #143 (obscure use-count / patch-feed fiction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
