### PR TITLE
fix(harness): wire run handlers on the playtest CLI load path

### DIFF
--- a/scripts/lib/headless-engine.js
+++ b/scripts/lib/headless-engine.js
@@ -41,8 +41,14 @@ export function initHeadlessEngine(opts = {}) {
 /**
  * Register every event-bus listener and timer handler a game run depends on.
  * Called after clearHandlers() so each run starts with exactly one copy of each.
+ *
+ * Exported so callers that restore a serialized game (the playtest CLI's
+ * one-command-per-process load path) can wire the same handlers without going
+ * through resetGame() — otherwise the action dispatcher and timer handlers are
+ * never registered and dispatched actions (target, probe, …) silently no-op.
+ * Requires initHeadlessEngine() to have set the action context first.
  */
-function wireRunHandlers() {
+export function wireRunHandlers() {
   // Timer → handler wiring
   on(TIMER.ICE_MOVE,   (payload) => handleIceTick(payload));
   on(TIMER.ICE_DETECT, (payload) => handleIceDetect(payload));

--- a/scripts/playtest.js
+++ b/scripts/playtest.js
@@ -14,7 +14,7 @@
 
 import { readFileSync, writeFileSync, existsSync } from "fs";
 import {
-  initHeadlessEngine, resetGame,
+  initHeadlessEngine, resetGame, wireRunHandlers,
   getState, serializeState, deserializeState,
   tick, on, emitEvent, E,
 } from "./lib/headless-engine.js";
@@ -26,7 +26,6 @@ import { A } from "../js/core/action-ids.js";
 import { addLogEntry } from "../js/core/log.js";
 import { runCommand } from "../js/ui/console.js";
 import { handleCheatCommand } from "../js/core/cheats.js";
-import { initDynamicActions } from "../js/core/console-commands/dynamic-actions.js";
 import { buildSetPieceMiniNetwork, buildMiniNetwork, listSetPieces } from "../js/core/node-graph/mini-network.js";
 
 // ── Arg parsing ────────────────────────────────────────────
@@ -269,7 +268,12 @@ if (!isReset) {
   if (existsSync(stateFile)) {
     try {
       deserializeState(JSON.parse(readFileSync(stateFile, "utf8")));
-      initDynamicActions();
+      // Restoring a serialized game still needs the full run-handler set wired —
+      // action dispatcher, ICE/alert/timer handlers, dynamic actions — otherwise
+      // dispatched commands (target, probe, …) and ticked timers no-op. resetGame()
+      // does this via clearHandlers()+wireRunHandlers(); on the load path we wire
+      // without clearing so the harness's own output listeners survive.
+      wireRunHandlers();
       // Emit STATE_CHANGED so dynamic actions sync for the restored state
       emitEvent(E.STATE_CHANGED, getState());
     } catch (e) {

--- a/tests/playtest-cli.test.js
+++ b/tests/playtest-cli.test.js
@@ -1,0 +1,78 @@
+// @ts-check
+// Regression: the playtest CLI runs ONE command per process, persisting state to
+// a JSON file between invocations. Actions dispatch a "starnet:action" event that
+// only executes if the unified action dispatcher (plus ICE/alert/timer handlers)
+// is wired. Before the fix, the non-reset LOAD path wired only initDynamicActions()
+// — never the dispatcher or timer handlers — so `target`, `probe`, `tick`, etc.
+// silently no-opped in any invocation that loaded saved state (i.e. every command
+// after `reset`). See scripts/lib/headless-engine.js wireRunHandlers().
+//
+// Honest test: drive the actual CLI across separate processes and assert the
+// observable consequence (selection persists, ticks advance ICE), not internals.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync, rmSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(new URL("../scripts/playtest.js", import.meta.url));
+
+/** Run one CLI command against an isolated state file. */
+function cli(stateFile, seed, cmd) {
+  execFileSync("node", [SCRIPT, "--state", stateFile, "--seed", seed, cmd], {
+    encoding: "utf8",
+  });
+}
+
+/** Read the persisted state JSON. */
+function loadState(stateFile) {
+  return JSON.parse(readFileSync(stateFile, "utf8"));
+}
+
+test("CLI: target persists selection across a separate load-path invocation", () => {
+  const dir = mkdtempSync(join(tmpdir(), "starnet-cli-"));
+  const stateFile = join(dir, "state.json");
+  try {
+    cli(stateFile, "cli-target", "reset");
+    const fresh = loadState(stateFile);
+    assert.equal(fresh.selectedNodeId, null, "fresh game should have no selection");
+
+    // Pick an accessible node (the gateway / entry) to target.
+    const target = Object.values(fresh.nodes).find((n) => n.visibility === "accessible");
+    assert.ok(target, "expected at least one accessible node after reset");
+
+    cli(stateFile, "cli-target", `target ${target.id}`);
+    const after = loadState(stateFile);
+    assert.equal(after.selectedNodeId, target.id, "target should persist selectedNodeId");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI: a timed action dispatched then ticked completes on the load path", () => {
+  // End-to-end proof that the load path wires the full run-handler set: the probe
+  // must dispatch (action dispatcher) AND its timed-action completion must fire
+  // during tick (timer→handler wiring). currentTick advancing alone proves neither,
+  // so we assert the observable outcome — the node ends up probed.
+  const dir = mkdtempSync(join(tmpdir(), "starnet-cli-"));
+  const stateFile = join(dir, "state.json");
+  try {
+    cli(stateFile, "cli-probe", "reset");
+    const fresh = loadState(stateFile);
+    const target = Object.values(fresh.nodes).find((n) => n.visibility === "accessible");
+    assert.ok(target, "expected at least one accessible node after reset");
+    assert.equal(target.probed, false, "node should start unprobed");
+
+    cli(stateFile, "cli-probe", `target ${target.id}`);
+    cli(stateFile, "cli-probe", "probe");      // dynamic command, available once selected
+    cli(stateFile, "cli-probe", "tick 300");   // 30s — long enough for any grade's probe
+
+    const after = loadState(stateFile);
+    assert.equal(after.nodes[target.id].probed, true, "probe should complete via the load path");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes the harness bug flagged in #156: `target <node>` (and in fact every dispatched command) silently no-opped in the playtest CLI, leaving `selectedNodeId` null.

## Root cause
The playtest CLI runs **one command per process**, persisting state to a JSON file between invocations. Console commands dispatch a `starnet:action` event that only executes if the unified **action dispatcher** is wired; ICE/trace progress needs the **timer→handler** wiring. Both (plus the ICE/alert/nav/graph-bridge listeners) live in `headless-engine.js` `wireRunHandlers()`, which is only called by `resetGame()`.

The non-reset **load path** wired only `initDynamicActions()` — never the dispatcher or timer handlers. So every invocation that restored saved state (i.e. every command after `reset`) ran without a `starnet:action` handler. `target`, `probe`, `xploit`, etc. dispatched into the void; selection never persisted; ticked timers fired into nothing.

These handlers used to be wired unconditionally at module load. They moved into reset-only `wireRunHandlers()` during the headless-engine extraction (`8d29052`), which is when it regressed. The in-process bot (`scripts/bot/run.js`) was unaffected because it calls `resetGame()` once and drives all commands in the same process.

## Fix
Export `wireRunHandlers()` and call it on the load path — **without** `clearHandlers()`, so the harness’s own output listeners (registered at module load) survive. It includes `initDynamicActions()`, so that standalone call/import is removed.

## Tests
New subprocess regression test (`tests/playtest-cli.test.js`) drives the **real CLI across separate processes** — the only honest way to catch a load-path-wiring omission:
- `target <node>` persists `selectedNodeId` across a separate invocation.
- A dispatched `probe` completes after `tick` (proves dispatcher **and** timer-handler wiring; asserts the node ends up `probed`, not just that `currentTick` advanced — the latter passes even with the bug).

Both fail pre-fix, pass post-fix. `make check` → 930 tests pass, lint clean. Manually confirmed `target gateway` → `selectedNodeId: gateway`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)