### PR TITLE
Vital-sign waveforms: animated ECG + square pulse in the HUD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /scripts/playtest-state.json
 /node_modules/
 /.worktrees/
+/tmp/
 
 # Superpowers brainstorming companion artifacts
 .superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,11 +384,11 @@ it is set is not testing the circuit — it's testing that assignment works.
 ## Design Aesthetic
 
 - Dark background (`#0a0a0f`), glowing neon vector phosphene look
-- Cyan nodes/borders, terminal-green text, magenta for selection
+- Cyan nodes/borders, terminal-green text, magenta for selection, violet for deck integrity
 - Alert states: green glow → yellow → red pulse
 - Scanline overlay on graph panel (CSS `::after`)
 - Monospace font throughout
-- Planned (future): screenshake, bloom, vector glitches on countermeasure hits
+- Vector visual effects are an active part of the aesthetic — graph degradation (health bloom, deck corruption) and HUD vital-sign waveforms have shipped. Specific effects still to come: screenshake, bloom, glitches on countermeasure hits.
 
 ### Rotation direction convention
 
@@ -425,7 +425,6 @@ and `preview.js`.
 - Sprites, daemons, machine elves
 - Player progression between runs
 - Wider world (galaxy, planets, cities)
-- Visual effects (screenshake, bloom, glitches)
 - Audio
 
 ## Backlog

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -61,7 +61,7 @@ every ICE movement that crosses into your territory appears here.
 **Console** — Type commands directly. Tab-complete node names. Full command reference
 at the end of this manual.
 
-**HUD** — Top bar shows global alert level, your current cash balance, and your two resource meters: **HEALTH** and **DECK INTEGRITY**. Both ramp from green through yellow to red as they deplete.
+**HUD** — Top bar shows global alert level, your current cash balance, and your two resource meters: **HEALTH** and **DECK INTEGRITY**, drawn as vector-CRT vital traces that sweep left-to-right with a fading phosphor trail. HEALTH is a green ECG/heartbeat (PQRST) complex — as health falls the beat speeds up and grows erratic; it flatlines at zero. DECK INTEGRITY is a violet double square-pulse — as deck integrity falls the pulses develop deepening ringing, dropouts and timing/amplitude glitches (the amplitude itself stays roughly constant); it flatlines at zero. Hover either trace to see the exact value as a percentage.
 
 **Seed** — Each run is generated from a seed string, shown in the status display.
 Sharing a seed lets someone else play the same network layout, vulnerabilities,
@@ -493,7 +493,7 @@ In addition to the trace, you have two resource pools that start each run at 100
   Depleting DECK INTEGRITY to zero ends the run — outcome: **bricked** (end screen: "DECK FRIED").
   Fiction: the deck's OS is corrupted past recovery.
 
-Both are shown in the HUD as color-ramping meters (green → yellow → red). They appear in
+Both are shown in the HUD as animated vector-CRT vital traces that sweep left-to-right with a fading phosphor trail: HEALTH as a green ECG/heartbeat (PQRST) complex (the beat speeds up and turns erratic as it falls; flatlines at zero), DECK INTEGRITY as a violet double square-pulse (it develops ringing, dropouts and timing/amplitude glitches as it falls, at roughly constant amplitude; flatlines at zero). Hover either trace to see the exact percentage. They also appear in
 `status` and `status full`. Damage events are logged with the offending node, e.g.
 `[ICE] gateway neural feedback: −20 HEALTH (80 left)` or `[ICE] router-2 deck corruption: −20 DECK (80 left)`.
 

--- a/css/style.css
+++ b/css/style.css
@@ -39,6 +39,8 @@
   --glow-sm: 0 0 4px;
   --glow-md: 0 0 8px;
   --glow-lg: 0 0 14px;
