### PR TITLE
fix: thread target seed into initGame for reproducible runs (#142)

### DIFF
--- a/docs/dev-sessions/2026-06-10-1822-thread-target-seed/notes.md
+++ b/docs/dev-sessions/2026-06-10-1822-thread-target-seed/notes.md
@@ -1,0 +1,52 @@
+# Notes — Thread target seed into initGame (#142)
+
+## Outcome
+
+One-line behavior fix in `startRun` (`js/ui/run-control.js`):
+
+```js
+- initGame(() => networkResult, undefined, { openDarknetsStore });
++ initGame(() => networkResult, networkResult.meta?.seed, { openDarknetsStore });
+```
+
+Run-time RNG (vulns, loot, combat) is now seeded from the target's deterministic
+`meta.seed` instead of `Math.random()`. Same-target launches are reproducible;
+variety still comes from the hub-visit counter rolling fresh tier seeds each visit.
+
+## Design decision
+
+Option (a) of the issue's three options, chosen with Les. Rationale captured in
+`spec.md` / `research.md`: variety is supplied by `_hubVisits`, not run-time RNG;
+determinism is a stated project value; seeding fixes the roll *stream*, not
+outcomes-regardless-of-choices, so skilled play still diverges.
+
+## Key finding — the fix makes the manual honest
+
+`MANUAL.md:66-68` already claims sharing a seed reproduces "the same network
+layout, **vulnerabilities**, and exploit hand." Before this fix, only the topology
+was reproducible — vulnerabilities were random per launch. So the old behavior was
+already a **bug against the manual** ("if the game behaves differently from what
+the manual describes, that is a bug"). The fix brings the game in line with the
+manual's existing promise. **No manual edit required.**
+
+## Testing
+
+New `js/ui/run-control.test.js` exercises the real `startRun` with a minimal
+`globalThis.document` stub (graph functions guard on a null `cy`; `addIceNode`
+bails when the "cy" container is absent). Four cases: seed threading,
+reproducibility across launches, variety across seeds, absent-seed fallback.
+TDD red→green confirmed: tests 1 & 2 failed on the old `undefined` code for the
+right reason, pass after the fix.
+
+## Parallel entry points
+
+- `make check`: 843 pass / 0 fail (was 839; +4 new), lint clean.
+- `make census SEEDS=10`: runs fine. The headless harness + bot go through
+  `scripts/lib/headless-engine.js`, which already passes explicit seeds and never
+  touches `startRun` — so this change can't regress them.
+
+## Out of scope (noted)
+
+`js/playground/main.js:317` also passes `undefined` to `initGame`. It's a separate
+dev harness, not the hub launch path. Left unchanged; candidate for a follow-up if
+playground reproducibility ever matters.

--- a/docs/dev-sessions/2026-06-10-1822-thread-target-seed/plan.md
+++ b/docs/dev-sessions/2026-06-10-1822-thread-target-seed/plan.md
@@ -1,0 +1,64 @@
+# Plan — Thread target seed into initGame (#142)
+
+## Approach
+
+One-line behavior change in `startRun`, guarded by a new co-located test that
+exercises the real function with the DOM stubbed. TDD: write the failing test
+first (current code passes `undefined` → `getSeed()` is a random `run-XXXX`,
+not `meta.seed`), then make it pass.
+
+## Phase 1 — Failing test (TDD red)
+
+New file `js/ui/run-control.test.js`:
+
+- Setup: `globalThis.document = { getElementById: () => null }` so `addIceNode`
+  no-ops. (Restore/leave as-is in teardown; tests run in isolated processes per
+  node:test, but be tidy.)
+- Build a real generated network: `buildNetwork({ seed: "seed-A", spec })` from
+  `data/networks/generated.js` (gives a `meta.seed`).
+- Test 1 (threading): `startRun(result)` → assert `getSeed() === result.meta.seed`.
+- Test 2 (reproducibility): `startRun(result)` twice with the same `result`,
+  snapshot each node's `vulnerabilities` from `getState().nodes`; assert deep-equal.
+- Test 3 (variety): two networks built from different seeds → vulnerabilities differ.
+- Test 4 (absent seed): `startRun({ graphDef, meta: { …, seed: undefined } })`
+  completes without throwing and `getSeed()` is a `run-` fallback.
+
+Run `make test` — Test 1/2 must FAIL on current code (proves the bug).
+
+## Phase 2 — Fix (TDD green)
+
+In `js/ui/run-control.js`, change:
+
+```js
+initGame(() => networkResult, undefined, { openDarknetsStore });
+```
+to:
+```js
+initGame(() => networkResult, networkResult.meta?.seed, { openDarknetsStore });
+```
+
+Update the `startRun` JSDoc to note the seed is threaded for reproducibility.
+
+Run `make test` — all green.
+
+## Phase 3 — Verify & guard the parallel paths
+
+- `make check` (lint + full suite) green.
+- `make census SEEDS=10` runs and is unaffected (sanity that headless path is
+  independent; compare against expectations, not a fixed threshold).
+
+## Phase 4 — Docs
+
+- Update `MANUAL.md` only if it claims anything about run randomness/seeds that
+  this change contradicts (likely no change needed — check the trace/ICE/RNG
+  sections). If nothing references it, no manual edit.
+- Fill `notes.md` with the final summary.
+
+## Risks / watch-items
+
+- Importing `js/ui/run-control.js` in node pulls in `graph.js` + `store.js`. They
+  are DOM-free at module-eval time (verified in research), but if import crashes,
+  the test must stub whatever top-level global is missing (`window`/`customElements`).
+  Adjust the stub minimally; do not weaken the assertions.
+- Keep the test asserting the **observable consequence** (`getSeed()`, node
+  vulnerabilities), not intermediate state.

--- a/docs/dev-sessions/2026-06-10-1822-thread-target-seed/research.md
+++ b/docs/dev-sessions/2026-06-10-1822-thread-target-seed/research.md
@@ -1,0 +1,72 @@
+# Research — Thread target seed into initGame (#142)
+
+## The seed flow today
+
+1. `openHub()` (`js/ui/hub.js`) increments `profile._hubVisits` and calls
+   `generateTargets(profile)`.
+2. `generateTargets()` (`js/core/profile/targets.js:33`) builds the tier list with
+   `seed: \`target-${visit}-${t.id}\``. **Every hub re-entry bumps the visit counter,
+   so each tier gets a brand-new seed → a brand-new topology.**
+3. `launchTarget(targetId)` (`js/ui/hub.js:115`) calls
+   `buildGenerated({ seed: target.seed, spec: target.spec })`.
+4. The seed lands in `meta.seed` — `assembleNetwork()` sets `meta: { …, seed }`
+   (`js/core/network/assemble.js:111`).
+5. `launchTarget` spreads it into the run meta:
+   `startRun({ graphDef, meta: { ...result.meta, ...launchMeta } })`.
+   `prepareLaunch()` returns only `{ startHandCards, startCash }`
+   (`js/ui/profile-store.js:106`) — **no `seed` key, so `meta.seed` survives the spread.**
+6. `startRun(networkResult)` (`js/ui/run-control.js:43`) calls
+   `initGame(() => networkResult, undefined, { openDarknetsStore })`.
+   **The `undefined` is the bug:** `meta.seed` is sitting in `networkResult.meta`
+   but never reaches `initGame`.
+7. `initGame(buildNetworkFn, seedString, opts)` (`js/core/state/index.js:77`) calls
+   `initRng(seedString)`. With `undefined`, `initRng` generates a random
+   `run-XXXX` seed (`js/core/rng.js:62-66`), so vulns / loot / combat rolls are
+   non-deterministic per launch.
+
+## Why option (a) is low-cost
+
+- **Variety is supplied by the visit counter, not run-time RNG.** Every hub
+  re-entry rolls new tier seeds → new maps. Normal play never replays an identical
+  target seed, so seeding run-time RNG removes no meaningful variety.
+- **Determinism is a stated project value** ("All gameplay randomness is
+  deterministic for a given seed" — CLAUDE.md playtest docs).
+- **Seeding fixes the roll *stream*, not outcomes.** Different probe/exploit order
+  consumes the stream differently → divergent runs. Only identical action sequences
+  reproduce identical results — exactly the reproducibility we want for debugging.
+
+## RNG mechanics
+
+`initRng(seedString)` seeds every named stream as
+`hashString(seed + ":" + name)` for `name in {exploit, combat, ice, loot, world}`
+(`js/core/rng.js:62-66`). One root seed → all streams deterministic. `getSeed()`
+(`js/core/rng.js:146`) returns the active root seed — usable as a test assertion.
+
+## The three parallel entry points — regression check
+
+- **Browser** (`js/ui/main.js` → hub → `startRun`): the path being fixed.
+- **Headless harness** (`scripts/playtest.js`) and **bot/census**
+  (`scripts/bot/`): both go through `scripts/lib/headless-engine.js:85`, which
+  already calls `initGame(buildNetworkFn, seed)` with an explicit seed. **They do
+  not touch `startRun`, so this change cannot regress `make census`.**
+- **Playground** (`js/playground/main.js:317`) also calls
+  `initGame(() => networkResult, undefined, {})`. Out of scope for #142 (separate
+  dev harness, not the hub launch path). Noted, not changed.
+
+## Testability of `startRun`
+
+`startRun` touches DOM/Cytoscape, but every graph function guards on a null `cy`:
+- `resetGraph` → `if (!cy) return;`
+- `syncInitialNodes` → `ensureNodeInGraph`/`updateNodeStyle` both `if (!cy) return;`
+- `getCy()` → null; `if (cy) fitGraph(cy)` skipped
+- `addIceNode` → `document.getElementById("cy")` then `if (!container) return;`
+- `startIce` → from `js/core/ice/runtime.js`, DOM-free (schedules timers)
+
+So with `cy` never initialized and a minimal `globalThis.document` stub whose
+`getElementById` returns `null`, the **real** `startRun` runs end-to-end in node.
+This lets us test the actual seed threading rather than a proxy helper.
+
+The test glob (`find tests js data -name '*.test.js'`, Makefile:30) picks up a new
+`js/ui/run-control.test.js`. No existing test imports `js/ui/`; `run-control.js`
+and its transitive imports (`graph.js`, `store.js`) are DOM-free at module-eval
+time, so importing them in node is safe.

--- a/docs/dev-sessions/2026-06-10-1822-thread-target-seed/spec.md
+++ b/docs/dev-sessions/2026-06-10-1822-thread-target-seed/spec.md
@@ -1,0 +1,52 @@
+# Spec — Thread target seed into initGame for reproducible runs (#142)
+
+## Problem
+
+`startRun()` (`js/ui/run-control.js`) calls `initGame(() => networkResult, undefined, …)`.
+The generated target's deterministic seed already rides along in
+`networkResult.meta.seed` (set by `assembleNetwork`), but `undefined` is passed
+instead — so the run-time RNG (vulnerabilities, loot, combat rolls) is seeded from
+`Math.random()` on every launch. The topology is reproducible per target; the
+gameplay rolls are not.
+
+This is pre-existing behavior carried over from the original boot/run-again path,
+not a deliberate design choice (confirmed in #142).
+
+## Decision
+
+**Option (a): thread `meta.seed` into `initGame`.** Same-target launches become
+fully reproducible. Run-to-run variety is preserved by the hub-visit counter
+(`_hubVisits`), which rolls fresh tier seeds on every hub re-entry — so normal play
+still gets a new map + new rolls each visit. Seeding the run-time RNG aligns the
+launch path with the project's determinism-first ethos and makes player-reported
+runs debuggable.
+
+## Behavior
+
+- `startRun(networkResult)` passes `networkResult.meta?.seed` to `initGame` as the
+  seed string instead of `undefined`.
+- When `meta.seed` is present (the generated-target launch path, the only real
+  caller), the run-time RNG is seeded deterministically from it.
+- When `meta.seed` is absent (defensive — a network built without a seed), behavior
+  is unchanged: `initGame` receives `undefined` and `initRng` falls back to a random
+  `run-XXXX` seed.
+
+## Acceptance criteria
+
+1. After `startRun(networkResult)` with `meta.seed = "X"`, `getSeed() === "X"`.
+2. Two `startRun` calls with the same `networkResult` produce identical node
+   vulnerabilities (and loot) — i.e. the run is reproducible.
+3. Different seeds produce different vulnerabilities (no accidental constant).
+4. When `meta.seed` is absent, `startRun` still completes and seeds randomly
+   (no crash, behavior unchanged).
+5. `make check` stays green (839+ tests, lint clean).
+6. `make census SEEDS=10` is unaffected (headless path does not use `startRun`).
+
+## Out of scope
+
+- `js/playground/main.js` also passes `undefined` to `initGame`; it's a separate
+  dev harness, not the hub launch path. Not changed here (noted for backlog).
+- No new debug/seed UI or console param (that would be option (b)).
+- No change to how target seeds are generated (`generateTargets`).
+
+<!-- dev-session:spec -->

--- a/js/ui/run-control.js
+++ b/js/ui/run-control.js
@@ -38,10 +38,16 @@ export function toCytoscapeFormat(result) {
  * would re-add the previous run's revealed nodes to the board. So: initGame first,
  * THEN resetGraph (wipes both the old board and any stale re-adds), THEN rebuild
  * the board from the authoritative new state via syncInitialNodes (Phase 3a root cause).
+ *
+ * The generated target's deterministic seed rides in `meta.seed`; thread it into
+ * initGame so the run-time RNG (vulns, loot, combat rolls) is reproducible for a
+ * given target — not reseeded from Math.random() each launch (#142). Variety
+ * across launches comes from the hub-visit counter rolling fresh target seeds.
+ * Falls back to a random seed when meta.seed is absent.
  * @param {{ graphDef: any, meta: any }} networkResult
  */
 export function startRun(networkResult) {
-  initGame(() => networkResult, undefined, { openDarknetsStore });
+  initGame(() => networkResult, networkResult.meta?.seed, { openDarknetsStore });
   resetGraph(toCytoscapeFormat(networkResult));
   syncInitialNodes(getState().nodes);
   const cy = getCy();

--- a/js/ui/run-control.test.js
+++ b/js/ui/run-control.test.js
@@ -1,0 +1,74 @@
+// Tests for startRun's seed threading (#142). startRun touches DOM/Cytoscape,
+// but every graph function guards on a null `cy` and addIceNode bails when the
+// "cy" container is missing — so with a minimal document stub and an
+// uninitialized graph, the real startRun runs end-to-end in node.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+// Stub the DOM before importing run-control's transitive graph deps. addIceNode
+// calls document.getElementById("cy"); returning null makes it a no-op.
+globalThis.document = globalThis.document ?? { getElementById: () => null };
+
+const { startRun } = await import("./run-control.js");
+const { getState } = await import("../core/state.js");
+const { getSeed } = await import("../core/rng.js");
+const { buildNetwork } = await import("../../data/networks/generated.js");
+
+/** Stable snapshot of every node's vulnerabilities, keyed + sorted by node id. */
+function vulnSnapshot() {
+  const nodes = getState().nodes;
+  return Object.keys(nodes)
+    .sort()
+    .map((id) => [id, nodes[id].vulnerabilities])
+    .filter(([, v]) => v !== undefined);
+}
+
+describe("startRun — seed threading", () => {
+  test("seeds the run-time RNG from networkResult.meta.seed", () => {
+    const result = buildNetwork({ seed: "seed-A" });
+    startRun(result);
+    assert.equal(getSeed(), result.meta.seed);
+  });
+
+  test("same network produces identical vulnerabilities across launches", () => {
+    const result = buildNetwork({ seed: "seed-repro" });
+
+    startRun(result);
+    const first = vulnSnapshot();
+
+    startRun(result);
+    const second = vulnSnapshot();
+
+    assert.ok(first.length > 0, "expected at least one node with vulnerabilities");
+    assert.deepEqual(second, first);
+  });
+
+  test("the seed drives vulnerability generation (same topology, different seed)", () => {
+    // Reuse one topology so node ids are identical across both runs; vary only the
+    // run-time seed. Any difference is therefore attributable to the seed, not to a
+    // different graph — proves the threaded seed reaches vuln generation.
+    const base = buildNetwork({ seed: "seed-topo" });
+
+    startRun({ graphDef: base.graphDef, meta: { ...base.meta, seed: "vulns-A" } });
+    const snapA = vulnSnapshot();
+
+    startRun({ graphDef: base.graphDef, meta: { ...base.meta, seed: "vulns-B" } });
+    const snapB = vulnSnapshot();
+
+    assert.deepEqual(
+      snapB.map(([id]) => id),
+      snapA.map(([id]) => id),
+      "expected identical node ids (same topology)",
+    );
+    assert.notDeepEqual(snapB, snapA);
+  });
+
+  test("absent meta.seed falls back to a random run- seed without crashing", () => {
+    const result = buildNetwork({ seed: "seed-fallback" });
+    delete result.meta.seed;
+
+    assert.doesNotThrow(() => startRun(result));
+    assert.match(getSeed(), /^run-/);
+  });
+});


### PR DESCRIPTION
## Summary

`startRun()` (`js/ui/run-control.js`) passed `undefined` as the seed to
`initGame()`, so the run-time RNG (vulnerabilities, loot, combat rolls) was
reseeded from `Math.random()` on every launch — even though generated targets
already carry a deterministic `meta.seed` (used to build the topology). The
topology was reproducible per target; gameplay rolls were not.

This threads `networkResult.meta?.seed` into `initGame`, so **same-target launches
are now fully reproducible.** Run-to-run variety is preserved by the hub-visit
counter (`_hubVisits`), which rolls fresh tier seeds on every hub re-entry.

```diff
- initGame(() => networkResult, undefined, { openDarknetsStore });
+ initGame(() => networkResult, networkResult.meta?.seed, { openDarknetsStore });
```

## Design decision

The issue framed three options. With the user, we chose **(a) thread `meta.seed`**:

- **Variety comes from the visit counter, not run-time RNG.** Every hub re-entry
  rolls new tier seeds → a fresh map + fresh rolls. Normal play never replays an
  identical target seed, so seeding the run-time RNG removes no meaningful variety.
- **Determinism is a stated project value** ("all gameplay randomness is
  deterministic for a given seed").
- **Seeding fixes the roll *stream*, not outcomes.** Different probe/exploit order
  consumes the stream differently → divergent runs. Only an identical sequence of
  actions reproduces identical results — exactly the reproducibility wanted for
  debugging player-reported runs.

## Makes the manual honest

`MANUAL.md` already promised that sharing a seed reproduces "the same network
layout, **vulnerabilities**, and exploit hand." Before this change only the
topology was reproducible, so the old behavior was a bug against the manual. The
fix brings the game in line with the manual's existing promise — no manual edit
needed.

## Testing

- New `js/ui/run-control.test.js` exercises the **real** `startRun` with a minimal
  `globalThis.document` stub (graph functions guard on a null `cy`; `addIceNode`
  bails when the "cy" container is absent). Cases: seed threading, reproducibility
  across launches, seed-drives-vuln-generation (same topology / different seed),
  and absent-seed fallback. TDD red→green confirmed.
- `make check`: **843 pass / 0 fail** (was 839; +4 new), lint clean.
- `make census SEEDS=10`: unaffected. The headless harness + bot go through
  `scripts/lib/headless-engine.js`, which already passes explicit seeds and never
  touches `startRun`.

## Out of scope

`js/playground/main.js` also passes `undefined` to `initGame`; it's a separate dev
harness, not the hub launch path. Left unchanged (candidate for a follow-up).

## References

- Closes #142
- Spec: `docs/dev-sessions/2026-06-10-1822-thread-target-seed/spec.md`
- Plan: `docs/dev-sessions/2026-06-10-1822-thread-target-seed/plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
