### PR TITLE
fix: restore in-run darknet broker access on the WAN node

### DIFF
--- a/data/biomes/corporate-pieces.js
+++ b/data/biomes/corporate-pieces.js
@@ -1871,7 +1871,7 @@ export const entryPoint = {
     {
       id: "wan",
       type: "wan",
-      traits: [],
+      traits: ["darknet"],
       attributes: { accessLevel: "owned", visibility: "accessible" },
       operators: [],
       actions: [],

--- a/js/core/network/set-pieces.test.js
+++ b/js/core/network/set-pieces.test.js
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { instantiate } from "./set-pieces.js";
-import { SET_PIECES, combinationLock, deadmanCircuit, idsRelayChain, honeyPot, encryptedVault, cascadeShutdown, tripwireGauntlet, probeBurstAlarm, noisySensor, tamperDetect, scatteredLock1, scatteredLock3, scatteredLock5, scatteredKeyVault2, scatteredKeyVault3, scatteredEncryptedVault2, scatteredEncryptedVault3 } from "../../../data/biomes/corporate-pieces.js";
+import { SET_PIECES, entryPoint, combinationLock, deadmanCircuit, idsRelayChain, honeyPot, encryptedVault, cascadeShutdown, tripwireGauntlet, probeBurstAlarm, noisySensor, tamperDetect, scatteredLock1, scatteredLock3, scatteredLock5, scatteredKeyVault2, scatteredKeyVault3, scatteredEncryptedVault2, scatteredEncryptedVault3 } from "../../../data/biomes/corporate-pieces.js";
 import { NodeGraph } from "../node-graph/runtime.js";
 import { mockCtx } from "../node-graph/ctx.js";
 import { createMessage } from "../node-graph/message.js";
@@ -999,5 +999,22 @@ describe("scatteredEncryptedVault: quality communication", () => {
     graph._nodes.get("ev/vault").attributes.accessLevel = "owned";
     graph.executeAction("ev/vault", "scan-vault");
     assert.ok(ctx.calls.log?.some(args => args[0] === "Encrypted vault: 0/3 keys collected"));
+  });
+});
+
+describe("entryPoint: WAN offers in-run darknet access", () => {
+  it("access-darknet is available on the WAN node", () => {
+    const inst = instantiate(entryPoint, "entry");
+    const graph = new NodeGraph(inst, mockCtx());
+    const available = graph.getAvailableActions("entry/wan").map((a) => a.id);
+    assert.ok(available.includes("access-darknet"));
+  });
+
+  it("executing access-darknet opens the broker", () => {
+    const ctx = mockCtx();
+    const inst = instantiate(entryPoint, "entry");
+    const graph = new NodeGraph(inst, ctx);
+    graph.executeAction("entry/wan", "access-darknet");
+    assert.equal(ctx.calls.openDarknetsStore?.length, 1);
   });
 });

--- a/js/core/node-graph/traits.js
+++ b/js/core/node-graph/traits.js
@@ -299,6 +299,13 @@ registerTrait("gate", {
   actions: [],
 });
 
+// WAN-boundary darknet broker: the access-darknet action opens the in-run store.
+registerTrait("darknet", {
+  attributes: {},
+  operators: [],
+  actions: [ACTION_TEMPLATES.ACCESS_DARKNET],
+});
+
 // ── New traits (stress-test the system) ─────────────────────
 
 registerTrait("hardened", {


### PR DESCRIPTION
The darknet broker was unreachable from the WAN node mid-run, even though `MANUAL.md` documents it as a core resupply path.

## Root cause
The `entry-point` set-piece (`data/biomes/corporate-pieces.js`) builds its WAN node inline with `traits: []` and `actions: []`, bypassing the `createWAN()` factory that attaches `ACCESS_DARKNET_ACTION`. So every generated network shipped a WAN node with no actions — selecting it in-run offered nothing.

This regressed during the **procedural-generation rewrite**, not the overworld-hub work. The hub (#139) added a *separate* bank-funded darknet path (`visit-darknet`), which masked the loss and made the timing look hub-related. The set-piece comments still say *"WAN (darknet access)"*, and the manual documents in-run access in ~7 places — so this was an oversight, not a deliberate removal.

## Fix
Add a `darknet` trait bundling `ACTION_TEMPLATES.ACCESS_DARKNET` — mirroring how the `detectable`/`security` traits attach `RECONFIGURE`/`CANCEL_TRACE` — and tag the WAN node with `traits: ["darknet"]`. The action now resolves through `getAvailableActions` for both the GUI context menu (under the `EXEC` group) and the console (`exec access-darknet` / `darknet`).

## Verification
- New tests against the `entry-point` set-piece: `access-darknet` is available on, and executable from, the WAN node (written failing first).
- `make check` → 928 tests pass, 0 failures, lint clean.
- End-to-end: the canonical `getAvailableActions(wan, state)` on a generated network now returns `access-darknet`.
- `make census SEEDS=10` runs clean; the bot reaches the broker again in-run (`avgStoreVisits: 1.7`).

## Out of scope (flagged)
While verifying, I noticed the **playtest harness `target <node>` command does not persist the selection** (`selectedNodeId` stays `null` for any node, not just WAN). Pre-existing and unrelated to this fix, but worth a separate look — it makes node-scoped commands hard to drive from the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)