### PR TITLE
fix: context menu no longer jumps after opening

### DIFF
--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -251,9 +251,16 @@ function syncContextMenu(node, state) {
   menu.nodeId = node.id;
   menu.visible = true;
 
-  _positionContextMenu(node.id);
-  menu.style.opacity = "1";
-  menu.style.pointerEvents = "auto";
+  // Lit renders asynchronously, so the menu's buttons aren't in the DOM yet —
+  // measuring offsetHeight now would read a stale (empty) height and mis-center
+  // the menu vertically. Defer positioning until the render flushes, and keep
+  // it hidden until then so it reveals already-centered (no visible jump).
+  menu.updateComplete.then(() => {
+    if (contextMenuNodeId !== node.id) return; // selection changed while awaiting
+    _positionContextMenu(node.id);
+    menu.style.opacity = "1";
+    menu.style.pointerEvents = "auto";
+  });
 }
 
 function clearContextMenu() {


### PR DESCRIPTION
The node context menu appeared too low on open, then abruptly adjusted upward to center on the node a moment later.

## Root cause

`syncContextMenu` positioned the menu **synchronously** right after setting `menu.visible = true` / `menu.actions`. But Lit renders **asynchronously** — the menu had no buttons in the DOM yet, so `menu.offsetHeight` read a stale (~0) height. The vertical centering math `y = pos.y - mh/2` therefore placed the menu *top* at the node center (too low). A later `pan`/`zoom`/`position` event re-ran the positioning with the correct height and recentered it — the visible upward jump.

The sibling `openActionChoices` flow already guards against this with a `requestAnimationFrame`-deferred measurement (with an explanatory comment); the context menu simply never got the same treatment.

## Fix

Defer positioning until after Lit flushes its render by awaiting the component’s `updateComplete` promise, and keep the menu at `opacity: 0` until then so it reveals already-centered.

## Verification

No unit test — `offsetHeight` is 0 under jsdom, so a node test can’t reproduce a real-layout timing bug. Verified in-browser via Playwright by sampling the menu’s `top` and computed `opacity` across animation frames after selecting a node:

- frame 0: opacity 0, top 188 (stale, invisible)
- frame 1: opacity 0, top 205 (repositioned, still invisible)
- frame 2: opacity 0.05 (first perceptible), top **205** ✓ already final
- frames 3–11: opacity → 1, top stays 205

The reposition completes entirely within the `opacity: 0` window, one frame before the menu becomes visible — no visible jump.

`make check`: 930 tests pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)