### PR TITLE
balance: make skip-to-owned fire meaningfully, driven by card quality

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -134,6 +134,10 @@ An IDS at this level can be corrupted to stop forwarding alerts.
 
 **Owned** — Full control. You can fetch macguffins, reboot the node, or kick ICE.
 
+A clean exploit on a **locked** node usually lands you at *compromised*, but a
+high-quality card can punch straight through to **owned** in a single shot,
+skipping the middle step. The better the card, the more often this happens.
+
 ---
 
 ## THE OVERWORLD HUB
@@ -245,7 +249,9 @@ improves your odds significantly.
 
 - Base success chance scales with **card quality** (the pip meter) vs **node grade**
 - A **matching vulnerability** boosts your odds considerably
-- Success: node access level rises (locked → compromised, compromised → owned)
+- Success: node access level rises (locked → compromised, compromised → owned).
+  A high-quality card can skip the middle step, jumping a locked node straight to
+  owned — more likely the better the card's quality pip
 - Success also **counts as a probe** — the node's vulnerabilities are revealed, so a
   blind gamble that lands shows you what you're working with (no need to probe after)
 - Failure: local alert rises; IDS nodes forward the alert event upstream

--- a/js/core/combat.js
+++ b/js/core/combat.js
@@ -42,24 +42,25 @@ const DISCLOSURE_CHANCE = {
   F: 0.05,
 };
 
-// Rarity multiplier for skip-to-owned chance on successful exploit.
-// Higher rarity = more likely to jump locked → owned in one shot.
-// Target ranges: common-low ~2%, uncommon-mid ~20%, rare-high ~70%.
-const SKIP_TO_OWNED_RARITY_MULT = {
-  common: 0.15,
-  uncommon: 0.4,
-  rare: 1.0,
-};
+// Skip-to-owned floor and quality scaling. The chance a successful exploit
+// jumps locked → owned in one shot is driven by card QUALITY, not rarity:
+//   0.08 + quality * 0.55
+// This lifts the floor across the board (a fresh common skips ~19–38% of the
+// time, up from the old ~2–6%) while still rewarding the best cards most —
+// rare cards skip more only because they carry higher quality, not because of
+// a separate multiplier. Tops out near 0.60 for a best-in-class rare (q≈0.95);
+// never approaches certainty.
+const SKIP_TO_OWNED_FLOOR = 0.08;
+const SKIP_TO_OWNED_QUALITY_SCALE = 0.55;
 
 /**
  * Chance that a successful exploit jumps from locked directly to owned,
- * skipping the compromised step. Based on exploit quality and rarity.
+ * skipping the compromised step. Driven by exploit quality.
  * @param {ExploitCard} exploit
  * @returns {number} probability 0-1
  */
 export function skipToOwnedChance(exploit) {
-  const rarityMult = SKIP_TO_OWNED_RARITY_MULT[exploit.rarity] ?? 0.15;
-  return exploit.quality * 0.75 * rarityMult;
+  return SKIP_TO_OWNED_FLOOR + exploit.quality * SKIP_TO_OWNED_QUALITY_SCALE;
 }
 
 // Patch lag in turns by grade (how quickly vulns get patched after disclosure)

