### PR TITLE
Fix XPLOIT picker card titles clipped at top

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -625,6 +625,13 @@ html, body {
   white-space: normal;
 }
 
+/* Picker cards don't run the executing progress-fill (the panel closes on pick),
+   so they don't need the hand's overflow:hidden. Keeping it clipped the Hershey
+   font's tall first-line glyph ink against the card's top edge, and its
+   side-effect of forcing a grid item's auto min-width to 0 over-narrowed the
+   cards (worsening the title wrap). Letting them overflow fixes both. */
+#action-choices .exploit-card { overflow: visible; }
+
 /* ── Action Buttons ─────────────────────────────────────── */
 
 .action-btn {


### PR DESCRIPTION
The express XPLOIT picker rendered exploit-card titles with their top edge clipped (reported with the new Hershey font).

## Root cause
Two interacting effects, both traced to `.exploit-card { overflow: hidden }` on the picker cards:
1. **Font metric** — the Hershey Futura webfont’s ascent metric is shorter than its actual glyph ink, so the first title line’s ink overshoots its line box by ~8px. `overflow: hidden` clips that ink against the card’s top edge. (Box geometry is identical with `overflow: visible` — only the clipping differs, which is how I confirmed it’s ink overshoot, not a spacing bug.)
2. **Auto min-width** — `overflow: hidden` also forces a grid item’s automatic min-width to `0`, narrowing the picker cards ~4px below their content and worsening the title wrap.

The hand needs `overflow: hidden` for its executing progress-fill sweep. The **picker does not** — it closes the instant you pick a card — so the clipping there is pure downside.

## Fix
Scope `overflow: visible` to `#action-choices .exploit-card`. Un-clips the titles and restores the cleaner wrap; the hand is untouched.

## Verification
Reproduced and verified in the live browser by opening the real picker and screenshotting before/after. No automated test added — the node test suite has no CSS layout engine to assert glyph clipping; this is a render-only regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)