+
+  --violet: #b06cff;
 }
 
 html, body {
@@ -1552,29 +1554,69 @@ html, body {
 /* Preview-harness toggle: disable the menace pulse. */
 #ice-overlay.ice-pulse-off .ice-cage { animation: none; }
 
-/* HUD resource meters (health / deck integrity) — scoped to #hud to match the
-   other HUD rules. */
-#hud .hud-meter {
-  position: relative;
+/* ── Waveform component ─────────────────────────────────── */
+
+/* Inline canvas container — sits cleanly next to HUD labels. */
+.hud-waveform {
   display: inline-block;
-  flex: 0 0 auto; /* the HUD is a flex row — don't let the meter shrink below 64px */
-  width: 64px;
-  height: 12px;
-  border: 1px solid var(--cyan);
   vertical-align: middle;
-  overflow: hidden;
+  line-height: 0;
 }
-#hud .hud-meter-fill {
-  position: absolute;
-  inset: 0 auto 0 0;
-  opacity: 0.35;
-  transition: width 0.3s ease;
+.hud-waveform canvas {
+  display: block;
 }
-#hud .hud-meter-text {
-  position: absolute;
-  inset: 0;
+
+/* Vital-sign traces — stacked pair at the top of the sidebar. */
+#vital-stack {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--border);
+  padding: 0.5rem 1rem;
+  background: #0a0a12;
   display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.vital-strip {
+  display: block;
+  width: 100%;
+  line-height: 0;
+  background: #06060a;
+  border: 1px solid var(--border);
+}
+.vital-strip .hud-waveform {
+  display: block;
+  width: 100%;
+}
+.vital-head {
+  display: flex;
+  justify-content: space-between;
   align-items: center;
-  justify-content: center;
-  font-size: 0.7em;
+  line-height: 1;
+  padding: 2px 4px 3px;
+}
+.vital-label {
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  color: #6b7a90;
+}
+.vital-pips {
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+}
+.vital-pips.ok   { color: var(--green); }
+.vital-pips.warn { color: #c9d11e; }
+.vital-pips.crit { color: #ff5a4d; }
+
+/* Preview harness — waveform demo layouts */
+#waveform-demo.layout-inline {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  align-items: center;
+}
+
+#waveform-demo.layout-strip {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }

--- a/docs/dev-sessions/2026-06-11-1315-vital-waveforms/notes.md
+++ b/docs/dev-sessions/2026-06-11-1315-vital-waveforms/notes.md
@@ -1,0 +1,49 @@
+# Notes — Vital-Sign Waveforms
+
+## Filed
+- Issue: https://github.com/lmorchard/starnet/issues/157
+- Date: 2026-06-11
+- Resume command: `/dev-session express https://github.com/lmorchard/starnet/issues/157`
+
+## Session log
+- Brainstormed design: Health+Deck mapping, faster+erratic ECG, flatten+glitch pulse,
+  inline placement now + stacked-strip prototype in preview.
+- Worktree: `.worktrees/vital-waveforms` on branch `vital-waveforms`.
+- Baseline: 928 tests passing.
+
+## Final summary
+
+Replaced the HUD's HEALTH/DECK bar meters with animated Zoids-style vital-sign waveforms
+(homage to the 1986 Zoids C64 dashboard). Executed subagent-driven (implementer + spec
+review + code-quality review per phase), all autonomous.
+
+**What shipped:**
+- `js/ui/waveform.js` — pure, deterministic SVG-waveform geometry (ECG + square pulse),
+  33 unit tests. No `Math.random` (deterministic `hash01`); straight segments only.
+- `js/ui/components/starnet-waveform.js` — `<starnet-waveform>` Lit component; self-animates
+  a scroll `_phase` via rAF (ephemeral, not in game state). Guards against double-start; phase wraps.
+- Preview demo (`preview.html` / `preview.js` / `style.css`) — health/deck sliders + an
+  inline-vs-stacked-strip layout toggle; added `--violet` palette token.
+- HUD (`starnet-hud.js`) — bar meters → waveforms (green ECG = health, violet pulse = deck);
+  `_meter` helper and dead `.hud-meter*` CSS removed. Numeric value now on hover `title`.
+- Docs — CLAUDE.md (visual effects moved into scope), MANUAL.md (HUD/HEALTH-DECK display).
+
+**Mappings (final):** HEALTH → green ECG, beats faster + more erratic as health falls,
+flatline at 0. DECK → violet square pulse, amplitude shrinks + dropout glitches as integrity
+falls, flatline at 0.
+
+**Verification:** `make check` green (957 tests, 0 fail; lint clean). Automated checks
+complete with evidence; **manual eyeball checks left unchecked for Les** (animation feel,
+violet hue, inline-vs-strip choice, degradation under real damage) — autonomous execution
+can't self-verify these.
+
+**Deferred / follow-ups:**
+- Layout decision: shipped HUD-inline (per spec default); stacked-strip exists in preview
+  only, for comparison. Whether to adopt the strip in-game is a follow-up.
+- Tuning by eye: `--violet` hue (`#b06cff` placeholder), HUD waveform dimensions
+  (`w=96 h=22`), scroll speed (`0.003`/frame), beat-count range (2–6) — all eyeball-tunable.
+- Geometry edge note: phase aliasing at beat-period multiples is expected/correct (see
+  `waveform.test.js` comment).
+
+**Commits:** Phase 1 `b7b4630` (+review `7a8cbab`), Phase 2 `11f3e81` (+review `685f201`),
+Phase 3 `71ea45f` (+review `a084275`), Phase 4 `6707c64` (+`acd91d4`), Phase 5 `353a915`.

--- a/docs/dev-sessions/2026-06-11-1315-vital-waveforms/plan.md
+++ b/docs/dev-sessions/2026-06-11-1315-vital-waveforms/plan.md
@@ -1,0 +1,214 @@
+# Vital-Sign Waveforms Implementation Plan
+
+**Goal:** Replace the HUD's HEALTH/DECK bar meters with animated Zoids-style vital-sign
+waveforms — green ECG for health, violet square pulse for deck integrity — that degrade
+in shape as each value falls.
+
+**Approach:** A pure, testable geometry module (`waveform.js`) produces vertex lists from
+`(frac, phase)`; a thin `<starnet-waveform>` Lit component renders them as a single SVG
+`<path>` and self-animates the scroll `phase` via `requestAnimationFrame`. All testable
+logic lives in the geometry module; the component, preview demo, and HUD wiring are
+presentation glue verified manually in the preview harness and browser.
+
+**Tech stack:** Vanilla ES modules, Lit (light-DOM `StarnetElement`), SVG polylines, esbuild
+(vendor only — game code unbundled). `make lint` = tsc over JSDoc; `make test` = node:test.
+
+---
+
+## Phase 1: Pure waveform geometry module (TDD)
+
+Deliver `js/ui/waveform.js` — pure functions mapping `(frac, phase, width, height)` to
+vertex lists for the two waveforms, plus a path-string serializer. Mirrors the
+`vuln-glyphs.js` pure-module + test convention.
+
+**Files:**
+- Create: `js/ui/waveform.js`
+- Test: `js/ui/waveform.test.js`
+
+**Key changes:**
+- `ecgPoints({ frac, phase, width, height }): Array<{x:number,y:number}>` — health waveform.
+  Baseline at `height/2`. Beat count across `width` scales up as `frac` falls
+  (`beats = round(lerp(MIN_BEATS, MAX_BEATS, 1 - frac))`); each beat is a sharp QRS spike
+  (baseline → tall peak → short undershoot → baseline) built from straight segments. `phase`
+  scrolls beat positions leftward (`(i * spacing - phase * width) mod width`). As `frac`
+  falls, beat spacing and spike height are perturbed by `hash01()` so the trace turns erratic.
+  `frac <= 0` returns a flat two-point baseline `[{x:0,y:mid},{x:width,y:mid}]`.
+- `pulsePoints({ frac, phase, width, height }): Array<{x:number,y:number}>` — deck waveform.
+  A square wave between baseline (`height/2 + amp/2`) and top (`height/2 - amp/2`), where
+  `amp = fullAmp * frac`. `phase` scrolls the wave leftward. As `frac` falls, an increasing
+  fraction of cells "drop out" (held flat at baseline) chosen by `hash01()` — the glitch gaps.
+  `frac <= 0` returns a flat two-point baseline.
+- `pointsToPath(points): string` — joins to an SVG path `d` (`M x y L x y …`), rounded to
+  2 decimals. Straight segments only.
+- `hash01(n): number` — deterministic `[0,1)` mixer (integer bit-mix or `fract(sin)`), used
+  for all "erratic"/"dropout" variation so output is a stable function of inputs (no `Math.random`).
+
+```js
+// shape of the ECG vertex builder (sketch)
+const mid = height / 2;
+if (frac <= 0) return [{ x: 0, y: mid }, { x: width, y: mid }];
+const beats = Math.round(lerp(MIN_BEATS, MAX_BEATS, 1 - frac)); // fewer when healthy
+const pts = [{ x: 0, y: mid }];
+for (let i = 0; i < beats; i++) {
+  const jitter = (1 - frac) * hash01(i * 7 + 1);           // erratic spacing when hurt
+  const cx = mod((i + jitter) * (width / beats) - phase * width, width);
+  const peak = mid - (PEAK * (0.6 + 0.4 * frac)) * (1 + (1 - frac) * (hash01(i) - 0.5));
+  pts.push({ x: cx - 4, y: mid }, { x: cx, y: peak }, { x: cx + 3, y: mid + UNDERSHOOT }, { x: cx + 6, y: mid });
+}
+pts.push({ x: width, y: mid });
+return pts.sort((a, b) => a.x - b.x);
+```
+
+**Verification — automated:**
+- [x] `make lint` passes (JSDoc types on all exports)
+- [x] `make test` passes
+- [x] `node --test js/ui/waveform.test.js` — new suite covers:
+  - `frac = 0` → both functions return a 2-point flat baseline (all `y === height/2`)
+  - `frac = 1` ECG → vertex count > 2 and max `|y - mid|` > 0 (visible spikes)
+  - `frac = 1` pulse → max `|y - mid|` equals full amplitude; lower `frac` → strictly smaller amplitude
+  - lower `frac` ECG → more beats than higher `frac` (count distinct peaks)
+  - determinism: identical args → identical output (deep-equal across two calls)
+  - all points within `[0,width] × [0,height]` bounds
+
+**Verification — manual:** (none — pure module)
+
+---
+
+## Phase 2: `<starnet-waveform>` component (TDD opt-out: DOM/rAF glue)
+
+Deliver a reusable Lit component that renders one waveform and self-animates. No pure logic
+of its own (all geometry is Phase 1, tested there), so this phase is verified visually in
+Phase 3's preview rather than unit-tested — consistent with the other DOM-only components
+(`starnet-hud.js` etc. have no unit tests).
+
+**Files:**
+- Create: `js/ui/components/starnet-waveform.js`
+- Modify: `index.html` — add `<script type="module" src="js/ui/components/starnet-waveform.js">` beside the other component tags (after `starnet-hud.js`, line ~67)
+
+**Key changes:**
+- `class StarnetWaveform extends StarnetElement` (light DOM base), `customElements.define("starnet-waveform", …)`.
+- `static properties = { kind: {type:String}, frac: {type:Number}, color: {type:String}, w: {type:Number}, h: {type:Number}, label: {type:String} }`.
+  Defaults: `kind="ecg"`, `frac=1`, `color="var(--green)"`, `w=120`, `h=28`.
+- Internal `_phase` (plain field, NOT a reactive prop and NOT game state — ephemeral scroll cursor).
+- `connectedCallback()` starts a `requestAnimationFrame` loop that advances `_phase`
+  (steady scroll rate; beat *rate* comes from geometry, scroll is constant)
+  and calls `this.requestUpdate()`. `disconnectedCallback()` cancels it (`cancelAnimationFrame`).
+- `render()` picks `ecgPoints`/`pulsePoints` by `kind`, builds the `d` via `pointsToPath`, returns
+  an `<svg viewBox="0 0 w h">` with one `<path stroke=color fill=none>`, wrapped in a span whose
+  `title` is `${label}: ${Math.round(frac*100)}%` for hover legibility.
+
+```js
+import { html } from "lit";
+import { StarnetElement } from "./starnet-element.js";
+import { ecgPoints, pulsePoints, pointsToPath } from "../waveform.js";
+// render(): const pts = this.kind === "pulse" ? pulsePoints(args) : ecgPoints(args);
+// return html`<span class="hud-waveform" title="${this.label}: ${Math.round(this.frac*100)}%">
+//   <svg viewBox="0 0 ${this.w} ${this.h}" width="${this.w}" height="${this.h}">
+//     <path d="${pointsToPath(pts)}" fill="none" stroke="${this.color}" stroke-width="1.5"/></svg></span>`;
+```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes (no new tests; confirm nothing regressed)
+
+**Verification — manual:**
+- [ ] Component verified in Phase 3 preview (deferred to that phase)
+
+---
+
+## Phase 3: Preview harness demo + layout comparison
+
+Deliver a preview panel with health%/deck% sliders driving a live `<starnet-waveform>` pair,
+plus a toggle between **inline** and **stacked-strip** arrangements — the tuning and
+decision surface. Satisfies the "new visual effects must be added to the preview harness"
+design principle.
+
+**Files:**
+- Modify: `preview.html` — add a `<div id="waveform-demo">` control group with two range sliders
+  (`#wave-health`, `#wave-deck`, 0–100), value labels, and a `#wave-layout-toggle` button;
+  add `<script type="module" src="js/ui/components/starnet-waveform.js">`
+- Modify: `js/ui/preview.js` — mount two `<starnet-waveform>` els into `#waveform-demo`
+  (ecg/green + pulse/violet), wire sliders to set `.frac`, wire the toggle to switch a CSS
+  class (`.layout-inline` ↔ `.layout-strip`) on the demo container
+- Modify: `css/style.css` — add `:root { --violet: #b06cff; }` (tune by eye), `.hud-waveform`
+  sizing, and `#waveform-demo.layout-strip` (full-width stacked rows) vs `.layout-inline`
+  (compact side-by-side) styles
+
+**Key changes:**
+- `preview.js`: follow the existing `degrade-health`/`degrade-deck` slider wiring (`preview.js:337-345`).
+  ```js
+  const ecg = document.createElement("starnet-waveform");
+  ecg.kind = "ecg"; ecg.color = "var(--green)"; ecg.label = "HEALTH";
+  const pulse = document.createElement("starnet-waveform");
+  pulse.kind = "pulse"; pulse.color = "var(--violet)"; pulse.label = "DECK";
+  // slider input → ecg.frac = v/100 (or pulse.frac); toggle → container.classList.toggle
+  ```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes
+
+**Verification — manual:**
+- [ ] `make serve`, open `/preview.html`: both waveforms animate (scroll)
+- [ ] Health slider 100→0: ECG goes slow/clean → fast/erratic → flatline at 0
+- [ ] Deck slider 100→0: pulse goes crisp → ragged/glitchy/low-amp → flatline at 0
+- [ ] Layout toggle switches inline ↔ stacked-strip cleanly; eyeball which we prefer
+- [ ] Violet reads as distinct from the surrounding cyan; tune `--violet` if not
+
+---
+
+## Phase 4: Wire into the HUD, ship inline (TDD opt-out: DOM wiring)
+
+Replace the two `_meter(...)` calls in the HUD with `<starnet-waveform>` elements bound to
+the existing health/deck Lit properties. State→prop bridge already exists
+(`visual-renderer.js:358-361`), so no renderer change is needed.
+
+**Files:**
+- Modify: `js/ui/components/starnet-hud.js` — replace `_meter("HEALTH", …)`/`_meter("DECK", …)`
+  (lines 91-92) with two `<starnet-waveform>` els; delete the `_meter` helper (52-62) if now
+  unused (grep confirms no other caller)
+- Modify: `css/style.css` — remove `.hud-meter*` rules only if `_meter` is gone and nothing else
+  uses them; otherwise leave untouched
+
+**Key changes:**
+- In `render()`:
+  ```js
+  <span class="hud-label">HEALTH:</span>
+  <starnet-waveform kind="ecg" color="var(--green)" label="HEALTH"
+    .frac=${this.healthMax > 0 ? this.health / this.healthMax : 0}></starnet-waveform>
+  <span class="hud-label">DECK:</span>
+  <starnet-waveform kind="pulse" color="var(--violet)" label="DECK"
+    .frac=${this.deckIntegrityMax > 0 ? this.deckIntegrity / this.deckIntegrityMax : 0}></starnet-waveform>
+  ```
+
+**Verification — automated:**
+- [x] `make lint` passes
+- [x] `make test` passes
+- [x] `make bundle-vendor` (so the browser check below has current vendor bundle)
+
+**Verification — manual:**
+- [ ] `make serve`, open `/`: HUD shows the two waveforms in place of the old bars
+- [ ] Take damage (cheat or play): waveforms degrade live as HEALTH/DECK fall; flatline at 0
+- [ ] Hover a waveform: `title` shows `HEALTH: NN%` / `DECK: NN%`
+- [ ] `node scripts/playtest.js reset` then `status` still reports health/deck numerically (unchanged)
+
+---
+
+## Phase 5: Docs — CLAUDE.md scope + MANUAL.md HUD (TDD opt-out: docs)
+
+Bring the docs in line: visual effects are in scope, and the HUD shows waveforms.
+
+**Files:**
+- Modify: `CLAUDE.md` — remove "Visual effects (screenshake, bloom, glitches)" from the
+  "Out of Scope (Future)" list (graph-degradation already shipped it; this seals it); adjust the
+  "Design Aesthetic → Planned (future)" line accordingly
+- Modify: `MANUAL.md` — update the HUD description (line 64) and the "HEALTH and DECK INTEGRITY"
+  section (lines 496+) to describe the ECG / square-pulse waveforms instead of "color-ramping meters"
+- Modify: `docs/dev-sessions/2026-06-11-1315-vital-waveforms/notes.md` — final session summary
+
+**Verification — automated:**
+- [x] `make check` passes (lint + test, full suite)
+
+**Verification — manual:**
+- [ ] MANUAL.md HUD/HEALTH-DECK sections match what the game now shows
+- [ ] CLAUDE.md no longer lists visual effects as out of scope

--- a/docs/dev-sessions/2026-06-11-1315-vital-waveforms/spec.md
+++ b/docs/dev-sessions/2026-06-11-1315-vital-waveforms/spec.md
@@ -1,0 +1,117 @@
+# Vital-Sign Waveforms Spec
+
+**Goal:** Replace the HUD's two numeric bar meters (HEALTH, DECK) with animated
+Zoids-style vital-sign waveforms — a green ECG heartbeat for the decker's health
+and a violet square pulse for deck integrity — that degrade in shape as each value
+falls, giving an at-a-glance, diegetic read on how the run is going.
+
+**Source:** User request from 2026-06-11 (inspired by the 1986 Zoids C64 game's
+dual heart-monitor / square-pulse HUD).
+
+## Current state
+
+- The HUD (`js/ui/components/starnet-hud.js`) shows HEALTH and DECK as horizontal
+  bar meters via `_meter(label, current, max)` (`starnet-hud.js:52-62`), called at
+  `starnet-hud.js:91-92`. The bar fills a width % and colors green/yellow/red by
+  fraction, with the raw number as text.
+- The HUD already receives `health` / `healthMax` / `deckIntegrity` /
+  `deckIntegrityMax` as Lit properties (`starnet-hud.js:17-20`), fed from state by
+  `js/ui/visual-renderer.js`.
+- The underlying quantities live in state at `js/core/state/index.js:165-166`:
+  `player.health` (`{current, max}`) and `player.deckIntegrity` (`{current, max}`).
+  ICE damages them (sentinel→health, spike→deck; see `index.js:200-202`).
+- Pure, testable geometry modules are an established convention:
+  `js/ui/node-glyphs.js`, `js/ui/ice-glyphs.js`, `js/ui/vuln-glyphs.js` (with
+  `vuln-glyphs.test.js`). They export functions returning SVG geometry, consumed by
+  both `graph.js` and `preview.js`.
+- Visual effects are demoed in the preview harness (`preview.html` / `js/ui/preview.js`).
+
+## Desired end state
+
+- Two animated SVG waveforms render where the HEALTH and DECK bar meters were:
+  - **ECG (health):** green polyline (`var(--green)`). `frac = health/healthMax`
+    drives **beat rate and jaggedness**. High frac → slow, clean, regular spikes.
+    Low frac → fast, erratic, irregular spikes. `frac = 0` → flat line.
+  - **Square pulse (deck):** violet polyline. `frac = deckIntegrity/deckIntegrityMax`
+    drives **amplitude and dropout glitches**. High frac → crisp full-amplitude square
+    wave. Low frac → ragged, lower-amplitude, with dropout gaps. `frac = 0` → flat line.
+- Both scroll horizontally (continuous animation). Both are built from straight
+  segments only (polylines) — no curves, per the vector-CRT aesthetic rule.
+- The raw numeric value remains available on hover via the element `title` attribute;
+  `status` continues to report both values (no change there).
+- The waveform pair is demoable in the preview harness with sliders for health % and
+  deck %, and a toggle between two layout arrangements: **HUD-inline** (current header
+  placement) and **Zoids stacked-strip** (ECG above / pulse below the graph panel), so
+  the two placements can be compared by eye before committing to one.
+- `CLAUDE.md`'s "Out of Scope (Future)" note listing visual effects is updated — visual
+  effects are now in scope.
+
+## Design decisions
+
+- **Decision:** Waveforms read `player.health` and `player.deckIntegrity`.
+  - **Why:** These are the two existing damage tracks, already shown as the HUD meters
+    this feature replaces, and they map 1:1 onto the Zoids pilot-health / machine-health
+    pair (both are *yours*, both under attack by ICE).
+  - **Rejected:** Mapping to alert/trace ("player exposure vs system defenses"). Those
+    aren't single numeric quantities, so the fraction→shape mapping would be fuzzy, and
+    it wouldn't replace the meters the user asked to replace.
+
+- **Decision:** Pure geometry module `js/ui/waveform.js` returning vertex-point arrays
+  (`ecgPoints`/`pulsePoints`), with a `pointsToPath()` serializer to an SVG path `d` string,
+  consumed by a reusable `<starnet-waveform>` Lit component.
+  - **Why:** Matches the `*-glyphs.js` convention — geometry stays pure and unit-testable;
+    the component is reusable so it drops into either layout placement unchanged.
+  - **Rejected:** Canvas rendering. These are small fixed-size widgets; canvas adds an
+    imperative draw loop and buys nothing over SVG, and breaks the testable-geometry pattern.
+
+- **Decision:** Erratic/glitch variation is derived *deterministically* from `phase`+`frac`
+  (a small hash), not `Math.random`.
+  - **Why:** Keeps the geometry function pure and snapshot-testable; produces a stable
+    repeating pattern rather than per-frame noise.
+  - **Rejected:** `Math.random()` per frame — untestable and visually noisier than wanted.
+
+- **Decision:** The scroll `phase` is render-time presentation state held in the component
+  (advanced by `requestAnimationFrame`), NOT in the game state object.
+  - **Why:** Per CLAUDE.md, gameplay state must be fully serializable. The scroll cursor is
+    ephemeral animation (like a CSS animation tick), exactly like the existing timed overlays;
+    the *shape* derives entirely from `frac`, which IS serializable state.
+  - **Rejected:** Storing phase in game state — would pollute the save format with animation
+    cruft for no gameplay benefit.
+
+- **Decision:** Deck pulse color defaults to violet, not cyan.
+  - **Why:** Cyan is already pervasive (nodes, borders); violet reads as a distinct "your
+    rig" channel without colliding with hostile red/magenta. Final hue tuned by eye in preview.
+  - **Rejected:** Cyan — too easily lost against the existing cyan UI.
+
+## Patterns to follow
+
+- Pure geometry module + test: mirror `js/ui/vuln-glyphs.js` + `js/ui/vuln-glyphs.test.js`.
+- Lit component: mirror `js/ui/components/starnet-hud.js` structure (light-DOM
+  `StarnetElement` base, `static properties`, `render()` returning `html`).
+- Preview demo: add a node/panel + controls in `js/ui/preview.js` following the existing
+  effect demos there (per the "new visual effects must be added to the preview harness"
+  design principle).
+- State→prop bridge: the HUD already gets health/deck props via `visual-renderer.js`;
+  no new bridge needed for the inline placement.
+
+## What we're NOT doing
+
+- **Not** changing any gameplay: health/deck damage, ICE behavior, alert, trace, or
+  game-over logic are untouched. The waveform only *reflects* state.
+- **Not** adding a third/fourth waveform for alert or trace (rejected mapping above).
+- **Not** committing to the Zoids stacked-strip layout in this session — we build it as a
+  preview-only comparison arrangement; the shipped HUD placement stays inline unless the
+  comparison changes our mind (a follow-up decision, not this spec's scope).
+- **Not** refactoring the HUD beyond swapping the two `_meter` calls and removing the now-unused
+  `_meter` helper if nothing else uses it.
+- **Not** adding audio, screenshake, or other juice effects — just the two waveforms.
+- **Not** changing `status` / log output or console commands.
+
+## Open questions
+
+- **Final deck pulse hue (exact violet) and waveform tile dimensions.**
+  - *Default:* a CSS-variable violet (introduce `--violet` if absent) at the same compact
+    height as the current meters; tune by eye in the preview harness during execute.
+- **Which layout ships (inline vs stacked-strip).**
+  - *Default:* ship HUD-inline (the placement the user confirmed "for now"); stacked-strip
+    is built in preview only for comparison and a possible follow-up.

--- a/index.html
+++ b/index.html
@@ -50,6 +50,16 @@
       </div>
 
       <aside id="sidebar">
+        <!-- Vital-sign traces: a stacked pair at the top of the sidebar. Canvas traces
+             driven by visual-renderer.syncVitals (health / deck integrity). -->
+        <div id="vital-stack">
+          <starnet-waveform id="vital-ecg" class="vital-strip" autosize
+            kind="ecg" color="var(--green)" label="HEALTH"
+            h="44" speed="100" trail="0.72" bloom="14" meter></starnet-waveform>
+          <starnet-waveform id="vital-deck" class="vital-strip" autosize
+            kind="pulse" color="var(--violet)" label="DECK"
+            h="44" speed="100" trail="0.72" bloom="14" meter></starnet-waveform>
+        </div>
         <starnet-mission-pane id="sidebar-mission"></starnet-mission-pane>
         <starnet-node-panel id="sidebar-node"></starnet-node-panel>
         <starnet-hand id="hand-strip"></starnet-hand>
@@ -64,6 +74,7 @@
   <script type="module" src="js/ui/components/starnet-log.js"></script>
   <script type="module" src="js/ui/components/starnet-mission-pane.js"></script>
   <script type="module" src="js/ui/components/starnet-ice-timers.js"></script>
+  <script type="module" src="js/ui/components/starnet-waveform.js"></script>
   <script type="module" src="js/ui/components/starnet-hud.js"></script>
   <script type="module" src="js/ui/components/starnet-context-menu.js"></script>
   <script type="module" src="js/ui/components/starnet-action-choices.js"></script>

--- a/js/ui/components/starnet-hud.js
+++ b/js/ui/components/starnet-hud.js
@@ -14,10 +14,6 @@ class StarnetHud extends StarnetElement {
     isCheating: { type: Boolean },
     phase: { type: String },
     paused: { type: Boolean },
-    health: { type: Number },
-    healthMax: { type: Number },
-    deckIntegrity: { type: Number },
-    deckIntegrityMax: { type: Number },
   };
 
   constructor() {
@@ -30,10 +26,6 @@ class StarnetHud extends StarnetElement {
     this.isCheating = false;
     this.phase = "";
     this.paused = false;
-    this.health = 100;
-    this.healthMax = 100;
-    this.deckIntegrity = 100;
-    this.deckIntegrityMax = 100;
   }
 
   _emit(action, detail = {}) {
@@ -47,18 +39,6 @@ class StarnetHud extends StarnetElement {
     if (!file) return;
     this._emit("load", { file });
     e.target.value = "";
-  }
-
-  _meter(label, current, max) {
-    const frac = max > 0 ? current / max : 0;
-    const color = frac > 0.6 ? "var(--green)" : frac > 0.3 ? "var(--yellow)" : "var(--red)";
-    return html`
-      <span class="hud-label">${label}:</span>
-      <span class="hud-meter" title="${label}: ${current}/${max}">
-        <span class="hud-meter-fill" style="width:${Math.round(frac * 100)}%;background:${color}"></span>
-        <span class="hud-meter-text" style="color:${color}">${current}</span>
-      </span>
-    `;
   }
 
   render() {
@@ -87,9 +67,6 @@ class StarnetHud extends StarnetElement {
 
       <span class="hud-label">WALLET:</span>
       <span class="hud-value" id="wallet">¥${this.cash.toLocaleString()}</span>
-
-      ${this._meter("HEALTH", this.health, this.healthMax)}
-      ${this._meter("DECK", this.deckIntegrity, this.deckIntegrityMax)}
 
       ${this.traceSeconds !== null && this.phase === "playing" ? html`
         <span id="trace-countdown" class="hud-value trace-countdown">TRACE: ${this.traceSeconds}s</span>

--- a/js/ui/components/starnet-waveform.js
+++ b/js/ui/components/starnet-waveform.js
@@ -1,0 +1,228 @@
+// <starnet-waveform> — animated vital-sign waveform component.
+//
+// Draws one waveform (ECG or square-pulse) onto a <canvas> like a vector-CRT scope:
+// the static shape (from waveform.js) is redrawn left-to-right by a sweep head, leaving
+// a phosphor trail that fades to nothing over one sweep. The trace is sampled into a
+// time-stamped history buffer and redrawn from scratch each frame (clear + age→alpha),
+// so the fade is exact (no burn-in) and a frac change ripples in behind the head rather
+// than snapping the whole graph. Glow is paid per age-band (~12), not per segment.
+//
+// All animation state (_buf/_head/_lastTs) is ephemeral render state — NOT reactive,
+// NOT part of game state.
+
+import { html, nothing } from "lit";
+import { StarnetElement } from "./starnet-element.js";
+import { ecgPoints, pulsePoints, sampleY } from "../waveform.js";
+
+const STEP = 2;  // px between trail samples
+const NB = 12;   // glow age-bands per frame
+
+class StarnetWaveform extends StarnetElement {
+  static properties = {
+    kind:  { type: String },
+    frac:  { type: Number },
+    color: { type: String },
+    w:     { type: Number },
+    h:     { type: Number },
+    label: { type: String },
+    speed: { type: Number },  // px/sec sweep
+    trail: { type: Number },  // trail length as a multiple of one sweep
+    bloom: { type: Number },  // glow blur radius
+    autosize: { type: Boolean }, // track host width (full-width strips); ignores `w`
+    meter: { type: Boolean }, // render a label + depleting pip header above the trace
+  };
+
+  constructor() {
+    super();
+    this.kind  = "ecg";
+    this.frac  = 1;
+    this.color = "var(--green)";
+    this.w     = 120;
+    this.h     = 28;
+    this.label = "";
+    this.speed = 100;
+    this.trail = 0.8;
+    this.bloom = 14;
+    this.autosize = false;
+    this.meter = false;
+
+    // Ephemeral render state — not reactive, not serialised.
+    this._buf = [];
+    this._head = 0;
+    this._lastTs = null;
+    this._rafId = null;
+    this._ctx = null;
+    this._resolvedColor = "#39ff7a";
+    this._W = this.w;     // effective draw size (autosize tracks host width)
+    this._H = this.h;
+    this._ro = null;      // ResizeObserver when autosize
+  }
+
+  render() {
+    const frac = Math.max(0, Math.min(1, Number(this.frac) || 0));
+    return html`
+      ${this.meter ? this._meterHeader(frac) : nothing}
+      <span class="hud-waveform" title="${this.label}: ${Math.round(frac * 100)}%">
+        <canvas></canvas>
+      </span>
+    `;
+  }
+
+  /** Label + depleting 5-pip meter (ramps green→yellow→red), mirroring the card pips. */
+  _meterHeader(frac) {
+    const PIPS = 5;
+    const filled = frac <= 0 ? 0 : Math.max(1, Math.round(frac * PIPS));
+    const pips = "█".repeat(filled) + "░".repeat(PIPS - filled);
+    const tier = frac > 0.6 ? "ok" : frac > 0.3 ? "warn" : "crit";
+    return html`
+      <div class="vital-head">
+        <span class="vital-label">${this.label}</span>
+        <span class="vital-pips ${tier}">${pips}</span>
+      </div>
+    `;
+  }
+
+  firstUpdated() {
+    this._resolveColor();
+    if (this.autosize && typeof ResizeObserver !== "undefined") {
+      this._ro = new ResizeObserver(() => { this._setupCanvas(); });
+      this._ro.observe(this);
+    }
+    this._setupCanvas();
+    this._startLoop();
+  }
+
+  updated(changed) {
+    if (changed.has("w") || changed.has("h")) this._setupCanvas();
+    if (changed.has("color")) this._resolveColor();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._startLoop(); // no-op until firstUpdated has the canvas; re-arms on reattach
+  }
+
+  disconnectedCallback() {
+    this._stopLoop();
+    if (this._ro) { this._ro.disconnect(); this._ro = null; }
+    super.disconnectedCallback();
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────────
+
+  /** Resolve a `var(--x)` color string to its computed value (canvas can't use vars). */
+  _resolveColor() {
+    const c = (this.color || "").trim();
+    const m = /^var\((--[\w-]+)\)$/.exec(c);
+    this._resolvedColor = m
+      ? (getComputedStyle(this).getPropertyValue(m[1]).trim() || "#39ff7a")
+      : (c || "#39ff7a");
+  }
+
+  _setupCanvas() {
+    const canvas = this.querySelector("canvas");
+    if (!canvas) return;
+    const W = this.autosize ? Math.round(this.clientWidth || this.w) : this.w;
+    const H = this.h;
+    if (W < 1 || H < 1) return; // not laid out yet — ResizeObserver will re-fire
+    if (this._ctx && this._W === W && this._H === H) return; // unchanged (avoid clearing the trail)
+    this._W = W;
+    this._H = H;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(W * dpr);
+    canvas.height = Math.round(H * dpr);
+    canvas.style.width = W + "px";
+    canvas.style.height = H + "px";
+    const ctx = canvas.getContext("2d");
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0); // draw in CSS px; crisp on hi-dpi
+    this._ctx = ctx;
+    this._buf = [];
+    this._head = 0;
+    this._lastTs = null;
+    ctx.clearRect(0, 0, W, H);
+  }
+
+  _startLoop() {
+    if (this._rafId != null || !this._ctx) return; // guard against double-start
+    const tick = (ts) => {
+      this._frame(ts);
+      this._rafId = requestAnimationFrame(tick);
+    };
+    this._rafId = requestAnimationFrame(tick);
+  }
+
+  _stopLoop() {
+    if (this._rafId != null) {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = null;
+    }
+    this._lastTs = null;
+  }
+
+  _frame(ts) {
+    const ctx = this._ctx;
+    if (!ctx) return;
+    const now = ts / 1000;
+    const dt = this._lastTs != null ? Math.min(now - this._lastTs, 0.05) : 0;
+    this._lastTs = now;
+
+    const W = this._W, H = this._H;
+    const frac = Math.max(0, Math.min(1, Number(this.frac) || 0));
+    const color = this._resolvedColor;
+    const pts = frac <= 0
+      ? [{ x: 0, y: H / 2 }, { x: W, y: H / 2 }]
+      : (this.kind === "pulse" ? pulsePoints({ frac, width: W, height: H })
+                               : ecgPoints({ frac, width: W, height: H }));
+
+    // Sample the swept slice with the CURRENT shape (history keeps older shapes).
+    const sweepT = W / Math.max(1, this.speed);
+    const trailDur = sweepT * Math.max(0.05, this.trail);
+    const target = this._head + this.speed * dt;
+    while (this._head < target) {
+      const segStart = this._head;
+      const next = Math.min(this._head + STEP, target);
+      const x = next % W;
+      const gap = Math.floor(next / W) !== Math.floor(segStart / W); // crossed the edge
+      this._buf.push({ x, y: sampleY(pts, x), t: now, gap });
+      this._head = next;
+    }
+    const cutoff = now - trailDur;
+    while (this._buf.length && this._buf[0].t < cutoff) this._buf.shift();
+
+    // Redraw from scratch: clear, then stroke each age-band as one glowing path.
+    ctx.clearRect(0, 0, W, H);
+    ctx.lineWidth = 1.3;
+    ctx.lineJoin = "round";
+    ctx.lineCap = "round";
+    ctx.strokeStyle = color;
+    ctx.shadowColor = color;
+    ctx.shadowBlur = this.bloom;
+    const bandOf = (p) => Math.floor(((now - p.t) / trailDur) * NB);
+    let curBand = -1, open = false;
+    const flush = () => { if (open) { ctx.globalAlpha = 1 - (curBand + 0.5) / NB; ctx.stroke(); open = false; } };
+    for (let i = 1; i < this._buf.length; i++) {
+      const a = this._buf[i - 1], b = this._buf[i];
+      const band = bandOf(b);
+      if (b.gap || band >= NB) { flush(); curBand = -1; continue; }
+      if (band !== curBand) { flush(); ctx.beginPath(); ctx.moveTo(a.x, a.y); curBand = band; open = true; }
+      ctx.lineTo(b.x, b.y);
+    }
+    flush();
+    ctx.globalAlpha = 1;
+
+    // Leading dot rides the newest point.
+    if (this._buf.length) {
+      const p = this._buf[this._buf.length - 1];
+      ctx.fillStyle = color;
+      ctx.shadowColor = color;
+      ctx.shadowBlur = this.bloom + 3;
+      ctx.beginPath(); ctx.arc(p.x, p.y, 2, 0, Math.PI * 2); ctx.fill();
+      ctx.fillStyle = "#eaffff";
+      ctx.shadowBlur = 0;
+      ctx.beginPath(); ctx.arc(p.x, p.y, 0.8, 0, Math.PI * 2); ctx.fill();
+    }
+    ctx.shadowBlur = 0;
+  }
+}
+
+customElements.define("starnet-waveform", StarnetWaveform);

--- a/js/ui/preview.js
+++ b/js/ui/preview.js
@@ -352,3 +352,67 @@ if (degH && degD) {
   degD.addEventListener("input", syncDegrade);
   syncDegrade();
 }
+
+// Vital waveforms demo
+const wfDemo        = document.getElementById("waveform-demo");
+const waveHealth    = document.getElementById("wave-health");
+const waveDeck      = document.getElementById("wave-deck");
+const waveHealthVal = document.getElementById("wave-health-val");
+const waveDeckVal   = document.getElementById("wave-deck-val");
+const waveToggle    = document.getElementById("wave-layout-toggle");
+
+if (wfDemo && waveHealth && waveDeck && waveToggle) {
+  const ecg = document.createElement("starnet-waveform");
+  ecg.kind = "ecg";
+  ecg.color = "var(--green)";
+  ecg.label = "HEALTH";
+  ecg.frac = 1;
+  const pulse = document.createElement("starnet-waveform");
+  pulse.kind = "pulse";
+  pulse.color = "var(--violet)";
+  pulse.label = "DECK";
+  pulse.frac = 1;
+  wfDemo.append(ecg, pulse);
+
+  waveHealth.addEventListener("input", () => {
+    ecg.frac = +waveHealth.value / 100;
+    waveHealthVal.textContent = String(waveHealth.value);
+  });
+  waveDeck.addEventListener("input", () => {
+    pulse.frac = +waveDeck.value / 100;
+    waveDeckVal.textContent = String(waveDeck.value);
+  });
+
+  // Sweep/persistence/glow tuning — applies to both traces.
+  const waveSpeed = document.getElementById("wave-speed");
+  const waveTrail = document.getElementById("wave-trail");
+  const waveBloom = document.getElementById("wave-bloom");
+  const bindBoth = (el, valId, prop, scale, fmt) => {
+    if (!el) return;
+    const out = document.getElementById(valId);
+    el.addEventListener("input", () => {
+      const v = scale ? +el.value / scale : +el.value;
+      ecg[prop] = v; pulse[prop] = v;
+      if (out) out.textContent = fmt ? fmt(el.value) : String(el.value);
+    });
+  };
+  bindBoth(waveSpeed, "wave-speed-val", "speed", 0);
+  bindBoth(waveTrail, "wave-trail-val", "trail", 100, (v) => (v / 100).toFixed(2));
+  bindBoth(waveBloom, "wave-bloom-val", "bloom", 0);
+
+  let waveLayout = "layout-inline";
+  waveToggle.addEventListener("click", () => {
+    wfDemo.classList.remove(waveLayout);
+    waveLayout = waveLayout === "layout-inline" ? "layout-strip" : "layout-inline";
+    wfDemo.classList.add(waveLayout);
+    if (waveLayout === "layout-strip") {
+      ecg.w = 240;
+      pulse.w = 240;
+      waveToggle.textContent = "INLINE";
+    } else {
+      ecg.w = 120;
+      pulse.w = 120;
+      waveToggle.textContent = "STRIP";
+    }
+  });
+}

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -51,6 +51,7 @@ export function initVisualRenderer() {
     }
     syncOverlays(state);
     syncHud(state);
+    syncVitals(state);
     updateGraphDegradation(state);
     const node = state.selectedNodeId ? state.nodes[state.selectedNodeId] : null;
     if (node && node.visibility !== "revealed") {
@@ -352,6 +353,18 @@ function syncOverlays(state) {
   }
 }
 
+// ── Vital waveform strips ─────────────────────────────────
+// Full-width ECG / deck-pulse traces framing the graph (index.html). Driven by the
+// player's health / deck-integrity fractions. Absent on preview/playground — guarded.
+
+function syncVitals(state) {
+  const ecgEl = /** @type {any} */ (document.getElementById("vital-ecg"));
+  const deckEl = /** @type {any} */ (document.getElementById("vital-deck"));
+  const h = state.player.health, d = state.player.deckIntegrity;
+  if (ecgEl) ecgEl.frac = h.max > 0 ? h.current / h.max : 0;
+  if (deckEl) deckEl.frac = d.max > 0 ? d.current / d.max : 0;
+}
+
 // ── HUD sync ──────────────────────────────────────────────
 
 function syncHud(state) {
@@ -362,10 +375,6 @@ function syncHud(state) {
     hudEl.traceSeconds = state.traceSecondsRemaining;
     hudEl.isCheating = state.isCheating;
     hudEl.phase = state.phase;
-    hudEl.health = state.player.health.current;
-    hudEl.healthMax = state.player.health.max;
-    hudEl.deckIntegrity = state.player.deckIntegrity.current;
-    hudEl.deckIntegrityMax = state.player.deckIntegrity.max;
 
     // Connection status
     const detecting = getVisibleTimers().some((t) => t.label === "ICE DETECTION");

--- a/js/ui/waveform.js
+++ b/js/ui/waveform.js
@@ -1,0 +1,232 @@
+// @ts-check
+// Pure SVG/canvas waveform geometry — no DOM, no Math.random.
+// Visualises player health (neural/meat) and deck integrity as vital-sign traces.
+//
+//   ecgPoints   — health: a clinical PQRST(+U) heartbeat complex; beats speed up and
+//                 grow erratic as health falls.
+//   pulsePoints — deck integrity: a clean double square pulse that develops ringing,
+//                 dropouts and amplitude/width glitches as integrity falls.
+//
+// The shapes are STATIC and anchored to [0,width] — they do not scroll. The animated
+// "drawn left-to-right on a vector CRT" sweep + phosphor trail lives in the
+// <starnet-waveform> component, which samples these points with sampleY(). Keeping the
+// geometry static and pure makes it deterministic and unit-testable.
+//
+// All variation uses hash01() (deterministic from a numeric seed) — never Math.random —
+// so a given (frac, width, height) always yields identical output.
+
+/**
+ * @typedef {{ x: number, y: number }} Point
+ */
+
+// ── private helpers ──────────────────────────────────────────────────────────
+
+/** Linear interpolation. @param {number} a @param {number} b @param {number} t @returns {number} */
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+/** Clamp to [0,1]; non-finite → 0. @param {number} v @returns {number} */
+function clamp01(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+// ── public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Deterministic hash: maps any number to a value in [0, 1). sin-based scatter — fast,
+ * no dependencies, no Math.random.
+ * @param {number} n
+ * @returns {number}
+ */
+export function hash01(n) {
+  const s = Math.sin(n) * 43758.5453;
+  return s - Math.floor(s);
+}
+
+/**
+ * Health ECG — a flat baseline punctuated by clinical heartbeat complexes:
+ * P (small hump) → flat PR → Q/R/S (sharp QRS spike) → flat ST → T (wider hump) →
+ * U (small trailing hump) → flat diastole to the next beat.
+ *
+ * Beat count rises with damage (4 healthy → 7 near-dead) and beat spacing/amplitude
+ * gain jitter as health falls.
+ *
+ * @param {{ frac: number, width: number, height: number }} opts
+ *   frac — health 0..1 (0 = flat line)
+ * @returns {Array<Point>} vertices in ascending x within [0,width]×[0,height]
+ */
+export function ecgPoints({ frac, width, height }) {
+  const f = clamp01(frac);
+  const W = width, H = height, mid = H / 2;
+  if (f <= 0) return [{ x: 0, y: mid }, { x: W, y: mid }];
+
+  // Period is height-relative, so each beat keeps the same aspect at any strip width;
+  // a wider strip shows MORE beats rather than stretching a fixed few. Damage shortens
+  // the period (faster heart rate). Tuned to match the lab proportions.
+  const period = H * lerp(1.15, 2.0, f);
+  const beats = Math.max(1, Math.floor(W / period));
+  const cw = Math.min(period * 0.72, period - 2); // complex width; rest is flat diastole
+  const top = H * 0.04, bot = H * 0.96;            // headroom so glow doesn't clip
+  const cl = (y) => Math.max(top, Math.min(bot, y));
+  const spike0 = H * 0.56;                          // R height
+  const P = H * 0.13, Q = H * 0.08, S = H * 0.2, T = H * 0.22, U = H * 0.07;
+  const erratic = 1 - f;
+
+  /** @type {Array<Point>} */
+  const pts = [{ x: 0, y: mid }];
+  for (let k = 0; k < beats; k++) {
+    const spike = spike0 * lerp(1, lerp(0.8, 1.2, hash01(k * 13.7 + 2.3)), erratic);
+    const jit = lerp(0, period * 0.12, erratic) * (hash01(k * 7.3 + 1.1) - 0.5) * 2;
+    const bx = k * period + period * 0.1 + jit;
+    const X = (fr) => bx + cw * fr;
+    pts.push({ x: X(0.00), y: mid });
+    pts.push({ x: X(0.06), y: mid });
+    pts.push({ x: X(0.10), y: mid - P * 0.7 });     // P wave
+    pts.push({ x: X(0.13), y: mid - P });
+    pts.push({ x: X(0.16), y: mid - P * 0.7 });
+    pts.push({ x: X(0.20), y: mid });
+    pts.push({ x: X(0.28), y: mid });               // PR segment
+    pts.push({ x: X(0.31), y: cl(mid + Q) });       // Q
+    pts.push({ x: X(0.34), y: cl(mid - spike) });   // R
+    pts.push({ x: X(0.37), y: cl(mid + S) });       // S
+    pts.push({ x: X(0.41), y: mid });               // J point
+    pts.push({ x: X(0.52), y: mid });               // ST segment
+    pts.push({ x: X(0.58), y: mid - T * 0.5 });     // T wave
+    pts.push({ x: X(0.66), y: mid - T });
+    pts.push({ x: X(0.74), y: mid - T * 0.5 });
+    pts.push({ x: X(0.80), y: mid });
+    pts.push({ x: X(0.86), y: mid - U * 0.7 });     // U wave
+    pts.push({ x: X(0.89), y: mid - U });
+    pts.push({ x: X(0.92), y: mid - U * 0.7 });
+    pts.push({ x: X(0.96), y: mid });
+  }
+  pts.push({ x: W, y: mid });
+  return pts;
+}
+
+/**
+ * Deck-integrity pulse — a clean, defined double square pulse (main + smaller follow),
+ * clustered early in each cell with flat space before the next. As integrity falls the
+ * regulation breaks down: edges develop deepening, lengthening overshoot/ring (jagged),
+ * plateaus shrink and go ragged, and pulses occasionally drop out or get their height/
+ * width glitched. Amplitude stays roughly constant (degradation reads as chaos, not
+ * flattening); timing stays metronomic.
+ *
+ * @param {{ frac: number, width: number, height: number }} opts
+ *   frac — integrity 0..1 (0 = flat line)
+ * @returns {Array<Point>} vertices in ascending x within [0,width]×[0,height]
+ */
+export function pulsePoints({ frac, width, height }) {
+  const f = clamp01(frac);
+  const W = width, H = height, mid = H / 2;
+  if (f <= 0) return [{ x: 0, y: mid }, { x: W, y: mid }];
+
+  const dmg = 1 - f;
+  // Height-relative cell width → constant aspect; wider strips show more pulses
+  // (lab-matched proportions) rather than stretching a fixed count.
+  const period = H * 2.0;
+  const CELLS = Math.max(1, Math.floor(W / period));
+  const mTop = H * 0.04, mBot = H * 0.96;
+  const cl = (y) => Math.max(mTop, Math.min(mBot, y));
+  const halfAmp = H * lerp(0.3, 0.38, f);   // ~constant amplitude across health
+  const base = cl(mid + halfAmp);
+  const top = cl(mid - halfAmp);
+  const follow = cl(mid - halfAmp * 0.55);   // smaller second pulse
+
+  // Ring escalates on a curve: shows EARLY and takes over near 0. Jaggedness is
+  // vertical (depth + wobble count); horizontal width stays modest so timing holds.
+  const ramp = Math.pow(dmg, 0.4);
+  const over = H * lerp(0.015, 0.34, ramp);
+  const ringW = period * lerp(0.018, 0.05, ramp);
+  const nw = Math.round(lerp(1, 7, ramp));
+
+  /** Damped overshoot edge from fromY to toY at x, settling over ringW with nw wobbles. */
+  const ring = (pts, x, fromY, toY) => {
+    const dir = toY < fromY ? -1 : 1;
+    const step = ringW / (nw + 2);
+    pts.push({ x, y: fromY });
+    pts.push({ x: x + step * 0.6, y: cl(toY + dir * over) });
+    for (let w = 1; w <= nw; w++) {
+      pts.push({ x: x + step * (w + 0.6), y: cl(toY + dir * over * Math.pow(-0.62, w)) });
+    }
+    pts.push({ x: x + ringW, y: toY });
+  };
+
+  const peaks = [
+    { level: top, gap: 0.08, w: 0.2 },     // main — wide square, shifted off the left edge
+    { level: follow, gap: 0.38, w: 0.09 }, // smaller follow
+  ];
+
+  /** @type {Array<Point>} */
+  const pts = [{ x: 0, y: base }];
+  for (let c = 0; c < CELLS; c++) {
+    const cx = c * period;
+    pts.push({ x: cx, y: base });
+    let cur = cx; // monotonic guard only — fixed gaps mean timing doesn't stretch
+    peaks.forEach((pk, pi) => {
+      const gk = c * 17.7 + pi * 4.3;
+      let level = pk.level, skip = false, wMul = 1;
+      if (hash01(gk * 1.7 + 2.1) < ramp * 0.6) {
+        const s = hash01(gk * 0.9 + 5.5);
+        if (s < 0.22) skip = true;                              // dropped pulse
+        else level = base - (base - pk.level) * lerp(0.3, 1.5, s); // scrambled height
+      }
+      if (hash01(gk * 2.3 + 8.8) < ramp * 0.5) {               // glitched width
+        wMul = lerp(0.4, 1.8, hash01(gk * 1.1 + 3.3));
+      }
+      const xr = Math.max(cx + period * pk.gap, cur + ringW * 0.6);
+      if (skip || Math.abs(level - base) < 1) {
+        pts.push({ x: xr, y: base }); cur = xr;                // flat — pulse skipped
+      } else {
+        pts.push({ x: xr, y: base });
+        ring(pts, xr, base, level);                            // rise + overshoot
+        const plW = period * pk.w * (1 - 0.55 * ramp) * wMul;  // plateau shrinks with damage
+        const x0 = xr + ringW, xf = x0 + plW, segs = 4;
+        for (let j = 1; j <= segs; j++) {
+          const noise = ramp * over * 0.6 * (hash01(gk * 5.3 + j * 2.7) - 0.5) * 2;
+          pts.push({ x: x0 + (plW * j) / segs, y: cl(level + noise) }); // ragged plateau
+        }
+        ring(pts, xf, level, base);                            // fall + undershoot
+        cur = xf + ringW;
+      }
+    });
+    pts.push({ x: cx + period, y: base });
+  }
+  pts.push({ x: W, y: base }); // flat tail to the right edge (count rarely divides W evenly)
+  return pts;
+}
+
+/**
+ * Sample the y of a monotonic-in-x polyline at a given x (linear interpolation along
+ * the segment spanning x). Used by the sweep renderer to draw the trace head.
+ * @param {Array<Point>} pts  vertices in ascending x
+ * @param {number} x
+ * @returns {number}
+ */
+export function sampleY(pts, x) {
+  if (pts.length === 0) return 0;
+  for (let i = 1; i < pts.length; i++) {
+    const a = pts[i - 1], b = pts[i];
+    if (x <= b.x) {
+      if (b.x === a.x) return b.y;
+      return lerp(a.y, b.y, (x - a.x) / (b.x - a.x));
+    }
+  }
+  return pts[pts.length - 1].y;
+}
+
+/**
+ * Serialize a vertex list to an SVG path `d` string using only M/L commands.
+ * Numbers rounded to 2 decimal places. (Kept for tests / any SVG consumer.)
+ * @param {Array<Point>} points
+ * @returns {string}
+ */
+export function pointsToPath(points) {
+  if (points.length === 0) return "";
+  return points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(2)} ${p.y.toFixed(2)}`)
+    .join(" ");
+}

--- a/js/ui/waveform.test.js
+++ b/js/ui/waveform.test.js
@@ -1,0 +1,174 @@
+// @ts-check
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ecgPoints,
+  pulsePoints,
+  sampleY,
+  pointsToPath,
+  hash01,
+} from "./waveform.js";
+
+const W = 120;
+const H = 28;
+const MID = H / 2; // 14
+
+const maxDev = (pts) => Math.max(...pts.map((p) => Math.abs(p.y - MID)));
+const inBounds = (pts) =>
+  pts.every((p) => p.x >= -0.01 && p.x <= W + 0.01 && p.y >= 0 && p.y <= H);
+const ascending = (pts) => pts.every((p, i) => i === 0 || p.x >= pts[i - 1].x);
+
+describe("hash01", () => {
+  test("returns a value in [0,1)", () => {
+    for (let i = 0; i < 20; i++) {
+      const v = hash01(i);
+      assert.ok(v >= 0 && v < 1, `hash01(${i}) = ${v} not in [0,1)`);
+    }
+  });
+  test("is deterministic", () => {
+    assert.equal(hash01(42), hash01(42));
+    assert.equal(hash01(999), hash01(999));
+  });
+  test("varies across inputs", () => {
+    const unique = new Set([0, 1, 2, 3, 4, 5].map((n) => hash01(n).toFixed(4)));
+    assert.ok(unique.size > 3);
+  });
+});
+
+describe("ecgPoints", () => {
+  test("frac 0 → flat 2-point baseline at mid", () => {
+    const pts = ecgPoints({ frac: 0, width: W, height: H });
+    assert.deepEqual(pts, [{ x: 0, y: MID }, { x: W, y: MID }]);
+  });
+
+  test("frac 1 → many points with a visible R spike", () => {
+    const pts = ecgPoints({ frac: 1, width: W, height: H });
+    assert.ok(pts.length > 2);
+    assert.ok(maxDev(pts) > H * 0.3, `expected tall R spike, maxDev=${maxDev(pts)}`);
+  });
+
+  test("points ascending in x and within bounds across frac", () => {
+    for (const frac of [0.1, 0.4, 0.7, 1.0]) {
+      const pts = ecgPoints({ frac, width: W, height: H });
+      assert.ok(ascending(pts), `not ascending at frac=${frac}`);
+      assert.ok(inBounds(pts), `out of bounds at frac=${frac}`);
+    }
+  });
+
+  test("beat count increases with damage", () => {
+    // R peaks sit well above the midline (small y); P/T/U humps stay below the threshold.
+    const peaks = (pts) => pts.filter((p) => MID - p.y > H * 0.25).length;
+    const healthy = peaks(ecgPoints({ frac: 1, width: W, height: H }));
+    const damaged = peaks(ecgPoints({ frac: 0.2, width: W, height: H }));
+    assert.ok(damaged > healthy, `damaged ${damaged} should exceed healthy ${healthy}`);
+  });
+
+  test("deterministic", () => {
+    assert.deepEqual(
+      ecgPoints({ frac: 0.6, width: W, height: H }),
+      ecgPoints({ frac: 0.6, width: W, height: H }),
+    );
+  });
+
+  test("different frac produces different output", () => {
+    assert.notDeepEqual(
+      ecgPoints({ frac: 1, width: W, height: H }),
+      ecgPoints({ frac: 0.5, width: W, height: H }),
+    );
+  });
+});
+
+describe("pulsePoints", () => {
+  test("frac 0 → flat 2-point baseline at mid", () => {
+    const pts = pulsePoints({ frac: 0, width: W, height: H });
+    assert.deepEqual(pts, [{ x: 0, y: MID }, { x: W, y: MID }]);
+  });
+
+  test("frac 1 → defined pulse with substantial amplitude", () => {
+    const pts = pulsePoints({ frac: 1, width: W, height: H });
+    assert.ok(pts.length > 2);
+    assert.ok(maxDev(pts) > H * 0.25, `expected bold pulse, maxDev=${maxDev(pts)}`);
+  });
+
+  test("amplitude stays substantial as integrity falls (does not flatten)", () => {
+    for (const frac of [1, 0.5, 0.2]) {
+      const dev = maxDev(pulsePoints({ frac, width: W, height: H }));
+      assert.ok(dev > H * 0.2, `frac=${frac} collapsed to maxDev=${dev}`);
+    }
+  });
+
+  test("points ascending in x and within bounds across frac", () => {
+    for (const frac of [0.1, 0.4, 0.7, 1.0]) {
+      const pts = pulsePoints({ frac, width: W, height: H });
+      assert.ok(ascending(pts), `not ascending at frac=${frac}`);
+      assert.ok(inBounds(pts), `out of bounds at frac=${frac}`);
+    }
+  });
+
+  test("deterministic", () => {
+    assert.deepEqual(
+      pulsePoints({ frac: 0.4, width: W, height: H }),
+      pulsePoints({ frac: 0.4, width: W, height: H }),
+    );
+  });
+});
+
+describe("frac clamping (both)", () => {
+  test("ecg: frac 1.5 == frac 1; frac -0.5 == flat", () => {
+    assert.deepEqual(
+      ecgPoints({ frac: 1.5, width: W, height: H }),
+      ecgPoints({ frac: 1, width: W, height: H }),
+    );
+    assert.deepEqual(ecgPoints({ frac: -0.5, width: W, height: H }),
+      [{ x: 0, y: MID }, { x: W, y: MID }]);
+  });
+  test("pulse: frac 1.5 == frac 1; frac -0.5 == flat", () => {
+    assert.deepEqual(
+      pulsePoints({ frac: 1.5, width: W, height: H }),
+      pulsePoints({ frac: 1, width: W, height: H }),
+    );
+    assert.deepEqual(pulsePoints({ frac: -0.5, width: W, height: H }),
+      [{ x: 0, y: MID }, { x: W, y: MID }]);
+  });
+});
+
+describe("sampleY", () => {
+  test("flat line returns the baseline anywhere", () => {
+    const flat = [{ x: 0, y: 14 }, { x: 120, y: 14 }];
+    assert.equal(sampleY(flat, 0), 14);
+    assert.equal(sampleY(flat, 60), 14);
+    assert.equal(sampleY(flat, 120), 14);
+  });
+  test("interpolates linearly along a segment", () => {
+    const line = [{ x: 0, y: 0 }, { x: 10, y: 10 }];
+    assert.equal(sampleY(line, 0), 0);
+    assert.equal(sampleY(line, 5), 5);
+    assert.equal(sampleY(line, 10), 10);
+  });
+  test("past the last point returns the last y", () => {
+    const line = [{ x: 0, y: 0 }, { x: 10, y: 10 }];
+    assert.equal(sampleY(line, 15), 10);
+  });
+  test("empty array returns 0", () => {
+    assert.equal(sampleY([], 5), 0);
+  });
+});
+
+describe("pointsToPath", () => {
+  test("starts with M, uses L thereafter", () => {
+    const path = pointsToPath([{ x: 0, y: 14 }, { x: 60, y: 4 }, { x: 120, y: 14 }]);
+    assert.ok(path.startsWith("M"));
+    assert.ok(path.includes("L"));
+  });
+  test("only M/L/digits/dot/minus/space, 2-decimal rounding", () => {
+    const path = pointsToPath([{ x: 1.23456, y: 7.89123 }, { x: 10.5, y: 4 }]);
+    assert.match(path, /^[ML0-9.\- ]+$/);
+    assert.ok(path.includes("1.23"));
+    assert.ok(!path.includes("1.2345"));
+  });
+  test("single point is only M; empty is ''", () => {
+    assert.ok(pointsToPath([{ x: 5, y: 10 }]).startsWith("M"));
+    assert.ok(!pointsToPath([{ x: 5, y: 10 }]).includes("L"));
+    assert.equal(pointsToPath([]), "");
+  });
+});

--- a/preview.html
+++ b/preview.html
@@ -243,11 +243,46 @@
         <h2>Alert States</h2>
         <p style="color:#445544; font-size:10px; margin:2px 0;">Green / Yellow / Red / Rebooting shown in graph</p>
       </div>
+
+      <!-- Vital Waveforms — <starnet-waveform> component demo (js/ui/preview.js). -->
+      <div class="section">
+        <h2>Vital Waveforms</h2>
+        <div id="waveform-demo" class="layout-inline"></div>
+        <div class="btn-row">
+          <label>HEALTH</label>
+          <input type="range" id="wave-health" min="0" max="100" step="1" value="100">
+          <span id="wave-health-val">100</span>
+        </div>
+        <div class="btn-row">
+          <label>DECK</label>
+          <input type="range" id="wave-deck" min="0" max="100" step="1" value="100">
+          <span id="wave-deck-val">100</span>
+        </div>
+        <div class="btn-row">
+          <label>SPEED</label>
+          <input type="range" id="wave-speed" min="20" max="320" step="5" value="100">
+          <span id="wave-speed-val">100</span>
+        </div>
+        <div class="btn-row">
+          <label>TRAIL×</label>
+          <input type="range" id="wave-trail" min="30" max="160" step="5" value="80">
+          <span id="wave-trail-val">0.80</span>
+        </div>
+        <div class="btn-row">
+          <label>BLOOM</label>
+          <input type="range" id="wave-bloom" min="0" max="20" step="1" value="14">
+          <span id="wave-bloom-val">14</span>
+        </div>
+        <div class="btn-row">
+          <button id="wave-layout-toggle">STRIP</button>
+        </div>
+      </div>
     </div>
   </div>
 
   <script src="dist/vendor.js"></script>
   <script type="module" src="js/ui/components/starnet-hand.js"></script>
+  <script type="module" src="js/ui/components/starnet-waveform.js"></script>
   <script type="module" src="js/ui/preview.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replaces the HUD's HEALTH/DECK bar meters with two animated **vital-sign traces** (a Zoids heart-monitor homage), stacked at the top of the sidebar.
- Why: the two existing damage tracks (`player.health`, `player.deckIntegrity`) read better as living instruments than as static bars, and it fits the retro vector-CRT aesthetic. After trying header and full-width-strip placements, the sidebar stack keeps the net graph as the hero while giving the traces room to read.

## What it looks like
- **HEALTH** — a clinical **PQRST(+U) ECG** complex; the beat speeds up and grows erratic as health falls; flatlines at zero.
- **DECK INTEGRITY** — a defined **double square-pulse**; as integrity falls it develops deepening ringing, dropouts and timing/amplitude/width glitches (amplitude stays roughly constant — degradation reads as *chaos*, not flattening).
- Both are drawn as a **vector-CRT sweep**: a dot draws the trace left→right with a fading phosphor trail. Each has a **label + depleting 5-pip meter** (green→yellow→red, card-style).

## Design / implementation
- **`js/ui/waveform.js`** — pure, deterministic, static geometry (no `Math.random`; `hash01`). Period is height-relative so wider panels show *more* pulses at constant aspect. Exposes `ecgPoints`/`pulsePoints`/`sampleY`/`pointsToPath`.
- **`<starnet-waveform>`** — SVG → `<canvas>` sweep renderer: time-stamped history buffer redrawn each frame (clear + age→alpha = exact fade, no burn-in), glow paid per age-band, dpr-scaled, `autosize` to container, optional `meter` header. Animation state is ephemeral (never in game state).
- **`visual-renderer.syncVitals`** drives the strip fracs from health/deck integrity; HUD header drops the meters.
- Tests rewritten for the static geometry (23). Preview harness has speed/trail/bloom sliders + inline/strip toggle. `CLAUDE.md` (visual effects now in scope) + `MANUAL.md` updated.

## Test Plan
- [x] `make check` (953 tests, 0 fail; lint clean)
- [x] Renders with no console errors on `/` and `/preview.html` (verified via Playwright)
- [ ] **Manual:** play a run and confirm the traces degrade with damage and the pip meters ramp green→red.

## References
- Spec: `docs/dev-sessions/2026-06-11-1315-vital-waveforms/spec.md`
- Plan: `docs/dev-sessions/2026-06-11-1315-vital-waveforms/plan.md`
- Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)