### PR TITLE
ICE: complete multi-instance runtime migration (#36)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -496,8 +496,14 @@ This is often worth the detour.
 ## ICE
 
 ICE — Intrusion Counter Electronics — is the autonomous security program patrolling the LAN.
-There is one ICE entity per run. It starts at its **resident node** (usually near the
-security monitor, deep in the network) and moves.
+Low-security LANs (threat C and below) field no ICE. On secured LANs (threat B and up),
+the network runs **one ICE program per security monitor** — so a heavily-monitored LAN may
+be patrolled by several at once (currently capped at three). Each ICE starts at its
+**resident node** (its security monitor, deep in the network) and patrols independently:
+they don't coordinate, move on their own schedules, and each can detect you on its own.
+And each is **its own type** — a single LAN can field a mix, so one ICE might drain your
+HEALTH while another corrupts your DECK and a third just raises the alert. Read the log:
+each instance announces what it did when it catches you.
 
 ### ICE Grades
 
@@ -516,7 +522,8 @@ your exploit resolves, it will start routing. Cancelling mid-run leaves that sig
 ICE moves every few seconds, traversing the network graph. You can only see ICE when it
 enters a node you **control** (compromised or owned) — it's invisible in the dark territory
 of unowned nodes. When it moves onto a node you control, a red diamond appears on the graph
-and the log reports its arrival.
+and the log reports its arrival. When a LAN has multiple ICE, each moves on its own
+cadence (set by its grade) and a node you control can be visited by more than one at a time.
 
 ### Passive vs Active Mode
 
@@ -539,10 +546,12 @@ then pull back.
 
 If ICE **dwells on your currently targeted node** long enough, a detection countdown begins.
 The sidebar shows the timer: `⚠ ICE DETECTION: Xs`. When it hits zero, ICE locks your signal
-and the global alert escalates by one level.
+and the global alert escalates by one level. Each ICE dwells and detects independently — if
+two ICE sit on your targeted node, each runs its own countdown, so you can be detected twice.
 
-Each detection event steps the alert up: **GREEN → YELLOW → RED → TRACE**. The number of
-detections before the trace countdown begins depends on ICE grade:
+Each detection event steps the alert up: **GREEN → YELLOW → RED → TRACE**. Detections from
+**all** ICE accumulate toward the same threshold — more ICE on you means the trace clock
+starts sooner. The number of detections before the trace countdown begins depends on ICE grade:
 
 | Grade | Detections to trace | What it means                                        |
 |-------|---------------------|------------------------------------------------------|
@@ -556,9 +565,12 @@ your node and returns, the dwell timer resets and another detection cycle begins
 **Counters:**
 
 - **Untarget** the node or target a different one — drops back to passive, cancels the dwell timer
-- **Eject** (owned nodes) — boots ICE to a random adjacent node: `> eject`
+- **Eject** (owned nodes) — boots the ICE present on this node to a random adjacent node: `> eject`
 - **Reboot** (owned nodes) — forces ICE back to its resident node and takes your node
   offline briefly: `> reboot`
+
+When several ICE are on the prowl, clearing one node doesn't help with the others — eject
+buys time against the ICE in front of you, not the swarm.
 
 ICE on a node you've untargeted continues its movement pattern but cannot detect you
 unless you target that node again.

--- a/docs/ICE.md
+++ b/docs/ICE.md
@@ -8,6 +8,18 @@ describes the conceptual model and its architectural shape.
 For the vision that drove the design and its multi-session rollout plan, see
 `docs/dev-sessions/2026-04-24-1243-ice-reinvention/spec.md`.
 
+### Implementation status
+
+The runtime is now **fully multi-instance**: detection, dwell timers, movement
+cadence, and alert/trace are all per-instance (the `getPrimaryIce` singleton shim
+is retired). Production spawns **one roaming ICE per security-monitor node**, at
+threat B and above, capped at three — the concrete instantiation of "configurable
+via network meta" below. That cap is a temporary swarm-guard; tuning network
+monitor density (the real ICE-count balance lever) is tracked in
+[#136](https://github.com/lmorchard/starnet/issues/136). Stationary/trap ICE, the
+effect-atom catalog, and the hack verbs described below remain forthcoming
+(ICE-reinvention sessions 2+).
+
 ---
 
 ## The model
@@ -36,8 +48,8 @@ IceInstance {
   that detonates on `on-select`, a vault honeypot that fires on `on-probe-fail`.
 - **Roaming** ICE patrols the graph. Its behavior pattern decides where to go
   each tick (`patrol-random`, `disturbance-tracker`, `player-hunter`,
-  `sentry-radius`, etc.). It reports through its host's IDS chain the same way
-  the current singleton does.
+  `sentry-radius`, etc.). It reports through its host's IDS chain into the global
+  alert ladder.
 
 Both share the same `hostNodeId`. The host is the management anchor: owning it
 unlocks the hack verbs (§ below) that let the player uninstall, disable, or

--- a/docs/dev-sessions/2026-06-10-1600-ice-multi-instance/notes.md
+++ b/docs/dev-sessions/2026-06-10-1600-ice-multi-instance/notes.md
@@ -1,0 +1,63 @@
+# Notes — ICE multi-instance runtime migration
+
+## Execution log
+
+### Phase 1 — per-instance detection/dwell/alert (commit `b5216c3`)
+- De-singletoned detection: each active instance dwells/detects on its own `ICE_DETECT` timer (keyed by `iceId`, cancelled by id). `recordIceDetection(nodeId, iceId)` sources the single global trace from the **sum** of `detectionCount` across instances, threshold by the detecting instance's grade.
+- Single-instance parity preserved; `tests/snapshot-ice-detection.test.js` untouched and green.
+- Reviews: spec ✅, code quality approved-with-minors (3 defensive nits fixed in-commit).
+
+### Phase 2 — per-instance move timers (commit `bfcb0ea`)
+- Each active instance moves on its own repeating `ICE_MOVE` timer (`{iceId}` payload) at its grade cadence; `handleIceTick(payload)` moves one instance. Added `moveTimerId` to `IceInstance`.
+- **Pre-existing bug fixed (worth flagging):** `startIce()` was not idempotent — `spawnICE: () => startIce()` (game-ctx.js) is called repeatedly by the `probeBurstAlarm` set-piece (corporate-pieces.js:987, every N probes), so move timers accumulated and ICE sped up over a run. Existed on `main` (one orphaned shared timer per call); our per-instance change made it leak one per instance per call. Fixed by `cancelAllByType(TIMER.ICE_MOVE)` at the top of `startIce` (now idempotent). Test added.
+  - **Census implication for Phase 6:** because this changes behavior even for a SINGLE ICE on `probeBurstAlarm` networks (no more accidental speed-up), single-monitor "parity vs main" will NOT be byte-identical on those specific networks. This is a correctness win, not a regression — the census comparison must account for it (don't misread the delta on probeBurstAlarm seeds as a bug).
+- Reviews: spec ✅, code quality approved-with-minors (idempotency fix + comment + test-shape nit fixed in-commit).
+
+### Phase 3 — one ICE per security-monitor, cap 3 (commit `dbb85d5`)
+- `assemble.js` emits `meta.ice = { instances: [{startNode, grade}, ...] }` — one per `security-monitor`, `.slice(0,3)`, threat ≥ B. `initGame` builds `ice-1..ice-N` (supports both new `{instances}` and legacy `{startNode,grade}` shapes, so hand-crafted networks are untouched). `endRun` deactivates all.
+- End-to-end confirmed: generated S network → 3 runtime instances on distinct monitors.
+- Reviews: spec ✅ (field-by-field parity), code quality approved-with-minors (`TEMP (#136)` marker — accurate, tracked).
+
+### Phase 4 — bot/status/EJECT enumerate instances (commit `aa1e1e7`)
+- `perception` aggregates all active instances (`ice.instances` + any-instance `isOnSelectedNode`); `execute.onIceMoved` ejects on any ICE arrival; EJECT availability + `cmd-status` (4 blocks, extracted `iceInstanceLines` helper) enumerate all.
+- Minor behavior refinement: `status` now shows "INACTIVE" (not "NONE") for a present-but-disabled single ICE — the old `INACTIVE` branch was dead code; this is better feedback after IDS-subverting an ICE host. No test regressed.
+- Reviews: spec ✅, code quality approved-with-minors (helper extraction applied).
+
+### Phase 5 — retire `getPrimaryIce` shim (commit `b6d1562`)
+- Deleted `getPrimaryIce`/`getPrimaryIceFromState`; added `hasActiveIce(state)`; migrated all call sites to `activeIceInstances(s)[0]` / `hasActiveIce` (behavior-identical: both = first active instance). Structural test `tests/no-primary-ice.test.js` asserts zero references remain (verified by injection).
+- Discovered `alert.js`'s `getPrimaryIce` was a **dead import** — the trace duration keys off `s.spec.threat` (run grade), not ICE grade. This happily means the trace clock already uses run-grade, matching the spec's intent.
+- Reviews: spec ✅, code quality **Approved**.
+
+### Phase 6 — census re-baseline + docs (this commit)
+**Census comparison (50 seeds; main baseline = single-ICE foundation):**
+
+| threat | main (single-ICE) | this branch (multi-ICE) | note |
+|--------|-------------------|--------------------------|------|
+| C (default, ICE-free) | 0.28 | **0.28** | identical (no ICE below B) |
+| B | 0.28 | **0.18** | multi-ICE difficulty at the threshold grade |
+| A | ~0.10 | ~0.10 | floor on both (pre-existing) |
+| S | 0.0 | 0.0 | floor on both (pre-existing) |
+
+- **Headline default census unchanged (0.28)** — the spec's tuning target (default within ±0.10 of 0.28) is hit dead-on, so **no cap/gate tuning applied**.
+- Multi-ICE *improved* the difficulty curve: previously B≈C (single ICE added no difficulty at B); now it's a clean monotonic gradient **C 0.28 → B 0.18 → A 0.10 → S 0.0**.
+- A/S were already at the floor on single-ICE main — the bot cannot beat A/S regardless of ICE count (pre-existing; related to #129 bot evasion). "threat-S 0%" is NOT a regression from this work.
+- Deeper monitor-density balance deferred to #136 (the cap-3 swarm-guard stands).
+- Docs: `MANUAL.md` ICE section + `docs/ICE.md` updated for multiple independent ICE.
+
+> Baseline caveat: the main baseline drifted to include #137 during the session; the C/A/S parity (identical on both) confirms #137 didn't move census, isolating the B delta as the genuine multi-ICE effect.
+
+### Integration with #133 (at PR time)
+
+While this session ran, **#133 "Health + deck loss clocks: damaging ICE made real"** merged to main — a parallel ICE reinvention that made the single ICE registry-driven/typed and wired effect dispatch at detection (sentinel → HEALTH, spike → DECK, classic → alert). It rewrote the same `triggerDetection` and `initGame` spawn this session touched. Per Les's call, the two were **fully integrated** (not deferred):
+
+- **Spawn:** the per-monitor loop now gives each instance its own `pickIceTypeId` roll → a multi-monitor LAN fields a **mix of typed ICE** (verified: e.g. spike + 2 classic; sentinel + 2 classic).
+- **Detection:** my per-instance `triggerDetection(ice, nodeId)` now calls #133's `applyIceEffects(ice, …)` — each instance dispatches **its own** type's effects with its own `iceId` (alert routed via `recordIceDetection(nid, ice.id)`).
+- One stale test assertion updated (legacy single-ICE `typeId` is now registry-driven, not `'standard-ice'`).
+
+**Re-census vs current main (#133, single typed ICE):** default (C) **0.28 — unchanged**; B 0.27→0.30, A 0.167 (same), S 0.0 (same) — all within noise. Multi-instance on top of #133 doesn't move aggregate success (more detections, but bot outcomes are trace-dominated and damage clocks rarely deplete under cap-3). No tuning needed. Final test count **859 pass** (this session's + #133's suites), lint clean.
+
+## Final summary
+
+Completed the singleton→multi-instance ICE runtime migration (#36). Every active ICE is now an independent roaming detector (own dwell/detection/move-timer), production spawns one per security-monitor (cap 3, threat ≥ B), the `getPrimaryIce` shim is retired (locked by a structural test), and the bot/status enumerate all instances. Default-grade balance is unchanged; the multi-ICE difficulty lands at threat B and produces a cleaner monotonic curve. Split out: #136 (monitor-density / IDS-sensor consolidation — the real ICE-count balance lever). 6 phases, one commit each, 794 tests + lint green throughout. Each phase passed independent spec-compliance and code-quality review.
+
+Incidental pre-existing bug fixed: `startIce` was not idempotent (orphaned move timers under the repeating `probeBurstAlarm` → `spawnICE` trigger) — now cancels-and-reschedules.

--- a/docs/dev-sessions/2026-06-10-1600-ice-multi-instance/plan.md
+++ b/docs/dev-sessions/2026-06-10-1600-ice-multi-instance/plan.md
@@ -1,0 +1,236 @@
+# ICE Multi-Instance Runtime Migration — Implementation Plan
+
+**Goal:** Make every active ICE instance an independent roaming detector (own dwell, detection, move cadence), spawn one per security-monitor (cap 3) in real networks, and retire the `getPrimaryIce()` singleton shim.
+
+**Approach:** De-singleton the detection/dwell path (per-instance timers keyed by `iceId`), keep a single global alert/trace sourced from any instance, spawn per-monitor in `assemble`/`initGame`, then make bot + status enumerate instances and delete the shim. Single-monitor networks stay byte-identical (regression guard); the cap of 3 is a temporary swarm-guard until #136.
+
+**Tech stack:** Vanilla JS ES modules, JSDoc `@ts-check`, node:test. Timer system is per-id (`timers.js`).
+
+---
+
+## Phase 1: Per-instance detection, dwell, and alert
+
+De-singleton the detection path: every active instance on the player's selected node dwells and detects independently, on its own `ICE_DETECT` timer, and each detection sources the global alert/trace. Movement already iterates instances; this removes the `getPrimaryIce()` detection gate at `runtime.js:184-190`.
+
+**Files:**
+- Modify: `js/core/ice/runtime.js` — per-instance detection; import `cancelEvent`.
+- Modify: `js/core/alert.js` — `recordIceDetection(nodeId, iceId)`; trace gate on total detections across instances.
+- Modify: `js/core/state/ice.js` — add `activeIceInstances(state)` helper (array of active instances).
+- Test: `tests/ice-multi-detection.test.js` — new.
+
+**Key changes:**
+- `activeIceInstances(state): IceInstance[]` — `Object.values(state.ice?.instances ?? {}).filter(i => i.active)`.
+- `checkIceDetection(ice, nodeId, { justArrived })` — takes the instance explicitly; cancels *that* instance's prior dwell via `cancelEvent(ice.dwellTimerId)`; schedules `scheduleEvent(TIMER.ICE_DETECT, totalMs, { iceId: ice.id, nodeId }, …)`; `setIceDwellTimer(timerId, ice.id)`.
+- `handleIceDetect({ iceId, nodeId })` — resolve instance via `s.ice.instances[iceId]`; fire only if still active and `s.selectedNodeId === nodeId`.
+- `triggerDetection(ice, nodeId)` — emit `ICE_DETECTED` with `ice.id`; `recordIceDetection(nodeId, ice.id)`.
+- `handleIceDeparture(iceId)` — `cancelEvent(instance.dwellTimerId)`; `setIceDetectedAt(null, iceId)`. `ICE_EJECTED`/`ICE_REBOOTED` handlers pass `iceId` from payload.
+- `moveInstance` — delete the `getPrimaryIce()` gate (`:184-190`); call `checkIceDetection(ice, nextNode, { justArrived: true })`.
+- `PLAYER_NAVIGATED` handler — iterate `activeIceInstances(s)`: cancel each dwell + clear each `detectedAtNode`; then for each whose `attentionNodeId === nodeId`, `checkIceDetection(ice, nodeId)`.
+- `ACTION_FEEDBACK` noise handler — iterate active instances; if any has `floor(progress*10) >= ICE_NOISE_THRESHOLD[ice.grade]`, `setLastDisturbedNode(nodeId)` (single global disturbance signal, unchanged).
+- `alert.js recordIceDetection(nodeId, iceId)`:
+```js
+export function recordIceDetection(nodeId, iceId) {
+  const s = getState();
+  const ice = iceId ? s.ice?.instances?.[iceId] : activeIceInstances(s)[0];
+  if (!ice) return;
+  setIceDetectedAt(nodeId, ice.id);
+  incrementIceDetectionCount(ice.id);
+  // Trace gate: TOTAL detections across all instances vs threshold of the
+  // detecting instance's grade (== run grade in production; instances share grade).
+  const count = Object.values(s.ice.instances).reduce((n, i) => n + i.detectionCount, 0);
+  const threshold = DETECTION_TRACE_THRESHOLD[ice.grade] ?? 2;
+  if (count >= threshold) { if (s.traceSecondsRemaining === null) startTraceCountdown(); return; }
+  // …existing sub-threshold global-alert step (unchanged)…
+}
+```
+  Note: `startTraceCountdown()` still reads grade via an active instance for `TRACE_SECONDS` — leave as-is this phase (cleaned in Phase 5).
+
+**Verification — automated:**
+- [x] New test: two active instances both on the player's selected node → after dwell, **two** `ICE_DETECTED` events (one per `iceId`).
+- [x] New test: cancelling/ejecting instance A's dwell does NOT cancel instance B's pending dwell (independent `cancelEvent` by id).
+- [x] New test: single-instance detection unchanged (one detection, same trace timing).
+- [x] `make check` passes.
+
+**Verification — manual:**
+- [x] Existing `tests/snapshot-ice-detection.test.js` still passes unchanged (single-instance parity). _(confirmed: file not in diff vs main; suite green)_
+
+---
+
+## Phase 2: Per-instance move timers (independent cadence)
+
+Each instance moves on its own repeating `ICE_MOVE` timer at its own grade interval, instead of one shared tick at the primary's grade.
+
+**Files:**
+- Modify: `js/core/types.js` — add `moveTimerId: number|null` to `IceInstance`.
+- Modify: `js/core/state/ice.js` — add `setIceMoveTimer(timerId, iceId)`.
+- Modify: `js/core/ice/runtime.js` — per-instance move scheduling; `handleIceTick(payload)`.
+- Modify: `js/ui/main.js:150`, `scripts/lib/headless-engine.js:47`, `js/playground/main.js:330` — pass payload to `handleIceTick`.
+- Test: `tests/ice-multi-detection.test.js` — add cadence test.
+
+**Key changes:**
+- `startIce()` — `for (const ice of activeIceInstances(s)) { const id = scheduleRepeating(TIMER.ICE_MOVE, MOVE_INTERVALS[ice.grade] ?? 6000, { iceId: ice.id }); setIceMoveTimer(id, ice.id); }`
+- `handleIceTick(payload)` — if `payload?.iceId`, move just `s.ice.instances[payload.iceId]` (if active); else iterate all active (back-compat). Guard `s.phase === "playing"`.
+- `teleportIce(nodeId)` — reschedule only that instance's move timer: `cancelEvent(ice.moveTimerId)` then `scheduleRepeating(..., { iceId: ice.id })`, `setIceMoveTimer`.
+- Handler sites: `on(TIMER.ICE_MOVE, (payload) => handleIceTick(payload))` (all three).
+- `initGame` instance objects (Phase 3 too) include `moveTimerId: null`.
+
+**Verification — automated:**
+- [x] New test: two active instances, grades S and D, run N ticks → S emits more `ICE_MOVED` (per `iceId`) than D (independent cadence).
+- [x] New test: single instance moves at exactly its grade interval (parity).
+- [x] `make check` passes.
+
+**Verification — manual:**
+- [ ] Browser/playground: load a 1-ICE network, confirm ICE still patrols at the expected rate (no double-speed / stalled movement).
+
+---
+
+## Phase 3: Production consumer — one ICE per security-monitor (cap 3)
+
+Generated networks spawn one roaming ICE per security-monitor node, threat ≥ B, each grade = run threat, capped at 3. One-monitor networks stay identical to today.
+
+**Files:**
+- Modify: `js/core/network/assemble.js:63-73` — build a list of ICE configs.
+- Modify: `js/core/state/index.js:186-210` — build N instances; `:268` endRun deactivates all.
+- Modify: `scripts/generate-network.js:104` — summary lists instances.
+- Modify: `js/core/types.js` — `meta.ice` typedef → `{ instances: { startNode, grade }[] } | null`.
+- Test: `tests/integration.test.js` (network suite) + `tests/init-game.test.js`.
+
+**Key changes:**
+- `assemble.js`:
+```js
+let iceConfig = null;
+if (gradeToNumber(spec.threat) >= 4) {
+  const monitors = allNodes.filter(n => n.type === "security-monitor").slice(0, 3); // cap 3 (temp swarm-guard, #136)
+  if (monitors.length) iceConfig = { instances: monitors.map(m => ({ startNode: m.id, grade: spec.threat })) };
+}
+// meta.ice = iceConfig
+```
+- `initGame`:
+```js
+if (meta.ice?.instances?.length) {
+  state.ice = { instances: {} };
+  meta.ice.instances.forEach((cfg, i) => {
+    const id = `ice-${i + 1}`;
+    state.ice.instances[id] = { id, typeId: 'standard-ice', hostNodeId: cfg.startNode,
+      residentNodeId: cfg.startNode, attentionNodeId: cfg.startNode, active: true, enabled: true,
+      grade: cfg.grade, focus: 'roaming', behaviorPattern: 'standard',
+      dwellTimerId: null, moveTimerId: null, detectedAtNode: null, detectionCount: 0 };
+  });
+} else { state.ice = { instances: {} }; }
+```
+- `endRun` (`index.js:268`): `Object.values(state.ice?.instances ?? {}).forEach(i => { if (i.active) setIceActive(false, i.id); });`
+- `generate-network.js`: print each instance `grade @ startNode`.
+
+**Verification — automated:**
+- [x] New test: assemble a network with ≥2 security-monitors at threat ≥ B → `meta.ice.instances.length === min(monitorCount, 3)`.
+- [x] New test: 1-monitor network → exactly 1 instance (parity); threat < B → `meta.ice` null / no instances.
+- [x] New test: `initGame` builds `ice-1..ice-N` matching `meta.ice.instances`.
+- [x] `make check` passes (790 tests).
+
+**Verification — manual:**
+- [x] `node scripts/generate-network.js --threat S --summary` lists multiple ICE on a multi-monitor seed _(seed s2 → 3 ICE, s3 → 2 ICE)_.
+- [x] Multiple instances confirmed end-to-end (Phase 4): a real generated S network (`generateNetwork("s2")` → `initGame`) yields 3 runtime instances `ice-1/2/3` on distinct monitors; `status ice` enumeration verified by Phase 4 test.
+
+---
+
+## Phase 4: Bot + status + actions enumerate all instances
+
+Keep the bot functional and the readout complete with multiple ICE. Bot evades when *any* instance threatens; `status` and EJECT availability consider all instances.
+
+**Files:**
+- Modify: `scripts/bot/perception.js:115-121` — aggregate over all active instances; add `ice.instances`.
+- Modify: `scripts/bot/execute.js:121-129` — `onIceMoved` reacts to any ICE arriving on the owned target.
+- Modify: `js/core/actions/node-actions.js:35-40` — EJECT available if any active instance at `node.id`.
+- Modify: `js/core/console-commands/cmd-status.js` (3 ICE blocks: ~`:22`, `:105`, `:178`) — enumerate instances.
+- Modify: `js/core/node-graph/game-ctx.js`, `js/playground/main.js` — exists-checks use any-active helper.
+- Test: `tests/integration.test.js` (status + EJECT availability); bot census smoke.
+
+**Key changes:**
+- `perception.js`: `const insts = activeIceInstances(state);` →
+```js
+const ice = {
+  instances: insts.map(i => ({ nodeId: i.attentionNodeId, grade: i.grade })),
+  isOnSelectedNode: insts.some(i => i.attentionNodeId === state.selectedNodeId),
+  isActive: insts.length > 0,
+  nodeId: insts.find(i => i.attentionNodeId === state.selectedNodeId)?.attentionNodeId ?? insts[0]?.attentionNodeId ?? null,
+};
+```
+  (`evasion.js:26` reads `world.ice.isOnSelectedNode` — preserved as any-instance aggregate.)
+- `execute.js onIceMoved({ toId })`: drop `getPrimaryIce`; `if (toId === s.selectedNodeId && toId === targetNodeId && s.nodes[targetNodeId]?.accessLevel === "owned") emit EJECT`. (The `ICE_MOVED` event itself confirms an ICE arrived at `toId`.)
+- `node-actions.js`: for `A.EJECT`, `return activeIceInstances(state).some(i => i.attentionNodeId === node.id);`
+- `cmd-status.js`: replace each `getPrimaryIce()` block with a loop over `activeIceInstances(s)`, one line per instance (NONE if empty). Keep single-instance output shape identical when exactly one.
+
+**Verification — automated:**
+- [x] New test: with 2 instances on different nodes, `status ice` lists both.
+- [x] New test: EJECT available at a node iff some active instance attends it.
+- [x] `node scripts/bot/census.js --seeds 10 --threat S` runs without error and reports multi-ICE detections _(avgIceDetections 0.4; threat-S success 0% — Phase 6 tuning)_.
+- [x] `make check` passes (793 tests).
+
+_Note: `game-ctx.js`/`playground/main.js` exists-checks were left on `getPrimaryIce` and folded into Phase 5 (shim retirement), where they're deleted anyway._
+
+**Verification — manual:**
+- [ ] Census transcript shows the bot ejecting/evading against ≥2 ICE without thrashing — **folded into Phase 6 census review**.
+
+---
+
+## Phase 5: Retire `getPrimaryIce` / `getPrimaryIceFromState`
+
+Remove the shim; every remaining caller uses explicit `iceId` or an any-active helper. Structural invariant: zero `getPrimaryIce` call sites remain.
+
+**Files:**
+- Modify: `js/core/state/ice.js` — delete `getPrimaryIce`/`getPrimaryIceFromState`; keep `activeIceInstances(state)` and add `hasActiveIce(state)`.
+- Modify: `js/core/ice/runtime.js` — `startIce`/`ejectIce`/`disableIce`/`rebootIce`/`teleportIce` operate on explicit instances (eject/disable/reboot gain optional `iceId`/`nodeId`; cheats/teleport act on `activeIceInstances` — first or all, documented).
+- Modify: `js/core/alert.js` `startTraceCountdown` — read grade from the detecting instance passed through, or `activeIceInstances(s)[0]` as the run-grade proxy.
+- Modify: remaining call sites from research table: `node-actions.js`, `perception.js`, `cmd-status.js`, `game-ctx.js`, `playground/main.js` (most already migrated in Phase 4).
+- Test: `tests/no-primary-ice.test.js` — new structural test.
+
+**Key changes:**
+- `eject`/`disable`/`reboot` action handlers pass the node's ICE id; verify call sites in `actions/` and `cheats.js`.
+- Structural test:
+```js
+// reads js/ + scripts/ source, asserts no `getPrimaryIce(` or `getPrimaryIceFromState(` calls remain
+import { readFileSync } from "node:fs";
+// glob the source files, assert /getPrimaryIce(FromState)?\(/ matches none
+```
+
+**Verification — automated:**
+- [x] `grep -rn 'getPrimaryIce' js scripts tests --include='*.js'` returns nothing (only the structural test's own strings).
+- [x] New structural test (`tests/no-primary-ice.test.js`) asserts zero call sites — verified by injection (fails on a stray reference).
+- [x] `make check` passes (794 tests; tsc clean).
+
+**Verification — manual:**
+- [ ] Full browser smoke: load a multi-monitor network, play a run, confirm multiple ICE move/detect and trace fires correctly — **consolidated into the end-of-session manual smoke (with Phase 6)**.
+
+---
+
+## Phase 6: Census re-baseline, light tuning, docs
+
+Re-baseline difficulty with the new spawn rule; tune the cap/threat gate to keep success in band; update player docs. (TDD opt-out: tuning + docs, no new behavior.)
+
+**Files:**
+- Modify (if needed): `js/core/network/assemble.js` — cap value / threat gate (tuning only).
+- Modify: `MANUAL.md` — ICE section: multiple ICE, one per security-monitor.
+- Modify: `docs/ICE.md` if present.
+- Modify: `notes.md` — record census deltas + tuning rationale.
+
+**Key changes:**
+- Run `make census` (default) and per grade B/A/S; capture success rate, trace-fired rate, avg ICE detections.
+- If default-grade success rate falls outside ~±0.10 of today's 0.28, lower the cap (3→2) or raise the threat gate; re-run. Do NOT touch detection internals.
+
+**Verification — automated:**
+- [x] `make check` passes (794 tests).
+- [x] `make census SEEDS=50` completes; results recorded in `notes.md` (default 0.28, unchanged).
+- [x] census at threat S/B/A completes without error (multi-ICE exercised).
+
+**Verification — manual:**
+- [x] Census success within band — default 0.28 (dead-on ±0.10 target); no cap/gate change needed. Curve improved to monotonic C 0.28 → B 0.18 → A 0.10 → S 0.0; rationale in `notes.md`.
+- [x] `MANUAL.md` ICE section reflects multiple-ICE behavior (+ `docs/ICE.md` implementation-status note).
+- [x] Default census (threat C, ICE-free) byte-identical to main (0.28 / avgCash 6738 / avgTicks 523.4); B isolates the intended multi-ICE delta.
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** per-instance detection (P1) ✓; per-instance move cadence (P2) ✓; per-monitor spawn cap 3 (P3) ✓; single global alert from any instance (P1) ✓; bot evades any (P4) ✓; status enumerates (P4) ✓; shim retired (P5) ✓; census re-baseline + light tuning + MANUAL (P6) ✓; single-monitor parity (P1/P2/P3 manual checks + P6 spot-check) ✓; #136 split honored (cap retained, no network-gen surgery) ✓.
+- **Placeholders:** none — each phase has concrete signatures/snippets.
+- **Type consistency:** `activeIceInstances(state)` (P1) reused P2/P4/P5; `moveTimerId` added P2, used P3 init + P2 teleport; `recordIceDetection(nodeId, iceId)` P1 matches `triggerDetection` caller; `meta.ice = { instances: [...] }` P3 matches `initGame` reader.

--- a/docs/dev-sessions/2026-06-10-1600-ice-multi-instance/research.md
+++ b/docs/dev-sessions/2026-06-10-1600-ice-multi-instance/research.md
@@ -1,0 +1,67 @@
+# Research — ICE multi-instance runtime migration
+
+Documentarian findings (factual, current state). All paths relative to worktree root.
+
+## 1. Timer system (`js/core/timers.js`)
+
+- TIMER catalog (`:12-17`): `ICE_MOVE`, `ICE_DETECT`, `TRACE_TICK`.
+- **Timers are per-id.** Each gets unique `id = nextId++` (`:37`); stored in `Map<timerId, entry>` (`:34`). Entry: `{ id, type, payload, fireAt, intervalTicks, visible, label, startedAt, durationTicks }` (`:39-49`).
+- `scheduleEvent(type, delayMs, payload, visibility)` → one-shot, returns id (`:36-51`).
+- `scheduleRepeating(type, intervalMs, payload)` → repeating (`:53-68`).
+- `tick(n)` fires when `currentTick >= entry.fireAt` (`:76`); emits `entry.type` with `timerId` in payload (`:77`); one-shot deletes (`:81`), repeating does `fireAt += intervalTicks` (`:79`).
+- **Cancel one vs all:** `cancelEvent(id)` removes one by id (`:97-99`); `cancelAllByType(type)` removes every timer of a type (`:101-105`). Caller must hold the id to cancel one.
+
+## 2. ICE runtime (`js/core/ice/runtime.js`)
+
+- `startIce()` (`:38-44`): reads `getPrimaryIce()` (`:39`), schedules a **single** repeating `ICE_MOVE` at primary's grade interval (`:42`).
+- `stopIce()` (`:45-48`): `cancelAllByType(ICE_MOVE)` + `cancelAllByType(ICE_DETECT)`.
+- `handleIceTick()` (`:118-126`): if phase playing, **iterates all active `state.ice.instances`** (`:121`), calls `moveInstance(ice, s)` each (`:124`). Movement is multi-instance.
+- `moveInstance()` (`:128-191`): per-instance position update (random walk D/F; BFS toward `lastDisturbedNodeId` for C/B/A/S). Calls `setIceAttention(nextNode)` (`:175`). **BUT** detection gated to primary: `:184-190` only the instance equal to `getPrimaryIce()` (`:187`) drives dwell/detection. Non-primary instances move but never detect.
+- Detection/dwell: `checkIceDetection(nodeId)` (`:198-220`) schedules **one** `ICE_DETECT` one-shot at grade dwell (`:217`), stores id in `ice.dwellTimerId` (`:218`) — **per-instance timer id field already exists**. `handleIceDetect({nodeId})` (`:222-231`) → `triggerDetection()` (`:233-239`) → `recordIceDetection()` (`:238`).
+- `cancelIceDwell()` (`:241-243`): `cancelAllByType(ICE_DETECT)` (cancels ALL dwells, not one).
+- `handleIceDeparture()` (`:20-23`): cancels pending `ICE_DETECT`, clears `detectedAtNode`.
+- Event handlers use `getPrimaryIce()`: `PLAYER_NAVIGATED` (`:62`), `ACTION_FEEDBACK` noise→grade (`:80`).
+
+## 3. Alert ladder (`js/core/alert.js`)
+
+- **Two layers, separated:**
+  - *ICE pursuit:* `recordIceDetection(nodeId)` (`:200-228`) — only ICE detection entry point. `incrementIceDetectionCount()` (`:205`, no iceId → primary), reads `DETECTION_TRACE_THRESHOLD[ice.grade]` (`:214`) where `ice = getPrimaryIce()` (`:202`). Steps global alert directly; starts trace when count ≥ threshold (S/A:1, B/C:2, D/F:3).
+  - *Puzzle:* exploit fail → IDS propagation → monitor → `recomputeGlobalAlert()` (`:85-111`, counts red detectors/monitors). Escalation-only, never de-escalates (`:100-110`).
+- Trace: `startTraceCountdown()` reads grade from `getPrimaryIce()`, `TRACE_SECONDS[grade]`, schedules **single** repeating `TRACE_TICK` @1000ms (`:152`); `handleTraceTick()` decrements, ends run at ≤0.
+
+## 4. ICE instantiation (single instance today)
+
+- `initGame` (`js/core/state/index.js:186-210`): reads `meta.ice`; if present creates **one** instance `ice-1` (`:190`) `{ hostNodeId, grade, active:true, detection fields null }`; stores `state.ice = { instances: { [id]: primary } }` (`:207`); else `{ instances: {} }` (`:209`).
+- Network gen (`js/core/network/assemble.js:63-73`): ICE only if threat ≥ B (`:65`); single config starting at security-monitor node (`:69`); returns `meta.ice = { startNode, grade }` (`:117`).
+- **No production path creates 2+ instances.** Only `tests/integration.test.js` "two active instances both move on a tick" manually injects `ice-2` into the collection to prove movement iteration. (Also "ice events: iceId in payload" suite.)
+
+## 5. Bot ICE interaction (`scripts/bot/`)
+
+- `perception.js:115-121`: `getPrimaryIceFromState(state)` (`:116`) → WorldModel.ice = `{ nodeId: attentionNodeId, isOnSelectedNode, isActive }` (`:118-120`, stored `:151`). Single ICE only.
+- `execute.js`: `onIceMoved()` (`:121-129`) reads `getPrimaryIce()` (`:125`); if ICE arrives on owned target & player present → dispatch EJECT. `onDetected()` (`:131-133`) sets `detected` → after loop, ABORT+UNTARGET (`recordIceDetection` already escalated alert).
+
+## 6. All `getPrimaryIce` / `getPrimaryIceFromState` call sites
+
+| File:Line | What it does |
+|---|---|
+| `js/core/state/ice.js:94` | the shim itself (`getPrimaryIce` → `getPrimaryIceFromState(getState())`) |
+| `js/core/ice/runtime.js:39` | startIce — exists-check before scheduling move timer |
+| `js/core/ice/runtime.js:62` | PLAYER_NAVIGATED handler — re-detect on new node |
+| `js/core/ice/runtime.js:80` | ACTION_FEEDBACK handler — read grade for noise threshold |
+| `js/core/ice/runtime.js:187` | moveInstance — gate detection to primary only |
+| `js/core/ice/runtime.js:200,225,235` | checkIceDetection / triggerDetection — exists-check, grade/dwell |
+| `js/core/ice/runtime.js:251,275,286,293` | teleportIce / ejectIce / disableIce / rebootIce |
+| `js/core/alert.js:202` | recordIceDetection — grade for threshold + trace duration |
+| `js/core/actions/node-actions.js:37` | getAvailableActions (FromState) — is EJECT available |
+| `js/core/console-commands/cmd-status.js` | status display (several) |
+| `js/core/node-graph/game-ctx.js` | spawnICE callback — start ICE timer |
+| `js/playground/main.js` | playground init — exists-check |
+| `scripts/bot/execute.js:125` | eject-on-arrival reactive check |
+| `scripts/bot/perception.js:116` | (FromState) extract ICE for WorldModel |
+
+## Key facts for design
+
+- Timer system **already supports per-id timers**; `ice.dwellTimerId` already a per-instance field.
+- Movement already iterates all instances; **only the single shared `ICE_MOVE` cadence** (primary's grade) and **detection gating to primary** (`runtime.js:184-190`) keep it singleton in practice.
+- `detectionCount` is a per-instance field but `recordIceDetection` increments the primary's and reads the primary's grade; trace clock is global.
+- Nothing in production spawns 2+ instances — the only multi-instance exercise is a test fixture.

--- a/docs/dev-sessions/2026-06-10-1600-ice-multi-instance/spec.md
+++ b/docs/dev-sessions/2026-06-10-1600-ice-multi-instance/spec.md
@@ -1,0 +1,70 @@
+# ICE Multi-Instance Runtime Migration Spec
+
+**Goal:** Make multiple concurrent ICE instances function as fully independent roaming detectors — each with its own movement cadence, dwell, and detection — and spawn them in real generated networks (one per security-monitor, capped), retiring the `getPrimaryIce()` singleton shim.
+
+**Source:** https://github.com/lmorchard/starnet/issues/36
+
+## Current state
+
+The state shape is already a collection (`state.ice.instances`) and movement already iterates it, but detection/dwell/timers/alert/bot are singleton-bound. See `research.md`. Load-bearing facts:
+
+- The timer system is **per-id** (`timers.js:34-49`); `cancelEvent(id)` cancels one, `cancelAllByType(type)` cancels all (`timers.js:97-105`). `ice.dwellTimerId` is already a per-instance field.
+- `startIce()` schedules **one** repeating `ICE_MOVE` at the primary's grade interval (`runtime.js:39-42`); `handleIceTick()` iterates all active instances and moves each (`runtime.js:118-126`).
+- Detection is gated to the primary: `moveInstance()` only starts a dwell when the instance equals `getPrimaryIce()` (`runtime.js:184-190`). Dwell uses a single shared `ICE_DETECT` timer; `cancelIceDwell()` does `cancelAllByType(ICE_DETECT)` (`runtime.js:241-243`).
+- `recordIceDetection()` reads grade + `detectionCount` from `getPrimaryIce()` and gates a **single** global trace clock (`alert.js:200-228`). Alert is global and escalation-only (`alert.js:85-111`).
+- Production spawns exactly one ICE, at threat ≥ B, grade = run threat, at the first `security-monitor` node (`assemble.js:63-73`, `state/index.js:186-210`). Generated networks have **2–5 security-monitors** (occasionally 0, up to 6) — measured across threat×complexity×depth.
+- Bot reads a single ICE via `getPrimaryIceFromState` into `WorldModel.ice` (`perception.js:115-121`); `execute.js` ejects-on-arrival / aborts-on-detection off that one ICE (`execute.js:121-133`).
+
+## Desired end state
+
+- **Each active instance detects independently.** Two instances on the player's node produce two detections; each runs its own dwell on its own per-id `ICE_DETECT` timer, cancelled individually.
+- **Each instance moves on its own per-id `ICE_MOVE` timer** at its own grade cadence. (Production instances share grade = threat, so equal cadence; the per-instance machinery is what enables differing grades and independent dwells.)
+- **Production spawns one roaming ICE per security-monitor node**, at threat ≥ B, each grade = run threat, each starting on its monitor node, **capped at 3 as a temporary swarm-guard** (not the balance solution — see #136). Networks with 0 monitors get 0 ICE (unchanged). Networks with exactly 1 monitor behave **identically to today** (single-instance parity).
+- **Alert/trace stays a single global ladder.** Any instance's detection steps the global alert and counts toward one global trace threshold (keyed to run threat grade). Per-zone alert remains deferred to #98.
+- **Bot perceives all active instances** and evades when any is on its selected node / threatens its current action — enough to keep the bot functional and the census meaningful.
+- **`status` and the graph enumerate every active instance.**
+- **`getPrimaryIce()` / `getPrimaryIceFromState()` removed** from runtime/alert/bot/status paths; exists-checks become "is any instance active?" helpers.
+- **Census re-baselined** with the new spawn rule; the cap (and threat gate) tuned to keep success rate in a sane band. Deep rebalancing is out of scope (see below).
+
+## Design decisions
+
+- **Spawn rule: one ICE per security-monitor, gated at threat ≥ B, grade = run threat, capped at 3 as a temporary swarm-guard.**
+  - **Why:** diegetically grounded (each security domain runs its own ICE), feeds future per-zone alert (#98), and fires often given measured monitor counts (2–5 per network).
+  - **The cap is a temporary guard, NOT the balance lever.** Monitor count is emergent from slot-filler piece selection (`slot-filler.js`, scaled by `budget.js:183` wing count), not a dial. Tuning it cleanly is network-gen + IDS-puzzle work that overlaps #98/#106, so it's split out to **#136**. Until #136 lands, the cap prevents 5–6-ICE swarms; it knowingly leaves "orphan" monitors (no ICE) on dense networks — accepted as cosmetic and temporary, and is the motivation for #136.
+  - **Rejected:** scale-with-threat (less grounded); scale-with-size (density unrelated to security); uncapped per-monitor *this session* (6-ICE swarms before #136 tames monitor count).
+- **Per-instance timers via per-id scheduling.** Replace the single repeating `ICE_MOVE` with one repeating `ICE_MOVE` per instance, payload carrying `iceId`; `handleIceTick({iceId})` moves just that instance. `ICE_DETECT` payload carries `iceId`; dwell cancelled via `cancelEvent(ice.dwellTimerId)`, not `cancelAllByType`. Add a `moveTimerId` field alongside `dwellTimerId`.
+  - **Why:** the timer system is already per-id and `dwellTimerId` already exists — this is the intended seam, not new infrastructure.
+  - **Rejected:** keeping one shared `ICE_MOVE` tick that moves all instances (works only while all share a grade; blocks independent cadence and is a non-obvious coupling).
+- **Detection de-gated from primary.** Remove the `getPrimaryIce()` check at `runtime.js:184-190`; every active instance evaluates dwell/detection on the player's node independently, keyed by its own `iceId`.
+  - **Why:** this gate *is* the singleton seam for detection.
+- **Single global alert/trace, sourced from any instance.** `recordIceDetection(nodeId, iceId)` increments the detecting instance's count and steps the same global ladder; the trace clock starts on total detection count ≥ threshold(run grade).
+  - **Why:** smallest change preserving the model's shape; per-zone is a separate, larger effort (#98/#106).
+  - **Rejected:** per-zone alert now (pulls #98/#106 scope forward, touches the whole alert subsystem).
+- **Bot: perceive all, evade any.** `WorldModel` exposes all active instances; existing evade/eject/abort heuristics trigger when *any* instance is on the selected node / threatens the action.
+  - **Why:** keep the bot functional and the census honest (CLAUDE.md). Smarter multi-threat back-off is #129, explicitly not this session.
+- **Verification = correctness fixtures + single-ICE parity + re-baselined census.**
+  - **Why:** single-monitor networks must stay byte-identical (regression guard); multi-monitor networks legitimately change (that's the feature); fixtures prove independent detect/dwell/move.
+
+## Patterns to follow
+
+- Per-id timer scheduling + `cancelEvent`: `timers.js:36-51`, `:97-99`. Mirror how `dwellTimerId` is stored (`runtime.js:218`) for the new `moveTimerId`.
+- Instance iteration: `handleIceTick` (`runtime.js:118-126`) is the model for "do X for each active instance."
+- `iceId`-in-payload events already exist (PR #108): `ICE_MOVED`/`ICE_DETECTED` carry `iceId` (`runtime.js`), tested in `tests/integration.test.js` "ice events: iceId in payload" — extend the same convention to timer payloads.
+- Setters already accept optional `iceId` (`state/ice.js`) — pass it explicitly everywhere instead of defaulting to primary.
+- Spawn placement mirrors current ICE block (`assemble.js:63-73`) — iterate monitor nodes instead of `find` first; `initGame` builds the instance collection from a list instead of one config (`state/index.js:186-210`).
+- Multi-instance test setup already demonstrated: `tests/integration.test.js` "two active instances both move on a tick" — extend for detection/dwell.
+
+## What we're NOT doing
+
+- **Tuning network monitor density / IDS-sensor consolidation** — split out to #136. This session keeps the temporary ICE cap (3) and does NOT touch network generation or the IDS-puzzle piece composition.
+- **Per-zone / per-domain alert** — stays global; that's #98 (and #106 alert rethink).
+- **Smart multi-threat bot back-off / patience heuristic** — #129. Bot gets minimal "evade any" only.
+- **Variant ICE types / trap / thief / defender** — sessions 2–5 (#93–#96). This is roaming patrol ICE only.
+- **Deep rebalancing.** We re-baseline census and do *light* tuning (the cap, threat gate) to keep success rate sane; a full difficulty-curve pass is a follow-up if needed.
+- **New ICE behaviors or detection mechanics** — same dwell-then-detect model, just per-instance.
+- **Changing the IDS→monitor exploit-failure puzzle layer** — untouched.
+
+## Open questions
+
+- **Trace threshold grade when instances differ in grade.** Production instances all share grade = run threat, so the threshold is unambiguous there. *Default:* key the global trace threshold on the run's threat grade (not any single instance). Revisit only if a future session spawns mixed-grade roaming ICE.
+- **Light-tuning target band.** *Default:* aim to keep default-grade census success rate within roughly ±0.10 of today's 0.28 after the cap; if the cap-at-3 overshoots, lower the cap or the threat gate rather than reworking detection. Not a blocker for planning.

--- a/js/core/actions/action-context.js
+++ b/js/core/actions/action-context.js
@@ -24,7 +24,7 @@ export function buildActionContext(openDarknetsStore = () => {}) {
     getState,
     selectNode:       (nodeId) => navigateTo(nodeId),
     deselectNode:     ()       => navigateAway(),
-    ejectIce:         ()       => ejectIce(),
+    ejectIce:         (nodeId) => ejectIce(nodeId),
     jackOut:          ()       => endRun("success"),
     cancelTrace:      ()       => cancelTraceCountdown(),
     openDarknetsStore: () => {

--- a/js/core/actions/node-actions.js
+++ b/js/core/actions/node-actions.js
@@ -14,7 +14,7 @@
 
 import { getGlobalActions } from "./global-actions.js";
 import { A } from "../action-ids.js";
-import { getPrimaryIceFromState } from "../state/ice.js";
+import { activeIceInstances } from "../state/ice.js";
 
 /**
  * Returns all available actions for the given node and game state.
@@ -32,10 +32,9 @@ export function getAvailableActions(node, state) {
 
   // Apply global state filters the graph can't check
   const filtered = graphActions.filter(action => {
-    // Eject requires ICE attention at this specific node
+    // Eject requires ICE attention at this specific node — any active instance.
     if (action.id === A.EJECT) {
-      const ice = getPrimaryIceFromState(state);
-      return !!(ice?.active && ice.attentionNodeId === node.id);
+      return activeIceInstances(state).some((i) => i.attentionNodeId === node.id);
     }
     return true;
   });

--- a/js/core/alert.js
+++ b/js/core/alert.js
@@ -8,7 +8,7 @@
 import { getState, endRun, ALERT_ORDER } from "./state.js";
 import { setNodeAlertState } from "./state/node.js";
 import { setGlobalAlert, setTraceCountdown, setTraceTimerId, decrementTraceCountdown } from "./state/alert.js";
-import { setIceDetectedAt, incrementIceDetectionCount, getPrimaryIce } from "./state/ice.js";
+import { setIceDetectedAt, incrementIceDetectionCount, activeIceInstances } from "./state/ice.js";
 import { emitEvent, on, E } from "./events.js";
 import { A } from "./action-ids.js";
 import { scheduleRepeating, cancelEvent, TIMER } from "./timers.js";
@@ -197,12 +197,12 @@ export function forceGlobalAlert(level) {
  * or propagate through the security monitor (that's the separate exploit-failure
  * puzzle layer in recomputeGlobalAlert). See MANUAL.md "Detection".
  */
-export function recordIceDetection(nodeId) {
+export function recordIceDetection(nodeId, iceId) {
   const s = getState();
-  const ice = getPrimaryIce();
+  const ice = iceId ? s.ice?.instances?.[iceId] : activeIceInstances(s)[0];
   if (!ice) return;
-  setIceDetectedAt(nodeId);
-  incrementIceDetectionCount();
+  setIceDetectedAt(nodeId, ice.id);
+  incrementIceDetectionCount(ice.id);
 
   // ICE detection drives the global alert directly (MANUAL.md "Detection"):
   // each detection steps the alert up; after a grade-scaled number of detections
@@ -210,7 +210,10 @@ export function recordIceDetection(nodeId) {
   // layer — distinct from the exploit-failure → IDS → monitor *puzzle* layer
   // (recomputeGlobalAlert). Trace here is gated purely on detection COUNT, not on
   // counting red IDS nodes (which is unreachable on a 1-detector network).
-  const count = ice.detectionCount;
+  //
+  // Trace gate: TOTAL detections across ALL instances vs the detecting instance's
+  // grade threshold (instances share the run grade in production).
+  const count = Object.values(s.ice?.instances ?? {}).reduce((n, i) => n + i.detectionCount, 0);
   const threshold = DETECTION_TRACE_THRESHOLD[ice.grade] ?? 2;
   if (count >= threshold) {
     if (getState().traceSecondsRemaining === null) startTraceCountdown();

--- a/js/core/cheats.js
+++ b/js/core/cheats.js
@@ -14,7 +14,7 @@ import { addCash, addCardToHand, applyCardDecay } from "./state/player.js";
 import { setCheating } from "./state/game.js";
 import { forceGlobalAlert, cancelTraceCountdown } from "./alert.js";
 import { teleportIce } from "./ice.js";
-import { getPrimaryIce } from "./state/ice.js";
+import { activeIceInstances, hasActiveIce } from "./state/ice.js";
 import { addLogEntry } from "./log.js";
 import { generateExploit, generateExploitForVuln } from "./exploits.js";
 
@@ -199,7 +199,7 @@ function cheatOwnAll() {
 // CHEAT: summon-ice [nodeId]
 function cheatSummonIce(args) {
   const s = getState();
-  if (!getPrimaryIce()) {
+  if (!hasActiveIce(s)) {
     addLogEntry("[CHEAT] No ICE active.", "error");
     return false;
   }
@@ -256,7 +256,7 @@ function cheatTrace(args) {
 // CHEAT: ice-state — read-only ICE diagnostic dump (no cheat flag)
 function cheatIceState() {
   const s = getState();
-  const ice = getPrimaryIce();
+  const ice = activeIceInstances(s)[0];
   if (!ice) {
     addLogEntry("[CHEAT] No ICE in this run.", "meta");
     return true;

--- a/js/core/console-commands/cmd-status.js
+++ b/js/core/console-commands/cmd-status.js
@@ -1,14 +1,37 @@
 // @ts-check
 // Implementations for all `status` sub-commands.
 
+/** @typedef {import('../types.js').GameState} GameState */
+
 import { getState, isIceVisible } from "../state.js";
-import { getPrimaryIce } from "../state/ice.js";
+import { activeIceInstances } from "../state/ice.js";
 import { addLogEntry } from "../log.js";
 import { getVisibleTimers } from "../timers.js";
 import { exploitSortKey } from "../exploits.js";
 import { resolveNode, resolveImplicitNode } from "./resolvers.js";
 import { isObscured } from "../state/node.js";
 import { mineYieldChance } from "../mining.js";
+
+/**
+ * Renders per-instance ICE status lines for both cmdStatusFull and cmdStatusIce.
+ * @param {GameState} s
+ * @returns {string[]} array of log lines
+ */
+function iceInstanceLines(s) {
+  const active = activeIceInstances(s);
+  if (active.length === 0) {
+    return [`- status: ${Object.keys(s.ice?.instances ?? {}).length > 0 ? "INACTIVE" : "NONE"}`];
+  }
+  return active.flatMap((ice) => {
+    const head = `- status: ACTIVE  grade: ${ice.grade}`;
+    if (!isIceVisible(ice, s.nodes, s.selectedNodeId)) {
+      return [head, `- attention: unknown`];
+    }
+    const pos = s.nodes[ice.attentionNodeId]?.label ?? ice.attentionNodeId;
+    const resident = s.nodes[ice.hostNodeId]?.label ?? ice.hostNodeId;
+    return [head, `- attention: ${pos}  resident: ${resident}`];
+  });
+}
 
 export function cmdStatusSummary() {
   const s = getState();
@@ -22,12 +45,19 @@ export function cmdStatusSummary() {
   lines.push(`  HEALTH: ${h.current}/${h.max}  |  DECK: ${d.current}/${d.max}`);
 
   let iceStr;
-  const ice = getPrimaryIce();
-  if (!ice) iceStr = "NONE";
-  else if (!ice.active) iceStr = "INACTIVE";
-  else if (isIceVisible(ice, s.nodes, s.selectedNodeId))
-    iceStr = `ACTIVE @ ${s.nodes[ice.hostNodeId]?.label ?? ice.hostNodeId} → ${s.nodes[ice.attentionNodeId]?.label ?? ice.attentionNodeId}`;
-  else iceStr = "ACTIVE (location unknown)";
+  const active = activeIceInstances(s);
+  const iceDescriptor = (ice) =>
+    isIceVisible(ice, s.nodes, s.selectedNodeId)
+      ? `ACTIVE @ ${s.nodes[ice.hostNodeId]?.label ?? ice.hostNodeId} → ${s.nodes[ice.attentionNodeId]?.label ?? ice.attentionNodeId}`
+      : "ACTIVE (location unknown)";
+  if (active.length === 0) {
+    // No active instances: distinguish "no ICE on this LAN" from "present but inactive".
+    iceStr = Object.keys(s.ice?.instances ?? {}).length === 0 ? "NONE" : "INACTIVE";
+  } else if (active.length === 1) {
+    iceStr = iceDescriptor(active[0]);
+  } else {
+    iceStr = `${active.length} ACTIVE — ${active.map(iceDescriptor).join("; ")}`;
+  }
   const detectTimer = timers.find((t) => t.label === "ICE DETECTION");
   const detectStr = detectTimer ? `${detectTimer.remaining}s remaining` : "—";
   lines.push(`  ICE: ${iceStr}  |  Detection: ${detectStr}`);
@@ -107,19 +137,7 @@ export function cmdStatusFull() {
   }
 
   lines.push(`### ICE`);
-  const iceF = getPrimaryIce();
-  if (iceF?.active) {
-    lines.push(`- status: ACTIVE  grade: ${iceF.grade}`);
-    if (isIceVisible(iceF, s.nodes, s.selectedNodeId)) {
-      const pos      = s.nodes[iceF.attentionNodeId]?.label ?? iceF.attentionNodeId;
-      const resident = s.nodes[iceF.hostNodeId]?.label  ?? iceF.hostNodeId;
-      lines.push(`- attention: ${pos}  resident: ${resident}`);
-    } else {
-      lines.push(`- attention: unknown`);
-    }
-  } else {
-    lines.push(`- status: ${iceF ? "INACTIVE" : "NONE"}`);
-  }
+  lines.push(...iceInstanceLines(s));
 
   lines.push(`### SELECTED`);
   if (s.selectedNodeId) {
@@ -180,20 +198,11 @@ export function cmdStatusIce() {
   const s = getState();
   const timers = getVisibleTimers();
   const lines = ["## STATUS: ICE"];
-  const iceI = getPrimaryIce();
-  if (iceI?.active) {
-    lines.push(`- status: ACTIVE  grade: ${iceI.grade}`);
-    if (isIceVisible(iceI, s.nodes, s.selectedNodeId)) {
-      const pos      = s.nodes[iceI.attentionNodeId]?.label ?? iceI.attentionNodeId;
-      const resident = s.nodes[iceI.hostNodeId]?.label  ?? iceI.hostNodeId;
-      lines.push(`- attention: ${pos}  resident: ${resident}`);
-    } else {
-      lines.push(`- attention: unknown`);
-    }
+  lines.push(...iceInstanceLines(s));
+  const activeI = activeIceInstances(s);
+  if (activeI.length > 0) {
     const detectTimer = timers.find((t) => t.label === "ICE DETECTION");
     if (detectTimer) lines.push(`- ⚠ detection in: ${detectTimer.remaining}s`);
-  } else {
-    lines.push(`- status: ${iceI ? "INACTIVE" : "NONE"}`);
   }
   lines.forEach((l) => addLogEntry(l, "meta"));
 }
@@ -262,9 +271,10 @@ export function cmdStatusNode(args) {
       lines.push(`- item: ${m.name}  ¥${m.cashValue.toLocaleString()}${isMission}  collected:${m.collected}`);
     });
   }
-  const iceN = getPrimaryIce();
-  if (iceN?.active && iceN.attentionNodeId === node.id && isIceVisible(iceN, s.nodes, s.selectedNodeId)) {
-    lines.push(`- ⚠ ICE present (grade: ${iceN.grade})`);
+  for (const iceN of activeIceInstances(s)) {
+    if (iceN.attentionNodeId === node.id && isIceVisible(iceN, s.nodes, s.selectedNodeId)) {
+      lines.push(`- ⚠ ICE present (grade: ${iceN.grade})`);
+    }
   }
   lines.forEach((l) => addLogEntry(l, "meta"));
 }

--- a/js/core/ice/runtime.js
+++ b/js/core/ice/runtime.js
@@ -7,21 +7,24 @@
 /** @typedef {import('../types.js').NodeState} NodeState */
 
 import { getState } from "../state.js";
-import { getPrimaryIce, setIceAttention, setIceDetectedAt, setIceDwellTimer, setIceActive, setLastDisturbedNode } from "../state/ice.js";
+import { activeIceInstances, setIceAttention, setIceDetectedAt, setIceDwellTimer, setIceMoveTimer, setIceActive, setLastDisturbedNode } from "../state/ice.js";
 import { recordIceDetection } from "../alert.js";
-import { scheduleEvent, scheduleRepeating, cancelAllByType, TIMER } from "../timers.js";
+import { scheduleEvent, scheduleRepeating, cancelAllByType, cancelEvent, TIMER } from "../timers.js";
 import { emitEvent, on, E } from "../events.js";
 import { A } from "../action-ids.js";
 import { RNG, randomPick } from "../rng.js";
 import { getType, getEffect } from "./index.js";
 import { damagePlayerHealth, damagePlayerDeck } from "../player-orchestration.js";
 
-// Called whenever ICE vacates a node for any reason: normal movement, eject, or reboot.
-// Cancels any pending detection dwell and releases the detection lock so ICE can
-// re-detect on its next visit.
-function handleIceDeparture() {
-  cancelAllByType(TIMER.ICE_DETECT);
-  setIceDetectedAt(null);
+// Called whenever an ICE instance vacates a node for any reason: normal movement,
+// eject, or reboot. Cancels that instance's pending detection dwell and releases
+// its detection lock so it can re-detect on its next visit.
+function handleIceDeparture(iceId) {
+  if (!iceId) return;
+  const s = getState();
+  const instance = s.ice?.instances?.[iceId];
+  if (instance?.dwellTimerId != null) cancelEvent(instance.dwellTimerId);
+  setIceDetectedAt(null, iceId);
 }
 
 // Grade → movement interval (ms); must be longer than the corresponding DWELL_TIMES entry.
@@ -38,10 +41,18 @@ const DWELL_TIMES = { S: 800, A: 1500, B: 4500, C: 5500, D: 9000, F: 10000 };
 const ICE_NOISE_THRESHOLD = { S: 1, A: 2, B: 3, C: 5, D: 7, F: 9 };
 
 export function startIce() {
-  const ice = getPrimaryIce();
-  if (!ice) return;
-  const interval = MOVE_INTERVALS[ice.grade] ?? 6000;
-  scheduleRepeating(TIMER.ICE_MOVE, interval);
+  const s = getState();
+  // Idempotent: drop any move timers from a prior call before scheduling fresh
+  // ones, so repeated startIce() calls re-schedule cleanly instead of stacking
+  // orphaned timers (which would accelerate ICE cadence over a run).
+  cancelAllByType(TIMER.ICE_MOVE);
+  // Each active instance gets its own repeating ICE_MOVE timer at its grade's
+  // interval, carrying its iceId so handleIceTick moves only that instance.
+  for (const ice of activeIceInstances(s)) {
+    const interval = MOVE_INTERVALS[ice.grade] ?? 6000;
+    const id = scheduleRepeating(TIMER.ICE_MOVE, interval, { iceId: ice.id });
+    setIceMoveTimer(id, ice.id);
+  }
 }
 
 export function stopIce() {
@@ -58,19 +69,26 @@ export function initIceHandlers() {
   // lock so ICE can re-detect on a revisit, and start a new dwell if ICE is already
   // at the node the player just entered. nodeId is null on deselect.
   on(E.PLAYER_NAVIGATED, ({ nodeId }) => {
-    cancelAllByType(TIMER.ICE_DETECT);
+    const s = getState();
+    // Reset every active instance's dwell + detection lock so each can re-detect
+    // on the node the player just entered (or simply clear on deselect).
+    for (const ice of activeIceInstances(s)) {
+      if (ice.dwellTimerId != null) cancelEvent(ice.dwellTimerId);
+      setIceDetectedAt(null, ice.id);
+    }
     if (nodeId !== null) {
-      setIceDetectedAt(null);
-      const ice = getPrimaryIce();
-      if (ice && ice.attentionNodeId === nodeId) {
-        checkIceDetection(nodeId);
+      for (const ice of activeIceInstances(getState())) {
+        if (ice.attentionNodeId === nodeId) {
+          checkIceDetection(ice, nodeId);
+        }
       }
     }
   });
 
-  // Eject and reboot forcibly move ICE off its current node — treat as a departure.
-  on(E.ICE_EJECTED,  handleIceDeparture);
-  on(E.ICE_REBOOTED, handleIceDeparture);
+  // Eject and reboot forcibly move an instance off its current node — treat as a
+  // departure for that specific instance (both events carry iceId).
+  on(E.ICE_EJECTED,  ({ iceId }) => handleIceDeparture(iceId));
+  on(E.ICE_REBOOTED, ({ iceId }) => handleIceDeparture(iceId));
 
   // Respond to exploit execution noise via ACTION_FEEDBACK progress events.
   // The timed-action operator emits progress at every tick. We convert the progress
@@ -79,13 +97,15 @@ export function initIceHandlers() {
   on(E.ACTION_FEEDBACK, ({ nodeId, action, phase, progress }) => {
     if (action !== A.XPLOIT || phase !== "progress") return;
     const s = getState();
-    const ice = getPrimaryIce();
-    if (!ice || s.phase !== "playing") return;
-    const noiseTick = Math.floor(progress * 10);
-    const threshold = ICE_NOISE_THRESHOLD[ice.grade] ?? 5;
-    if (noiseTick < threshold) return;
+    if (s.phase !== "playing") return;
     if (s.lastDisturbedNodeId === nodeId) return;
-    setLastDisturbedNode(nodeId);
+    const noiseTick = Math.floor(progress * 10);
+    // Disturbance is a single global signal. If ANY active instance is sensitive
+    // enough at this noise level, record it once.
+    const disturbed = activeIceInstances(s).some(
+      (ice) => noiseTick >= (ICE_NOISE_THRESHOLD[ice.grade] ?? 5)
+    );
+    if (disturbed) setLastDisturbedNode(nodeId);
   });
 }
 
@@ -117,9 +137,17 @@ function nextHopToward(src, dst, adjacency) {
   return null;
 }
 
-export function handleIceTick() {
+export function handleIceTick(payload) {
   const s = getState();
   if (s.phase !== "playing") return;
+  // Per-instance timer: payload carries the iceId of the single instance to move.
+  if (payload?.iceId) {
+    const ice = s.ice?.instances?.[payload.iceId];
+    if (ice?.active) moveInstance(ice, s);
+    return;
+  }
+  // No iceId in payload: move all active instances. No production caller forwards
+  // an empty payload — retained as a defensive fallback / for direct test invocation.
   const instances = Object.values(s.ice?.instances ?? {});
   for (const instance of instances) {
     if (!instance.active) continue;
@@ -183,13 +211,8 @@ function moveInstance(ice, s) {
   const toLabel = toVisible ? (s.nodes[nextNode]?.label ?? nextNode) : "???";
   emitEvent(E.ICE_MOVED, { iceId: ice.id, fromId, toId: nextNode, fromLabel, toLabel, fromVisible, toVisible });
 
-  // Detection state is singleton-bound to the primary ICE for session 1.
-  // Only the primary instance drives dwell timer creation/cancellation;
-  // non-primary instances moving would otherwise cancel the primary's dwell.
-  const primaryIce = getPrimaryIce();
-  if (primaryIce?.id === ice.id) {
-    checkIceDetection(nextNode, { justArrived: true });
-  }
+  // Each instance drives its own per-id dwell timer on arrival.
+  checkIceDetection(ice, nextNode, { justArrived: true });
 }
 
 // Delay before detection starts when ICE arrives via movement (ms).
@@ -197,50 +220,51 @@ function moveInstance(ice, s) {
 // detection timer stay in sync — player sees ICE arrive, then countdown starts.
 const ARRIVAL_DELAY_MS = 400;
 
-function checkIceDetection(nodeId, { justArrived = false } = {}) {
+function checkIceDetection(ice, nodeId, { justArrived = false } = {}) {
   const s = getState();
-  const ice = getPrimaryIce();
   if (!ice) return;
   if (s.selectedNodeId !== nodeId) {
-    // ICE moved away from player's node — use shared departure handler.
-    handleIceDeparture();
+    // This instance moved away from the player's node — clear its own dwell/lock.
+    handleIceDeparture(ice.id);
     return;
   }
   if (ice.detectedAtNode === nodeId) return; // already detected here; player must move first
 
   const dwellMs = DWELL_TIMES[ice.grade];
-  cancelAllByType(TIMER.ICE_DETECT);
+  // Cancel only THIS instance's prior dwell — never the whole type.
+  if (ice.dwellTimerId != null) cancelEvent(ice.dwellTimerId);
 
   if (dwellMs === null) {
     // Instant detection — no escape possible
-    triggerDetection(nodeId);
+    triggerDetection(ice, nodeId);
   } else {
     const totalMs = dwellMs + (justArrived ? ARRIVAL_DELAY_MS : 0);
-    const timerId = scheduleEvent(TIMER.ICE_DETECT, totalMs, { nodeId }, { label: "ICE DETECTION" });
-    setIceDwellTimer(timerId);
+    const timerId = scheduleEvent(TIMER.ICE_DETECT, totalMs, { iceId: ice.id, nodeId }, { label: "ICE DETECTION" });
+    setIceDwellTimer(timerId, ice.id);
     emitEvent(E.ICE_DETECT_PENDING, { iceId: ice.id, nodeId, label: s.nodes[nodeId]?.label ?? nodeId, dwellMs: totalMs });
   }
 }
 
-export function handleIceDetect({ nodeId }) {
+export function handleIceDetect({ iceId, nodeId }) {
   const s = getState();
-  const ice = getPrimaryIce();
-  if (!ice) return;
+  // Resolve by id when present; fall back to the primary instance for legacy
+  // timer payloads serialized before per-instance iceId keying (snapshot parity).
+  const ice = iceId ? s.ice?.instances?.[iceId] : activeIceInstances(s)[0];
+  if (!ice || !ice.active) return;
   // Only fire if player is still on the detected node
   if (s.selectedNodeId === nodeId) {
-    triggerDetection(nodeId);
+    triggerDetection(ice, nodeId);
+    setIceDwellTimer(null, ice.id);
   }
 }
 
-function triggerDetection(nodeId) {
+function triggerDetection(ice, nodeId) {
   const s = getState();
-  const ice = getPrimaryIce();
   emitEvent(E.ICE_DETECTED, { iceId: ice?.id ?? null, nodeId, label: s.nodes[nodeId]?.label ?? nodeId });
   if (!ice) return;
   // Detection lock — applies to ALL ICE regardless of effects, so the same node
-  // doesn't re-detect until the player moves. (recordIceDetection also sets this
-  // for classic ICE; idempotent.)
-  setIceDetectedAt(nodeId);
+  // doesn't re-detect until the player moves. Per-instance: lock THIS instance.
+  setIceDetectedAt(nodeId, ice.id);
   applyIceEffects(ice, s, nodeId);
 }
 
@@ -250,6 +274,10 @@ function triggerDetection(nodeId) {
  * the player-orchestration wrappers (which end the run on depletion) and log a
  * readout. Untyped/legacy instances fall back to raise-alert — preserving
  * pre-dispatch behavior for fixtures like 'standard-ice'.
+ *
+ * Multi-instance: each detecting instance dispatches ITS OWN type's effects with
+ * its own id — a sentinel and a spike on the same run drain HEALTH and DECK
+ * independently, and a classic instance steps the shared alert via its own iceId.
  * @param {import('../types.js').IceInstance} ice
  * @param {import('../types.js').GameState} state
  * @param {string} nodeId
@@ -258,7 +286,7 @@ function applyIceEffects(ice, state, nodeId) {
   const type = getType(ice.typeId);
   const effects = type?.effects ?? [{ atom: "raise-alert", params: {} }];
   const ctx = {
-    propagateAlertEvent: (nid) => recordIceDetection(nid),
+    propagateAlertEvent: (nid) => recordIceDetection(nid, ice.id),
     damagePlayerHealth,
     damagePlayerDeck,
   };
@@ -305,14 +333,16 @@ export function cancelIceDwell() {
 // Resets detectedAtNode so the detection dwell fires immediately on arrival.
 export function teleportIce(nodeId) {
   const s = getState();
-  const ice = getPrimaryIce();
+  const ice = activeIceInstances(s)[0];
   if (!ice) return;
   if (!s.nodes[nodeId]) return;
   setIceDetectedAt(null);
-  // Reschedule ICE_MOVE from now so it doesn't fire mid-dwell and cancel detection.
+  // Reschedule only THIS instance's ICE_MOVE from now so it doesn't fire mid-dwell
+  // and cancel detection — leave other instances' move timers untouched.
+  if (ice.moveTimerId != null) cancelEvent(ice.moveTimerId);
   const interval = MOVE_INTERVALS[ice.grade] ?? 6000;
-  cancelAllByType(TIMER.ICE_MOVE);
-  scheduleRepeating(TIMER.ICE_MOVE, interval);
+  const id = scheduleRepeating(TIMER.ICE_MOVE, interval, { iceId: ice.id });
+  setIceMoveTimer(id, ice.id);
   const fromId = ice.attentionNodeId;
   if (fromId !== nodeId) {
     setIceAttention(nodeId);
@@ -322,32 +352,56 @@ export function teleportIce(nodeId) {
     const toLabel   = toVisible   ? (s.nodes[nodeId]?.label  ?? nodeId) : "???";
     emitEvent(E.ICE_MOVED, { iceId: ice.id, fromId, toId: nodeId, fromLabel, toLabel, fromVisible, toVisible });
   }
-  checkIceDetection(nodeId);
+  checkIceDetection(ice, nodeId);
 }
 
 // ── ICE orchestration (moved from state/index.js) ────────
 
-export function ejectIce() {
+// Eject the ICE instance present at a node. The EJECT action is node-targeted,
+// so `target` is normally a nodeId — we eject the active instance whose attention
+// is on that node (multi-instance correctness: a co-active instance elsewhere is
+// left alone). `target` may also be an explicit iceId (programmatic/test callers),
+// and a missing arg falls back to the first active instance (single-instance legacy).
+export function ejectIce(target) {
   const s = getState();
-  const ice = getPrimaryIce();
+  const active = activeIceInstances(s);
+  let ice;
+  if (target && s.ice?.instances?.[target]?.active) {
+    ice = s.ice.instances[target]; // explicit iceId
+  } else if (target) {
+    ice = active.find((i) => i.attentionNodeId === target); // nodeId
+  } else {
+    ice = active[0]; // legacy no-arg fallback
+  }
   if (!ice) return;
   const fromId = ice.attentionNodeId;
   const neighbors = s.adjacency[fromId] || [];
   if (neighbors.length === 0) return;
   const toId = randomPick(RNG.ICE, neighbors);
-  setIceAttention(toId);
+  setIceAttention(toId, ice.id);
   emitEvent(E.ICE_EJECTED, { iceId: ice.id, fromId, toId });
 }
 
+// Trigger-driven (IDS subversion of the ICE host monitor). Operates on the first
+// active instance — a single-instance assumption. No generated multi-ICE network
+// currently wires a disable trigger (only the legacy single-ICE corporate-exchange).
+// Revisit when multi-ICE networks gain disable triggers.
 export function disableIce() {
-  const ice = getPrimaryIce();
+  const ice = activeIceInstances(getState())[0];
   if (!ice) return;
   setIceActive(false);
   emitEvent(E.ICE_DISABLED, { iceId: ice.id });
 }
 
-export function rebootIce() {
-  const ice = getPrimaryIce();
+// Send the ICE instance present at `nodeId` back to its host node. Reboot is a
+// node-targeted action, so we resolve the instance whose attention is on the
+// rebooted node — leaving any co-active instance elsewhere untouched. A missing
+// arg falls back to the first active instance (single-instance legacy).
+export function rebootIce(nodeId) {
+  const active = activeIceInstances(getState());
+  const ice = nodeId
+    ? active.find((i) => i.attentionNodeId === nodeId)
+    : active[0];
   if (!ice) return;
-  setIceAttention(ice.hostNodeId);
+  setIceAttention(ice.hostNodeId, ice.id);
 }

--- a/js/core/network/assemble.js
+++ b/js/core/network/assemble.js
@@ -60,15 +60,14 @@ export function assembleNetwork(pieces, crossEdges, spec, biome, seed) {
     }
   }
 
-  // 3. ICE placement
+  // 3. ICE placement — one roaming ICE per security-monitor (cap 3), threat >= B.
+  /** @type {{ instances: { startNode: string, grade: import('../types.js').Grade }[] } | null} */
   let iceConfig = null;
   if (gradeToNumber(spec.threat) >= 4) { // B or better
-    const monitorNode = allNodes.find(n => n.type === "security-monitor");
-    if (monitorNode) {
-      iceConfig = {
-        startNode: monitorNode.id,
-        grade: spec.threat,
-      };
+    const monitors = allNodes.filter(n => n.type === "security-monitor").slice(0, 3); // cap 3 — TEMP swarm-guard (#136)
+    if (monitors.length) {
+      const grade = /** @type {import('../types.js').Grade} */ (spec.threat);
+      iceConfig = { instances: monitors.map(m => ({ startNode: m.id, grade })) };
     }
   }
 

--- a/js/core/node-graph/game-ctx.js
+++ b/js/core/node-graph/game-ctx.js
@@ -18,7 +18,7 @@ import { startTraceCountdown, cancelTraceCountdown } from "../alert.js";
 import { addCash, setMissionComplete, addCardToHand } from "../state/player.js";
 import { mineYieldChance, isMineExhausted, generateMinedCard } from "../mining.js";
 import { startIce, ejectIce, rebootIce, stopIce, disableIce } from "../ice.js";
-import { getPrimaryIce } from "../state/ice.js";
+import { activeIceInstances } from "../state/ice.js";
 import { on } from "../events.js";
 import { setSelectedNode } from "../state/game.js";
 import { setNodeRebooting } from "../state/node.js";
@@ -136,7 +136,7 @@ export function buildGameCtx(opts = {}) {
     cancelRead: () => { /* now handled by cancel-read action effects */ },
     startLoot: (_nodeId) => { /* now handled by timed-action operator */ },
     cancelLoot: () => { /* now handled by cancel-loot action effects */ },
-    ejectIce: () => ejectIce(),
+    ejectIce: (nodeId) => ejectIce(nodeId),
     rebootNode: (nodeId) => {
       // Legacy stub — reboot now handled by startReboot + timed-action operator
     },
@@ -152,14 +152,15 @@ export function buildGameCtx(opts = {}) {
       const node = s.nodes[nodeId];
       if (!node || node.rebooting) return;
 
-      // Send ICE home if on this node
-      const ice = getPrimaryIce();
-      if (ice?.active && ice.attentionNodeId === nodeId) {
-        rebootIce();
+      // Send the ICE present on this node home (the instance AT nodeId, not just
+      // the first active one — multi-instance correctness).
+      const ice = activeIceInstances(s).find((i) => i.attentionNodeId === nodeId);
+      if (ice) {
+        rebootIce(nodeId);
         emitEvent(E.ICE_REBOOTED, {
           iceId: ice.id,
           residentNodeId: ice.hostNodeId ?? null,
-          residentLabel: ice ? (s.nodes[ice.hostNodeId]?.label ?? ice.hostNodeId) : null,
+          residentLabel: s.nodes[ice.hostNodeId]?.label ?? ice.hostNodeId,
         });
       }
 

--- a/js/core/node-graph/game-types.js
+++ b/js/core/node-graph/game-types.js
@@ -161,7 +161,7 @@ const EJECT_ACTION = {
     { type: "node-attr", attr: "accessLevel", eq: "owned" },
   ],
   effects: [
-    { effect: "ctx-call", method: "ejectIce", args: [] },
+    { effect: "ctx-call", method: "ejectIce", args: ["$nodeId"] },
   ],
 };
 

--- a/js/core/state/ice.js
+++ b/js/core/state/ice.js
@@ -1,7 +1,7 @@
 // @ts-check
 // Pure ICE state mutations. No event emission, no orchestration.
 
-import { mutate, getState } from "./index.js";
+import { mutate } from "./index.js";
 
 /**
  * Resolve an ICE instance from the collection.
@@ -42,6 +42,14 @@ export function setIceDwellTimer(timerId, iceId) {
   });
 }
 
+/** Sets ice.moveTimerId. */
+export function setIceMoveTimer(timerId, iceId) {
+  mutate((s) => {
+    const ice = resolveIce(s, iceId);
+    if (ice) ice.moveTimerId = timerId;
+  });
+}
+
 /** Increments ice.detectionCount. */
 export function incrementIceDetectionCount(iceId) {
   mutate((s) => {
@@ -66,30 +74,20 @@ export function setLastDisturbedNode(nodeId) {
 }
 
 /**
- * Pure variant of getPrimaryIce: derives the first active instance from the
- * passed-in state argument, not the module-global state. Use when callers
- * already hold a state parameter (perception, action availability, etc.) so
- * the function stays a pure derivation.
- *
+ * Return all active ICE instances from the passed-in state.
+ * Pure derivation — does not read module-global state.
  * @param {import('../types.js').GameState} state
- * @returns {import('../types.js').IceInstance|null}
+ * @returns {import('../types.js').IceInstance[]}
  */
-export function getPrimaryIceFromState(state) {
-  const inst = state.ice?.instances ?? {};
-  for (const id of Object.keys(inst)) {
-    if (inst[id]?.active) return inst[id];
-  }
-  return null;
+export function activeIceInstances(state) {
+  return Object.values(state.ice?.instances ?? {}).filter((i) => i.active);
 }
 
 /**
- * Return the first active instance, or null if none.
- * Compatibility shim — callers iterate `state.ice.instances` directly in
- * later sessions. Phase 4 of session 1 migrates existing callers to use
- * this shim before broader iteration changes.
- *
- * @returns {import('../types.js').IceInstance|null}
+ * True if at least one ICE instance is active in the passed-in state.
+ * @param {import('../types.js').GameState} state
+ * @returns {boolean}
  */
-export function getPrimaryIce() {
-  return getPrimaryIceFromState(getState());
+export function hasActiveIce(state) {
+  return activeIceInstances(state).length > 0;
 }

--- a/js/core/state/ice.test.js
+++ b/js/core/state/ice.test.js
@@ -8,8 +8,11 @@ import { clearAll } from "../timers.js";
 import {
   setIceAttention, setIceDetectedAt, setIceDwellTimer,
   incrementIceDetectionCount, setIceActive, setLastDisturbedNode,
-  getPrimaryIce,
+  activeIceInstances, hasActiveIce,
 } from "./ice.js";
+
+/** First active ICE instance, or null. */
+const firstIce = () => activeIceInstances(getState())[0] ?? null;
 
 describe("state/ice — ICE mutations", () => {
   beforeEach(() => {
@@ -20,37 +23,37 @@ describe("state/ice — ICE mutations", () => {
   it("setIceAttention changes attentionNodeId", () => {
     const v = getVersion();
     setIceAttention("gateway");
-    assert.equal(getPrimaryIce().attentionNodeId, "gateway");
+    assert.equal(firstIce().attentionNodeId, "gateway");
     assert.equal(getVersion(), v + 1);
   });
 
   it("setIceDetectedAt sets detectedAtNode", () => {
     setIceDetectedAt("gateway");
-    assert.equal(getPrimaryIce().detectedAtNode, "gateway");
+    assert.equal(firstIce().detectedAtNode, "gateway");
   });
 
   it("setIceDetectedAt(null) clears detectedAtNode", () => {
     setIceDetectedAt("gateway");
     setIceDetectedAt(null);
-    assert.equal(getPrimaryIce().detectedAtNode, null);
+    assert.equal(firstIce().detectedAtNode, null);
   });
 
   it("setIceDwellTimer sets dwellTimerId", () => {
     setIceDwellTimer(42);
-    assert.equal(getPrimaryIce().dwellTimerId, 42);
+    assert.equal(firstIce().dwellTimerId, 42);
   });
 
   it("incrementIceDetectionCount increments count", () => {
-    const before = getPrimaryIce().detectionCount;
+    const before = firstIce().detectionCount;
     incrementIceDetectionCount();
-    assert.equal(getPrimaryIce().detectionCount, before + 1);
+    assert.equal(firstIce().detectionCount, before + 1);
   });
 
   it("setIceActive sets active flag", () => {
     setIceActive(false);
-    assert.equal(getPrimaryIce(), null);
+    assert.equal(firstIce(), null);
     setIceActive(true, "ice-1");
-    assert.equal(getPrimaryIce().active, true);
+    assert.equal(firstIce().active, true);
   });
 
   it("setLastDisturbedNode sets lastDisturbedNodeId", () => {
@@ -79,15 +82,16 @@ describe("state/ice — multi-instance shape", () => {
     assert.equal(ids.length, 1);
   });
 
-  it("getPrimaryIce() returns the first active instance", () => {
-    const ice = getPrimaryIce();
+  it("activeIceInstances()[0] is the first active instance", () => {
+    const ice = activeIceInstances(getState())[0];
     assert.ok(ice);
     assert.equal(ice.active, true);
     assert.equal(ice.id, "ice-1");
   });
 
-  it("getPrimaryIce() returns null when no active instances", () => {
+  it("hasActiveIce() is false when no active instances", () => {
     setIceActive(false);
-    assert.equal(getPrimaryIce(), null);
+    assert.equal(hasActiveIce(getState()), false);
+    assert.equal(activeIceInstances(getState()).length, 0);
   });
 });

--- a/js/core/state/index.js
+++ b/js/core/state/index.js
@@ -189,40 +189,50 @@ export function initGame(buildNetworkFn, seedString, opts = {}) {
     ? { targetMacguffinId: missionTarget.id, targetName: missionTarget.name, complete: false }
     : null;
 
-  // Spawn ICE if defined in meta
+  // Spawn ICE if defined in meta.
+  // Two meta.ice shapes are supported:
+  //   - { instances: [{ startNode, grade }, ...] }  — generated networks (multi-ICE)
+  //   - { startNode, grade }                         — legacy hand-crafted networks (single ICE)
+  state.ice = { instances: {} };
   if (meta.ice) {
     const nodeIds = Object.keys(nodes);
-    const hostNodeId = meta.ice.startNode ?? randomPick(RNG.WORLD, nodeIds);
-    const id = 'ice-1';
-    const grade = meta.ice.grade;
-    // Registry-driven type: damaging presets (sentinel/spike) appear at B+.
-    // An explicit meta.ice.typeId (cheats/tests) overrides the seeded roll.
-    // NOTE: the hostNodeId draw above is conditional (skipped when startNode is
-    // pinned), so the WORLD-stream position entering this roll differs between
-    // networks that pin startNode and those that don't — same seed, different type.
-    const typeId = meta.ice.typeId ?? pickIceTypeId(grade, random(RNG.WORLD));
-    const typeDef = getType(typeId);
-    /** @type {import('../types.js').IceInstance} */
-    const primary = {
-      id,
-      typeId,
-      hostNodeId,
-      residentNodeId: hostNodeId, // deprecated, kept for migration; remove when callers stop reading it
-      attentionNodeId: hostNodeId,
-      active: true,
-      enabled: true,
-      grade,
-      focus: typeDef?.focus ?? 'roaming',
-      // Derive from the registry type so the serialized instance stays honest
-      // (sentinel/spike are 'disturbance-tracker', not the old 'standard' default).
-      behaviorPattern: typeDef?.behaviorPattern ?? 'standard',
-      dwellTimerId: null,
-      detectedAtNode: null,
-      detectionCount: 0,
-    };
-    state.ice = { instances: { [id]: primary } };
-  } else {
-    state.ice = { instances: {} };
+    // One config per monitor for generated networks; a single legacy config
+    // otherwise. Each instance rolls its OWN registry-driven type (#133):
+    // damaging presets (sentinel→health, spike→deck) appear at B+, so a
+    // multi-monitor network can field a mix. An explicit typeId (cheats/tests)
+    // overrides the seeded roll.
+    // NOTE: each config does a conditional hostNodeId draw (skipped when startNode
+    // is pinned, which it always is for generated per-monitor configs) followed by
+    // one WORLD-stream type roll — N instances consume N type rolls.
+    const configs = meta.ice.instances
+      ?? [{ startNode: meta.ice.startNode, grade: meta.ice.grade, typeId: meta.ice.typeId }];
+    configs.forEach((cfg, i) => {
+      const id = `ice-${i + 1}`;
+      const hostNodeId = cfg.startNode ?? randomPick(RNG.WORLD, nodeIds);
+      const grade = cfg.grade;
+      const typeId = cfg.typeId ?? pickIceTypeId(grade, random(RNG.WORLD));
+      const typeDef = getType(typeId);
+      /** @type {import('../types.js').IceInstance} */
+      const instance = {
+        id,
+        typeId,
+        hostNodeId,
+        residentNodeId: hostNodeId, // deprecated, kept for migration; remove when callers stop reading it
+        attentionNodeId: hostNodeId,
+        active: true,
+        enabled: true,
+        grade,
+        // Derive from the registry type so the serialized instance stays honest
+        // (sentinel/spike are 'disturbance-tracker', not the old 'standard' default).
+        focus: typeDef?.focus ?? 'roaming',
+        behaviorPattern: typeDef?.behaviorPattern ?? 'standard',
+        dwellTimerId: null,
+        moveTimerId: null,
+        detectedAtNode: null,
+        detectionCount: 0,
+      };
+      state.ice.instances[id] = instance;
+    });
   }
 
   if (state.mission) {
@@ -281,8 +291,9 @@ export function endRun(outcome) {
   setPhase("ended");
   setRunOutcome(outcome);
   if (outcome === "caught") setCash(0);
-  const primaryIce = state.ice ? Object.values(state.ice.instances).find(i => i?.active) : null;
-  if (primaryIce) setIceActive(false);
+  Object.values(state.ice?.instances ?? {}).forEach((i) => {
+    if (i?.active) setIceActive(false, i.id);
+  });
   emitEvent(E.RUN_ENDED, { outcome });
 }
 

--- a/js/core/types.js
+++ b/js/core/types.js
@@ -114,6 +114,7 @@
  *   focus: "stationary" | "roaming",
  *   behaviorPattern: string,
  *   dwellTimerId: number|null,
+ *   moveTimerId: number|null,
  *   detectedAtNode: string|null,
  *   detectionCount: number,
  * }} IceInstance

--- a/js/playground/main.js
+++ b/js/playground/main.js
@@ -8,7 +8,7 @@
 import { initGraph, getCy, fitGraph, syncInitialNodes, addIceNode, flashNode } from "../ui/graph.js";
 import { initGame, getState } from "../core/state.js";
 import { startIce, handleIceTick, handleIceDetect } from "../core/ice.js";
-import { getPrimaryIce } from "../core/state/ice.js";
+import { hasActiveIce } from "../core/state/ice.js";
 import { initConsole, runCommand } from "../ui/console.js";
 import { on, emitEvent, E } from "../core/events.js";
 import { tick, TICK_MS, TIMER, getVisibleTimers } from "../core/timers.js";
@@ -321,13 +321,13 @@ async function init() {
   fitGraph(cy);
 
   // ICE (may not exist in mini-networks)
-  if (getPrimaryIce()) {
+  if (hasActiveIce(getState())) {
     addIceNode();
     startIce();
   }
 
   // Timer handlers (non-action timers still use the old system)
-  on(TIMER.ICE_MOVE, () => handleIceTick());
+  on(TIMER.ICE_MOVE, (payload) => handleIceTick(payload));
   on(TIMER.ICE_DETECT, (payload) => handleIceDetect(payload));
   on(TIMER.TRACE_TICK, () => handleTraceTick());
 

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -138,7 +138,7 @@ function init() {
   const ctx = buildActionContext(openDarknetsStore);
   initActionDispatcher(ctx);
 
-  on(TIMER.ICE_MOVE,     () => handleIceTick());
+  on(TIMER.ICE_MOVE,     (payload) => handleIceTick(payload));
   on(TIMER.ICE_DETECT,   (payload) => handleIceDetect(payload));
   on(TIMER.TRACE_TICK,   () => handleTraceTick());
   // Probe, exploit, read, loot, reboot timers removed — timed-action operator drives these

--- a/scripts/bot/execute.js
+++ b/scripts/bot/execute.js
@@ -7,7 +7,6 @@
 import { emitEvent, on, off, E, tick, getState } from "../lib/headless-engine.js";
 import { buyFromStore } from "../../js/core/store-logic.js";
 import { A } from "../../js/core/action-ids.js";
-import { getPrimaryIce } from "../../js/core/state/ice.js";
 
 /** Actions that start a timed process and need tick-forward */
 const TIMED_ACTIONS = new Set([A.PROBE, A.XPLOIT, A.DUMP, A.FETCH, A.REBOOT, A.MINE]);
@@ -121,9 +120,11 @@ function tickUntilResolved(choice, budget) {
   const onIceMoved = ({ toId }) => {
     const s = getState();
     if (toId !== s.selectedNodeId || toId !== targetNodeId) return;
-    const node = s.nodes[targetNodeId];
-    const primaryIce = getPrimaryIce();
-    if (node && node.accessLevel === "owned" && primaryIce?.active && primaryIce.attentionNodeId === targetNodeId) {
+    // ICE_MOVED's toId already confirms an ICE arrived on this node; on an OWNED
+    // node, eject is free, so push it off and keep working. (Reacts to ANY ICE.)
+    if (s.nodes[targetNodeId]?.accessLevel === "owned") {
+      // With multiple ICE instances, each arrival fires this handler, but the EJECT action
+      // is idempotent on the second+ calls (clears an already-clear node).
       emitEvent("starnet:action", { actionId: A.EJECT, nodeId: targetNodeId });
     }
   };

--- a/scripts/bot/perception.js
+++ b/scripts/bot/perception.js
@@ -8,7 +8,7 @@
 
 import { getAvailableActions } from "../../js/core/actions/node-actions.js";
 import { A } from "../../js/core/action-ids.js";
-import { getPrimaryIceFromState } from "../../js/core/state/ice.js";
+import { activeIceInstances } from "../../js/core/state/ice.js";
 
 /**
  * Build a WorldModel snapshot from current game state.
@@ -112,12 +112,18 @@ export function perceive(state, context = {}) {
     if (matching.length > 0) cardMatchesByNode.set(nodeId, matching);
   }
 
-  // ICE state
-  const primaryIce = getPrimaryIceFromState(state);
+  // ICE state — aggregate over ALL active instances. isOnSelectedNode and
+  // nodeId are any-instance aggregates so evasion (which reads them) keeps
+  // working with multiple ICE in play.
+  const insts = activeIceInstances(state);
   const ice = {
-    nodeId: primaryIce?.attentionNodeId ?? null,
-    isOnSelectedNode: !!(primaryIce?.active && primaryIce.attentionNodeId === state.selectedNodeId),
-    isActive: primaryIce?.active ?? false,
+    instances: insts.map((i) => ({ nodeId: i.attentionNodeId, grade: i.grade })),
+    isOnSelectedNode: insts.some((i) => i.attentionNodeId === state.selectedNodeId),
+    isActive: insts.length > 0,
+    nodeId:
+      insts.find((i) => i.attentionNodeId === state.selectedNodeId)?.attentionNodeId ??
+      insts[0]?.attentionNodeId ??
+      null,
   };
 
   // Player state

--- a/scripts/bot/types.js
+++ b/scripts/bot/types.js
@@ -20,9 +20,10 @@
 
 /**
  * @typedef {Object} WorldIce
- * @property {string|null} nodeId — current ICE attention node
- * @property {boolean} isOnSelectedNode
- * @property {boolean} isActive
+ * @property {{ nodeId: string, grade: string }[]} instances — all active ICE instances
+ * @property {string|null} nodeId — attention node of the instance on the selected node, else the first active instance
+ * @property {boolean} isOnSelectedNode — true if ANY active instance is on the selected node
+ * @property {boolean} isActive — true if any ICE instance is active
  */
 
 /**

--- a/scripts/generate-network.js
+++ b/scripts/generate-network.js
@@ -101,7 +101,7 @@ try {
     console.log(`Spec: threat=${spec.threat} wealth=${spec.wealth} complexity=${spec.complexity} depth=${spec.depth}`);
     console.log(`Nodes: ${graphDef.nodes.length}  Edges: ${graphDef.edges.length}  Triggers: ${graphDef.triggers.length}`);
     console.log(`Start cash: ¥${meta.startCash.toLocaleString()}`);
-    console.log(`ICE: ${meta.ice ? `grade ${meta.ice.grade} at ${meta.ice.startNode}` : "none"}`);
+    console.log(`ICE: ${meta.ice?.instances?.length ? meta.ice.instances.map(c => `${c.grade}@${c.startNode}`).join(", ") : "none"}`);
     console.log(`Node types:`);
     for (const [type, count] of Object.entries(nodeTypes).sort((a, b) => b[1] - a[1])) {
       console.log(`  ${type}: ${count}`);

--- a/scripts/lib/headless-engine.js
+++ b/scripts/lib/headless-engine.js
@@ -44,7 +44,7 @@ export function initHeadlessEngine(opts = {}) {
  */
 function wireRunHandlers() {
   // Timer → handler wiring
-  on(TIMER.ICE_MOVE,   () => handleIceTick());
+  on(TIMER.ICE_MOVE,   (payload) => handleIceTick(payload));
   on(TIMER.ICE_DETECT, (payload) => handleIceDetect(payload));
   on(TIMER.TRACE_TICK, () => handleTraceTick());
 

--- a/tests/ice-multi-detection.test.js
+++ b/tests/ice-multi-detection.test.js
@@ -1,0 +1,249 @@
+// @ts-check
+// Phase 1: per-instance ICE detection, dwell, and alert.
+//
+// Verifies that every active ICE instance on the player's selected node dwells
+// and detects independently — one ICE_DETECT timer per instance, keyed by iceId,
+// cancelled by id (not cancelAllByType). Each detection sources the single
+// global alert/trace.
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  createGateway, createRouter,
+} from "../js/core/node-graph/game-types.js";
+import { initGame, getState } from "../js/core/state.js";
+import { startIce, handleIceTick, handleIceDetect, ejectIce } from "../js/core/ice.js";
+import { handleTraceTick } from "../js/core/alert.js";
+import { getAvailableActions } from "../js/core/actions/node-actions.js";
+import { A } from "../js/core/action-ids.js";
+import { emitEvent, on, off, E } from "../js/core/events.js";
+import { clearAll, tick, TIMER } from "../js/core/timers.js";
+import "../js/core/alert.js";
+
+function buildIceLAN({ startCash = 0, grade = "C" } = {}) {
+  return {
+    graphDef: {
+      nodes: [
+        createGateway("gateway", { attributes: { visibility: "accessible" } }),
+        createRouter("router-a"),
+      ],
+      edges: [["gateway", "router-a"]],
+      triggers: [],
+    },
+    meta: { startNode: "gateway", startCash, moneyCost: "C", ice: { grade, startNode: "gateway" } },
+  };
+}
+
+function withEvents(type, fn) {
+  const captured = [];
+  const handler = (payload) => captured.push(payload);
+  on(type, handler);
+  fn();
+  off(type, handler);
+  return captured;
+}
+
+/** Inject a second active instance at the given node. */
+function injectInstance(id, nodeId, grade) {
+  const s = getState();
+  s.ice.instances[id] = {
+    id,
+    typeId: `patrol-${grade}`,
+    hostNodeId: nodeId,
+    attentionNodeId: nodeId,
+    active: true,
+    enabled: true,
+    grade,
+    focus: "roaming",
+    behaviorPattern: "standard",
+    dwellTimerId: null,
+    moveTimerId: null,
+    detectedAtNode: null,
+    detectionCount: 0,
+  };
+  return s.ice.instances[id];
+}
+
+describe("ice multi-instance detection", () => {
+  const moveHandler = () => handleIceTick();
+  const detectHandler = (p) => handleIceDetect(p);
+  const traceHandler = () => handleTraceTick();
+
+  before(() => {
+    on(TIMER.ICE_MOVE, moveHandler);
+    on(TIMER.ICE_DETECT, detectHandler);
+    on(TIMER.TRACE_TICK, traceHandler);
+  });
+  after(() => {
+    off(TIMER.ICE_MOVE, moveHandler);
+    off(TIMER.ICE_DETECT, detectHandler);
+    off(TIMER.TRACE_TICK, traceHandler);
+  });
+
+  beforeEach(() => {
+    clearAll();
+    // Grade B: dwell 4500ms, trace threshold 2 — gives room for two detections
+    // before trace and a generous dwell window.
+    initGame(() => buildIceLAN({ grade: "B" }));
+  });
+
+  it("two instances on the player's node both detect, one per iceId", () => {
+    const s = getState();
+    // Player selects gateway; ice-1 already resides there.
+    s.selectedNodeId = "gateway";
+    s.ice.instances["ice-1"].attentionNodeId = "gateway";
+    injectInstance("ice-2", "gateway", "B");
+
+    // Kick off the dwell for both instances via PLAYER_NAVIGATED.
+    const detected = withEvents(E.ICE_DETECTED, () => {
+      emitNav("gateway");
+      // Dwell is 4500ms = 45 ticks; advance well past it.
+      tick(60);
+    });
+
+    const ids = detected.map((p) => p.iceId).sort();
+    assert.equal(detected.length, 2, `expected 2 detections, got ${detected.length}`);
+    assert.deepEqual(ids, ["ice-1", "ice-2"]);
+    for (const p of detected) assert.equal(p.nodeId, "gateway");
+  });
+
+  it("cancelling instance A's dwell leaves instance B's dwell intact", () => {
+    const s = getState();
+    s.selectedNodeId = "gateway";
+    s.ice.instances["ice-1"].attentionNodeId = "gateway";
+    injectInstance("ice-2", "gateway", "B");
+
+    // Start both dwells.
+    emitNav("gateway");
+
+    // Eject instance ice-1 — this cancels ITS dwell only (departure for ice-1).
+    const detected = withEvents(E.ICE_DETECTED, () => {
+      ejectIce("ice-1");
+      tick(60);
+    });
+
+    // ice-2 still on gateway and still dwelling → exactly one detection, for ice-2.
+    assert.equal(detected.length, 1, `expected 1 detection, got ${detected.length}`);
+    assert.equal(detected[0].iceId, "ice-2");
+  });
+
+  it("EJECT at a node boots the instance on THAT node, not a co-active instance elsewhere", () => {
+    const s = getState();
+    // ice-1 dwells on router-a; ice-2 dwells on the player's owned target (gateway).
+    s.ice.instances["ice-1"].attentionNodeId = "router-a";
+    injectInstance("ice-2", "gateway", "B");
+    // Gateway is owned so EJECT is available; it has router-a as a neighbor to eject toward.
+    s.nodeGraph.setNodeAttr("gateway", "accessLevel", "owned");
+
+    // Dispatch EJECT at gateway via the real action path.
+    const ejected = withEvents(E.ICE_EJECTED, () => {
+      const node = s.nodes["gateway"];
+      const action = getAvailableActions(node, s).find((a) => a.id === A.EJECT);
+      assert.ok(action, "EJECT should be available on owned gateway with ICE present");
+      action.execute(node, s, {}, { nodeId: "gateway" });
+    });
+
+    // The instance at gateway (ice-2) is the one ejected and moved off gateway.
+    assert.equal(ejected.length, 1, `expected 1 eject, got ${ejected.length}`);
+    assert.equal(ejected[0].iceId, "ice-2", "the instance AT gateway must be ejected");
+    assert.notEqual(getState().ice.instances["ice-2"].attentionNodeId, "gateway", "ice-2 must move off gateway");
+    // ice-1 (elsewhere) must not move.
+    assert.equal(getState().ice.instances["ice-1"].attentionNodeId, "router-a", "ice-1 must NOT move");
+  });
+
+  it("single active instance detects exactly once", () => {
+    const s = getState();
+    s.selectedNodeId = "gateway";
+    s.ice.instances["ice-1"].attentionNodeId = "gateway";
+
+    const detected = withEvents(E.ICE_DETECTED, () => {
+      emitNav("gateway");
+      tick(60);
+    });
+
+    assert.equal(detected.length, 1);
+    assert.equal(detected[0].iceId, "ice-1");
+  });
+});
+
+describe("ice multi-instance move cadence (per-instance timers)", () => {
+  // Wire the move handler WITH payload so per-instance iceId routing is exercised.
+  const moveHandler = (p) => handleIceTick(p);
+  before(() => {
+    on(TIMER.ICE_MOVE, moveHandler);
+  });
+  after(() => {
+    off(TIMER.ICE_MOVE, moveHandler);
+  });
+
+  beforeEach(() => {
+    clearAll();
+    initGame(() => buildIceLAN({ grade: "S" }));
+  });
+
+  it("instances of different grades move on independent cadences", () => {
+    const s = getState();
+    // Primary instance is grade S (move interval 4000ms = 40 ticks).
+    s.ice.instances["ice-1"].grade = "S";
+    s.ice.instances["ice-1"].attentionNodeId = "gateway";
+    // Inject a slow grade-D instance (move interval 12000ms = 120 ticks).
+    injectInstance("ice-2", "router-a", "D");
+
+    const moves = withEvents(E.ICE_MOVED, () => {
+      startIce();
+      tick(240); // 6 S-intervals, 2 D-intervals
+    });
+
+    const sMoves = moves.filter((m) => m.iceId === "ice-1").length;
+    const dMoves = moves.filter((m) => m.iceId === "ice-2").length;
+
+    assert.ok(sMoves > 0, "S instance should have moved");
+    assert.ok(dMoves > 0, "D instance should have moved");
+    assert.ok(
+      sMoves > dMoves,
+      `S (${sMoves}) should move strictly more than D (${dMoves}) — independent cadence`,
+    );
+  });
+
+  it("single instance schedules exactly one move timer at its grade interval", () => {
+    const s = getState();
+    // Grade S: interval 4000ms = 40 ticks.
+    s.ice.instances["ice-1"].grade = "S";
+    s.ice.instances["ice-1"].attentionNodeId = "gateway";
+
+    const moves = withEvents(E.ICE_MOVED, () => {
+      startIce();
+      tick(200); // 200 / 40 = 5 intervals
+    });
+
+    const myMoves = moves.filter((m) => m.iceId === "ice-1").length;
+    assert.equal(myMoves, 5, `expected 5 S-grade moves over 200 ticks, got ${myMoves}`);
+  });
+
+  it("startIce() is idempotent — a second call does not double move cadence", () => {
+    const s = getState();
+    // Grade S: interval 4000ms = 40 ticks.
+    s.ice.instances["ice-1"].grade = "S";
+    s.ice.instances["ice-1"].attentionNodeId = "gateway";
+
+    const moves = withEvents(E.ICE_MOVED, () => {
+      startIce();
+      startIce(); // back-to-back: must cancel the first call's timer, not stack
+      tick(200); // 200 / 40 = 5 intervals
+    });
+
+    const myMoves = moves.filter((m) => m.iceId === "ice-1").length;
+    assert.equal(
+      myMoves,
+      5,
+      `expected 5 S-grade moves over 200 ticks after two startIce() calls, got ${myMoves}`,
+    );
+  });
+});
+
+// PLAYER_NAVIGATED is what the ice runtime listens to; emit it directly so the
+// test does not depend on navigation.js side effects.
+function emitNav(nodeId) {
+  emitEvent(E.PLAYER_NAVIGATED, { nodeId });
+}

--- a/tests/ice-serialization.test.js
+++ b/tests/ice-serialization.test.js
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 import { buildNetwork as buildCorporateExchange } from "../data/networks/corporate-exchange.js";
 import { initGame, getState, serializeState, deserializeState } from "../js/core/state.js";
 import { clearAll } from "../js/core/timers.js";
-import { getPrimaryIce } from "../js/core/state/ice.js";
+import { activeIceInstances } from "../js/core/state/ice.js";
 
 describe("ice: multi-instance serialization round-trip", () => {
   beforeEach(() => { clearAll(); });
@@ -49,8 +49,8 @@ describe("ice: multi-instance serialization round-trip", () => {
     assert.equal(rehydrated.ice.instances["ice-2"].active, true);
     assert.equal(rehydrated.ice.instances["ice-3"].active, false);
 
-    // getPrimaryIce returns the first active instance
-    const primary = getPrimaryIce();
+    // first active instance after round-trip
+    const primary = activeIceInstances(rehydrated)[0];
     assert.ok(primary);
     assert.equal(primary.active, true);
   });
@@ -68,6 +68,6 @@ describe("ice: multi-instance serialization round-trip", () => {
 
     const rehydrated = getState();
     assert.equal(Object.keys(rehydrated.ice.instances).length, 0);
-    assert.equal(getPrimaryIce(), null);
+    assert.equal(activeIceInstances(rehydrated).length, 0);
   });
 });

--- a/tests/init-game.test.js
+++ b/tests/init-game.test.js
@@ -1,7 +1,8 @@
 import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { initGame, getState, serializeState, deserializeState } from "../js/core/state.js";
-import { getPrimaryIce } from "../js/core/state/ice.js";
+import { activeIceInstances } from "../js/core/state/ice.js";
+import { getType } from "../js/core/ice/index.js";
 import { clearHandlers } from "../js/core/events.js";
 import { clearAll } from "../js/core/timers.js";
 import { buildNetwork as buildCorporateFoothold } from "../data/networks/corporate-foothold.js";
@@ -73,10 +74,66 @@ describe("initGame", () => {
 
   it("spawns ICE from meta when defined", () => {
     initGame(() => buildCorporateExchange(), "test-seed-7");
-    const ice = getPrimaryIce();
+    const ice = activeIceInstances(getState())[0];
     assert.ok(ice);
     assert.equal(ice.active, true);
     assert.equal(ice.grade, "B");
+  });
+
+  it("spawns one instance per meta.ice.instances entry (ice-1..ice-N)", () => {
+    // Reuse a real generated graphDef but override meta.ice with a 3-instance list.
+    const base = buildCorporateExchange();
+    const ids = base.graphDef.nodes.map(n => n.id);
+    const startNodes = [ids[0], ids[1], ids[2]];
+    const build = () => ({
+      graphDef: base.graphDef,
+      meta: {
+        ...base.meta,
+        ice: { instances: startNodes.map(sn => ({ startNode: sn, grade: "A" })) },
+      },
+    });
+    initGame(build, "multi-instance-seed");
+    const s = getState();
+    assert.equal(Object.keys(s.ice.instances).length, 3);
+    ["ice-1", "ice-2", "ice-3"].forEach((id, i) => {
+      const inst = s.ice.instances[id];
+      assert.ok(inst, `${id} should exist`);
+      assert.equal(inst.id, id);
+      assert.equal(inst.active, true);
+      assert.equal(inst.grade, "A");
+      assert.equal(inst.hostNodeId, startNodes[i]);
+      assert.equal(inst.attentionNodeId, startNodes[i]);
+    });
+  });
+
+  it("single-monitor (legacy) meta.ice → exactly one ice-1 (parity)", () => {
+    // corporate-exchange uses the legacy { startNode, grade } shape.
+    initGame(() => buildCorporateExchange(), "parity-seed");
+    const s = getState();
+    assert.equal(Object.keys(s.ice.instances).length, 1);
+    const inst = s.ice.instances["ice-1"];
+    assert.ok(inst);
+    assert.equal(inst.id, "ice-1");
+    assert.equal(inst.active, true);
+    assert.equal(inst.grade, "B");
+    // Post-#133 integration: every spawned instance (including legacy single-ICE
+    // networks) gets a registry-driven type, with focus/behaviorPattern derived
+    // from it — not the old hardcoded 'standard-ice'/'roaming'.
+    const typeDef = getType(inst.typeId);
+    assert.ok(typeDef, `typeId ${inst.typeId} should resolve to a registered ICE type`);
+    assert.equal(inst.focus, typeDef.focus ?? "roaming");
+    assert.equal(inst.behaviorPattern, typeDef.behaviorPattern ?? "standard");
+  });
+
+  it("empty instances list → no ICE instances", () => {
+    const base = buildCorporateExchange();
+    const build = () => ({
+      graphDef: base.graphDef,
+      meta: { ...base.meta, ice: { instances: [] } },
+    });
+    initGame(build, "empty-instances-seed");
+    const s = getState();
+    assert.equal(Object.keys(s.ice.instances).length, 0);
   });
 
   it("graph tick advances without error", () => {

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -44,7 +44,11 @@ import { setGlobalAlert } from "../js/core/state/alert.js";
 // NODE_RECONFIGURED listeners. No separate init call needed.
 // Old executor imports removed — timed actions now graph-native
 import { RNG, _forceNext } from "../js/core/rng.js";
-import { getPrimaryIce } from "../js/core/state/ice.js";
+import { activeIceInstances } from "../js/core/state/ice.js";
+import { cmdStatusIce } from "../js/core/console-commands/cmd-status.js";
+
+/** First active ICE instance, or null. */
+const firstIce = () => activeIceInstances(getState())[0] ?? null;
 
 // Register the node lifecycle dispatcher once for this test file.
 
@@ -215,14 +219,14 @@ describe("Lifecycle: iceResident — owning security-monitor stops ICE", () => {
   });
 
   it("ICE starts active after initState + startIce", () => {
-    assert.ok(getPrimaryIce()?.active);
+    assert.ok(firstIce()?.active);
   });
 
   it("owning security-monitor sets ice.active to false", () => {
     const s = getState();
     s.nodeGraph.setNodeAttr("sec-mon", "accessLevel", "owned");
-    // ICE_DISABLED setIceActive(false) makes getPrimaryIce() return null
-    assert.equal(getPrimaryIce(), null);
+    // ICE_DISABLED setIceActive(false) makes firstIce() return null
+    assert.equal(firstIce(), null);
   });
 
   it("owning security-monitor emits ICE_DISABLED", () => {
@@ -237,7 +241,7 @@ describe("Lifecycle: iceResident — owning security-monitor stops ICE", () => {
     const s = getState();
     s.nodes["gateway"].accessLevel = "owned";
     emitEvent(E.NODE_ACCESSED, { nodeId: "gateway", label: "gateway", prev: "locked", next: "owned" });
-    assert.ok(getPrimaryIce()?.active, "ICE should remain active");
+    assert.ok(firstIce()?.active, "ICE should remain active");
   });
 });
 
@@ -411,22 +415,22 @@ describe("ICE detection: detectedAtNode resets when player moves", () => {
   it("moving to a different node resets detectedAtNode to null", () => {
     const s = getState();
     s.selectedNodeId = "gateway";
-    getPrimaryIce().detectedAtNode = "gateway"; // simulate: detection already happened here
+    firstIce().detectedAtNode = "gateway"; // simulate: detection already happened here
 
     navigateTo("router-a");
 
-    assert.equal(getPrimaryIce().detectedAtNode, null,
+    assert.equal(firstIce().detectedAtNode, null,
       "detectedAtNode should clear so ICE can detect at gateway again after player returns");
   });
 
   it("re-selecting the SAME node does NOT reset detectedAtNode", () => {
     const s = getState();
     s.selectedNodeId = "gateway";
-    getPrimaryIce().detectedAtNode = "gateway";
+    firstIce().detectedAtNode = "gateway";
 
     navigateTo("gateway");
 
-    assert.equal(getPrimaryIce().detectedAtNode, "gateway",
+    assert.equal(firstIce().detectedAtNode, "gateway",
       "detectedAtNode must not reset when player re-selects the already-selected node");
   });
 });
@@ -443,7 +447,7 @@ describe("ICE detection: player navigates to node where ICE is already present",
   it("starts detection dwell when player enters ICE's current node", () => {
     const s = getState();
     // Place ICE at gateway (accessible from start) without triggering handleIceTick
-    getPrimaryIce().attentionNodeId = "gateway";
+    firstIce().attentionNodeId = "gateway";
 
     const events = withEvents(E.ICE_DETECT_PENDING, () => {
       navigateTo("gateway");
@@ -469,11 +473,15 @@ describe("ICE detection: ejecting ICE cancels the pending dwell timer", () => {
 
     const s = getState();
     s.selectedNodeId = "gateway";
-    getPrimaryIce().attentionNodeId = "gateway";
+    firstIce().attentionNodeId = "gateway";
     s.nodes["gateway"].accessLevel = "owned";
 
-    // Simulate a detection dwell that is already running
-    scheduleEvent(TIMER.ICE_DETECT, 500, { nodeId: "gateway" });
+    // Simulate a detection dwell that is already running. The runtime tracks the
+    // dwell as the instance's own dwellTimerId (keyed by iceId) — mirror that so
+    // ejection cancels the right timer.
+    const ice = firstIce();
+    const dwellId = scheduleEvent(TIMER.ICE_DETECT, 500, { iceId: ice.id, nodeId: "gateway" });
+    ice.dwellTimerId = dwellId;
 
     // Eject, then advance past the dwell window
     const fired = withEvents(E.ICE_DETECTED, () => {
@@ -499,13 +507,13 @@ describe("ICE detection: detectedAtNode resets when ICE leaves player's node", (
     const s = getState();
     // Position ICE at the player's node
     s.selectedNodeId = "gateway";
-    getPrimaryIce().attentionNodeId = "gateway";
-    getPrimaryIce().detectedAtNode = "gateway";
+    firstIce().attentionNodeId = "gateway";
+    firstIce().detectedAtNode = "gateway";
 
     // handleIceTick moves ICE to a neighbor of gateway (not gateway itself)
     handleIceTick();
 
-    assert.equal(getPrimaryIce().detectedAtNode, null,
+    assert.equal(firstIce().detectedAtNode, null,
       "detectedAtNode should clear when ICE leaves, so it can re-detect on next visit");
   });
 });
@@ -584,7 +592,7 @@ describe("teleportIce: self-teleport does not emit ICE_MOVED", () => {
   });
 
   it("does not emit ICE_MOVED when teleporting to the current node", () => {
-    const currentNode = getPrimaryIce().attentionNodeId;
+    const currentNode = firstIce().attentionNodeId;
 
     const fired = withEvents(E.ICE_MOVED, () => {
       teleportIce(currentNode);
@@ -595,10 +603,10 @@ describe("teleportIce: self-teleport does not emit ICE_MOVED", () => {
 
   it("still triggers detection check when teleporting to the current node", () => {
     const s = getState();
-    const currentNode = getPrimaryIce().attentionNodeId;
+    const currentNode = firstIce().attentionNodeId;
     s.selectedNodeId = currentNode;
     s.nodes[currentNode].accessLevel = "owned";
-    getPrimaryIce().detectedAtNode = null;
+    firstIce().detectedAtNode = null;
 
     const fired = withEvents(E.ICE_DETECT_PENDING, () => {
       teleportIce(currentNode);
@@ -662,7 +670,7 @@ describe("isIceVisible: ICE visible on selected locked node", () => {
     // gateway starts locked, no selection
     assert.equal(s.nodes["gateway"].accessLevel, "locked");
     assert.equal(s.selectedNodeId, null);
-    assert.equal(isIceVisible(getPrimaryIce(), s.nodes, s.selectedNodeId), false);
+    assert.equal(isIceVisible(firstIce(), s.nodes, s.selectedNodeId), false);
   });
 
   it("ICE IS visible on a locked node when player is actively selected there", () => {
@@ -670,7 +678,7 @@ describe("isIceVisible: ICE visible on selected locked node", () => {
     teleportIce("gateway");
     s.selectedNodeId = "gateway";
     assert.equal(s.nodes["gateway"].accessLevel, "locked");
-    assert.equal(isIceVisible(getPrimaryIce(), s.nodes, s.selectedNodeId), true);
+    assert.equal(isIceVisible(firstIce(), s.nodes, s.selectedNodeId), true);
   });
 
   it("ICE IS visible on a compromised node regardless of selection", () => {
@@ -678,7 +686,7 @@ describe("isIceVisible: ICE visible on selected locked node", () => {
     teleportIce("gateway");
     s.nodes["gateway"].accessLevel = "compromised";
     s.selectedNodeId = null;
-    assert.equal(isIceVisible(getPrimaryIce(), s.nodes, s.selectedNodeId), true);
+    assert.equal(isIceVisible(firstIce(), s.nodes, s.selectedNodeId), true);
   });
 });
 
@@ -727,14 +735,14 @@ describe("WAN node", () => {
     const wanNeighbor = Object.keys(s.adjacency).find(nid =>
       s.adjacency[nid]?.includes("wan")
     );
-    if (!wanNeighbor || !getPrimaryIce()) { assert.ok(true, "no ICE or WAN not wired"); return; }
+    if (!wanNeighbor || !firstIce()) { assert.ok(true, "no ICE or WAN not wired"); return; }
     startIce();
     teleportIce(wanNeighbor);
     // Run 50 ICE ticks — WAN should never be visited
     for (let i = 0; i < 50; i++) {
       handleIceTick();
     }
-    assert.notEqual(getPrimaryIce()?.attentionNodeId, "wan", "ICE should never move to WAN");
+    assert.notEqual(firstIce()?.attentionNodeId, "wan", "ICE should never move to WAN");
   });
 });
 
@@ -1136,11 +1144,12 @@ describe("mine action", () => {
 });
 
 describe("ice runtime: iterates all active instances", () => {
-  // Wire the ICE_MOVE timer → handleIceTick. This mirrors what main.js does.
+  // Wire the ICE_MOVE timer → handleIceTick. This mirrors what main.js does:
+  // each per-instance timer carries an iceId, so the handler forwards the payload.
   // The handler is registered once for the suite and persists across tests;
   // we do NOT call clearHandlers() here to avoid breaking the module-level
   // alert.js / ice.js listeners that other tests in this file depend on.
-  const iceMoveHandler = () => handleIceTick();
+  const iceMoveHandler = (payload) => handleIceTick(payload);
   before(() => {
     on(TIMER.ICE_MOVE, iceMoveHandler);
   });
@@ -1167,6 +1176,7 @@ describe("ice runtime: iterates all active instances", () => {
       focus: "roaming",
       behaviorPattern: "patrol-random",
       dwellTimerId: null,
+      moveTimerId: null,
       detectedAtNode: null,
       detectionCount: 0,
     };
@@ -1190,7 +1200,7 @@ describe("ice runtime: iterates all active instances", () => {
 });
 
 describe("ice events: iceId in payload", () => {
-  const iceMoveHandler = () => handleIceTick();
+  const iceMoveHandler = (payload) => handleIceTick(payload);
   before(() => {
     on(TIMER.ICE_MOVE, iceMoveHandler);
   });
@@ -1218,5 +1228,103 @@ describe("ice events: iceId in payload", () => {
     });
     assert.ok(payloads.length > 0, "expected at least one ICE_EJECTED");
     assert.equal(payloads[0].iceId, "ice-1");
+  });
+});
+
+// ── Phase 4: EJECT + status enumerate all active ICE instances ────────────────
+
+/** Inject a second active ICE instance at the given node, returning it. */
+function injectIceInstance(id, nodeId, grade) {
+  const s = getState();
+  s.ice.instances[id] = {
+    id,
+    typeId: `patrol-${grade}`,
+    hostNodeId: nodeId,
+    attentionNodeId: nodeId,
+    active: true,
+    enabled: true,
+    grade,
+    focus: "roaming",
+    behaviorPattern: "standard",
+    dwellTimerId: null,
+    moveTimerId: null,
+    detectedAtNode: null,
+    detectionCount: 0,
+  };
+  return s.ice.instances[id];
+}
+
+describe("EJECT availability: enumerates all active ICE instances", () => {
+  beforeEach(() => {
+    clearAll();
+    // gateway → router-a → sec-mon; reveal all so each is a real, queryable node.
+    initGame(() => buildIceWithMonitorLAN({ grade: "B" }), "itest-eject-multi");
+    const s = getState();
+    for (const n of Object.values(s.nodes)) n.visibility = "accessible";
+  });
+
+  it("EJECT is available at each instance's node and not at an ICE-free node", () => {
+    const s = getState();
+    // EJECT is a graph action gated on accessLevel === "owned"; own all three so
+    // the action is offered and the only differentiator is ICE presence.
+    for (const id of Object.keys(s.nodes)) setNodeAccessLevel(id, "owned");
+    // Place the primary instance on gateway, a second instance on router-a.
+    s.ice.instances["ice-1"].active = true;
+    s.ice.instances["ice-1"].attentionNodeId = "gateway";
+    injectIceInstance("ice-2", "router-a", "B");
+
+    const gatewayActions = getAvailableActions(s.nodes["gateway"], s).map((a) => a.id);
+    const routerActions = getAvailableActions(s.nodes["router-a"], s).map((a) => a.id);
+    const secMonActions = getAvailableActions(s.nodes["sec-mon"], s).map((a) => a.id);
+
+    assert.ok(gatewayActions.includes(A.EJECT), "EJECT should be available where ice-1 is");
+    assert.ok(routerActions.includes(A.EJECT), "EJECT should be available where ice-2 is");
+    assert.ok(!secMonActions.includes(A.EJECT), "EJECT should NOT be available at an ICE-free node");
+  });
+});
+
+describe("status ice: enumerates all active ICE instances", () => {
+  beforeEach(() => {
+    clearAll();
+    initGame(() => buildIceWithMonitorLAN({ grade: "B" }), "itest-status-multi");
+    const s = getState();
+    for (const n of Object.values(s.nodes)) n.visibility = "accessible";
+  });
+
+  it("lists one line per active instance when there are multiple", () => {
+    const s = getState();
+    // Make both instances visible: ice-1's attention node is selected; ice-2's
+    // attention node is owned (isIceVisible passes for owned/compromised nodes).
+    s.selectedNodeId = "gateway";
+    s.nodes["gateway"].accessLevel = "owned";
+    s.nodes["router-a"].accessLevel = "owned";
+    s.ice.instances["ice-1"].active = true;
+    s.ice.instances["ice-1"].attentionNodeId = "gateway";
+    injectIceInstance("ice-2", "router-a", "B");
+
+    const lines = withEvents(E.LOG_ENTRY, () => cmdStatusIce()).map((e) => e.text);
+    const joined = lines.join("\n");
+
+    // Both instances' attention-node labels must appear.
+    const gwLabel = s.nodes["gateway"].label;
+    const raLabel = s.nodes["router-a"].label;
+    assert.ok(joined.includes(gwLabel), `expected gateway label "${gwLabel}" in:\n${joined}`);
+    assert.ok(joined.includes(raLabel), `expected router-a label "${raLabel}" in:\n${joined}`);
+  });
+
+  it("single active instance: output shape unchanged", () => {
+    const s = getState();
+    s.selectedNodeId = "gateway";
+    s.nodes["gateway"].accessLevel = "owned";
+    s.ice.instances["ice-1"].active = true;
+    s.ice.instances["ice-1"].attentionNodeId = "gateway";
+
+    const lines = withEvents(E.LOG_ENTRY, () => cmdStatusIce()).map((e) => e.text);
+
+    assert.deepEqual(lines.slice(0, 3), [
+      "## STATUS: ICE",
+      "- status: ACTIVE  grade: B",
+      `- attention: ${s.nodes["gateway"].label}  resident: ${s.nodes["sec-mon"].label}`,
+    ]);
   });
 });

--- a/tests/network-gen.test.js
+++ b/tests/network-gen.test.js
@@ -25,6 +25,7 @@ import {
 import { fillSkeleton } from "../js/core/network/slot-filler.js";
 import { generateSkeleton, generateHierarchicalSkeleton, printSkeleton } from "../js/core/network/skeleton.js";
 import { generateNetwork } from "../js/core/network/generate.js";
+import { assembleNetwork } from "../js/core/network/assemble.js";
 
 // ---------------------------------------------------------------------------
 // Phase 1: Grade offset utilities
@@ -568,6 +569,81 @@ describe("Per-wing palette filtering", () => {
       for (const [idx, count] of wingCounts) {
         assert.ok(count >= 1, `seed ${seed}: wing-${idx} should have >= 1 node, got ${count}`);
       }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ICE placement — one roaming ICE per security-monitor (cap 3), threat >= B
+// ---------------------------------------------------------------------------
+
+describe("assembleNetwork: ICE placement per security-monitor", () => {
+  // Build a minimal PlacedPiece carrying a list of nodes, no edges/triggers.
+  function pieceWithNodes(nodes) {
+    return { nodes, edges: [], triggers: [], pieceDef: {}, gradeOffset: 0 };
+  }
+  function monitorNodes(n) {
+    const nodes = [];
+    for (let i = 1; i <= n; i++) {
+      nodes.push({ id: `mon-${i}`, type: "security-monitor", attributes: { grade: "B" } });
+    }
+    return nodes;
+  }
+  function assemble(nodes, spec) {
+    return assembleNetwork([pieceWithNodes(nodes)], [], spec, { id: "test-biome" }, "seed-x");
+  }
+
+  it("threat >= B with 2 monitors → 2 instances, each {startNode, grade: threat}", () => {
+    const spec = { threat: "B", wealth: "B", complexity: "B", depth: "B" };
+    const { meta } = assemble(monitorNodes(2), spec);
+    assert.ok(meta.ice, "meta.ice should be set");
+    assert.equal(meta.ice.instances.length, 2);
+    assert.deepEqual(meta.ice.instances[0], { startNode: "mon-1", grade: "B" });
+    assert.deepEqual(meta.ice.instances[1], { startNode: "mon-2", grade: "B" });
+  });
+
+  it("caps at 3 instances even with 5 monitors", () => {
+    const spec = { threat: "A", wealth: "A", complexity: "A", depth: "A" };
+    const { meta } = assemble(monitorNodes(5), spec);
+    assert.equal(meta.ice.instances.length, 3);
+    for (const cfg of meta.ice.instances) assert.equal(cfg.grade, "A");
+  });
+
+  it("single-monitor network → exactly 1 instance (parity)", () => {
+    const spec = { threat: "B", wealth: "B", complexity: "B", depth: "B" };
+    const { meta } = assemble(monitorNodes(1), spec);
+    assert.equal(meta.ice.instances.length, 1);
+    assert.deepEqual(meta.ice.instances[0], { startNode: "mon-1", grade: "B" });
+  });
+
+  it("zero monitors at threat >= B → meta.ice is null", () => {
+    const spec = { threat: "B", wealth: "B", complexity: "B", depth: "B" };
+    const { meta } = assemble([{ id: "fs-1", type: "fileserver", attributes: { grade: "B" } }], spec);
+    assert.equal(meta.ice, null);
+  });
+
+  it("threat < B → meta.ice is null even with monitors", () => {
+    const spec = { threat: "C", wealth: "C", complexity: "C", depth: "C" };
+    const { meta } = assemble(monitorNodes(2), spec);
+    assert.equal(meta.ice, null);
+  });
+
+  it("generated B network with multiple monitors yields multiple ICE instances", () => {
+    // Defense-contractor recipe has 2 security-ops wings → commonly >= 2 monitors.
+    const specB = { threat: "B", wealth: "B", complexity: "B", depth: "B", recipeId: "defense-contractor" };
+    let multi = null;
+    for (const seed of ["mon-multi-1", "mon-multi-2", "mon-multi-3", "mon-multi-4", "mon-multi-5"]) {
+      const result = generateNetwork(seed, specB, CORPORATE_BIOME);
+      const monitors = result.graphDef.nodes.filter(n => n.type === "security-monitor");
+      if (monitors.length >= 2) { multi = { result, monitors }; break; }
+    }
+    assert.ok(multi, "expected at least one seed with >= 2 security-monitors");
+    const { result, monitors } = multi;
+    assert.ok(result.meta.ice, "meta.ice should be set");
+    assert.equal(result.meta.ice.instances.length, Math.min(monitors.length, 3));
+    for (const cfg of result.meta.ice.instances) {
+      assert.equal(cfg.grade, "B");
+      assert.ok(monitors.some(m => m.id === cfg.startNode));
     }
   });
 });

--- a/tests/no-primary-ice.test.js
+++ b/tests/no-primary-ice.test.js
@@ -1,0 +1,47 @@
+// @ts-check
+// Structural invariant: the getPrimaryIce / getPrimaryIceFromState singleton
+// shim has been fully retired. ICE is resolved per-instance via
+// activeIceInstances / hasActiveIce. This test scans production + test source
+// and fails if any reference to the retired symbols reappears.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, dirname, basename } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Repo root = parent of this test file's directory (tests/ -> repo root).
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// Build the forbidden symbol regex from fragments so this file does not match
+// its own scan.
+const FORBIDDEN = new RegExp("getPrimary" + "Ice(FromState)?");
+
+// This file deliberately references the forbidden name in prose/regex, so
+// exclude it from the scan by basename.
+const SELF = basename(fileURLToPath(import.meta.url));
+
+function* jsFiles(dir) {
+  for (const e of readdirSync(dir)) {
+    if (e === "node_modules" || e === "dist" || e.startsWith(".")) continue;
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) yield* jsFiles(p);
+    else if (e.endsWith(".js")) yield p;
+  }
+}
+
+test("getPrimaryIce / getPrimaryIceFromState references are fully retired", () => {
+  const offenders = [];
+  for (const root of ["js", "scripts", "tests"]) {
+    for (const f of jsFiles(join(REPO_ROOT, root))) {
+      if (basename(f) === SELF) continue;
+      const src = readFileSync(f, "utf8");
+      if (FORBIDDEN.test(src)) offenders.push(f);
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `getPrimary${""}Ice should be fully retired; found in:\n${offenders.join("\n")}`,
+  );
+});

--- a/tests/snapshot-ice-detection.test.js
+++ b/tests/snapshot-ice-detection.test.js
@@ -10,7 +10,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "fs";
 
 import { deserializeState, getState } from "../js/core/state.js";
-import { getPrimaryIce } from "../js/core/state/ice.js";
+import { activeIceInstances } from "../js/core/state/ice.js";
 import { tick, clearAll, TIMER } from "../js/core/timers.js";
 import { on, off, E } from "../js/core/events.js";
 // Import alert.js to register its event listeners
@@ -23,6 +23,9 @@ import { handleTraceTick } from "../js/core/alert.js";
 on(TIMER.ICE_MOVE,   () => handleIceTick());
 on(TIMER.ICE_DETECT, (payload) => handleIceDetect(payload));
 on(TIMER.TRACE_TICK, () => handleTraceTick());
+
+/** First active ICE instance, or null. */
+const firstIce = () => activeIceInstances(getState())[0] ?? null;
 
 function loadSnapshot() {
   const json = readFileSync("tests/fixtures/ice-detection-at-player-node.json", "utf-8");
@@ -37,11 +40,11 @@ describe("Snapshot: ICE detection at player node", () => {
   it("ICE is at the same node as the player", () => {
     const s = getState();
     assert.equal(s.selectedNodeId, "router-b");
-    assert.equal(getPrimaryIce().attentionNodeId, "router-b");
+    assert.equal(firstIce().attentionNodeId, "router-b");
   });
 
   it("detection timer is active for router-b", () => {
-    assert.equal(getPrimaryIce().dwellTimerId, 10);
+    assert.equal(firstIce().dwellTimerId, 10);
   });
 
   it("advancing ticks fires detection at router-b", () => {
@@ -74,6 +77,6 @@ describe("Snapshot: ICE detection at player node", () => {
     tick(70); // ICE move interval
     const s = getState();
     // ICE should have moved — either to gateway or ids (router-b's neighbors)
-    assert.notEqual(getPrimaryIce().attentionNodeId, "router-b");
+    assert.notEqual(firstIce().attentionNodeId, "router-b");
   });
 });


### PR DESCRIPTION
## Summary

Completes the singleton→multi-instance ICE runtime migration begun in #92 (the foundation that landed via #108). Every active ICE is now a fully independent roaming detector — its own dwell/detection, its own movement cadence — and generated networks spawn **one ICE per security-monitor** so a secured LAN is patrolled by several at once. The `getPrimaryIce()` singleton shim is retired.

This branch was developed against the #92 foundation, then **integrated with #133** (typed/damaging ICE), which landed on main mid-session and reworked the same detection/spawn code. The two compose into the natural endpoint of the ICE-reinvention arc: **multiple *typed* ICE** — a single LAN can field a sentinel draining HEALTH, a spike corrupting DECK, and a classic raising the alert, each detecting and acting independently.

## Design Decisions

- **One roaming ICE per security-monitor, threat ≥ B, capped at 3.** Diegetically grounded (each security domain runs its own ICE) and feeds the future per-zone alert direction. Generated networks commonly have 2–5 monitors, so multi-ICE is the norm at B+. The cap is a **temporary swarm-guard** — monitor count is emergent from network generation, and tuning it (the real ICE-count balance lever) is split out to **#136**.
- **Single global alert/trace, sourced from any instance.** Detections from all instances accumulate toward one trace threshold; per-zone alert stays deferred to #98/#106. Smallest change that preserves the model's shape.
- **Per-instance type rolls.** Each per-monitor instance rolls its own #133 registry type, so a LAN fields a *mix*; each instance's detection dispatches *its own* effects with its own `iceId`.
- **Single-instance/legacy parity is the regression guard.** One-monitor and hand-crafted (legacy `{startNode, grade}`) networks behave identically to #133's single typed ICE.

## Changes

- **`js/core/ice/runtime.js`** — per-instance dwell (`ICE_DETECT` timers cancelled by id), per-instance move (`ICE_MOVE` timers by grade), `triggerDetection(ice, …)` dispatches the detecting instance's effects. `startIce` made idempotent (fixes a pre-existing orphaned-timer leak under the repeating `probeBurstAlarm → spawnICE` trigger). EJECT/reboot now target the ICE on the acted node.
- **`js/core/state/index.js`** — `initGame` builds `ice-1..ice-N` from one config per monitor, each registry-typed; `endRun` deactivates all.
- **`js/core/network/assemble.js`** — emits one ICE config per security-monitor (cap 3, threat ≥ B).
- **`js/core/state/ice.js`** — `activeIceInstances`/`hasActiveIce`; `getPrimaryIce`/`getPrimaryIceFromState` deleted.
- **`js/core/alert.js`** — `recordIceDetection(nodeId, iceId)`; trace gate on summed detection count.
- **bot (`scripts/bot/*`), `cmd-status.js`, node-actions** — enumerate/target all instances.
- **Docs** — `MANUAL.md` + `docs/ICE.md` updated; `tests/no-primary-ice.test.js` structurally guards the shim retirement.

## Test Plan

- [x] `make check` — 859 tests pass, lint (tsc) clean
- [x] Census re-baselined vs current main (#133): default (threat C) **0.28 unchanged**; B/A/S within noise. No tuning needed.
- [x] End-to-end: generated multi-monitor networks field a mix of typed ICE; each detection applies its own effect; serialization round-trips.
- [x] `tests/no-primary-ice.test.js` confirms zero `getPrimaryIce` call sites remain.
- [ ] Manual browser smoke: load a multi-monitor threat-B+ network, confirm multiple typed ICE move/detect and the HEALTH/DECK/alert effects fire per type.

## References

- Spec: `docs/dev-sessions/2026-06-10-1600-ice-multi-instance/spec.md`
- Plan: `docs/dev-sessions/2026-06-10-1600-ice-multi-instance/plan.md`
- Notes (incl. census + #133 integration): `docs/dev-sessions/2026-06-10-1600-ice-multi-instance/notes.md`
- Builds on #133 (typed/damaging ICE). Monitor-density balance split to #136. Bot multi-threat evasion is #129.
- Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
