### PR TITLE
fix: reconcile duplicate exploit-card ids so every hand card is playable

### DIFF
--- a/js/core/exploits.js
+++ b/js/core/exploits.js
@@ -148,6 +148,35 @@ const EXPLOIT_SUFFIXES = ["v1.0", "v2.1", "v3.0", "mk2", "Pro", "X", "Zero", "Pr
 export let _exploitIdCounter = 1;
 export function setExploitIdCounter(n) { _exploitIdCounter = n; }
 
+/**
+ * Ensure every card in `hand` has an id unique within the hand, and advance
+ * _exploitIdCounter past every hand id so future mints (store/mine) can't collide.
+ *
+ * Card ids are minted `${vuln}-${counter}`, but the counter resets per browser
+ * session while profile cards persist across sessions — so a carried card and a
+ * freshly-minted one can share an id. The whole exploit pipeline keys off `id` and
+ * takes the first match, so a collision makes the second card un-selectable
+ * (lookups land on the first card). Re-mint duplicates to restore the per-card-unique
+ * invariant. Idempotent for already-unique hands. Mutates cards in place.
+ * @param {ExploitCard[]} hand
+ */
+export function reconcileHandIds(hand) {
+  if (!Array.isArray(hand)) return;
+  // First pass: lift the counter above every existing suffix so re-mints are safe.
+  for (const card of hand) {
+    const m = /-(\d+)$/.exec(card?.id ?? "");
+    if (m) _exploitIdCounter = Math.max(_exploitIdCounter, Number(m[1]) + 1);
+  }
+  // Second pass: re-mint any duplicate (or missing) id, keeping the first occurrence.
+  const seen = new Set();
+  for (const card of hand) {
+    if (card.id && !seen.has(card.id)) { seen.add(card.id); continue; }
+    const primary = card.targetVulnTypes?.[0] ?? "card";
+    card.id = `${primary}-${_exploitIdCounter++}`;
+    seen.add(card.id);
+  }
+}
+
 function rollRarity() {
   let roll = random(RNG.EXPLOIT) * TOTAL_WEIGHT;
   for (const { rarity, weight } of RARITY_WEIGHTS) {

--- a/js/core/state/index.js
+++ b/js/core/state/index.js
@@ -25,7 +25,7 @@
 
 import { RNG, initRng, getSeed, serializeRng, deserializeRng, randomPick, randomInt, random } from "../rng.js";
 import { pickIceTypeId, getType } from "../ice/index.js";
-import { generateStartingHand, generateVulnerabilities, _exploitIdCounter, setExploitIdCounter } from "../exploits.js";
+import { generateStartingHand, generateVulnerabilities, _exploitIdCounter, setExploitIdCounter, reconcileHandIds } from "../exploits.js";
 import { generateMacguffin, flagMissionMacguffin } from "../loot.js";
 import { clearAll as clearAllTimers, serializeTimers, deserializeTimers, setGraphForTick } from "../timers.js";
 import { emitEvent, E } from "../events.js";
@@ -176,6 +176,11 @@ export function initGame(buildNetworkFn, seedString, opts = {}) {
     lastDisturbedNodeId: null,
     mission: null,
   };
+
+  // Guarantee per-card-unique ids: carried profile cards may bring ids that
+  // collide with freshly-generated ones (the counter resets per session). The
+  // exploit pipeline keys off `id`, so duplicates make cards un-selectable.
+  reconcileHandIds(state.player.hand);
 
   // Register graph sync on the node setter module
   setNodeGraph(graph);
@@ -346,6 +351,10 @@ export function deserializeState(snapshot, opts = {}) {
   if (_rng) deserializeRng(_rng);
   else initRng(gameState.seed ?? undefined);
   if (exploitId != null) setExploitIdCounter(exploitId);
+
+  // Heal saves whose hand carries colliding card ids (see initGame). Runs after
+  // the counter is restored so re-mints continue above the snapshot's id space.
+  if (state?.player?.hand) reconcileHandIds(state.player.hand);
 
   // Restore NodeGraph from snapshot
   if (_nodeGraph) {

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1459,3 +1459,61 @@ describe("EXEC dispatch echo", () => {
     assert.equal(getState().nodes["ids-1"].forwardingEnabled, false, "script ran");
   });
 });
+
+// ── Exploit card id uniqueness ────────────────────────────────────────────────
+// Regression: card ids are minted `${vuln}-${counter}`, but the counter resets per
+// session while profile cards persist across sessions — so a carried card and a
+// freshly-minted one can share an id. The exploit pipeline keys off `id` and takes
+// the first match, so the second card silently no-ops (the reported "SnmpWalker X
+// does nothing" bug — first match was a disclosed/0-uses card).
+
+describe("Exploit cards: duplicate id reconciliation", () => {
+  const DUP_ID = "stale-firmware-1";
+  const makeDupHand = () => ([
+    // Mirrors the reported save: same id, first is dead, second is the one the
+    // player tries to play.
+    { id: DUP_ID, name: "AuthBrute Prime", rarity: "common", quality: 0.22, targetVulnTypes: ["stale-firmware"], decayState: "disclosed", usesRemaining: 0, instanceId: "inv-0" },
+    { id: DUP_ID, name: "SnmpWalker X",    rarity: "common", quality: 0.47, targetVulnTypes: ["stale-firmware"], decayState: "fresh",     usesRemaining: 3, instanceId: "inv-6" },
+  ]);
+
+  function buildDupHandLAN() {
+    return {
+      graphDef: {
+        nodes: [
+          createGateway("gateway", { attributes: { visibility: "accessible" } }),
+          createRouter("router-a"),
+        ],
+        edges: [["gateway", "router-a"]],
+        triggers: [],
+      },
+      meta: { startNode: "gateway", startCash: 0, moneyCost: "C", ice: null, startHandCards: makeDupHand() },
+    };
+  }
+
+  beforeEach(() => {
+    clearAll();
+    initGame(buildDupHandLAN, "itest-dupid");
+  });
+
+  it("gives each hand card a unique id at game init", () => {
+    const ids = getState().player.hand.map((c) => c.id);
+    assert.equal(new Set(ids).size, ids.length, `hand ids must be unique, got: ${ids.join(", ")}`);
+  });
+
+  it("lets the live duplicate-id card execute instead of no-opping on the dead one", () => {
+    const snmp = getState().player.hand.find((c) => c.name === "SnmpWalker X");
+    assert.ok(snmp, "SnmpWalker X present in hand");
+    // The GUI/console dispatch the clicked card's own id; with a collision this
+    // resolves to the first (disclosed) card and returns early.
+    getState().nodeGraph._ctx.startExploit("gateway", snmp.id);
+    assert.equal(getState().nodes["gateway"].exploiting, true, "the fresh card's exploit should start");
+  });
+
+  it("reconciles duplicate ids when loading a serialized save", () => {
+    const snap = serializeState();
+    snap.player.hand = makeDupHand(); // simulate a corrupt save like the reported one
+    deserializeState(snap);
+    const ids = getState().player.hand.map((c) => c.id);
+    assert.equal(new Set(ids).size, ids.length, `loaded hand ids must be unique, got: ${ids.join(", ")}`);
+  });
+});


### PR DESCRIPTION
A playtest save surfaced a bug: the **SnmpWalker X** card did nothing when executed from either the XPLOIT menu or the sidebar.

## Root cause

`ExploitCard.id` is minted `` `${vuln}-${counter}` `` with `_exploitIdCounter`, but the counter **resets per browser session** while profile-banked cards persist across sessions via localStorage. So a carried card and a freshly-minted one can collide on the same `id`.

The entire exploit pipeline keys off `id` and takes the **first** match (`game-ctx.js` `startExploit`, `combat.js` `launchExploit`, `player.js` `applyCardDecay`, console resolvers, status). In the reported save, SnmpWalker X (`fresh`, 3 uses) shared `stale-firmware-1` with AuthBrute Prime (`disclosed`, 0 uses), which sorts first — so `startExploit`s `decayState === "disclosed"` guard returned early. Silent no-op.

## Fix

Per discussion, keep `id` as the card key (it is woven through ~10 sites and works fine when unique) and fix the actual defect — uniqueness:

- New `reconcileHandIds(hand)` in `exploits.js` re-mints any duplicate id and advances the counter past every hand id, so store/mine cards cannot collide either. Idempotent for already-unique hands.
- Wired into **`initGame`** (fresh runs + carried-loadout hands) and **`deserializeState`** (heals existing saves like the reported one on load).
- `instanceId` — the decay-write-back key used by profile commit — is untouched.

## Tests

3 regression tests in `tests/integration.test.js`, all red before / green after:
1. each hand card gets a unique id at game init
2. the live duplicate-id card actually starts exploiting (reproduces the exact no-op symptom)
3. a serialized save with colliding ids is reconciled on load

`make check`: 956 tests pass, lint clean.

## Known minor edge (not addressed)

If a save is serialized *exactly* mid-exploit on a duplicate-id card, that node`s transient `activeExploitId` could point at the re-minted card. Vanishingly rare (exploits last seconds) and no node in the reported save was mid-exploit. Easy to add a guard if we want to close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)