### PR TITLE
UI tweaks: scroll hub lists; drop XPLOIT on owned nodes

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -232,8 +232,8 @@ on the node:
   shown disabled in the menu with a short reason ("No matching exploit available." / "No
   exploits available."). When that happens, play a long shot from the hand or shop the
   darknet broker.
-- On an **already-owned node**, XPLOIT is disabled ("Already owned.") — there's no further
-  access to gain. You can still play a card from the hand to re-exploit it if you really want.
+- On an **already-owned node**, XPLOIT isn't offered at all — there's no further access to
+  gain. You can still play a card from the hand to re-exploit it if you really want.
 
 The picker is the *guided* path. The **hand strip** and the `xploit <n>` console command
 are *full-agency* channels: they can play any usable card against the selected node,
@@ -647,7 +647,7 @@ Actions depend on the selected node's type and access level:
 | `exec access-darknet` | WAN node is targeted                       | Opens the darknet broker store; pauses the LAN while shopping (run via `exec`) |
 | `probe`           | Node is locked and unprobed                   | Timed scan — reveals vulnerabilities, raises local alert |
 | `abort`           | Timed action in progress on targeted node      | Aborts the current action (probe, xploit, dump, or fetch) |
-| `xploit` (menu) / `xploit <n>` (console) | Node is accessible and not currently exploiting | Opens a node-anchored card picker. Unprobed → all usable cards (blind); probed → only cards matching revealed vulns; disabled with a reason when no card applies or the node is already owned. The hand strip and `xploit <n>` console command stay full-agency (play any usable card). Raises access level on success. |
+| `xploit` (menu) / `xploit <n>` (console) | Node is accessible and not currently exploiting | Opens a node-anchored card picker. Unprobed → all usable cards (blind); probed → only cards matching revealed vulns; disabled with a reason when no card applies. Not offered at all on an already-owned node. The hand strip and `xploit <n>` console command stay full-agency (play any usable card). Raises access level on success. |
 | `dump`         | Node is compromised or owned, unread           | Timed scan — reveals macguffins |
 | `fetch`        | Node is owned + has uncollected macguffins     | Timed extraction — collects macguffins for cash |
 | `mine`         | Node is owned and not exhausted                | Timed data-mining — rolls a yield chance for one exploit card targeting the node's own vuln classes; yield decays per attempt; disappears when the node is exhausted |

--- a/css/style.css
+++ b/css/style.css
@@ -1186,6 +1186,14 @@ html, body {
 
 .hub-empty { color: var(--text-dim); font-size: 0.78rem; font-style: italic; }
 
+.hub-list {
+  max-height: 13rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
 .hub-card, .hub-target {
   display: flex;
   justify-content: space-between;

--- a/js/core/node-graph/actions.js
+++ b/js/core/node-graph/actions.js
@@ -36,6 +36,9 @@ function fillNodeId(condition, nodeId) {
   if (condition.type === "all-of" || condition.type === "any-of") {
     return { ...condition, conditions: condition.conditions.map((c) => fillNodeId(c, nodeId)) };
   }
+  if (condition.type === "not") {
+    return { ...condition, condition: fillNodeId(condition.condition, nodeId) };
+  }
   return condition;
 }
 

--- a/js/core/node-graph/conditions.js
+++ b/js/core/node-graph/conditions.js
@@ -29,6 +29,9 @@ export function evaluateCondition(condition, { getNodeAttr, getQuality }) {
         evaluateCondition(c, { getNodeAttr, getQuality })
       );
 
+    case "not":
+      return !evaluateCondition(condition.condition, { getNodeAttr, getQuality });
+
     case "quality-from-attr": {
       // Read quality name from a node attribute, then check the quality value.
       // Enables dynamic quality gating — the quality name can change at runtime.

--- a/js/core/node-graph/conditions.test.js
+++ b/js/core/node-graph/conditions.test.js
@@ -88,6 +88,22 @@ describe("evaluateCondition: any-of", () => {
   });
 });
 
+describe("evaluateCondition: not", () => {
+  it("returns true when the inner condition fails", () => {
+    assert.equal(evaluateCondition({
+      type: "not",
+      condition: { type: "node-attr", nodeId: "node-B", attr: "accessLevel", eq: "owned" },
+    }, accessors), true);
+  });
+
+  it("returns false when the inner condition passes", () => {
+    assert.equal(evaluateCondition({
+      type: "not",
+      condition: { type: "node-attr", nodeId: "node-A", attr: "accessLevel", eq: "owned" },
+    }, accessors), false);
+  });
+});
+
 describe("evaluateCondition: unknown type", () => {
   it("throws for unknown condition type", () => {
     assert.throws(() => evaluateCondition(/** @type {any} */ ({ type: "bogus" }), accessors));

--- a/js/core/node-graph/game-types.js
+++ b/js/core/node-graph/game-types.js
@@ -78,6 +78,9 @@ const EXPLOIT_ACTION = {
     { type: "node-attr", attr: "visibility", eq: "accessible" },
     { type: "node-attr", attr: "rebooting", eq: false },
     { type: "node-attr", attr: "exploiting", eq: false },
+    // Owned nodes are already at max access — don't offer XPLOIT at all (the
+    // hand stays a full-agency override for a deliberate re-exploit).
+    { type: "not", condition: { type: "node-attr", attr: "accessLevel", eq: "owned" } },
   ],
   followup: {
     title: (node) => `XPLOIT ${node.id}`,

--- a/js/core/node-graph/game-types.test.js
+++ b/js/core/node-graph/game-types.test.js
@@ -183,6 +183,20 @@ describe("action availability", () => {
     assert.ok(actions.some(a => a.id === "xploit"));
   });
 
+  it("exploit not available on owned node", () => {
+    const gw = createGateway("gw", { attributes: { visibility: "accessible", accessLevel: "owned" } });
+    const graph = new NodeGraph({ nodes: [gw], edges: [] });
+    const actions = graph.getAvailableActions("gw");
+    assert.ok(!actions.some(a => a.id === "xploit"));
+  });
+
+  it("exploit still available on compromised node", () => {
+    const gw = createGateway("gw", { attributes: { visibility: "accessible", accessLevel: "compromised" } });
+    const graph = new NodeGraph({ nodes: [gw], edges: [] });
+    const actions = graph.getAvailableActions("gw");
+    assert.ok(actions.some(a => a.id === "xploit"));
+  });
+
   it("exploit not available on hidden node", () => {
     const gw = createGateway("gw");
     const graph = new NodeGraph({ nodes: [gw], edges: [] });

--- a/js/core/node-graph/types.js
+++ b/js/core/node-graph/types.js
@@ -106,7 +106,7 @@
 
 /**
  * Condition — union of supported condition shapes.
- * @typedef {NodeAttrCondition | QualityGteCondition | QualityEqCondition | QualityFromAttrCondition | AllOfCondition | AnyOfCondition} Condition
+ * @typedef {NodeAttrCondition | QualityGteCondition | QualityEqCondition | QualityFromAttrCondition | AllOfCondition | AnyOfCondition | NotCondition} Condition
  */
 
 /**
@@ -150,6 +150,12 @@
  * @typedef {Object} AnyOfCondition
  * @property {'any-of'} type
  * @property {Condition[]} conditions
+ */
+
+/**
+ * @typedef {Object} NotCondition
+ * @property {'not'} type
+ * @property {Condition} condition   - passes when the inner condition fails
  */
 
 /**

--- a/js/ui/components/starnet-hub.js
+++ b/js/ui/components/starnet-hub.js
@@ -69,14 +69,16 @@ class StarnetHub extends StarnetElement {
         </div>
 
         <div class="hub-section">EXPLOIT INVENTORY — loadout ${loadout.length}/5</div>
-        ${this.inventory.length === 0
-          ? html`<div class="hub-empty">(inventory empty — mine or buy exploits)</div>`
-          : repeat(this.inventory, (c) => c.instanceId, (c) => html`
-              <div class="hub-card ${loadout.includes(c.instanceId) ? "equipped" : ""} ${c.decayState === "disclosed" ? "burned" : ""}"
-                   @click=${() => this._toggle(c.instanceId)}>
-                <span class="hub-card-name">${loadout.includes(c.instanceId) ? "▣" : "▢"} ${c.name}</span>
-                <span class="hub-card-meta">[${c.rarity}] ${c.decayState} ×${c.usesRemaining}</span>
-              </div>`)}
+        <div class="hub-list">
+          ${this.inventory.length === 0
+            ? html`<div class="hub-empty">(inventory empty — mine or buy exploits)</div>`
+            : repeat(this.inventory, (c) => c.instanceId, (c) => html`
+                <div class="hub-card ${loadout.includes(c.instanceId) ? "equipped" : ""} ${c.decayState === "disclosed" ? "burned" : ""}"
+                     @click=${() => this._toggle(c.instanceId)}>
+                  <span class="hub-card-name">${loadout.includes(c.instanceId) ? "▣" : "▢"} ${c.name}</span>
+                  <span class="hub-card-meta">[${c.rarity}] ${c.decayState} ×${c.usesRemaining}</span>
+                </div>`)}
+        </div>
 
         <div class="hub-actions">
           <button class="hub-btn" ?disabled=${disclosed === 0} @click=${this._discardDisclosed}>
@@ -89,11 +91,13 @@ class StarnetHub extends StarnetElement {
                .value=${String(this.withdrawAmount)} @input=${this._withdraw} />
 
         <div class="hub-section">AVAILABLE TARGETS</div>
-        ${repeat(this.targets, (t) => t.id, (t) => html`
-          <div class="hub-target" @click=${() => this._launch(t.id)}>
-            <span class="hub-target-label">▸ ${t.label}</span>
-            <span class="hub-target-grade">threat ${t.spec.threat} · wealth ${t.spec.wealth}</span>
-          </div>`)}
+        <div class="hub-list">
+          ${repeat(this.targets, (t) => t.id, (t) => html`
+            <div class="hub-target" @click=${() => this._launch(t.id)}>
+              <span class="hub-target-label">▸ ${t.label}</span>
+              <span class="hub-target-grade">threat ${t.spec.threat} · wealth ${t.spec.wealth}</span>
+            </div>`)}
+        </div>
       </div>`;
   }
 }


### PR DESCRIPTION
Two small, unrelated UI tweaks.

## Overworld Hub — scroll the lists, not the whole dialog
When the inventory or target list grew long, the entire hub dialog scrolled. Now the exploit inventory and available-targets lists each sit in their own scrollable `.hub-list` container (capped at `13rem`), so the chrome (title, bank, carry-cash input, buttons) stays put while only the lists scroll.

## Drop XPLOIT on owned nodes
Owned nodes are already at max access, so offering a disabled `XPLOIT — Already owned.` entry in the node menu was just noise. XPLOIT is now dropped from the menu entirely for owned nodes. The hand strip and `xploit <n>` console command remain full-agency for a deliberate re-exploit.

To express "not owned" cleanly, this adds a general `not` condition operator to the node-graph condition system (`conditions.js`, `types.js`, plus `fillNodeId` recursion in `actions.js`).

## Notes
- `getExploitEmptyReason` still returns `"Already owned."` — now unreachable from the menu (the picker never opens for owned nodes). Left as harmless defensive behavior; can prune in a follow-up.

## Testing
- Tests written first (failing → passing): `not` operator in `conditions.test.js`; owned/compromised XPLOIT availability in `game-types.test.js`.
- `make check` → 919 tests pass, 0 failures, lint clean.
- `MANUAL.md` updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)