### PR TITLE
Code-review + deep-audit pass: cleanups, correctness fixes, doc reframe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,9 @@
 
 ## Project Overview
 
-Starnet is a cyberpunk nethacking game with an interplanetary setting. The immediate focus is a web-based HTML prototype of the core **LAN dungeon mechanic** — a network graph puzzle the player navigates by exploiting vulnerabilities, subverting security systems, and looting macguffins for cash.
+Starnet is a cyberpunk nethacking game with an interplanetary setting. Its core is the **LAN dungeon mechanic** — a network graph puzzle the player navigates by exploiting vulnerabilities, subverting security systems, and looting macguffins for cash.
+
+It began as a single-mechanic HTML prototype and has since grown into an actively-developed game: procedural network generation, hand-authored set-piece puzzles, multiple ICE behaviors, a darknet store, health/deck loss-clock pressure, and a headless bot/census harness all ship today. "Prototype" no longer describes the scope — treat it as a maturing game in active development. (The early experiment sketches that seeded it are still listed under "Experiments / prototypes" in `docs/SPEC.md` for historical context.)
 
 See `docs/SPEC.md` for the full game design document.
 
@@ -435,20 +437,28 @@ or raster textures. This governs HUD/UI chrome, not just the graph.
 When in doubt: would an oscilloscope or a vector arcade cabinet draw it that way? If it
 needs a fill, a circle, or a dither, it's the wrong primitive.
 
-## What's In Scope (Current Prototype)
+## What's Shipped (Current Build)
 
-- Single static LAN dungeon, hand-crafted
-- Freeform macguffin hunting (no mission objectives)
-- Probe → Xploit → Dump → Fetch → Jack Out loop
-- Two-layer alert system with IDS subversion puzzle
-- Exploit card decay (use/disclosure)
+- Probe → Xploit → Dump → Fetch → Jack Out core loop
+- Procedural network generation (skeleton → slot-filler → assemble) plus hand-crafted
+  named networks and hand-authored set-piece puzzles (biomes)
+- Node-graph runtime: nodes as composable atoms/operators/triggers driving reactive behavior
+- Alert + trace system and ICE (multiple instances, grade-scaled behavior, detection/dwell)
+- Darknet store, exploit card decay (use/disclosure), health/deck loss-clock pressure
+- Headless playtest harness + automated bot + census for balance testing
+
+> **Known gap (2026-06-11 deep audit):** the *documented* two-layer IDS→monitor→TRACE
+> alert ladder is only partially wired in graph mode (the live escalation comes from graph
+> triggers, set-piece alarms, and ICE detection; the legacy `recomputeGlobalAlert` /
+> `alertState` path is largely vestigial). See the deep-audit analysis in
+> `docs/dev-sessions/2026-06-11-1810-code-review-refactor/`. Don't treat the manual's alert
+> model as fully implemented until that's reconciled.
 
 ## Out of Scope (Future)
 
-- Procedural network generation
-- Missions / quest objectives
+- Missions / quest objectives (freeform macguffin hunting today)
 - Sprites, daemons, machine elves
-- Player progression between runs
+- Full player progression / persistent meta-loop between runs (overworld is early)
 - Wider world (galaxy, planets, cities)
 - Audio
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ A cyberpunk nethacking game with an interplanetary setting.
 
 You are a decker. You jack into a corporate LAN, probe its nodes for vulnerabilities,
 exploit your way through security systems, and loot macguffins before the trace countdown