--- a/js/core/combat.test.js
+++ b/js/core/combat.test.js
@@ -1,0 +1,49 @@
+// @ts-check
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { skipToOwnedChance } from "./combat.js";
+
+/** Minimal exploit card — only the fields skipToOwnedChance reads. */
+function card(quality, rarity = "common") {
+  return /** @type {any} */ ({ quality, rarity });
+}
+
+describe("skipToOwnedChance", () => {
+  // The skip-to-owned chance is driven primarily by card QUALITY, with a modest
+  // floor so even low cards occasionally jump locked → owned. Formula:
+  //   0.08 + quality * 0.55
+  // Rarity is no longer a hard gate — rare cards skip more only because they
+  // carry higher quality. See the balance-skip-to-owned session.
+
+  test("is a floor (0.08) plus a quality-scaled term", () => {
+    assert.ok(Math.abs(skipToOwnedChance(card(0)) - 0.08) < 1e-9);
+    assert.ok(Math.abs(skipToOwnedChance(card(1)) - 0.63) < 1e-9);
+    assert.ok(Math.abs(skipToOwnedChance(card(0.5)) - 0.355) < 1e-9);
+  });
+
+  test("rises monotonically with quality regardless of rarity", () => {
+    const qualities = [0.1, 0.3, 0.5, 0.7, 0.9];
+    for (const rarity of ["common", "uncommon", "rare"]) {
+      const chances = qualities.map((q) => skipToOwnedChance(card(q, rarity)));
+      for (let i = 1; i < chances.length; i++) {
+        assert.ok(chances[i] > chances[i - 1], `quality must drive skip chance (${rarity})`);
+      }
+    }
+  });
+
+  test("two cards of equal quality skip equally often regardless of rarity", () => {
+    // Quality is the lever; rarity is not a separate multiplier anymore.
+    assert.equal(skipToOwnedChance(card(0.5, "common")), skipToOwnedChance(card(0.5, "rare")));
+  });
+
+  test("lifts the common floor well above the old ~2-6% range", () => {
+    // A typical fresh common (quality 0.2–0.55) now skips ~19–38% of the time.
+    assert.ok(skipToOwnedChance(card(0.2, "common")) > 0.15);
+    assert.ok(skipToOwnedChance(card(0.55, "common")) > 0.35);
+  });
+
+  test("never exceeds a sane ceiling for the best cards", () => {
+    // Best possible rare (quality 0.95) tops out around 0.60, never near certainty.
+    assert.ok(skipToOwnedChance(card(0.95, "rare")) < 0.65);
+  });
+});


### PR DESCRIPTION
A successful exploit on a *locked* node can jump straight to **owned**, skipping
*compromised*. In practice this almost never fired — so the mechanic was invisible.

## Diagnosis

The old formula matched its original design intent (`common ~2%, uncommon ~20%,
rare ~70%`), but it was structurally invisible:

- Commons are 11/15 of draws and skipped only **2–6%** of the time.
- The rarity multiplier (`common 0.15`) smothered the quality signal even on
  high-quality commons (a 0.55-quality common skipped just 6%).

```js
// before
skipToOwnedChance = quality * 0.75 * rarityMult   // common 0.15 / uncommon 0.4 / rare 1.0
```

## Change

Quality is now the lever; rarity falls out naturally (rare cards carry high
quality, so they still skip most — no separate multiplier needed):

```js
// after
skipToOwnedChance = 0.08 + quality * 0.55
```

| rarity | quality range | before | after |
|--------|---------------|--------|-------|
| common | 0.20–0.55 | 2.3–6.2% | **19–38%** |
| uncommon | 0.45–0.75 | 13.5–22.5% | **33–49%** |
| rare | 0.70–0.95 | 52.5–71% | **46–60%** |

Lifts the floor across the board, stays monotonic in quality, and tops out near
0.60 — never approaching certainty.

## Census (same 50 seeds, C/B/C/C — identical networks)

| metric | main | branch | Δ |
|---|---|---|---|
| successRate | 0.28 | 0.30 | +0.02 |
| traceFiredRate | 0.76 | 0.76 | — |
| avgNodesOwned | 3.68 | **3.92** | +0.24 |
| avgCardsUsed | 6.76 | **8.06** | +1.30 |
| avgCash | 6164 | 6392 | +228 |

The bot reaches *owned* faster per node and pushes deeper — more nodes owned,
more cards used, slightly more wins — **without** easing the trace axis (76%
unchanged). The skip now fires and rewards good cards without trivializing alert
pressure.

## Changes

- `js/core/combat.js` — new quality-driven formula
- `js/core/combat.test.js` — new unit test pinning the curve (written first,
  confirmed failing against the old formula, then made to pass)
- `MANUAL.md` — documented the locked → owned jump (previously undocumented)

## Open tuning questions

- The `0.08` floor means a junk common (quality 0.2) still jumps to owned ~19%
  of the time. Lower to ~0.04 if that feels too generous for trash cards.
- Rarity multiplier dropped entirely. Could fold a small rarity bonus back in if
  we want rarity to stay a *visible* signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)