-reaches zero. One ICE entity patrols the network. The alert system is layered — subvert
-the IDS before it reports you to the security monitor.
+reaches zero. ICE patrols the network, hunting your disturbances. The alert system is
+layered — subvert the IDS before it reports you to the security monitor.
+
+Networks are either hand-crafted or procedurally generated, and seeded with hand-authored
+set-piece puzzles.
 
 **→ [Read the Player's Manual](MANUAL.md)**
 
@@ -23,8 +26,9 @@ Then open `http://localhost:3000` in a browser. No build step required.
 
 ## Tech Stack
 
-- Vanilla HTML/CSS/JS — no framework, no bundler
-- [Cytoscape.js](https://cytoscape.org/) (CDN) for network graph rendering
+- Vanilla HTML/CSS/JS — no framework; game code is unbundled ES modules
+- [Cytoscape.js](https://cytoscape.org/) for network graph rendering and [Lit](https://lit.dev/)
+  for UI components, both bundled locally via esbuild into `dist/` (run `make bundle-vendor`)
 - ES modules, JSDoc `@ts-check` for lightweight type safety
 
 ## Development

--- a/data/networks/index.js
+++ b/data/networks/index.js
@@ -1,0 +1,25 @@
+// @ts-check
+// Single source of truth for the hand-crafted named-network registry.
+// Imported by every entry point (browser main.js + headless scripts) so a new
+// network only needs to be registered here, not in four places.
+
+import { buildNetwork as buildCorporateFoothold } from "./corporate-foothold.js";
+import { buildNetwork as buildResearchStation } from "./research-station.js";
+import { buildNetwork as buildCorporateExchange } from "./corporate-exchange.js";
+import { buildNetwork as buildGenerated } from "./generated.js";
+
+/**
+ * Hand-crafted networks keyed by name. Procedural generation (`buildGenerated`)
+ * is intentionally not in this dict — it takes a spec and is selected separately.
+ * @type {Record<string, () => any>}
+ */
+export const NAMED_NETWORKS = {
+  "corporate-foothold": buildCorporateFoothold,
+  "research-station": buildResearchStation,
+  "corporate-exchange": buildCorporateExchange,
+};
+
+/** The default network name when none is specified. */
+export const DEFAULT_NETWORK = "corporate-foothold";
+
+export { buildGenerated };

--- a/docs/dev-sessions/2026-06-11-1810-code-review-refactor/deep-audit.md
+++ b/docs/dev-sessions/2026-06-11-1810-code-review-refactor/deep-audit.md
@@ -1,0 +1,212 @@
+# Deep Audit — node-graph runtime + alert/ICE event flow
+
+**Date:** 2026-06-11
+**Method:** Two agents read the named subsystems **and their tests in full** (not excerpts),
+traced complete signal paths (input → atoms/operators → edges → triggers → effects → ctx
+calls → state mutations → emitted events), and ran isolated reproductions. **Every
+high/medium finding below was then re-verified by hand against the code** before recording —
+file/line, attribute names, and the dropped/branching paths were all confirmed. Full suite
+is green (1026 tests); the bugs below are ones the green suite does **not** catch (that's
+finding T, the test-honesty problem).
+
+---
+
+## The root theme: two regimes, and the legacy alert layer is vestigial in graph mode
+
+Most of the alert findings share one cause. The game has an **older alert layer** in
+`js/core/alert.js` (`propagateAlertEvent`, `recomputeGlobalAlert`, gated on node
+`alertState` + `eventForwardingDisabled`) that predates the node-graph rewrite. Production
+always builds a `nodeGraph`, and `alert.js`'s `NODE_ALERT_RAISED` handler branches on it:
+
+```
+on(NODE_ALERT_RAISED): if (s.nodeGraph) recomputeGlobalAlert();   // graph mode (production)
+                       else { propagateAlertEvent(); recomputeGlobalAlert(); }  // legacy
+```
+
+In graph mode the real IDS→monitor chain is meant to run through graph operators/triggers
+(`relay`/`flag` operators, `forwardingEnabled` attr, `alerted` boolean). But the two layers
+drifted apart and use **different attributes for the same concepts**:
+
+| Concept | Legacy layer (alert.js) | Graph layer (shipped) |
+|---|---|---|
+| IDS subverted | `eventForwardingDisabled` (true) | `forwardingEnabled` (false) |
+| Detector tripped | `alertState` = red | `alerted` = true (boolean) |
+
+Consequences (all verified):
+- `recomputeGlobalAlert` counts red detectors/monitors by `alertState`, but **nothing in
+  graph mode ever sets an IDS/monitor `alertState`** (verified: `setNodeAlertState` is only
+  ever called on the *acted-on* node in combat/game-ctx, which is rarely a detector). So
+  `recomputeGlobalAlert` always sees zero red detectors → returns green → **inert**.
+- The CORRUPT action sets `forwardingEnabled:false` (honored by the `relay` operator), but
+  `recomputeGlobalAlert` gates on `eventForwardingDisabled` (never set). So IDS subversion
+  doesn't register with the legacy recompute — **latent**, harmless only because recompute
+  is already inert.
+- **The documented two-layer IDS→monitor→TRACE ladder does not function in graph mode.**
+  Live global escalation actually comes from: the `security` trait's `alert-escalate`
+  trigger (caps at *yellow*), set-piece `startTrace` triggers, and ICE detection
+  (`recordIceDetection`). The IDS→monitor chain tops out at yellow; TRACE arrives only from
+  ICE or set-piece alarms. This contradicts `MANUAL.md` "Detection" and CLAUDE.md's "Alert
+  System (Two-Layer)" section.
+
+**This is a decision, not just a bug:** either retire the legacy
+`eventForwardingDisabled`/`recomputeGlobalAlert`/`alertState` path (and the tests that
+exercise it), or finish wiring IDS `alertState` in graph mode and unify on one forwarding
+attribute. Leaving the polarity mismatch latent is the worst option.
+
+---
+
+## Resolution status (added after the audit)
+
+- **B1, B2, B3 — FIXED in this PR (#163)**, each TDD with a failing test first. B2's fix
+  also caught a third phantom-attr site the audit missed (the `encrypted` trait's custom
+  DUMP action) via a grep sweep — now fixed too.
+- **Root theme (legacy alert layer) — filed as #173 (P1)** for an immediate next session;
+  it's a design decision (retire vs finish-wire), not a mechanical fix.
+- **B4 — intentional**, left alone (ICE-reinvention rewrite in progress).
+- **B5/B6/B7 — not yet addressed** (low severity / latent); fold in when those areas are touched.
+
+## Confirmed bugs (verified against code)
+
+### B1. `sendMessage` silently drops any message whose origin == target node — HIGH / HIGH
+`runtime.js:101` → `_deliver` → `hasCycle(message, nodeId)` (`runtime.js:322`).
+`createMessage({origin})` seeds `path:[origin]` (`message.js:11`); `hasCycle` returns
+`path.includes(nodeId)`. So `sendMessage(nodeId, createMessage({origin: nodeId}))` is
+dropped before the node's operators run.
+
+`graph-bridge.js` does exactly this for two of three bridges:
+- `:36` XPLOIT → `exploit` message at its own node → **dropped**
+- `:46` NODE_ALERT_RAISED → `alert` message at its own node → **dropped**
+- `:31` PROBE → `probe-noise` to *neighbors* (origin ≠ target) → delivered fine.
+
+So graph-side circuits fed by the bridge's `exploit`/`alert` injection are dead: the
+`relay filter:alert` → `flag on:alert` IDS chain (corporate-pieces idsRelayChain) never
+fires via the bridge, and the honeypot `flag(on:"exploit")` never poisons via message
+(masked because `resolveLoot`/`resolveMine` also set `poisoned` directly). The core global
+alert still escalates only because of the separate legacy path. **Fix direction:** give
+bridge-injected messages a sentinel origin (e.g. `"__external__"`), or have `sendMessage`
+deliver to the named node without pre-seeding the path with it (cf. `_emitFrom`, which
+deliberately seeds the path with the *source* and delivers to neighbors — `sendMessage`
+looks like it was meant to deliver *to* the node).
+
+### B2. DUMP/FETCH timed-action progress attr desync → stale progress on cancel-restart — HIGH / MEDIUM
+Operator default progress attr is `_ta_${action}_progress` (`operators.js:358`). DUMP's
+operator uses `action:"dump"` (`traits.js:213`) → `_ta_dump_progress`, but the DUMP action
+effect resets `_ta_read_progress` (`game-types.js:115`). FETCH: operator `action:"fetch"`
+(`traits.js:220`) → `_ta_fetch_progress`, but the effect resets `_ta_loot_progress`
+(`game-types.js:135`). The verb/noun diverge for these two only (probe/xploit/mine match).
+
+Completion still works (operator drives its own attr). The bug is the **navigation-cancel**
+path (`game-ctx.js:389/394`) clears the *wrong* attrs, leaving real progress stale: DUMP to
+4/10, navigate away, restart → resumes at 5 and finishes early (reproduced). The explicit
+ABORT action is correct (it reads `active.progressAttr` from the operator). Same stringly-
+typed coupling family as backlog item / issue #170.
+
+### B3. `owned-cancel-trace` is a one-shot trigger on a repeating condition — HIGH / MEDIUM
+`traits.js:286-292` (security trait) fires `cancelTrace` `when accessLevel === "owned"` with
+no `repeating:true`, so it defaults one-shot (`triggers.js:51`). If the player owns the
+security monitor *before* any trace (a sensible "disarm the kill switch early" play), the
+trigger fires once into a no-op and is permanently `_fired`; a later trace then runs to
+`caught` even though the player owns the monitor (reproduced). The manual frames owning the
+monitor as the trace kill switch. The explicit `CANCEL_TRACE_ACTION` still works as a manual
+recovery. **Fix:** `repeating: true` (cancelTrace is idempotent). Classic CLAUDE.md
+"one-shot trigger on a repeating behavior" anti-pattern. Reproduce with a failing test first.
+
+### B4. ICE movement-pattern layer (`js/core/ice/patterns/`) is dead code — HIGH / LOW
+**Status: intentional / leave for now.** This is scaffolding for an in-progress ICE-system
+rewrite (see the "ICE reinvention" GitHub issues). Not a defect to fix in isolation — it
+will be resolved by that work. Recorded here for completeness only.
+
+Zero production imports of `patterns/` (verified); `behaviorPattern` is stored
+(`registry.js`, `state/index.js:233`) but never dispatched on. `moveInstance`
+(`ice/runtime.js:158-216`) re-implements movement inline by grade and duplicates
+`nextHopToward` verbatim in three files. Worse, the catalog *lies*: `registry.js` assigns
+A/S the `player-hunter` pattern (pathfinds to `selectedNodeId`), but the runtime gives A/S
+disturbance-tracking (pathfinds to `lastDisturbedNodeId`). The `patterns/*.test.js` files
+give false coverage — they test code nothing calls. **Fix:** either dispatch `moveInstance`
+through the registry (and resolve the A/S disagreement) or delete the unused modules + tests.
+
+### B5 (lower). Order-dependent ICE trace gating — MEDIUM / LOW (acknowledged in comments)
+`recordIceDetection` (`alert.js:200-231`) sums `detectionCount` across all ICE instances but
+gates on `DETECTION_TRACE_THRESHOLD[grade]` of whichever instance detected last. Benign
+while instances share the run grade (the code says so), but the multi-grade spawn path
+(`sentinel`/`spike`) could expose it.
+
+### B6 (latent). `endRun` leaves `traceTimerId`/`traceCountdown` dangling — LOW / LOW
+`endRun` calls `clearAllTimers()` but not `setTraceTimerId(null)`/`setTraceCountdown(null)`,
+so a serialized ended-run round-trips a stale timer id. Phase-gating protects re-fire today;
+`cancelTraceCountdown` clears both cleanly, `endRun` doesn't. Cheap to make consistent.
+
+### B7 (latent footgun). `tick(n>1)` evaluates triggers once — LOW / LOW
+`runtime.js:110-118` delivers n tick messages then evaluates triggers once; a repeating
+trigger that should pulse multiple times in the batch fires once. **Not hit in production**
+(timers and bot both loop `tick(1)`), but worth a guard or comment.
+
+---
+
+## Test honesty (finding T) — the suite is green but partly hollow in these areas
+
+These are why the bugs above survived a 1026-test suite. Verified by reading the tests:
+
+- **`runtime.test.js` IDS-relay suite asserts nothing.** The "IDS relay chain" blocks use
+  `assert.ok(true)` (`:70`) and `assert.doesNotThrow(...)` (`:134`) with comments admitting
+  they can't observe the relay ("mon has no operator to set alerted… verify it doesn't
+  throw"). These exercise the exact path B1 breaks and would never catch it. *(The
+  underlying relay/flag operators ARE honestly tested in `operators.test.js`; it's the
+  end-to-end runtime delivery that's untested.)*
+- **`integration.test.js:317-338` injects dead state.** "ids alert escalates global alert"
+  sets `s.nodes["ids-1"].alertState = "yellow"` directly (graph mode never sets it) and "does
+  NOT escalate when forwarding disabled" sets `eventForwardingDisabled = true` directly (the
+  CORRUPT action never sets it). Both pass while testing assignments the game never performs.
+- **Trigger/availability tests reach into private state** (`runtime.test.js:348/410`,
+  `runtime-extensions.test.js:301`): `graph._nodes.get(id).attributes.x = true` then `tick(0)`,
+  testing the condition read given a hand-set attr, not the circuit that sets it.
+- **`gate: all-of` test** (`runtime.test.js:174-231`) asserts intermediate `_allof_state`
+  scratch and watches an attr (`_allof_A_active`) no operator sets — the trigger can't fire;
+  the test passes via the scratch map. Testing assignment, not the circuit.
+
+Honest rewrites would drive the real signal path (exploit-fail → alert message → IDS relay →
+monitor flag → trigger → global alert moves) and assert the observable consequence.
+
+---
+
+## What is genuinely solid (traced, not assumed)
+
+- **node-graph pure core**: `conditions.js`/`fillConditionNodeId` (correct recursion, non-
+  mutating), `qualities.js`, `effects.js` ($nodeId resolution consistent, throws on missing
+  target), `traits.js` composition + per-node trigger id-namespacing, operator purity +
+  progressive patch merge, `enabledAttr` gating (`=== false` only), snapshot/restore
+  round-trip (attrs, qualities, fired-set, mid-clock state).
+- **timed-action core lifecycle**: start/progress/complete, grade-table duration,
+  `durationMultiplier`, milestone-interval math — all correct and covered. (Only the
+  DUMP/FETCH attr *naming* is wrong, B2 — the state machine itself is right.)
+- **Global alert never accidentally de-escalates**: `recomputeGlobalAlert`/`raiseGlobalAlert`/
+  `recordIceDetection` all guard `next > current`; only deliberate `cancelTraceCountdown` and
+  the cheat downgrade. Multi-event coalescing in one tick is idempotent. `STATE_CHANGED` is
+  correctly gated to one emit per tick boundary.
+- **Per-instance ICE dwell/detection isolation**: each instance owns its dwell timer; departure/
+  detection cancel only that instance's timer; detection lock + `PLAYER_NAVIGATED` reset are
+  correct and **honestly tested** (`ice-multi-detection.test.js`, `snapshot-ice-detection.test.js`
+  assert observable consequences). Effect-atom dispatch (sentinel/spike → health/deck damage,
+  classic → recordIceDetection) is genuinely wired and asserted on deltas.
+- **Trace countdown** fires once and cleans up; `handleTraceTick` phase-guards post-end ticks.
+
+The ICE *effect* and *detection-isolation* machinery is the strongest part. The weakness is
+concentrated in the **alert-layer seam** and the **message-delivery / timed-action attribute
+coupling** — exactly the stringly-typed, two-regime areas.
+
+---
+
+## Recommended sequencing (for discussion — several need a design call)
+
+1. **B3** (`owned-cancel-trace` → `repeating:true`) — smallest, clearest player-facing fix.
+   Failing test first.
+2. **B1** (sendMessage origin) — real and currently masking dead set-piece circuits. Fix the
+   delivery semantics; then the honeypot/IDS-relay circuits become live (re-check they behave).
+3. **B2** (DUMP/FETCH attr unify) — fold into the timed-action registry work (issue #170).
+4. **The legacy alert layer (root theme)** — Les's call: retire vs finish-wiring the two-layer
+   ladder. This also dictates whether the manual's "Detection" section is a spec to implement
+   or prose to correct. Pair with honest rewrites of the integration alert tests (finding T).
+5. **B4** (ICE patterns dead code) — delete or dispatch-through-registry.
+6. Housekeeping: B5/B6/B7 comments/guards as touched.
+
+No code changed in this audit.

--- a/docs/dev-sessions/2026-06-11-1810-code-review-refactor/notes.md
+++ b/docs/dev-sessions/2026-06-11-1810-code-review-refactor/notes.md
@@ -1,0 +1,67 @@
+# Notes — Whole-project code review & refactor
+
+## Execution log
+
+(filled in as work proceeds)
+
+### Setup
+- Worktree: `.claude/worktrees/code-review-refactor` on `worktree-code-review-refactor`.
+- Baseline `make check`: 1020 tests pass, lint clean.
+- Five parallel review agents → findings hand-verified → `research.md`.
+
+### Executed edits (Tier A/B/C) — all merged on branch, `make check` green after each
+1. [x] Remove unused `relayout` import — visual-renderer.js (+ dead `typeVulnConfig`
+       branch and unused `nodeType` param in exploits.js). Commit `refactor: remove dead code`.
+2. [x] (folded into #1)
+3. [x] Extract pure `nextAlertLevel()` in state/index.js; used in combat.js, alert.js,
+       game-ctx.js. Behavior-preserving. Commit `refactor: extract nextAlertLevel()`.
+4. [x] Shared `data/networks/index.js` (NAMED_NETWORKS/DEFAULT_NETWORK/buildGenerated) +
+       `scripts/lib/grade-args.js` (parseGradeArgs). Wired main.js + all 3 scripts.
+       Exercised all CLI entry points. Commit `refactor: share network registry...`.
+5. [x] Unify `fillNodeId` → `fillConditionNodeId` in conditions.js (superset; closed two
+       diverged latent gaps). Added 6 unit tests. Commit `refactor: unify fillNodeId...`.
+6. [x] Filed deferred items as GitHub issues (#164–#172). Moving away from BACKLOG.md for
+       this kind of tracking, so the temporary BACKLOG section was reverted.
+
+### Outcome
+- 1020 → 1026 tests, 0 failures, lint clean throughout.
+- No behavior change except #5's strictly-more-correct edge cases (now covered by tests).
+- Deferred work filed as issues (NOT done this session):
+  - #164 slot-filler rollback bug (bug, P2) — needs repro test + census re-baseline
+  - #165 graph.js dedup (pulse animator + BFS)
+  - #166 graph-degradation.js split
+  - #167 visual-renderer ↔ preview shared overlay init
+  - #168 combat.js resolve/apply split
+  - #169 centralize balance constants
+  - #170 node-graph timed-action registry
+  - #171 network-gen cleanups (tree-utils + fillSlot options)
+  - #172 enable @ts-check on remaining UI entry files
+- **Waveform tip filled circle: NOT a bug** — Les clarified the filled dot deliberately
+  simulates the electron-gun beam painting the trace. Diegetic exception to the no-fills
+  rule; no issue filed.
+
+### Deep audit (second pass — Les asked to go deeper)
+Two agents deep-read the node-graph runtime + alert/ICE flow and their tests, traced full
+signal paths, ran reproductions; all high/medium findings hand-verified. Write-up:
+`deep-audit.md`. Three confirmed bugs fixed in this PR (TDD, failing test first):
+- **B3** owned-cancel-trace one-shot → `repeating:true` (security trait kill-switch).
+- **B1** sendMessage dropped origin==target messages → un-suppressed dead graph-bridge
+  exploit/alert circuits. Census (20 seeds, main vs branch): successRate/traceFiredRate
+  identical → no difficulty regression; avgCash +14% from now-live loot circuits.
+- **B2** DUMP/FETCH timed-action progress attr desync. Grep sweep caught a 3rd site the
+  audit missed (encrypted trait DUMP). All fixed.
+
+Root theme (legacy vs graph-mode alert regime drift; two-layer ladder vestigial in graph
+mode) filed as **#173 (P1)** — design decision for the immediate next session.
+
+**Process miss to remember:** while census-comparing main vs branch I ran
+`git checkout HEAD -- js` to restore, which silently reverted the *uncommitted* B1 fix.
+Commit each fix BEFORE doing file-swap comparisons, or use a stash. Caught it via grep
+and re-applied.
+
+### Notes for next time
+- The `fillNodeId` divergence + the B2 phantom-attr triplet are the same disease:
+  stringly-typed duplication that drifts. Issue #170 (timed-action registry) is the
+  structural cure. A broader grep sweep for hand-coded `_ta_*` / duplicated helpers is warranted.
+- #173 (alert layer) is the highest-value next session — it's why the manual's headline
+  mechanic doesn't actually work in play.

--- a/docs/dev-sessions/2026-06-11-1810-code-review-refactor/research.md
+++ b/docs/dev-sessions/2026-06-11-1810-code-review-refactor/research.md
@@ -1,0 +1,135 @@
+# Research — Whole-project code review
+
+**Date:** 2026-06-11
+**Scope:** Code-quality / refactor review of the whole JS codebase (~32k LOC) after a
+run of merged PRs. Five parallel review agents covered node-graph engine, network
+generation, UI/visual layer, core game systems, and the headless tooling/bot. All
+findings below were **verified by hand** (grep + reading the cited code) before being
+recorded — agent line numbers and claims were not taken on faith.
+
+Baseline at session start: `make check` green — 1020 tests, 0 failures, lint clean.
+
+## Codebase shape
+
+- `js/core/` — 76 src + 47 test files (pure JS engine)
+- `js/ui/` — 48 src + 6 test files (Cytoscape graph + Lit components)
+- `scripts/` — 21 files (playtest harness, bot, census, generators)
+- `data/` — 7 files (incl. `biomes/corporate-pieces.js`, 2288 lines of hand-authored set-pieces)
+- Biggest non-data src: `graph.js` (1112), `slot-filler.js` (580), `skeleton.js` (575),
+  `graph-degradation.js` (525), `node-graph/runtime.js` (513), `visual-renderer.js` (490).
+
+**Overall health is good.** The core/ui split is clean, state mutations route through
+`mutate()`, the three headless entry points already share `headless-engine.js`, and the
+set-piece data file is appropriately data-shaped. The opportunities are mostly
+*duplication* and *dead code*, not architectural rot.
+
+---
+
+## Verified findings
+
+### Tier A — trivially safe (zero behavior change) — DO THIS SESSION
+
+1. **Unused `relayout` import in visual-renderer.js**
+   `js/ui/visual-renderer.js:15` imports `relayout` from `./graph.js`; it is never
+   referenced in the file body (verified). Remove from the import list. `relayout`
+   stays exported for its real consumer (cheats/console).
+
+2. **Dead `typeVulnConfig` branch in exploits.js**
+   `js/core/exploits.js:396-400` — `const typeVulnConfig = null;` followed by
+   `typeVulnConfig?.count?.[grade] ?? baseConfig.count` etc. The `?.` chains always
+   short-circuit to `baseConfig`. A leftover from removed per-type vuln config. Collapse
+   to direct `baseConfig` reads. Behavior identical.
+
+### Tier B — behavior-preserving dedup (verified identical logic) — DO THIS SESSION
+
+3. **Node-alert-level stepping repeated in 3 places**
+   Identical "indexOf in ALERT_ORDER, bump if not at max" pattern at:
+   - `js/core/combat.js:292-294`
+   - `js/core/alert.js:70-72`
+   - `js/core/node-graph/game-ctx.js:203-205` (has an extra `idx >= 0` guard)
+   Extract `raiseNodeAlertState(nodeId, currentLevel)` (or a pure
+   `nextAlertLevel(level)`) and use it in all three. The `idx >= 0` guard is a strict
+   superset and safe to keep in the shared helper.
+
+4. **Duplicated CLI scaffolding across headless entry points**
+   - The 3-network dict (corporate-foothold / research-station / corporate-exchange) is
+     defined identically in `scripts/playtest.js`, `scripts/bot/cli.js`,
+     `scripts/bot/census.js`, and `js/ui/main.js` (verified 4 copies).
+   - Grade-arg parsing (`--threat/--wealth/--complexity/--depth`) is reimplemented in
+     `scripts/playtest.js:61`, `scripts/bot/cli.js:34`, `scripts/bot/census.js:31`,
+     `scripts/generate-network.js:42`.
+   Extract a shared `scripts/lib/networks.js` (the dict) and a `parseGradeArgs()` helper.
+   `js/ui/main.js` is a browser entry — keep its copy or share via a core module; do the
+   scripts first (lowest risk).
+
+### Tier C — dedup that ALSO fixes a latent divergence (flag explicitly) — DO THIS SESSION
+
+5. **`fillNodeId` condition-tree helper duplicated AND diverged**
+   - `js/core/node-graph/actions.js:32` handles `node-attr`, `all-of/any-of`, **`not`**.
+   - `js/core/node-graph/runtime.js:487` (`_fillNodeId`) handles `node-attr`,
+     `all-of/any-of`, **`quality-from-attr`**.
+   Each handles a case the other misses — so an action `requires` with `quality-from-attr`
+   doesn't get its nodeId filled, and a trigger `when` with `not` doesn't recurse. Extract
+   one `fillConditionNodeId()` in `conditions.js` covering all four cases; wire both. This
+   removes the copy *and* closes both latent gaps. **Behavior change in edge cases** —
+   strictly more correct, but call it out and lean on the full suite.
+
+### Tier D — real but out of scope for a "safe refactor" pass — DOCUMENT ONLY
+
+6. **slot-filler wire-failure rollback is incomplete (genuine generation bug)**
+   `js/core/network/slot-filler.js:193-209` — on the "can't wire to parent" path the code
+   pops the piece from `pieces` and refunds budget, but does **not** roll back
+   `usedPieceIds.add(chosen.id)` (line 194) or `placed.set(slot.id, piece)` (line 193).
+   The stale `usedPieceIds` entry applies a diversity penalty to a piece that was never
+   placed; the stale `placed` entry maps a slot to a discarded piece. Minor, but real.
+   *Deferred:* per CLAUDE.md, generation bugs need a reproducing test first, and a fix
+   shifts generated networks for existing seeds → must re-baseline snapshots + run
+   `make census`. Its own session.
+
+7. **Waveform tip uses filled canvas circles (CRT-vocabulary violation)**
+   `js/ui/components/starnet-waveform.js:213-219` — `ctx.arc(...); ctx.fill()` draws
+   filled dots at the trace tip. CLAUDE.md's vector-CRT vocabulary bans fills/filled
+   circles. *Deferred:* the waveform is recently hand-tuned feel-work (PR #159); changing
+   its render is a feel decision for Les, not an autonomous edit. Flagged for his call.
+
+### Tier E — larger refactors worth a dedicated session — DOCUMENT ONLY
+
+- **`graph.js` (1112 LOC) decomposition.** Three near-identical pulse animators
+  (red/yellow/reboot, ~90 LOC) → one `createPulseAnimator`. Two copies of BFS pathfinding
+  (`flashIcePath` ~807, `drawIceTrace` ~861) → one `findPath(cy, from, to)`. MEDIUM.
+- **`graph-degradation.js` (525 LOC) split** into health-plasma / deck-perturbation /
+  wiring. MEDIUM.
+- **`visual-renderer.js` ↔ `preview.js` shared overlay init.** Both repeat
+  initGraph→mountOverlays→onViewport wiring. MEDIUM/LARGE.
+- **`combat.js launchExploit` (220-316)** mixes resolution + mutation + emission; split
+  into pure `resolveCombat` + `applyCombatResult` for testability. LARGE.
+- **Centralize balance constants** (alert thresholds, trace seconds, combat modifiers,
+  ICE timings) into one `balance.js`. MEDIUM. Currently scattered but all UPPER_SNAKE.
+- **Timed-action coupling in node-graph.** game-ctx builds magic `_ta_<action>_progress`
+  attribute names by hand (`game-ctx.js`); a shared `getTimedActionAttrNames(action)` in
+  runtime + a `TIMED_ACTIONS` registry would centralize the list now spread across
+  traits.js / game-types.js (ABORT requires) / game-ctx.js. MEDIUM/LARGE.
+- **Network tree-traversal helpers** (`collectAll/collectLeaves/collectExpandable/
+  collectSlots`) duplicated across skeleton.js + slot-filler.js → `tree-utils.js`. SMALL/MED.
+- **`fillSlot` 14 positional params** (slot-filler.js:120) → options object. MEDIUM (touches gen).
+- **Enable `@ts-check`** on `preview.js`, `main.js`, `run-control.js` (graph.js can keep
+  `@ts-nocheck` for the untyped Cytoscape API but add JSDoc typedefs for its own shapes). LARGE.
+
+### Confirmed clean (no action)
+
+- State module: all mutations via `mutate()`, submodules pure data, no leaks. ✓
+- Event bus, seeded RNG named streams, set-piece honesty (internalEdges, no hidden
+  `destinations`), Lit light-DOM component pattern — all consistent. ✓
+- `corporate-pieces.js` (2288 LOC) is hand-authored data; factories already dedupe the
+  scattered-puzzle variants. Maintainable as-is. ✓
+- Headless entry points already share `headless-engine.js` — no wiring drift found
+  (the duplication is only in CLI arg/network scaffolding, not engine wiring). ✓
+
+---
+
+## Execution plan for THIS session
+
+Do Tier A + B + C (items 1-5). All behavior-preserving except #5's edge-case
+correctness extension, which the test suite guards. Run `make check` after each change.
+Document Tiers D + E in `docs/BACKLOG.md` for future sessions. Keep changes small and
+isolated; one logical change per commit where practical.

--- a/docs/dev-sessions/2026-06-11-1810-code-review-refactor/spec.md
+++ b/docs/dev-sessions/2026-06-11-1810-code-review-refactor/spec.md
@@ -1,0 +1,30 @@
+# Spec — Whole-project code review & refactor
+
+## Goal
+
+Step back after a run of merged PRs, review the whole JS codebase for code-quality and
+refactor opportunities, write up findings, and execute the obvious safe wins.
+
+## Approach
+
+Parallel review agents across the five subsystems → hand-verify every finding → record in
+`research.md` → execute only the behavior-preserving / verified-safe items this session →
+document larger refactors in `docs/BACKLOG.md`.
+
+## In scope (this session)
+
+- Tier A: dead-code removal (unused import, dead branch)
+- Tier B: behavior-preserving dedup (alert-stepping helper, shared CLI scaffolding)
+- Tier C: `fillNodeId` consolidation (also closes a latent divergence)
+
+## Out of scope (documented, deferred)
+
+- slot-filler rollback bug (needs reproducing test + census re-baseline)
+- waveform CRT-vocabulary fix (feel-work; Les's call)
+- Large decompositions: graph.js, graph-degradation.js, combat.js, balance-constants,
+  timed-action registry, ts-check enablement (each its own session)
+
+## Success criteria
+
+`make check` green after every change; no behavior change except #5's strictly-more-correct
+edge cases; session docs + backlog updated; PR opened.

--- a/js/core/alert.js
+++ b/js/core/alert.js
@@ -5,7 +5,7 @@
 
 /** @typedef {import('./types.js').GlobalAlertLevel} GlobalAlertLevel */
 
-import { getState, endRun, ALERT_ORDER } from "./state.js";
+import { getState, endRun, nextAlertLevel } from "./state.js";
 import { setNodeAlertState } from "./state/node.js";
 import { setGlobalAlert, setTraceCountdown, setTraceTimerId, decrementTraceCountdown } from "./state/alert.js";
 import { setIceDetectedAt, incrementIceDetectionCount, activeIceInstances } from "./state/ice.js";
@@ -67,9 +67,9 @@ export function propagateAlertEvent(fromNodeId) {
   (s.adjacency[fromNodeId] || []).forEach((neighborId) => {
     const neighbor = s.nodes[neighborId];
     if (neighbor && MONITOR_TYPES.has(neighbor.type)) {
-      const idx = ALERT_ORDER.indexOf(neighbor.alertState);
-      if (idx < ALERT_ORDER.length - 1) {
-        setNodeAlertState(neighborId, ALERT_ORDER[idx + 1]);
+      const raised = nextAlertLevel(neighbor.alertState);
+      if (raised !== neighbor.alertState) {
+        setNodeAlertState(neighborId, raised);
       }
       emitEvent(E.ALERT_PROPAGATED, {
         fromNodeId,

--- a/js/core/combat.js
+++ b/js/core/combat.js
@@ -6,7 +6,7 @@
 /** @typedef {import('./types.js').ExploitResult} ExploitResult */
 /** @typedef {import('./types.js').Grade} Grade */
 
-import { getState, ALERT_ORDER, revealNeighbors } from "./state.js";
+import { getState, nextAlertLevel, revealNeighbors } from "./state.js";
 import { RNG, random, randomPick } from "./rng.js";
 import {
   setNodeAccessLevel, setNodeAlertState, setNodeVisible, setNodeVulnHidden, setNodeProbed,
@@ -289,9 +289,9 @@ export function launchExploit(nodeId, exploitId) {
   } else {
     // Raise node alert on failure
     const prevAlert = node.alertState;
-    const idx = ALERT_ORDER.indexOf(node.alertState);
-    if (idx < ALERT_ORDER.length - 1) {
-      setNodeAlertState(nodeId, ALERT_ORDER[idx + 1]);
+    const raised = nextAlertLevel(node.alertState);
+    if (raised !== prevAlert) {
+      setNodeAlertState(nodeId, raised);
     }
 
     setLastDisturbedNode(nodeId);

--- a/js/core/exploits.js
+++ b/js/core/exploits.js
@@ -388,17 +388,11 @@ const VULN_CONFIG = {
 
 /**
  * @param {Grade} grade
- * @param {string} [nodeType] - when provided, per-type vulnConfig overrides VULN_CONFIG
  */
-export function generateVulnerabilities(grade, nodeType) {
+export function generateVulnerabilities(grade) {
   const baseConfig = VULN_CONFIG[grade] ?? VULN_CONFIG["C"];
-  // Type-specific vuln config is no longer used — all nodes use grade-based defaults.
-  const typeVulnConfig = null;
-  // vulnConfig shape: { count: { S: [min,max], ... }, rarities: { S: [...], ... } }
-  // extract grade-specific values, falling back to base table
-  const countRange = typeVulnConfig?.count?.[grade]    ?? baseConfig.count;
-  const rarities   = typeVulnConfig?.rarities?.[grade] ?? baseConfig.rarities;
-  const [min, max] = countRange;
+  const [min, max] = baseConfig.count;
+  const rarities = baseConfig.rarities;
   const count = randomInt(RNG.EXPLOIT, min, max);
 
   const pool = VULNERABILITY_TYPES.filter((v) =>

--- a/js/core/node-graph/actions.js
+++ b/js/core/node-graph/actions.js
@@ -1,7 +1,6 @@
 // @ts-check
 /** @typedef {import('./types.js').ActionDef} ActionDef */
-/** @typedef {import('./types.js').Condition} Condition */
-import { evaluateCondition } from "./conditions.js";
+import { evaluateCondition, fillConditionNodeId } from "./conditions.js";
 import { applyEffect } from "./effects.js";
 
 /**
@@ -24,25 +23,6 @@ import { applyEffect } from "./effects.js";
  */
 
 /**
- * Fill in missing nodeId on node-attr conditions that target self.
- * @param {Condition} condition
- * @param {string} nodeId
- * @returns {Condition}
- */
-function fillNodeId(condition, nodeId) {
-  if (condition.type === "node-attr" && !condition.nodeId) {
-    return { ...condition, nodeId };
-  }
-  if (condition.type === "all-of" || condition.type === "any-of") {
-    return { ...condition, conditions: condition.conditions.map((c) => fillNodeId(c, nodeId)) };
-  }
-  if (condition.type === "not") {
-    return { ...condition, condition: fillNodeId(condition.condition, nodeId) };
-  }
-  return condition;
-}
-
-/**
  * Check whether all requires conditions pass for the given node.
  * @param {ActionDef} action
  * @param {string} nodeId
@@ -51,7 +31,7 @@ function fillNodeId(condition, nodeId) {
  */
 function requiresPass(action, nodeId, accessors) {
   return (action.requires ?? []).every((condition) =>
-    evaluateCondition(fillNodeId(condition, nodeId), accessors)
+    evaluateCondition(fillConditionNodeId(condition, nodeId), accessors)
   );
 }
 

--- a/js/core/node-graph/conditions.js
+++ b/js/core/node-graph/conditions.js
@@ -47,3 +47,25 @@ export function evaluateCondition(condition, { getNodeAttr, getQuality }) {
       throw new Error(`Unknown condition type: "${/** @type {any} */ (condition).type}"`);
   }
 }
+
+/**
+ * Pre-fill a missing `nodeId` on a condition tree so self-targeting conditions
+ * resolve against the owning node. Recurses through all-of/any-of/not and fills
+ * the two node-bearing condition types (node-attr, quality-from-attr).
+ *
+ * @param {Condition} condition
+ * @param {string} nodeId
+ * @returns {Condition}
+ */
+export function fillConditionNodeId(condition, nodeId) {
+  if ((condition.type === "node-attr" || condition.type === "quality-from-attr") && !condition.nodeId) {
+    return { ...condition, nodeId };
+  }
+  if (condition.type === "all-of" || condition.type === "any-of") {
+    return { ...condition, conditions: condition.conditions.map((c) => fillConditionNodeId(c, nodeId)) };
+  }
+  if (condition.type === "not") {
+    return { ...condition, condition: fillConditionNodeId(condition.condition, nodeId) };
+  }
+  return condition;
+}

--- a/js/core/node-graph/conditions.test.js
+++ b/js/core/node-graph/conditions.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { evaluateCondition } from "./conditions.js";
+import { evaluateCondition, fillConditionNodeId } from "./conditions.js";
 
 const attrs = {
   "node-A": { accessLevel: "owned", grade: "B" },
@@ -107,5 +107,48 @@ describe("evaluateCondition: not", () => {
 describe("evaluateCondition: unknown type", () => {
   it("throws for unknown condition type", () => {
     assert.throws(() => evaluateCondition(/** @type {any} */ ({ type: "bogus" }), accessors));
+  });
+});
+
+describe("fillConditionNodeId", () => {
+  it("fills a missing nodeId on a node-attr condition", () => {
+    const filled = fillConditionNodeId({ type: "node-attr", attr: "accessLevel", eq: "owned" }, "self");
+    assert.equal(filled.nodeId, "self");
+  });
+
+  it("fills a missing nodeId on a quality-from-attr condition", () => {
+    const filled = fillConditionNodeId({ type: "quality-from-attr", attr: "tokenName", gte: 1 }, "self");
+    assert.equal(filled.nodeId, "self");
+  });
+
+  it("leaves an existing nodeId untouched", () => {
+    const filled = fillConditionNodeId({ type: "node-attr", nodeId: "other", attr: "x", eq: 1 }, "self");
+    assert.equal(filled.nodeId, "other");
+  });
+
+  it("recurses into all-of and any-of compositions", () => {
+    const filled = fillConditionNodeId({
+      type: "all-of",
+      conditions: [
+        { type: "node-attr", attr: "a", eq: 1 },
+        { type: "any-of", conditions: [{ type: "quality-from-attr", attr: "q", eq: 1 }] },
+      ],
+    }, "self");
+    assert.equal(filled.conditions[0].nodeId, "self");
+    assert.equal(filled.conditions[1].conditions[0].nodeId, "self");
+  });
+
+  it("recurses into not compositions", () => {
+    const filled = fillConditionNodeId({
+      type: "not",
+      condition: { type: "node-attr", attr: "a", eq: 1 },
+    }, "self");
+    assert.equal(filled.condition.nodeId, "self");
+  });
+
+  it("does not mutate the input condition", () => {
+    const input = { type: "node-attr", attr: "a", eq: 1 };
+    fillConditionNodeId(input, "self");
+    assert.equal(input.nodeId, undefined);
   });
 });

--- a/js/core/node-graph/game-ctx.js
+++ b/js/core/node-graph/game-ctx.js
@@ -30,7 +30,7 @@ import { emitEvent, E } from "../events.js";
 function exploitDuration(quality) {
   return Math.round((2 + quality * 5) * 1000); // ms
 }
-import { endRun, ALERT_ORDER, revealNeighbors } from "../state.js";
+import { endRun, nextAlertLevel, revealNeighbors } from "../state.js";
 import { pauseTimers } from "../timers.js";
 import { getState } from "../state.js";
 import { setNodeProbed, setNodeAlertState, setNodeRead, collectMacguffins, setNodeLooted, incrementMineAttempts, setMineExhausted } from "../state/node.js";
@@ -200,9 +200,9 @@ export function buildGameCtx(opts = {}) {
       }
 
       const prevAlert = node.alertState ?? "green";
-      const idx = ALERT_ORDER.indexOf(prevAlert);
-      if (idx >= 0 && idx < ALERT_ORDER.length - 1) {
-        setNodeAlertState(nodeId, ALERT_ORDER[idx + 1]);
+      const raised = nextAlertLevel(prevAlert);
+      if (raised !== prevAlert) {
+        setNodeAlertState(nodeId, raised);
       }
 
       emitEvent(E.ACTION_RESOLVED, { action: A.PROBE, nodeId, label: node.label });
@@ -386,12 +386,12 @@ export function initNavigationCancelHandler() {
     }
     if (attrs.reading) {
       graph.setNodeAttr(nodeId, "reading", false);
-      graph.setNodeAttr(nodeId, "_ta_read_progress", 0);
+      graph.setNodeAttr(nodeId, "_ta_dump_progress", 0);
       emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.DUMP, phase: "cancel", progress: 0 });
     }
     if (attrs.looting) {
       graph.setNodeAttr(nodeId, "looting", false);
-      graph.setNodeAttr(nodeId, "_ta_loot_progress", 0);
+      graph.setNodeAttr(nodeId, "_ta_fetch_progress", 0);
       emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.FETCH, phase: "cancel", progress: 0 });
     }
     if (attrs.mining) {

--- a/js/core/node-graph/game-types.js
+++ b/js/core/node-graph/game-types.js
@@ -112,7 +112,9 @@ const DUMP_ACTION = {
   ],
   effects: [
     { effect: "set-attr", attr: "reading", value: true },
-    { effect: "set-attr", attr: "_ta_read_progress", value: 0 },
+    // Must match the dump timed-action operator's progress attr (_ta_dump_progress,
+    // derived from action:"dump"), not a phantom _ta_read_progress.
+    { effect: "set-attr", attr: "_ta_dump_progress", value: 0 },
   ],
 };
 
@@ -132,7 +134,9 @@ const FETCH_ACTION = {
   ],
   effects: [
     { effect: "set-attr", attr: "looting", value: true },
-    { effect: "set-attr", attr: "_ta_loot_progress", value: 0 },
+    // Must match the fetch timed-action operator's progress attr (_ta_fetch_progress,
+    // derived from action:"fetch"), not a phantom _ta_loot_progress.
+    { effect: "set-attr", attr: "_ta_fetch_progress", value: 0 },
   ],
 };
 

--- a/js/core/node-graph/runtime.js
+++ b/js/core/node-graph/runtime.js
@@ -11,6 +11,7 @@ import { applyOperators } from "./operators.js";
 import { QualityStore } from "./qualities.js";
 import { TriggerStore } from "./triggers.js";
 import { getAvailableActions, executeAction } from "./actions.js";
+import { fillConditionNodeId } from "./conditions.js";
 import { applyEffect } from "./effects.js";
 import { nullCtx } from "./ctx.js";
 import { resolveTraits } from "./traits.js";
@@ -69,7 +70,7 @@ export class NodeGraph {
             ...t,
             id: `${n.id}/${t.id}`,
             _nodeId: n.id,
-            when: _fillNodeId(t.when, n.id),
+            when: fillConditionNodeId(t.when, n.id),
             then: t.then.map(eff => _fillEffectNodeId(eff, n.id)),
           });
         }
@@ -97,7 +98,12 @@ export class NodeGraph {
     const msg = /** @type {Message} */ (
       "path" in message ? message : createMessage({ type: message.type, origin: nodeId, payload: message.payload ?? {}, destinations: message.destinations })
     );
-    this._deliver(nodeId, msg);
+    // A message may originate at its own target (origin === nodeId — e.g. graph-bridge
+    // injecting exploit/alert events). createMessage seeds path:[origin], so the entry
+    // delivery's cycle guard would drop it. Strip the target from the entry path; _deliver
+    // re-appends it, keeping onward propagation cycle-safe.
+    const entry = msg.path.includes(nodeId) ? { ...msg, path: msg.path.filter((p) => p !== nodeId) } : msg;
+    this._deliver(nodeId, entry);
     this._evaluateTriggers();
   }
 
@@ -476,27 +482,6 @@ export class NodeGraph {
 }
 
 // ── Per-node trigger helpers ────────────────────────────────
-
-/**
- * Pre-fill nodeId in a condition tree. For node-attr conditions without a nodeId,
- * sets it to the owning node's ID. Recurses into all-of/any-of compositions.
- * @param {import('./types.js').Condition} cond
- * @param {string} nodeId
- * @returns {import('./types.js').Condition}
- */
-function _fillNodeId(cond, nodeId) {
-  if (cond.type === "node-attr" && !cond.nodeId) {
-    return { ...cond, nodeId };
-  }
-  if (cond.type === "all-of" || cond.type === "any-of") {
-    return { ...cond, conditions: cond.conditions.map(c => _fillNodeId(c, nodeId)) };
-  }
-  // quality-from-attr needs nodeId for attr lookup
-  if (cond.type === "quality-from-attr" && !cond.nodeId) {
-    return { ...cond, nodeId };
-  }
-  return cond;
-}
 
 /**
  * Pre-fill $nodeId in effect args. Replaces "$nodeId" string with the actual nodeId.

--- a/js/core/node-graph/runtime.test.js
+++ b/js/core/node-graph/runtime.test.js
@@ -453,3 +453,33 @@ describe("player action execute — full pipeline", () => {
     assert.deepEqual(ctx.calls.giveReward[0], [500]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 11. sendMessage delivers to the target even when origin === target (B1)
+// ---------------------------------------------------------------------------
+describe("sendMessage: origin == target node", () => {
+  it("an alert injected at its own node reaches that node's operators and relays onward", () => {
+    // graph-bridge.js injects exploit/alert messages with origin === the node it
+    // delivers to (createMessage seeds path:[origin]). The cycle guard must not drop
+    // this initial delivery.
+    const graph = new NodeGraph({
+      nodes: [
+        { id: "ids", type: "ids", attributes: { alerted: false }, operators: [
+          { name: "relay", filter: "alert" },
+          { name: "flag", on: "alert", attr: "alerted", value: true },
+        ] },
+        { id: "mon", type: "security-monitor", attributes: { alerted: false }, operators: [
+          { name: "flag", on: "alert", attr: "alerted", value: true },
+        ] },
+      ],
+      edges: [["ids", "mon"]],
+    });
+
+    graph.sendMessage("ids", createMessage({ type: "alert", origin: "ids", payload: {} }));
+
+    assert.equal(graph.getNodeState("ids").alerted, true,
+      "IDS flag operator must run on an alert injected at the IDS itself");
+    assert.equal(graph.getNodeState("mon").alerted, true,
+      "relay must forward the alert to the monitor");
+  });
+});

--- a/js/core/node-graph/traits.js
+++ b/js/core/node-graph/traits.js
@@ -284,7 +284,11 @@ registerTrait("security", {
       ],
     },
     {
+      // Repeating, not one-shot: owning the monitor must cancel a trace even if the
+      // node was owned BEFORE the trace started (a one-shot would fire once into a
+      // no-op and never re-fire). cancelTrace is idempotent, so re-firing is safe.
       id: "owned-cancel-trace",
+      repeating: true,
       when: { type: "node-attr", attr: "accessLevel", eq: "owned" },
       then: [
         { effect: "ctx-call", method: "cancelTrace", args: [] },
@@ -350,7 +354,8 @@ registerTrait("encrypted", {
     ],
     effects: [
       { effect: "set-attr", attr: "reading", value: true },
-      { effect: "set-attr", attr: "_ta_read_progress", value: 0 },
+      // Matches the lootable dump operator's progress attr (_ta_dump_progress).
+      { effect: "set-attr", attr: "_ta_dump_progress", value: 0 },
     ],
   }],
 });

--- a/js/core/node-graph/traits.test.js
+++ b/js/core/node-graph/traits.test.js
@@ -2,6 +2,8 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { registerTrait, getTrait, resolveTraits, clearTraits } from "./traits.js";
+import { NodeGraph } from "./runtime.js";
+import { mockCtx } from "./ctx.js";
 
 // traits.js self-registers built-in traits at import time.
 // Save them before tests clear the registry.
@@ -353,5 +355,34 @@ describe("Built-in traits", () => {
     assert.equal(t.triggers[0].id, "volatile-arm");
     assert.equal(t.operators.length, 1);
     assert.equal(t.operators[0].action, "volatile");
+  });
+});
+
+describe("security trait: owned-cancel-trace behavior", () => {
+  beforeEach(() => { restoreBuiltIns(); });
+
+  it("re-fires cancelTrace while the monitor stays owned (not one-shot)", () => {
+    // Reproduces the bug where owning the security monitor BEFORE a trace starts
+    // spends the one-shot trigger, so a later trace is never auto-cancelled.
+    const ctx = mockCtx();
+    const graph = new NodeGraph({
+      nodes: [{
+        id: "mon", type: "security-monitor", traits: ["security"],
+        attributes: { accessLevel: "owned" },
+      }],
+      edges: [],
+    }, ctx);
+
+    // First evaluation: trigger fires once (no trace active yet — cancelTrace is idempotent).
+    graph.tick(0);
+    const afterFirst = ctx.calls.cancelTrace?.length ?? 0;
+
+    // A trace starts later while the monitor is still owned. The trigger must fire
+    // AGAIN to cancel it. A one-shot trigger would already be spent and stay silent.
+    graph.tick(0);
+    const afterSecond = ctx.calls.cancelTrace?.length ?? 0;
+
+    assert.ok(afterSecond > afterFirst,
+      `owned-cancel-trace must re-fire while owned (got ${afterFirst} then ${afterSecond})`);
   });
 });

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -8,7 +8,7 @@ export {
   // Graph traversal utilities
   revealNeighbors, accessNeighbors,
   // Alert constants
-  ALERT_ORDER,
+  ALERT_ORDER, nextAlertLevel,
   // End run
   endRun,
   // Visibility

--- a/js/core/state/index.js
+++ b/js/core/state/index.js
@@ -110,7 +110,7 @@ export function initGame(buildNetworkFn, seedString, opts = {}) {
   // Generate vulnerabilities for each node (seeded RNG)
   for (const nodeId of graph.getNodeIds()) {
     const nodeData = graph.getNode(nodeId);
-    const vulns = generateVulnerabilities(nodeData.grade, nodeData.type);
+    const vulns = generateVulnerabilities(nodeData.grade);
     graph.setNodeAttr(nodeId, "vulnerabilities", vulns);
   }
 
@@ -288,6 +288,18 @@ export function accessNeighbors(nodeId) {
 
 /** @type {NodeAlertLevel[]} */
 export const ALERT_ORDER = ["green", "yellow", "red"];
+
+/**
+ * The next node alert level up from `level`, or `level` unchanged if it's already
+ * at the top or not a recognized level. Pure — does not mutate state.
+ * @param {NodeAlertLevel} level
+ * @returns {NodeAlertLevel}
+ */
+export function nextAlertLevel(level) {
+  const idx = ALERT_ORDER.indexOf(level);
+  if (idx < 0 || idx >= ALERT_ORDER.length - 1) return level;
+  return ALERT_ORDER[idx + 1];
+}
 
 // ── End run ──────────────────────────────────────────────
 

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -18,22 +18,12 @@ import { openHub, initHub } from "./hub.js";
 import { initProfileRunCommit } from "./profile-store.js";
 import "./hub-commands.js";
 
-import { buildNetwork as buildCorporateFoothold } from "../../data/networks/corporate-foothold.js";
-import { buildNetwork as buildResearchStation } from "../../data/networks/research-station.js";
-import { buildNetwork as buildCorporateExchange } from "../../data/networks/corporate-exchange.js";
-import { buildNetwork as buildGenerated } from "../../data/networks/generated.js";
-
-/** Available graph-based networks. */
-const NETWORKS = {
-  "corporate-foothold": buildCorporateFoothold,
-  "research-station": buildResearchStation,
-  "corporate-exchange": buildCorporateExchange,
-};
+import { NAMED_NETWORKS, DEFAULT_NETWORK, buildGenerated } from "../../data/networks/index.js";
 
 /** Read network from URL params. Supports hand-crafted networks and generated. */
 function getSelectedNetwork() {
   const p = new URLSearchParams(location.search);
-  const name = p.get("network") ?? "corporate-foothold";
+  const name = p.get("network") ?? DEFAULT_NETWORK;
 
   if (name === "generated") {
     const spec = {
@@ -51,7 +41,7 @@ function getSelectedNetwork() {
     return () => result;
   }
 
-  return NETWORKS[name] ?? buildCorporateFoothold;
+  return NAMED_NETWORKS[name] ?? NAMED_NETWORKS[DEFAULT_NETWORK];
 }
 
 /** Module-scope: the default network builder, used to seed the empty graph at boot. */

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -12,7 +12,7 @@ import { A } from "../core/action-ids.js";
 import { getState as _getState } from "../core/state.js";
 import { getAvailableActions } from "../core/actions/node-actions.js";
 import { isScriptAction } from "../core/actions/scripts.js";
-import { updateNodeStyle, getCy, flashNode, addIceNode, syncIceGraph, syncSelection, relayout, onViewport, setReticleOverlay } from "./graph.js";
+import { updateNodeStyle, getCy, flashNode, addIceNode, syncIceGraph, syncSelection, onViewport, setReticleOverlay } from "./graph.js";
 import { mountOverlays } from "./overlays/index.js";
 import { mountReticle } from "./overlays/selection-reticle.js";
 import { dispatchActionFeedback } from "./overlays/dispatch.js";

--- a/scripts/bot/census.js
+++ b/scripts/bot/census.js
@@ -7,36 +7,22 @@
 //   node scripts/bot/census.js --seeds 20 --network corporate-foothold
 
 import { runBot } from "./run.js";
-import { buildNetwork as buildCorporateFoothold } from "../../data/networks/corporate-foothold.js";
-import { buildNetwork as buildResearchStation } from "../../data/networks/research-station.js";
-import { buildNetwork as buildCorporateExchange } from "../../data/networks/corporate-exchange.js";
-import { buildNetwork as buildGenerated } from "../../data/networks/generated.js";
-
-const NETWORKS = {
-  "corporate-foothold": buildCorporateFoothold,
-  "research-station": buildResearchStation,
-  "corporate-exchange": buildCorporateExchange,
-};
+import { NAMED_NETWORKS, buildGenerated } from "../../data/networks/index.js";
+import { parseGradeArgs } from "../lib/grade-args.js";
 
 // ── Arg parsing ─────────────────────────────────────────────
 
 let seedCount = 50;
-let threat = "C", wealth = "B", complexity = "C", depth = "C";
 let networkName = null;
 let full = false;
 
 const argv = process.argv.slice(2);
+const spec = parseGradeArgs(argv);
 for (let i = 0; i < argv.length; i++) {
   if (argv[i] === "--seeds" && argv[i + 1]) seedCount = parseInt(argv[++i], 10) || 50;
-  else if (argv[i] === "--threat" && argv[i + 1]) threat = argv[++i];
-  else if (argv[i] === "--wealth" && argv[i + 1]) wealth = argv[++i];
-  else if (argv[i] === "--complexity" && argv[i + 1]) complexity = argv[++i];
-  else if (argv[i] === "--depth" && argv[i + 1]) depth = argv[++i];
   else if (argv[i] === "--network" && argv[i + 1]) networkName = argv[++i];
   else if (argv[i] === "--full") full = true;
 }
-
-const spec = { threat, wealth, complexity, depth };
 
 // ── Run census ──────────────────────────────────────────────
 
@@ -49,9 +35,9 @@ for (let i = 0; i < seedCount; i++) {
     /** @returns {{ graphDef: any, meta: any }} */
     const buildFn = () => {
       if (networkName) {
-        const fn = NETWORKS[networkName];
+        const fn = NAMED_NETWORKS[networkName];
         if (!fn) {
-          throw new Error(`Unknown network: ${networkName}. Available: ${Object.keys(NETWORKS).join(", ")}`);
+          throw new Error(`Unknown network: ${networkName}. Available: ${Object.keys(NAMED_NETWORKS).join(", ")}`);
         }
         return fn();
       }

--- a/scripts/bot/cli.js
+++ b/scripts/bot/cli.js
@@ -7,44 +7,32 @@
 //   node scripts/bot/cli.js --generated --seed test-1 --threat C --wealth B
 
 import { runBot } from "./run.js";
-import { buildNetwork as buildCorporateFoothold } from "../../data/networks/corporate-foothold.js";
-import { buildNetwork as buildResearchStation } from "../../data/networks/research-station.js";
-import { buildNetwork as buildCorporateExchange } from "../../data/networks/corporate-exchange.js";
-import { buildNetwork as buildGenerated } from "../../data/networks/generated.js";
-
-const NETWORKS = {
-  "corporate-foothold": buildCorporateFoothold,
-  "research-station": buildResearchStation,
-  "corporate-exchange": buildCorporateExchange,
-};
+import { NAMED_NETWORKS, DEFAULT_NETWORK, buildGenerated } from "../../data/networks/index.js";
+import { parseGradeArgs } from "../lib/grade-args.js";
 
 // Parse args
-let networkName = "corporate-foothold";
+let networkName = DEFAULT_NETWORK;
 let seed = undefined;
 let verbose = false;
 let generated = false;
-let threat = "C", wealth = "B", complexity = "C", depth = "C";
 
 const argv = process.argv.slice(2);
+const spec = parseGradeArgs(argv);
 for (let i = 0; i < argv.length; i++) {
   if (argv[i] === "--network" && argv[i + 1]) networkName = argv[++i];
   else if (argv[i] === "--seed" && argv[i + 1]) seed = argv[++i];
   else if (argv[i] === "--verbose" || argv[i] === "-v") verbose = true;
   else if (argv[i] === "--generated" || argv[i] === "-g") generated = true;
-  else if (argv[i] === "--threat" && argv[i + 1]) threat = argv[++i];
-  else if (argv[i] === "--wealth" && argv[i + 1]) wealth = argv[++i];
-  else if (argv[i] === "--complexity" && argv[i + 1]) complexity = argv[++i];
-  else if (argv[i] === "--depth" && argv[i + 1]) depth = argv[++i];
 }
 
 /** @returns {{ graphDef: any, meta: any }} */
 function getBuildNetwork() {
   if (generated) {
-    return buildGenerated({ seed: seed ?? "gen-1", spec: { threat, wealth, complexity, depth } });
+    return buildGenerated({ seed: seed ?? "gen-1", spec });
   }
-  const fn = NETWORKS[networkName];
+  const fn = NAMED_NETWORKS[networkName];
   if (!fn) {
-    console.error(`Unknown network: ${networkName}. Available: ${Object.keys(NETWORKS).join(", ")}, --generated`);
+    console.error(`Unknown network: ${networkName}. Available: ${Object.keys(NAMED_NETWORKS).join(", ")}, --generated`);
     process.exit(1);
   }
   return fn();

--- a/scripts/lib/grade-args.js
+++ b/scripts/lib/grade-args.js
@@ -1,0 +1,21 @@
+// @ts-check
+// Shared CLI parsing for the four network grade flags. Used by playtest.js,
+// bot/cli.js, and bot/census.js so the flag names and defaults stay in sync.
+
+/**
+ * Scan argv for --threat/--wealth/--complexity/--depth and return a spec object.
+ * Unrecognized args are ignored, so callers can keep their own loops for other
+ * flags. Defaults match the documented census defaults.
+ * @param {string[]} argv
+ * @returns {{ threat: string, wealth: string, complexity: string, depth: string }}
+ */
+export function parseGradeArgs(argv) {
+  const spec = { threat: "C", wealth: "B", complexity: "C", depth: "C" };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--threat" && argv[i + 1]) spec.threat = argv[++i];
+    else if (argv[i] === "--wealth" && argv[i + 1]) spec.wealth = argv[++i];
+    else if (argv[i] === "--complexity" && argv[i + 1]) spec.complexity = argv[++i];
+    else if (argv[i] === "--depth" && argv[i + 1]) spec.depth = argv[++i];
+  }
+  return spec;
+}

--- a/scripts/playtest.js
+++ b/scripts/playtest.js
@@ -18,10 +18,8 @@ import {
   getState, serializeState, deserializeState,
   tick, on, emitEvent, E,
 } from "./lib/headless-engine.js";
-import { buildNetwork as buildCorporateFoothold } from "../data/networks/corporate-foothold.js";
-import { buildNetwork as buildResearchStation } from "../data/networks/research-station.js";
-import { buildNetwork as buildCorporateExchange } from "../data/networks/corporate-exchange.js";
-import { buildNetwork as buildGenerated } from "../data/networks/generated.js";
+import { NAMED_NETWORKS, DEFAULT_NETWORK, buildGenerated } from "../data/networks/index.js";
+import { parseGradeArgs } from "./lib/grade-args.js";
 import { A } from "../js/core/action-ids.js";
 import { addLogEntry } from "../js/core/log.js";
 import { runCommand } from "../js/ui/console.js";
@@ -37,7 +35,8 @@ let networkArg = null;
 let pieceArg = null;
 let graphFileArg = null;
 let generatedArg = false;
-let threatArg = "C", wealthArg = "B", complexityArg = "C", depthArg = "C";
+const { threat: threatArg, wealth: wealthArg, complexity: complexityArg, depth: depthArg } =
+  parseGradeArgs(process.argv.slice(2));
 let recipeArg = null, lanGradeArg = null;
 let jsonMode = false;
 
@@ -59,13 +58,13 @@ let jsonMode = false;
     } else if (argv[i] === "--generated" || argv[i] === "-g") {
       generatedArg = true;
     } else if (argv[i] === "--threat" && argv[i + 1]) {
-      threatArg = argv[++i];
+      i++; // grade flags handled by parseGradeArgs; just consume the value
     } else if (argv[i] === "--wealth" && argv[i + 1]) {
-      wealthArg = argv[++i];
+      i++;
     } else if (argv[i] === "--complexity" && argv[i + 1]) {
-      complexityArg = argv[++i];
+      i++;
     } else if (argv[i] === "--depth" && argv[i + 1]) {
-      depthArg = argv[++i];
+      i++;
     } else if (argv[i] === "--recipe" && argv[i + 1]) {
       recipeArg = argv[++i];
     } else if (argv[i] === "--lan-grade" && argv[i + 1]) {
@@ -77,12 +76,6 @@ let jsonMode = false;
 }
 
 // ── Network selection ───────────────────────────────────────
-const GRAPH_NETWORKS = {
-  "corporate-foothold": buildCorporateFoothold,
-  "research-station": buildResearchStation,
-  "corporate-exchange": buildCorporateExchange,
-};
-
 let buildNetworkFn;
 if (generatedArg) {
   // Procedural generation mode
@@ -106,10 +99,10 @@ if (generatedArg) {
   buildNetworkFn = () => buildMiniNetwork(graphJson, { name: `File: ${graphFileArg}` });
 } else {
   // Standard network mode
-  const selectedNetwork = networkArg ?? "corporate-foothold";
-  buildNetworkFn = GRAPH_NETWORKS[selectedNetwork];
+  const selectedNetwork = networkArg ?? DEFAULT_NETWORK;
+  buildNetworkFn = NAMED_NETWORKS[selectedNetwork];
   if (!buildNetworkFn) {
-    console.error(`Unknown network: ${selectedNetwork}. Available: ${Object.keys(GRAPH_NETWORKS).join(", ")}, --generated`);
+    console.error(`Unknown network: ${selectedNetwork}. Available: ${Object.keys(NAMED_NETWORKS).join(", ")}, --generated`);
     process.exit(1);
   }
 }
@@ -240,7 +233,7 @@ function runCmd(raw) {
     resetGame(() => buildNetworkFn(), seedArg ?? undefined);
     const s = getState();
     const nodeCount = Object.keys(s.nodes).length;
-    const networkName = generatedArg ? `generated (${threatArg}/${wealthArg}/${complexityArg}/${depthArg})` : pieceArg ? `piece:${pieceArg}` : graphFileArg ? `file:${graphFileArg}` : (networkArg ?? "corporate-foothold");
+    const networkName = generatedArg ? `generated (${threatArg}/${wealthArg}/${complexityArg}/${depthArg})` : pieceArg ? `piece:${pieceArg}` : graphFileArg ? `file:${graphFileArg}` : (networkArg ?? DEFAULT_NETWORK);
     out(`[SYS] Initialized. Seed: "${s.seed}". Network: ${nodeCount} nodes (${networkName}).`);
     return;
   }

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1165,6 +1165,30 @@ describe("honey-pot trap: MINE springs the counter-trace", () => {
   });
 });
 
+describe("timed-action cancel clears the operator's real progress attr (B2)", () => {
+  beforeEach(() => { clearAll(); });
+
+  it("navigating away from an in-progress DUMP resets _ta_dump_progress", () => {
+    initGame(() => buildCorporateExchange(), "b2-dump-cancel-seed");
+    const graph = getState().nodeGraph;
+
+    navigateTo("pot/honey-pot");
+    graph.executeAction("pot/honey-pot", "dump");
+    graph.tick(3); // advance but do not complete (dump duration is >= 8 ticks)
+
+    assert.equal(graph.getNodeState("pot/honey-pot").reading, true, "dump should be in progress");
+    assert.ok(graph.getNodeState("pot/honey-pot")._ta_dump_progress > 0,
+      "operator should have advanced _ta_dump_progress");
+
+    navigateAway(); // emits PLAYER_NAVIGATED → navigation-cancel handler
+
+    const after = graph.getNodeState("pot/honey-pot");
+    assert.equal(after.reading, false, "navigation must cancel the dump");
+    assert.equal(after._ta_dump_progress, 0,
+      "cancel must reset the operator's real progress attr, not a phantom _ta_read_progress");
+  });
+});
+
 describe("honey-pot trap: FETCH springs the counter-trace", () => {
   beforeEach(() => {
     clearAll();


### PR DESCRIPTION
## What

A code-review session that grew in three stages:
1. **Breadth cleanup** — safe dead-code removal + dedup across subsystems.
2. **Deep audit** — targeted correctness + test-honesty audit of the node-graph runtime and alert/ICE event flow (`docs/dev-sessions/2026-06-11-1810-code-review-refactor/deep-audit.md`), with the confirmed self-contained bugs fixed here (TDD, failing test first).
3. **Doc reframe** — the project has outgrown "prototype."

Every finding was hand-verified against the code before acting. Larger refactors and the one architectural decision are filed as issues, not rushed in.

## Cleanups (behavior-preserving)

- Remove dead code: unused `relayout` import (`visual-renderer.js`); dead `typeVulnConfig` branch + unused param (`exploits.js`).
- `nextAlertLevel()` helper — dedup the alert-stepping pattern across `combat.js`/`alert.js`/`game-ctx.js`.
- Shared `data/networks/index.js` + `scripts/lib/grade-args.js` — kill the network-dict (×4) and grade-arg (×3) duplication across entry points.
- Unify `fillNodeId` → one `fillConditionNodeId()` in `conditions.js`; this also **closed a latent divergence** (the two copies each missed a condition type the other handled). +6 unit tests.

## Bug fixes from the deep audit (TDD)

- **B3** — `owned-cancel-trace` was a one-shot trigger on a repeating condition; owning the security monitor before a trace permanently spent the auto-cancel kill-switch. → `repeating: true`.
- **B1** — `sendMessage` dropped any message whose `origin == target` (cycle-guard self-collision), silently killing the graph-bridge's `exploit`/`alert` injection (dead IDS-relay and honeypot circuits). → strip the target from the entry path. **Census (20 seeds, main vs branch): successRate/traceFiredRate identical — no difficulty regression.**
- **B2** — DUMP/FETCH timed-action progress attr desync (`_ta_read_progress`/`_ta_loot_progress` vs the operator's `_ta_dump_progress`/`_ta_fetch_progress`); navigating away from an in-progress dump/fetch leaked stale progress. Fixed all three sites — a grep sweep caught a third (encrypted-trait DUMP) the audit missed.

## Docs

- `CLAUDE.md` / `README.md` reframed: project is a maturing game in active development, not a one-mechanic prototype (procgen, set-pieces, multi-ICE, darknet store, loss-clock, bot/census all ship). Fixed stale README facts (multiple ICE; vendor bundled locally, not CDN). Added a known-gap note about the alert layer (#173).

## Deferred — filed as issues

- **#173 (P1)** — reconcile the legacy vs graph-mode alert layer: the documented two-layer IDS→monitor→TRACE ladder is vestigial in graph mode. Design decision (retire vs finish-wire) for the immediate next session.
- #164 slot-filler rollback bug · #165 graph.js dedup · #166 graph-degradation split · #167 overlay-init dedup · #168 combat resolve/apply split · #169 balance constants · #170 timed-action registry · #171 network-gen cleanups · #172 @ts-check enablement.
- ICE pattern dead code: intentionally left (ICE-reinvention rewrite in progress). Waveform tip filled-circle: intentional (electron-gun beam sim) — not a bug.

## Verification

`make check` green after every commit — **1029 tests** (now incl. the bug-repro tests), 0 failures, lint clean. All three headless entry points exercised; census compared against main.

Session docs: `docs/dev-sessions/2026-06-11-1810-code-review-refactor/` (spec, research, deep-audit, notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
