### PR TITLE
Reconcile the alert layer: two sensors, one ladder (#173)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,12 +142,28 @@ Rules:
 8. Global alert rises as detection nodes fire events to security monitors
 9. At TRACE: countdown begins (30–90s by threat grade) — jack out or lose your score
 
-## Alert System (Two-Layer)
+## Alert System (two sensors, one ladder)
 
-- **Detection nodes** (type: `ids`): raise alert on exploit failures, propagate events to connected security monitors
-- **Security monitors** (type: `security-monitor`): aggregate detection events, drive global alert
-- **Global alert** recomputes from monitor/detector states; only escalates, never de-escalates
-- Subverting an IDS (`eventForwardingDisabled: true`) severs the chain
+Global alert (`green → yellow → red → trace`) is driven by two independent sensors that share
+the same ladder and trace clock. It only escalates, never de-escalates (below trace), except
+the deliberate cancel paths (own the monitor → `cancelTrace`; jack out). Both sensors live in
+`js/core/alert.js` and call into the trace-countdown machinery there.
+
+- **Security grid (passive).** On a *failed* exploit (the graph bridge's `ACTION_RESOLVED`
+  handler, `XPLOIT` with `success:false` — routine probing does NOT trip the grid), the bridge
+  broadcasts an `alert` message to every `ids` node. Each IDS relays it to its `security-monitor`
+  via the `relay` operator — *unless corrupted* (`forwardingEnabled:false`, set by the
+  `corrupt`/CORRUPT action). The monitor's `report` operator calls `recordMonitorAlert`,
+  which accumulates per-monitor and climbs the ladder, starting the trace at a grade-scaled count
+  (`MONITOR_TRACE_THRESHOLD`). Grid-wide sensing, subversion-scoped: corrupt an IDS to blind its
+  monitor.
+- **ICE (active).** `recordIceDetection` — detections climb the same ladder and start the trace
+  at a grade-scaled count. Owned by the ICE subsystem.
+- An ICE-less LAN relies entirely on the grid — its only failure clock.
+
+Escalation lives in `recordMonitorAlert` / `recordIceDetection` (+ set-piece `startTrace`
+alarms). There is no node-`alertState`-counting global recompute — that legacy layer was
+retired in #173. (Node `alertState` is now purely the per-node visual alert glow.)
 
 ## Branching and Pull Requests
 
@@ -446,13 +462,6 @@ needs a fill, a circle, or a dither, it's the wrong primitive.
 - Alert + trace system and ICE (multiple instances, grade-scaled behavior, detection/dwell)
 - Darknet store, exploit card decay (use/disclosure), health/deck loss-clock pressure
 - Headless playtest harness + automated bot + census for balance testing
-
-> **Known gap (2026-06-11 deep audit):** the *documented* two-layer IDS→monitor→TRACE
-> alert ladder is only partially wired in graph mode (the live escalation comes from graph
-> triggers, set-piece alarms, and ICE detection; the legacy `recomputeGlobalAlert` /
-> `alertState` path is largely vestigial). See the deep-audit analysis in
-> `docs/dev-sessions/2026-06-11-1810-code-review-refactor/`. Don't treat the manual's alert
-> model as fully implemented until that's reconciled.
 
 ## Out of Scope (Future)
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -442,8 +442,8 @@ around it.
 
 ## THE ALERT SYSTEM
 
-The LAN has a two-layer security architecture. Understanding it is the difference between
-a clean run and a trace.
+The LAN watches you through two sensors — a passive security grid and active ICE — both
+feeding one alert ladder. Understanding it is the difference between a clean run and a trace.
 
 ### Node Alert State
 
@@ -454,17 +454,25 @@ Every node has its own alert level: **GREEN → YELLOW → RED**. This escalates
 A **successful exploit resets the node's alert to green** — you found a clean way in and
 contained the noise. Failed attempts leave their mark; successes erase it.
 
-### Global Alert
+### Global Alert — two sensors, one ladder
 
-The **global alert** (shown in the HUD) is driven by **security monitors** — special nodes
-that aggregate alerts from **IDS nodes** connected to them.
+The **global alert** (shown in the HUD) climbs `GREEN → YELLOW → RED → TRACE`. It is driven by
+**two independent sensors** that feed the same ladder and the same trace clock:
+
+**1. The security grid (passive).** Sloppy hacking trips it. Every failed exploit raises an
+alert that the LAN's **IDS** nodes hear; each un-corrupted IDS relays it to its **security
+monitor**, which accumulates the alerts and climbs the ladder — starting the trace once enough
+have piled up (a grade-scaled count: fewer on tougher networks).
 
 ```
-IDS node  →  (alert event)  →  Security Monitor  →  Global Alert
+exploit failure  →  IDS  →  (relay, unless corrupted)  →  Security Monitor  →  Global Alert
 ```
 
-An IDS node that detects an exploit failure on a connected node fires an alert event
-upstream to its security monitor. The security monitor raises the global alert.
+**2. ICE (active).** A roaming ICE that detects you climbs the *same* ladder and starts the
+trace after a grade-scaled number of detections (see ICE, below).
+
+A LAN with no ICE is more static and forgiving — the grid is the only clock, and you control
+it: hack carefully, corrupt the IDS to go dark, or own the monitor to cancel a trace.
 
 **Global alert levels** (lamp shape: hexagon → point-up triangle → inverted triangle → inverted triangle):
 
@@ -475,9 +483,9 @@ upstream to its security monitor. The security monitor raises the global alert.
 
 ### The TRACE Countdown
 
-When global alert hits red and security monitors confirm active intrusion, a **TRACE
-countdown** begins (30–90 seconds depending on network threat grade). The countdown shows in the HUD and sidebar. If it reaches zero,
-your tether is traced back to your home node — run over, score lost.
+When either sensor reaches its threshold, a **TRACE countdown** begins (30–90 seconds
+depending on network threat grade). The countdown shows in the HUD and sidebar. If it reaches
+zero, your tether is traced back to your home node — run over, score lost.
 
 To stop it: **jack out** before zero, or **own the security monitor** and run
 `exec cancel-trace`.
@@ -522,9 +530,10 @@ If you can compromise and then **corrupt** an IDS node:
 > exec corrupt
 ```
 
-Event forwarding from that IDS to its connected security monitor is severed. Subsequent
-exploit failures on nodes watched by that IDS will no longer escalate the global alert.
-This is often worth the detour.
+Event forwarding from that IDS to its connected security monitor is severed — that monitor
+goes dark and stops climbing the alert ladder, no matter how many exploits you fail. (A LAN
+with more than one IDS/monitor pair needs each IDS corrupted to fully go dark.) This is often
+worth the detour, especially on an ICE-less LAN where the grid is your only clock.
 
 ---
 

--- a/data/biomes/corporate-pieces.js
+++ b/data/biomes/corporate-pieces.js
@@ -34,7 +34,8 @@ export const idsRelayChain = {
       type: "ids",
       traits: ["graded", "hackable", "rebootable", "detectable", "gate"],
       attributes: { accessLevel: "locked", forwardingEnabled: true },
-      operators: [{ name: "relay", filter: "alert" }],
+      // relay(filter:alert) comes from the detectable trait — no inline duplicate
+      // (a second relay would double-count alerts at the monitor → recordMonitorAlert).
       actions: [
         {
           id: "corrupt",
@@ -1092,7 +1093,8 @@ export const tamperDetect = {
       type: "ids",
       traits: ["graded", "hackable", "rebootable", "detectable", "gate"],
       attributes: { accessLevel: "locked", forwardingEnabled: true },
-      operators: [{ name: "relay", filter: "alert" }],
+      // relay(filter:alert) comes from the detectable trait — no inline duplicate
+      // (a second relay would double-count alerts at the monitor → recordMonitorAlert).
       actions: [
         {
           id: "corrupt",
@@ -1404,7 +1406,8 @@ export const defensePlex = {
       id: "ids-1", type: "ids",
       traits: ["graded", "hackable", "rebootable", "detectable", "gate"],
       attributes: { accessLevel: "locked", forwardingEnabled: true },
-      operators: [{ name: "relay", filter: "alert" }],
+      // relay(filter:alert) comes from the detectable trait — no inline duplicate
+      // (a second relay would double-count alerts at the monitor → recordMonitorAlert).
       actions: [{
         id: "corrupt", label: "Corrupt IDS",
         requires: [{ type: "node-attr", attr: "accessLevel", eq: "owned" }],
@@ -1415,7 +1418,8 @@ export const defensePlex = {
       id: "ids-2", type: "ids",
       traits: ["graded", "hackable", "rebootable", "detectable", "gate"],
       attributes: { accessLevel: "locked", forwardingEnabled: true },
-      operators: [{ name: "relay", filter: "alert" }],
+      // relay(filter:alert) comes from the detectable trait — no inline duplicate
+      // (a second relay would double-count alerts at the monitor → recordMonitorAlert).
       actions: [{
         id: "corrupt", label: "Corrupt IDS",
         requires: [{ type: "node-attr", attr: "accessLevel", eq: "owned" }],
@@ -1455,7 +1459,8 @@ export const fortifiedGate = {
       id: "ids", type: "ids",
       traits: ["graded", "hackable", "rebootable", "detectable", "gate"],
       attributes: { accessLevel: "locked", forwardingEnabled: true },
-      operators: [{ name: "relay", filter: "alert" }],
+      // relay(filter:alert) comes from the detectable trait — no inline duplicate
+      // (a second relay would double-count alerts at the monitor → recordMonitorAlert).
       actions: [{
         id: "corrupt", label: "Corrupt IDS",
         requires: [{ type: "node-attr", attr: "accessLevel", eq: "owned" }],

--- a/docs/dev-sessions/2026-06-11-2241-alert-layer-reconcile/notes.md
+++ b/docs/dev-sessions/2026-06-11-2241-alert-layer-reconcile/notes.md
@@ -1,0 +1,49 @@
+# Notes — Reconcile the alert layer (#173)
+
+## Execution summary
+
+Built the two-sensors-one-ladder alert model per spec, retired the legacy layer, fixed the
+status display, made the tests honest, corrected the docs, and tuned difficulty.
+
+- **P1** — grid escalation to TRACE: `report` operator + `recordMonitorAlert` (mirrors
+  `recordIceDetection`) + ctx wiring + security trait (`report` op, removed `alert-escalate`) +
+  bridge broadcast. Removed redundant inline `relay` on 5 set-piece IDS nodes (the `detectable`
+  trait already provides it; the duplicate double-counted at the monitor).
+- **P2** — retired the legacy alert.js layer (`recomputeGlobalAlert`, `propagateAlertEvent`,
+  `raiseGlobalAlert`, `DETECTOR/MONITOR_TYPES`, `initAlertHandlers` hooks, `eventForwardingDisabled`
+  + `setNodeEventForwarding`). Removed the two dishonest integration tests + the node.test for the
+  deleted setter.
+- **P3** — `cmd-status` reads `forwardingEnabled` (it read the dead `eventForwardingDisabled`, so
+  it always showed "enabled"). Verified: corrupt → `[fwd:OFF]`.
+- **P4** — MANUAL.md + CLAUDE.md rewritten to the two-sensor model; #173 caveat removed.
+- **P5** — tuning (below).
+
+## Key design correction during execution
+
+The grid initially tripped on **every probe**, not just failures — `NODE_ALERT_RAISED` fires on
+probe (green→yellow) as well as exploit failure. With grid-wide sensing that made the trace fire
+on routine recon (0% success even at threshold 6). Fix: the bridge broadcasts the grid `alert`
+on **exploit failure** (`ACTION_RESOLVED`, XPLOIT, `success===false`), not on `NODE_ALERT_RAISED`.
+Probes still emit `probe-noise` for dedicated sensors (nthAlarm); they don't trip the grid.
+
+## Difficulty tuning (census, 25 seeds/grade)
+
+Baseline **main**: threat C → 0.32 success / 0.76 trace / $6964; threat B → 0.32 / 0.76 / $11656.
+
+`MONITOR_TRACE_THRESHOLD` sweep (failures-only grid):
+
+| threshold (by grade) | threat C | threat B |
+|---|---|---|
+| {C:2} (initial, ICE-mirror) | 0/1.00 | 0.04/0.96 |
+| {S3 A4 B5 C6 D8 F10} | 0.20/0.84 | 0.20/0.88 |
+| **{S4 A5 B7 C9 D12 F15}** (chosen) | **0.28/0.76** | **0.24/0.84** |
+
+Chosen rationale: at **threat C (no ICE — the passive-grid-only tier)** the branch matches main's
+0.76 trace / ~0.3 success, so the ICE-less LAN now has a *real* clock at comparable, forgiving-ish
+difficulty. At **threat B (ICE + grid, two sensors)** it's slightly harder (0.84 trace), which is
+the intended cost of a second sensor. The upcoming cooldown levers (#174) will add relief on top.
+The threshold table is the obvious knob for Les's hands-on tuning pass.
+
+## Follow-ups
+- #174 — alert cooldown levers ("lie low" EXEC, "scrub logs" action), depends on this.
+- Difficulty is tuned-to-the-bot; revisit by feel + with #174 in place.

--- a/docs/dev-sessions/2026-06-11-2241-alert-layer-reconcile/plan.md
+++ b/docs/dev-sessions/2026-06-11-2241-alert-layer-reconcile/plan.md
@@ -1,0 +1,255 @@
+# Plan — Reconcile the alert layer (#173)
+
+Vertical slices. TDD except where noted (deletion/docs). Run `make check` after each phase.
+
+Escalation mechanism (validated): an operator emits an `operator-effect` event carrying a
+`ctx-call`; the runtime applies it via `applyEffect(payload, _actionMutators(nodeId))`, which
+sets `targetNodeId = nodeId` so `args:["$nodeId"]` resolves to the node. This is exactly how
+`timed-action.onComplete` fires ctx-calls (`operators.js:420-447`, `runtime.js:351-358`,
+`effects.js:58-62`, `runtime.js:474-476`).
+
+---
+
+## Phase 1 — Grid escalation: monitor climbs to TRACE (new behavior, TDD)
+
+End-to-end slice: exploit failure → bridge broadcasts `alert` to IDS nodes → un-corrupted IDS
+relays to its monitor → monitor fires `recordMonitorAlert` per alert → global alert steps up
+and starts the trace at a grade-scaled count. Corrupting the IDS severs it.
+
+### Files
+- `js/core/node-graph/operators.js` — add a `report` operator.
+- `js/core/alert.js` — add `recordMonitorAlert(monitorId)` + `MONITOR_TRACE_THRESHOLD`.
+- `js/core/node-graph/ctx.js` — add `recordMonitorAlert` to `nullCtx` and `mockCtx`.
+- `js/core/node-graph/types.js` — add `recordMonitorAlert` to `CtxInterface`.
+- `js/core/node-graph/game-ctx.js` — wire `recordMonitorAlert: (nodeId) => recordMonitorAlert(nodeId)`.
+- `js/core/node-graph/traits.js` — `security` trait: add `alertCount: 0` attribute, add the
+  `report` operator, **remove** the one-shot `alert-escalate` trigger. Keep `flag(alerted)`.
+- `js/core/graph-bridge.js` — `NODE_ALERT_RAISED` handler broadcasts `alert` to every type-`ids`
+  node instead of only the origin node.
+- `js/core/node-graph/runtime.test.js` — rewrite the dishonest IDS-relay blocks (`assert.ok(true)`
+  / `assert.doesNotThrow`, ~lines 44-97, 103-148) to assert the real relayed consequence.
+- `tests/integration.test.js` — new suite for the full grid chain.
+
+### Key changes
+
+`operators.js` — generic per-message ctx-call:
+```js
+/**
+ * report — on a matching message, fire a ctx-call (as an operator-effect).
+ * config.on: message type to match. config.call: ctx method name (called with the node id).
+ */
+registerOperator("report", (config, _attrs, message, _ctx) => {
+  if (!message || message.type === "tick") return {};
+  if (config.on && message.type !== config.on) return {};
+  return { events: [{ type: "operator-effect",
+    payload: { effect: "ctx-call", method: config.call, args: ["$nodeId"] } }] };
+});
+```
+
+`alert.js` — mirror `recordIceDetection` (count lives on the monitor graph node; grade from
+`s.spec.threat`; separate threshold table so the grid tunes independently of ICE):
+```js
+// Security-grid trace gate: accumulated monitor alerts before trace, by network grade.
+// Mirrors DETECTION_TRACE_THRESHOLD (ICE) but separate so the two tune independently.
+const MONITOR_TRACE_THRESHOLD = { S: 1, A: 1, B: 2, C: 2, D: 3, F: 3 };
+
+/**
+ * Record an alert reaching a security monitor (the passive grid sensor). Mirrors
+ * recordIceDetection: steps the global alert up per alert (capped below trace), and at the
+ * grade-scaled accumulated count starts the trace. Count lives on the monitor graph node
+ * (serializes with the graph). Reaches the monitor only via an un-corrupted IDS relay.
+ */
+export function recordMonitorAlert(monitorId) {
+  const s = getState();
+  const graph = s.nodeGraph;
+  if (!graph) return;
+  const count = (graph.getNodeState(monitorId)?.alertCount ?? 0) + 1;
+  graph.setNodeAttr(monitorId, "alertCount", count);
+
+  const threat = s.spec?.threat ?? "C";
+  const threshold = MONITOR_TRACE_THRESHOLD[threat] ?? 2;
+  if (count >= threshold) {
+    if (getState().traceSecondsRemaining === null) startTraceCountdown();
+    return;
+  }
+  const idx = GLOBAL_ALERT_ORDER.indexOf(s.globalAlert);
+  if (idx < GLOBAL_ALERT_ORDER.indexOf("red")) {
+    const prev = s.globalAlert;
+    const next = GLOBAL_ALERT_ORDER[idx + 1];
+    setGlobalAlert(next);
+    emitEvent(E.ALERT_GLOBAL_RAISED, { prev, next });
+  }
+}
+```
+
+`ctx.js` — `nullCtx`: `recordMonitorAlert(_nodeId) {}`; `mockCtx`: `recordMonitorAlert: spy("recordMonitorAlert")`.
+`types.js` — `@property {(nodeId: string) => void} recordMonitorAlert`.
+`game-ctx.js` — import `recordMonitorAlert` from `../alert.js`; add `recordMonitorAlert: (nodeId) => recordMonitorAlert(nodeId)`.
+
+`traits.js` security trait:
+```js
+registerTrait("security", {
+  attributes: { alerted: false, alertState: "green", alertCount: 0 },
+  operators: [
+    { name: "flag", on: "alert", attr: "alerted", value: true },
+    { name: "report", on: "alert", call: "recordMonitorAlert" },
+  ],
+  actions: [ACTION_TEMPLATES.CANCEL_TRACE],
+  triggers: [
+    // owned-cancel-trace stays (repeating). alert-escalate REMOVED — escalation now
+    // flows per-alert through the report operator → recordMonitorAlert.
+    { id: "owned-cancel-trace", repeating: true,
+      when: { type: "node-attr", attr: "accessLevel", eq: "owned" },
+      then: [{ effect: "ctx-call", method: "cancelTrace", args: [] }] },
+  ],
+});
+```
+
+`graph-bridge.js` — broadcast to IDS nodes (assumption: alert-relaying detectors are type
+`ids`; all current relay(filter:alert) nodes are):
+```js
+on(E.NODE_ALERT_RAISED, () => {
+  const graph = getState().nodeGraph;
+  if (!graph) return;
+  const nodes = getState().nodes;
+  for (const id of Object.keys(nodes)) {
+    if (nodes[id].type !== "ids") continue;
+    const msg = createMessage({ type: "alert", origin: id, payload: { nodeId: id } });
+    try { graph.sendMessage(id, msg); } catch (_) { }
+  }
+});
+```
+
+### Tests (write first, watch fail)
+- `tests/integration.test.js` new suite "security grid: IDS→monitor escalation":
+  - On a graph with one `idsRelayChain`-style IDS→monitor pair at grade C, emitting
+    `E.NODE_ALERT_RAISED` (or a failed exploit) twice climbs `globalAlert` and a third starts the
+    trace (`traceSecondsRemaining !== null`). Assert observable global alert / trace, not attrs.
+  - Corrupting the IDS first (`forwardingEnabled:false` via its `corrupt` action) → repeated
+    alerts leave `globalAlert` green and `traceSecondsRemaining === null`.
+  - Owning the monitor mid-climb cancels an in-flight trace (exercises `owned-cancel-trace`).
+- `runtime.test.js`: replace the `assert.ok(true)` / `assert.doesNotThrow` IDS-relay assertions
+  with real ones — inject an `alert` at the IDS, assert the monitor's `alerted` flips true (and
+  stays false when `forwardingEnabled:false`).
+
+### Verification — automated
+- [ ] new integration test fails before implementation, passes after
+- [ ] `make check` (1029+ tests, 0 fail, lint clean)
+- [ ] `node scripts/playtest.js --generated --seed t1 reset` then a few failed exploits climb alert (smoke)
+
+### Verification — manual
+- [ ] Read the new test: it drives exploit-fail → bridge → IDS → monitor → global alert, and asserts the consequence (not intermediate attrs).
+- [ ] Confirm corrupting the IDS demonstrably prevents escalation in the test.
+
+---
+
+## Phase 2 — Retire the legacy alert.js layer (deletion; guarded by Phase 1 + existing tests)
+
+TDD opt-out: pure removal. Behavior guarded by Phase 1's grid tests + the existing ICE/trace tests.
+
+### Files
+- `js/core/alert.js` — delete `recomputeGlobalAlert`, `propagateAlertEvent`, `raiseGlobalAlert`,
+  the `DETECTOR_TYPES`/`MONITOR_TYPES` consts, and the `initAlertHandlers` handlers
+  (`NODE_ALERT_RAISED` → recompute; `ACTION_RESOLVED`/CORRUPT → recompute). If `initAlertHandlers`
+  is then empty, remove it + its module-load call (`alert.js:58`).
+- `scripts/lib/headless-engine.js` — if `initAlertHandlers` removed, drop the import (line 18) and
+  call (line 66).
+- `js/core/state/node.js` — delete `setNodeEventForwarding` and the `eventForwardingDisabled`
+  write; remove `eventForwardingDisabled` from any node default shape.
+- `js/core/state.js` — remove the `setNodeEventForwarding` re-export.
+- `js/core/types.js` — remove `eventForwardingDisabled` from `NodeState` typedef if present.
+- `tests/integration.test.js` — remove/rewrite the two dishonest tests (`:317` sets `alertState`
+  directly; `:330` sets `eventForwardingDisabled`). They test the deleted path; replace with the
+  Phase 1 real-path coverage (delete if now redundant).
+- Any other reference surfaced by grep (e.g. `cmd-status.js` — handled in Phase 3).
+
+### Key changes
+- `initAlertHandlers` becomes empty → remove it and the headless-engine wiring, OR keep a no-op if
+  other callers need the symbol (grep first: only `alert.js:58` + `headless-engine.js:66`).
+- `recordMonitorAlert` and `recordIceDetection` are the only global-escalation entry points left
+  (plus `startTraceCountdown`, `cancelTraceCountdown`, `forceGlobalAlert` cheat).
+
+### Verification — automated
+- [ ] `grep -rn "recomputeGlobalAlert\|propagateAlertEvent\|raiseGlobalAlert\|eventForwardingDisabled\|setNodeEventForwarding\|DETECTOR_TYPES\|MONITOR_TYPES" js scripts` → only comments, if any
+- [ ] `make check` green
+- [ ] `node scripts/bot/census.js --seeds 5` runs without error (headless wiring intact)
+
+### Verification — manual
+- [ ] `alert.js` now contains only: trace-countdown machinery, `recordIceDetection`, `recordMonitorAlert`, `forceGlobalAlert`, `MONITOR_TRACE_THRESHOLD`, `DETECTION_TRACE_THRESHOLD`, `GLOBAL_ALERT_ORDER`.
+
+---
+
+## Phase 3 — Fix the IDS forwarding status display (small)
+
+`cmd-status.js` reads the deleted `eventForwardingDisabled`, so it always showed "enabled".
+
+### Files
+- `js/core/console-commands/cmd-status.js` — lines 258-259 and 296: read `forwardingEnabled`
+  (`true`/undefined = enabled; `false` = disabled/subverted).
+
+### Key changes
+```js
+// node detail
+if (node.forwardingEnabled !== undefined) {
+  lines.push(`- event forwarding: ${node.forwardingEnabled === false ? "disabled" : "enabled"}`);
+}
+// node list tag
+? (n.forwardingEnabled === false ? "  [fwd:OFF]" : "  [fwd:ON]")
+```
+
+### Verification — automated
+- [ ] `make check` green
+- [ ] `node scripts/playtest.js --piece ids-relay-chain reset && node scripts/playtest.js "status node <monitor/ids>"` shows forwarding state (smoke; adjust node id)
+
+### Verification — manual
+- [ ] After corrupting an IDS in a playtest, `status` shows `[fwd:OFF]` / "disabled" for it.
+
+---
+
+## Phase 4 — Docs (doc-only, no test)
+
+### Files
+- `MANUAL.md` — "Detection" section: describe two sensors (ICE active, security grid passive)
+  feeding one ladder; grid climbs to trace via exploit failures through IDS→monitor; subvert the
+  IDS to go dark; own the monitor to cancel a trace.
+- `CLAUDE.md` — "Alert System" section: same model; **remove** the #173 known-gap caveat added
+  to the "What's Shipped" scope section.
+
+### Verification — manual
+- [ ] MANUAL.md "Detection" matches the shipped two-sensor model (no IDS-counting language).
+- [ ] CLAUDE.md alert section updated; the `> Known gap (2026-06-11 deep audit)` block is gone.
+
+---
+
+## Phase 5 — Census + tune
+
+The grid becoming a real trace driver shifts difficulty.
+
+### Steps
+- Run `make census SEEDS=20` on the branch; compare to `main` on the same seeds (commit ALL work
+  first, then the checkout-main-files comparison — per [[commit-before-file-swap-comparison]]).
+- Report successRate / traceFiredRate / avgCash deltas in `notes.md`.
+- If the grid over-pressures (traceFiredRate spikes) or under-pressures, tune
+  `MONITOR_TRACE_THRESHOLD` and note the rationale. No fixed target — compare to main.
+
+### Verification — automated
+- [ ] `make census SEEDS=20` completes; deltas recorded in `notes.md`
+- [ ] `make check` still green after any threshold tuning
+
+### Verification — manual
+- [ ] Difficulty delta is reasonable / explained; threshold table reflects any tuning.
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** grid sensing (P1 bridge), monitor climbs to trace (P1 recordMonitorAlert),
+  subversion-scoped (P1, forwardingEnabled gate preserved), legacy retired (P2), status fixed
+  (P3), honest tests (P1+P2 rewrites), docs (P4), census (P5). All spec success criteria mapped.
+- **Placeholders:** none — all code shown.
+- **Type/name consistency:** `recordMonitorAlert` (alert.js, ctx.js, types.js, game-ctx.js,
+  report operator `call`), `report` operator, `MONITOR_TRACE_THRESHOLD`, `alertCount` attribute —
+  consistent across phases.
+- **Open assumption (documented):** alert-relaying detectors are type `ids`; the bridge broadcasts
+  to type-`ids` nodes. Verified true for all current relay(filter:alert) nodes; extend the type set
+  if future detector set-pieces use another type.

--- a/docs/dev-sessions/2026-06-11-2241-alert-layer-reconcile/spec.md
+++ b/docs/dev-sessions/2026-06-11-2241-alert-layer-reconcile/spec.md
@@ -1,0 +1,165 @@
+# Spec — Reconcile the alert layer: two sensors, one ladder
+
+GitHub issue: #173. Background analysis: `../2026-06-11-1810-code-review-refactor/deep-audit.md`.
+
+## Goal
+
+Make the IDS→monitor security grid a real, climbable failure mode (up to TRACE), retire the
+vestigial legacy `alert.js` layer that shadows it, and make the docs + tests describe the
+system that actually ships. The grid is the **passive-adversary** failure mode for LANs that
+have no ICE; ICE remains the **active-adversary** mode. Both feed one global alert ladder.
+
+## Mental model (the design we're building toward)
+
+**Two sensors, one ladder.** Global alert (`green → yellow → red → trace`) is driven by two
+independent sensors that share the same ladder and the same trace clock:
+
+- **ICE (active):** hunts the player's disturbances; detections accumulate and start the
+  trace at a grade-scaled count. Unchanged by this work. (`recordIceDetection`, `alert.js`.)
+- **Security grid (passive):** sloppy hacking (exploit failures) raises alerts that flow to
+  IDS → security-monitor; the monitor accumulates them and climbs the ladder to trace.
+  Subverting an IDS (`corrupt` → `forwardingEnabled:false`) blinds its monitor. NEW: today
+  this caps at yellow and barely trips; this work makes it a full ladder.
+
+An ICE-less LAN is more static and forgiving: the only clock is the grid, and you can
+pre-empt it (corrupt the IDS to go dark) or cancel it (own the monitor → `owned-cancel-trace`).
+
+## Current state (verified, post-PR-#163)
+
+What works:
+- `idsRelayChain` set-piece (+ tamper and two-IDS variants) in `data/biomes/corporate-pieces.js`
+  IS the IDS→monitor puzzle. IDS = `relay(filter:alert)` gated by `forwardingEnabled` + a
+  `corrupt` action; monitor rides the `security` trait.
+- Graph chain fires (post-B1): alert → IDS relay → monitor `flag(alerted:true)` →
+  `security` trait `alert-escalate` trigger → `setGlobalAlert("yellow")`. Corrupting the IDS
+  severs it. Empirically confirmed.
+- `recordIceDetection` (`alert.js:200`) — the live ICE trace driver.
+- Trace countdown machinery (`startTraceCountdown` / `handleTraceTick` /
+  `cancelTraceCountdown`, `alert.js:136-174`) — essential, keep.
+
+What's broken / vestigial:
+- The grid caps at **yellow** (`traits.js:279-284`, hardcoded one-shot) and only trips when a
+  failure happens *on the IDS node itself* — the bridge sends `alert` only to the originating
+  node (`graph-bridge.js:42-47`).
+- Legacy `alert.js` layer duplicates/shadows the graph chain and is mostly dead in graph mode:
+  - `propagateAlertEvent` (`alert.js:62`) — only runs in the non-graph `else` branch. Dead.
+  - `recomputeGlobalAlert` (`alert.js:85`) — counts IDS/monitor by `alertState` (graph nodes
+    use `alerted`, a boolean) and filters on the never-set `eventForwardingDisabled`.
+    Semi-live only via the accidental "exploit-fail directly on a detector" path.
+  - `raiseGlobalAlert` (`alert.js:115`) — zero callers, fully dead.
+  - `DETECTOR_TYPES` / `MONITOR_TYPES` sets (`alert.js:20-21`) — only used by the above.
+  - `eventForwardingDisabled` attribute + `setNodeEventForwarding` (`state/node.js:181`) — zero
+    production writers; opposite polarity to the real `forwardingEnabled`.
+- `cmd-status.js:258-259,296` reads the dead `eventForwardingDisabled`, so the console's IDS
+  forwarding display is **always wrong** (shows enabled regardless of actual subversion).
+- Dishonest tests (pass on injected dead state): `tests/integration.test.js:317` (sets
+  `alertState` directly), `:330` (sets `eventForwardingDisabled` directly); the IDS-relay
+  blocks in `js/core/node-graph/runtime.test.js` (`assert.ok(true)` / `assert.doesNotThrow`).
+
+## Desired end state
+
+1. **Grid-wide, subversion-scoped sensing.** On any exploit failure, an `alert` reaches every
+   IDS node in the LAN (not just the failed node). Each un-corrupted IDS relays to its monitor;
+   a corrupted IDS (`forwardingEnabled:false`) does not. Multiple IDS/monitor pairs each need
+   subverting to fully go dark.
+2. **Monitor climbs the full ladder.** Each alert that reaches a monitor steps the global alert
+   up one level and, at a grade-scaled accumulated count, starts the trace — mirroring
+   `recordIceDetection` (thresholds `S/A:1, B/C:2, D/F:3`). No longer hardcoded at yellow.
+3. **Legacy `alert.js` layer removed.** Graph triggers + `recordIceDetection` are the only
+   escalation sources. `recomputeGlobalAlert`, `propagateAlertEvent`, `raiseGlobalAlert`, the
+   `DETECTOR/MONITOR_TYPES` sets, the `eventForwardingDisabled` attr + `setNodeEventForwarding`,
+   and the legacy `else` branch are gone.
+4. **Status display fixed** to read `forwardingEnabled`.
+5. **Docs match reality** (MANUAL.md "Detection", CLAUDE.md alert section); the #173 known-gap
+   caveat in CLAUDE.md's scope section is removed.
+6. **Tests are honest** — drive the real signal path and assert observable consequences.
+
+## Design decisions (with reasoning)
+
+- **Grid-wide sensing over segment-scoped.** Simpler, predictable, and matches the "passive,
+  static, forgiving" intent for ICE-less LANs. Segment-scoping is a richer puzzle but more
+  wiring; deferred (see What we're NOT doing). Grid-wide is a strict subset, so it doesn't
+  paint us into a corner.
+- **Subversion stays meaningful by routing alerts through IDS nodes, not directly to monitors.**
+  The bridge broadcasts `alert` to IDS-type nodes; the monitor is only reached via an
+  un-corrupted IDS's relay. (Sending `alert` straight to monitors would bypass the
+  `forwardingEnabled` gate and break the core subversion mechanic.)
+- **Mirror `recordIceDetection` for the escalation curve.** Two sensors with the same
+  step-up-then-trace-at-grade-threshold shape gives one coherent feel and reuses a proven
+  pattern. Put the monitor's accumulation+escalation in a new `recordMonitorAlert(monitorId)`
+  in `alert.js`, invoked once per alert a monitor receives via a new `ctx.recordMonitorAlert`
+  method (the graph only has `ctx`). Keeps escalation authority in `alert.js`, symmetric with
+  ICE, and out of the trait data.
+- **Per-monitor accumulation.** Each monitor counts its own received alerts (a `counter`
+  operator or an accumulating attribute), so corrupting one IDS only blinds its monitor.
+- **Keep `owned-cancel-trace`** (now `repeating`, fixed in #163) as the player's escape hatch.
+
+## Implementation outline (parts; details to the plan)
+
+1. **Bridge: broadcast alerts to IDS nodes.** `graph-bridge.js` `NODE_ALERT_RAISED` handler →
+   send the `alert` message to every node of type `ids` (filter `getState().nodes`), instead of
+   only the originating node. Keep the probe-noise / exploit bridges as-is.
+2. **Monitor escalation.** Replace the `security` trait's one-shot `alert-escalate → yellow`
+   with a per-alert path that invokes `ctx.recordMonitorAlert(nodeId)` once per received alert
+   (mechanism: a monitor-side operator returning an operator-effect ctx-call, or a `counter` +
+   threshold — plan decides). Add `recordMonitorAlert` to `alert.js` mirroring
+   `recordIceDetection` (step up below threshold; `startTraceCountdown` at the grade-scaled
+   count). Wire the new ctx method in `ctx.js` (nullCtx + mockCtx), `types.js` (CtxInterface),
+   and `game-ctx.js`.
+3. **Retire legacy.** Delete `recomputeGlobalAlert`, `propagateAlertEvent`, `raiseGlobalAlert`,
+   `DETECTOR_TYPES`/`MONITOR_TYPES`, the legacy `else` branch (the `NODE_ALERT_RAISED` handler
+   becomes graph-only or is removed if the bridge fully covers it), the `eventForwardingDisabled`
+   attribute, and `setNodeEventForwarding` (+ its `state.js` re-export).
+4. **Fix status display.** `cmd-status.js:258-259,296` → read `forwardingEnabled`.
+5. **Tests.** Rewrite `integration.test.js:317,330` and the `runtime.test.js` IDS-relay blocks to
+   drive exploit-failure → bridge → IDS → monitor → global-alert-climbs, assert observable
+   escalation, assert corrupting the IDS prevents it, and assert reaching trace at threshold.
+   Add a focused test for `recordMonitorAlert` (mirror the ICE detection tests).
+6. **Docs.** Rewrite MANUAL.md "Detection" and CLAUDE.md "Alert System" to the two-sensors-one-
+   ladder model; remove the CLAUDE.md scope-section known-gap caveat.
+7. **Census.** Re-run `make census` (same seeds, main vs branch); the grid becoming a real trace
+   driver can shift difficulty — report the delta, tune the threshold table if needed.
+
+## Patterns to follow
+
+- Escalation symmetry: `recordIceDetection` (`js/core/alert.js:200-231`) — copy its
+  step-up + grade-threshold + `startTraceCountdown` shape for `recordMonitorAlert`.
+- ctx method wiring: `cancelTrace` across `ctx.js:10,67`, `types.js:250`, `game-ctx.js:56`.
+- Counter primitive: `counter` operator (`operators.js:249`); `nthAlarm` set-piece
+  (`corporate-pieces.js:81`) is an example of a counter emitting at a threshold.
+- Operator-returned ctx effects: `runtime.js:351-357` applies `operator-effect` events via
+  `applyEffect` — the route for a per-message ctx-call from the monitor.
+- Test honesty rules: CLAUDE.md "Node graph / set-piece test honesty"; assert observable
+  consequences (`ctx.calls.*`, global alert level), trace the full signal path.
+
+## What we're NOT doing
+
+- **Segment-scoped / ranged IDS (DEFERRED — Les wants to try this for larger LANs).** Instead of
+  grid-wide sensing, an IDS would cover only a *segment*: alerts propagate along edges but stop
+  at a boundary node (switch / hub / router), so each IDS covers a bounded range and corrupting
+  it blinds only that segment. Richer "which sensor covers what" puzzle for big graphs. Grid-wide
+  (this spec) is the strict subset, so this is a clean future extension — file as a follow-up
+  issue at PR time.
+- **Alert cooldown / de-escalation levers (DEFERRED — filed as #174).** Cheaper ways to cool the
+  ladder — a "lie low" EXEC script (proposed at the WAN node) and a "scrub logs" action on a
+  *compromised* IDS/monitor — so the grid is a managed pressure, not a one-way ratchet. Depends
+  on this work's real ladder + `recordMonitorAlert` accumulation; its own session right after.
+  This spec keeps the "only escalates below trace" ratchet intact; #174 is where we relax it.
+- **ICE detection / pursuit changes** — owned by the separate ICE-reinvention work. We only add
+  a parallel sensor; we don't touch `recordIceDetection` or ICE movement.
+- **New alert *levels* or trace-countdown mechanics** — same `green/yellow/red/trace` ladder and
+  the same grade-scaled `TRACE_SECONDS`.
+- **Probe-driven grid alerts** — probing emits `probe-noise`, not `alert`; only dedicated sensor
+  set-pieces (e.g. `nthAlarm`) convert probe activity to alerts. The grid trips on exploit
+  failures, not probes. (Unchanged.)
+
+## Success criteria
+
+- `make check` green; new/rewritten tests drive the real path and would fail if the chain breaks
+  or if subversion stops working.
+- In an ICE-less LAN, repeated exploit failures climb the alert to trace; corrupting the IDS
+  before/while failing prevents escalation; owning the monitor cancels an in-flight trace.
+- No remaining references to `eventForwardingDisabled`, `recomputeGlobalAlert`,
+  `propagateAlertEvent`, `raiseGlobalAlert` (grep clean).
+- `make census` delta reported and acceptable (tune threshold if the grid over/under-pressures).
+- MANUAL.md / CLAUDE.md describe the shipped model; #173 caveat removed.

--- a/js/core/alert.js
+++ b/js/core/alert.js
@@ -1,132 +1,31 @@
 // @ts-check
-// Alert subsystem — node alert propagation, global alert computation, trace countdown.
-// Registers event listeners so state.js can emit NODE_ALERT_RAISED / NODE_RECONFIGURED
-// without importing this module (no circular dependency).
+// Alert subsystem — global alert escalation (two sensors) and the trace countdown.
 
 /** @typedef {import('./types.js').GlobalAlertLevel} GlobalAlertLevel */
 
-import { getState, endRun, nextAlertLevel } from "./state.js";
-import { setNodeAlertState } from "./state/node.js";
+import { getState, endRun } from "./state.js";
 import { setGlobalAlert, setTraceCountdown, setTraceTimerId, decrementTraceCountdown } from "./state/alert.js";
 import { setIceDetectedAt, incrementIceDetectionCount, activeIceInstances } from "./state/ice.js";
-import { emitEvent, on, E } from "./events.js";
-import { A } from "./action-ids.js";
+import { emitEvent, E } from "./events.js";
 import { scheduleRepeating, cancelEvent, TIMER } from "./timers.js";
 
 /** @type {GlobalAlertLevel[]} */
 const GLOBAL_ALERT_ORDER = ["green", "yellow", "red", "trace"];
 
-// Node types that act as detectors (IDS) or monitors (security-monitor)
-const DETECTOR_TYPES = new Set(["ids"]);
-const MONITOR_TYPES = new Set(["security-monitor"]);
-
 // Detection thresholds: cumulative detections before trace starts, by ICE grade
 const DETECTION_TRACE_THRESHOLD = { S: 1, A: 1, B: 2, C: 2, D: 3, F: 3 };
 
-// ── Event-driven hooks ────────────────────────────────────
+// Security-grid trace gate: accumulated monitor alerts before trace starts, by network grade.
+// Mirrors DETECTION_TRACE_THRESHOLD (ICE) but kept separate so the passive grid and the active
+// ICE pursuit can be tuned independently.
+const MONITOR_TRACE_THRESHOLD = { S: 4, A: 5, B: 7, C: 9, D: 12, F: 15 };
 
-/**
- * Register alert event handlers. Called at module load and can be re-called
- * after clearHandlers() (e.g. in the bot census loop).
- */
-export function initAlertHandlers() {
-  on(E.NODE_ALERT_RAISED, ({ nodeId }) => {
-    const s = getState();
-    const node = s.nodes[nodeId];
-    if (!node) return;
-
-    // When a graph is active, alert propagation is handled by graph operators/triggers.
-    // Just recompute global alert from node states.
-    if (s.nodeGraph) {
-      recomputeGlobalAlert();
-      return;
-    }
-
-    // Legacy path: IDS detection nodes propagate alerts to monitors
-    if (DETECTOR_TYPES.has(node.type)) {
-      propagateAlertEvent(nodeId);
-    }
-    recomputeGlobalAlert();
-  });
-
-  on(E.ACTION_RESOLVED, ({ action }) => {
-    if (action === A.CORRUPT) recomputeGlobalAlert();
-  });
-}
-
-// Register on first import
-initAlertHandlers();
-
-// ── Propagation ───────────────────────────────────────────
-
-export function propagateAlertEvent(fromNodeId) {
-  const s = getState();
-  const fromNode = s.nodes[fromNodeId];
-  if (!fromNode || fromNode.eventForwardingDisabled) return;
-
-  (s.adjacency[fromNodeId] || []).forEach((neighborId) => {
-    const neighbor = s.nodes[neighborId];
-    if (neighbor && MONITOR_TYPES.has(neighbor.type)) {
-      const raised = nextAlertLevel(neighbor.alertState);
-      if (raised !== neighbor.alertState) {
-        setNodeAlertState(neighborId, raised);
-      }
-      emitEvent(E.ALERT_PROPAGATED, {
-        fromNodeId,
-        fromLabel: fromNode.label,
-        toNodeId: neighborId,
-        toLabel: neighbor.label,
-      });
-      recomputeGlobalAlert();
-    }
-  });
-}
-
-function recomputeGlobalAlert() {
-  const s = getState();
-  const monitors  = Object.values(s.nodes).filter((n) => MONITOR_TYPES.has(n.type));
-  const detectors = Object.values(s.nodes).filter((n) => DETECTOR_TYPES.has(n.type));
-
-  const redMonitors    = monitors.filter((n) => n.alertState === "red").length;
-  const redDetectors   = detectors.filter((n) => n.alertState === "red"   && !n.eventForwardingDisabled).length;
-  const yellowDetectors = detectors.filter((n) => n.alertState !== "green" && !n.eventForwardingDisabled).length;
-
-  /** @type {GlobalAlertLevel} */
-  let newLevel = "green";
-  if (yellowDetectors >= 1)                  newLevel = "yellow";
-  if (redDetectors >= 1)                     newLevel = "red";
-  if (redDetectors >= 2 || redMonitors >= 1) newLevel = "trace";
-
-  // Only escalate, never de-escalate
-  const current = GLOBAL_ALERT_ORDER.indexOf(s.globalAlert);
-  const next    = GLOBAL_ALERT_ORDER.indexOf(newLevel);
-  if (next > current) {
-    const prev = s.globalAlert;
-    setGlobalAlert(newLevel);
-    emitEvent(E.ALERT_GLOBAL_RAISED, { prev, next: newLevel });
-    if (newLevel === "trace" && s.traceSecondsRemaining === null) {
-      startTraceCountdown();
-    }
-  }
-}
-
-// ── Global alert ──────────────────────────────────────────
-
-export function raiseGlobalAlert() {
-  const s = getState();
-  const prev = s.globalAlert;
-  const idx = GLOBAL_ALERT_ORDER.indexOf(s.globalAlert);
-  if (idx < GLOBAL_ALERT_ORDER.length - 1) {
-    setGlobalAlert(GLOBAL_ALERT_ORDER[idx + 1]);
-  }
-  const updated = getState().globalAlert;
-  if (prev !== updated) {
-    emitEvent(E.ALERT_GLOBAL_RAISED, { prev, next: updated });
-  }
-  if (updated === "trace" && getState().traceSecondsRemaining === null) {
-    startTraceCountdown();
-  }
-}
+// Global alert escalation now flows entirely through the two sensors:
+//   - recordIceDetection (active ICE pursuit), below
+//   - recordMonitorAlert (passive security grid: IDS → monitor), below
+// plus set-piece startTrace alarms. The legacy node-type-counting layer
+// (recomputeGlobalAlert / propagateAlertEvent / raiseGlobalAlert, gated on
+// alertState + eventForwardingDisabled) was retired in #173.
 
 // ── Trace countdown ───────────────────────────────────────
 
@@ -193,9 +92,9 @@ export function forceGlobalAlert(level) {
  * Record an ICE detection event. Drives the global alert directly: each
  * detection steps the alert up one level (capped below trace), and once the
  * grade-scaled detection count is reached (DETECTION_TRACE_THRESHOLD), the trace
- * countdown begins. This is the ICE pursuit layer — it does NOT colour IDS nodes
- * or propagate through the security monitor (that's the separate exploit-failure
- * puzzle layer in recomputeGlobalAlert). See MANUAL.md "Detection".
+ * countdown begins. This is the active-ICE-pursuit sensor; the passive security
+ * grid (exploit-failure → IDS → monitor) is the separate recordMonitorAlert sensor.
+ * Both feed the same global alert ladder. See MANUAL.md "Detection".
  */
 export function recordIceDetection(nodeId, iceId) {
   const s = getState();
@@ -206,10 +105,8 @@ export function recordIceDetection(nodeId, iceId) {
 
   // ICE detection drives the global alert directly (MANUAL.md "Detection"):
   // each detection steps the alert up; after a grade-scaled number of detections
-  // the trace countdown begins (S/A:1, B/C:2, D/F:3). This is the ICE *pursuit*
-  // layer — distinct from the exploit-failure → IDS → monitor *puzzle* layer
-  // (recomputeGlobalAlert). Trace here is gated purely on detection COUNT, not on
-  // counting red IDS nodes (which is unreachable on a 1-detector network).
+  // the trace countdown begins (S/A:1, B/C:2, D/F:3). The active-ICE sensor; the
+  // passive grid sensor (recordMonitorAlert) climbs the same ladder in parallel.
   //
   // Trace gate: TOTAL detections across ALL instances vs the detecting instance's
   // grade threshold (instances share the run grade in production).
@@ -224,6 +121,39 @@ export function recordIceDetection(nodeId, iceId) {
   const idx = GLOBAL_ALERT_ORDER.indexOf(s.globalAlert);
   if (idx < GLOBAL_ALERT_ORDER.indexOf("red")) {
     const prev = s.globalAlert;
+    const next = GLOBAL_ALERT_ORDER[idx + 1];
+    setGlobalAlert(next);
+    emitEvent(E.ALERT_GLOBAL_RAISED, { prev, next });
+  }
+}
+
+/**
+ * Record an alert reaching a security monitor — the passive security-grid sensor. The
+ * counterpart to recordIceDetection: each alert steps the global alert up one level (capped
+ * below trace), and once a grade-scaled number of alerts have accumulated on the monitor the
+ * trace countdown begins. The accumulated count lives on the monitor's graph node (so it
+ * serializes with the graph). An alert only reaches a monitor via an un-corrupted IDS relay,
+ * so corrupting the IDS (forwardingEnabled:false) severs this sensor. See MANUAL.md "Detection".
+ * @param {string} monitorId
+ */
+export function recordMonitorAlert(monitorId) {
+  const s = getState();
+  const graph = s.nodeGraph;
+  if (!graph) return;
+
+  const count = (graph.getNodeState(monitorId)?.alertCount ?? 0) + 1;
+  graph.setNodeAttr(monitorId, "alertCount", count);
+
+  const threat = s.spec?.threat ?? "C";
+  const threshold = MONITOR_TRACE_THRESHOLD[threat] ?? 2;
+  if (count >= threshold) {
+    if (getState().traceSecondsRemaining === null) startTraceCountdown();
+    return;
+  }
+  // Sub-threshold: step the alert up one level for feedback, capped below trace.
+  const idx = GLOBAL_ALERT_ORDER.indexOf(getState().globalAlert);
+  if (idx < GLOBAL_ALERT_ORDER.indexOf("red")) {
+    const prev = getState().globalAlert;
     const next = GLOBAL_ALERT_ORDER[idx + 1];
     setGlobalAlert(next);
     emitEvent(E.ALERT_GLOBAL_RAISED, { prev, next });

--- a/js/core/console-commands/cmd-status.js
+++ b/js/core/console-commands/cmd-status.js
@@ -255,8 +255,8 @@ export function cmdStatusNode(args) {
     lines.push(`- mine: attempts:${attempts}  exhausted:${node.mineExhausted ?? false}  next-yield:${yieldPct}%`);
   }
   if (node.rebooting) lines.push(`- REBOOTING`);
-  if (node.eventForwardingDisabled !== undefined) {
-    lines.push(`- event forwarding: ${node.eventForwardingDisabled ? "disabled" : "enabled"}`);
+  if (node.forwardingEnabled !== undefined) {
+    lines.push(`- event forwarding: ${node.forwardingEnabled === false ? "disabled" : "enabled"}`);
   }
   if (node.probed && node.vulnerabilities.length > 0) {
     const vulns = node.vulnerabilities
@@ -293,7 +293,7 @@ export function cmdStatusAlert() {
     lines.push("- security nodes:");
     secNodes.forEach((n) => {
       const fwd = n.type === "ids"
-        ? (n.eventForwardingDisabled ? "  [fwd:OFF]" : "  [fwd:ON]")
+        ? (n.forwardingEnabled === false ? "  [fwd:OFF]" : "  [fwd:ON]")
         : "";
       lines.push(`  ${n.id}  [${n.type}]  alert:${n.alertState}${fwd}`);
     });

--- a/js/core/graph-bridge.js
+++ b/js/core/graph-bridge.js
@@ -31,18 +31,31 @@ export function initGraphBridge() {
         try { graph.sendMessage(neighborId, msg); } catch (_) { }
       }
     } else if (action === A.XPLOIT) {
-      // Exploit attempt → send "exploit" message to the node.
+      // Exploit attempt → send "exploit" message to the node (honeypots etc.).
       const msg = createMessage({ type: "exploit", origin: nodeId, payload: { nodeId, success } });
       try { graph.sendMessage(nodeId, msg); } catch (_) { }
+      // A FAILED exploit is what the security grid notices: broadcast an "alert" to every
+      // IDS. Each un-corrupted IDS relays it to its monitor (forwardingEnabled gate), which
+      // accumulates and climbs the alert ladder (recordMonitorAlert). Grid-wide sensing,
+      // subversion-scoped: corrupting an IDS blinds its monitor. Routine probing does NOT
+      // trip the grid — only failures do (dedicated sensors like nthAlarm handle probe-noise).
+      // (Detectors are type "ids"; extend if a future set-piece adds another detector type.)
+      if (success === false) broadcastAlertToIds(graph, getState().nodes, nodeId);
     }
   });
+}
 
-  // Alert raised on a node → send "alert" message to that node.
-  // IDS relay chain forwards alerts to security monitors via the relay operator.
-  on(E.NODE_ALERT_RAISED, ({ nodeId }) => {
-    const graph = getState().nodeGraph;
-    if (!graph) return;
-    const msg = createMessage({ type: "alert", origin: nodeId, payload: { nodeId } });
-    try { graph.sendMessage(nodeId, msg); } catch (_) { }
-  });
+/**
+ * Send an "alert" message to every IDS node so the security grid hears it. The message
+ * keeps the *triggering* node (the one whose exploit failed) as origin/payload, so the
+ * alert stays attributable through the relay chain — consistent with the other bridge
+ * messages.
+ * @param {string} sourceNodeId  the node whose exploit failure raised the alert
+ */
+function broadcastAlertToIds(graph, nodes, sourceNodeId) {
+  for (const id of Object.keys(nodes)) {
+    if (nodes[id].type !== "ids") continue;
+    const msg = createMessage({ type: "alert", origin: sourceNodeId, payload: { nodeId: sourceNodeId } });
+    try { graph.sendMessage(id, msg); } catch (_) { }
+  }
 }

--- a/js/core/network/set-pieces.test.js
+++ b/js/core/network/set-pieces.test.js
@@ -178,10 +178,11 @@ describe("ids-relay-chain: alert forwarding and subversion", () => {
     const graph = new NodeGraph({ nodes, edges: inst.edges, triggers: inst.triggers }, ctx);
 
     // Send an alert into IDS — relay forwards it to monitor — monitor flags alerted:true
-    // security trait per-node trigger fires setGlobalAlert("yellow")
+    // and its report operator reports the alert to the global alert layer.
     graph.sendMessage("east/ids", createMessage({ type: "alert", origin: "probe-node", payload: {} }));
-    assert.equal(ctx.calls.setGlobalAlert?.length, 1);
-    assert.deepEqual(ctx.calls.setGlobalAlert[0], ["yellow"]);
+    assert.equal(graph.getNodeState("east/monitor").alerted, true);
+    assert.equal(ctx.calls.recordMonitorAlert?.length, 1);
+    assert.deepEqual(ctx.calls.recordMonitorAlert[0], ["east/monitor"]);
   });
 
   it("corrupt action requires owned", () => {
@@ -777,7 +778,8 @@ describe("tamper-detect: corrupting IDS without neutralizing relay triggers trac
 
     graph.sendMessage("td1/ids", createMessage({ type: "alert", origin: "probe-node", payload: {} }));
     assert.equal(graph.getNodeState("td1/security-monitor").alerted, true);
-    assert.equal(ctx.calls.setGlobalAlert?.length, 1);
+    assert.equal(ctx.calls.recordMonitorAlert?.length, 1);
+    assert.deepEqual(ctx.calls.recordMonitorAlert[0], ["td1/security-monitor"]);
   });
 });
 

--- a/js/core/node-graph/ctx.js
+++ b/js/core/node-graph/ctx.js
@@ -8,6 +8,7 @@
 export const nullCtx = {
   startTrace() {},
   cancelTrace() {},
+  recordMonitorAlert(_nodeId) {},
   giveReward(_amount) {},
   spawnICE(_nodeId) {},
   stopIce() {},
@@ -65,6 +66,7 @@ export function mockCtx() {
   const ctx = {
     startTrace: spy("startTrace"),
     cancelTrace: spy("cancelTrace"),
+    recordMonitorAlert: spy("recordMonitorAlert"),
     giveReward: spy("giveReward"),
     spawnICE: spy("spawnICE"),
     stopIce: spy("stopIce"),

--- a/js/core/node-graph/game-ctx.js
+++ b/js/core/node-graph/game-ctx.js
@@ -14,7 +14,7 @@
 /** @typedef {import('./types.js').CtxInterface} CtxInterface */
 
 import { A } from "../action-ids.js";
-import { startTraceCountdown, cancelTraceCountdown } from "../alert.js";
+import { startTraceCountdown, cancelTraceCountdown, recordMonitorAlert } from "../alert.js";
 import { addCash, setMissionComplete, addCardToHand } from "../state/player.js";
 import { mineYieldChance, isMineExhausted, generateMinedCard } from "../mining.js";
 import { startIce, ejectIce, rebootIce, stopIce, disableIce } from "../ice.js";
@@ -54,6 +54,7 @@ export function buildGameCtx(opts = {}) {
     // ── Set-piece callbacks ─────────────────────────────
     startTrace: () => startTraceCountdown(),
     cancelTrace: () => cancelTraceCountdown(),
+    recordMonitorAlert: (nodeId) => recordMonitorAlert(nodeId),
     giveReward: (amount) => addCash(amount),
     spawnICE: (_nodeId) => startIce(),
     stopIce: () => stopIce(),

--- a/js/core/node-graph/operators.js
+++ b/js/core/node-graph/operators.js
@@ -262,6 +262,25 @@ registerOperator("counter", (config, attrs, message, _ctx) => {
 });
 
 /**
+ * report — on a matching message, fire a ctx-call (as an operator-effect the runtime applies).
+ * config.on: message type to match (if omitted, matches any non-tick message).
+ * config.call: ctx method name; invoked with the node id ($nodeId).
+ * Used by security monitors to report each received alert to the global alert layer.
+ */
+registerOperator("report", (config, _attrs, message, _ctx) => {
+  if (!message) return {};
+  if (message.type === "tick") return {};
+  if (config.on && message.type !== config.on) return {};
+  if (!config.call) return {};
+  return {
+    events: [{
+      type: "operator-effect",
+      payload: { effect: "ctx-call", method: config.call, args: ["$nodeId"] },
+    }],
+  };
+});
+
+/**
  * flag — set a named attribute when a matching message arrives.
  * config.on: message type to match (if omitted, matches any non-tick message).
  * config.when: optional { key: value, ... } payload filter — all pairs must match.

--- a/js/core/node-graph/operators.test.js
+++ b/js/core/node-graph/operators.test.js
@@ -568,3 +568,35 @@ describe("debounce operator", () => {
     assert.deepEqual(result.outgoing?.[0].destinations, ["Y"]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// report
+// ---------------------------------------------------------------------------
+describe("report operator", () => {
+  it("emits a ctx-call operator-effect (with $nodeId) on a matching message", () => {
+    const msg = createMessage({ type: "alert", origin: "A" });
+    const result = invoke("report", { on: "alert", call: "recordMonitorAlert" }, {}, msg);
+    assert.deepEqual(result.events, [{
+      type: "operator-effect",
+      payload: { effect: "ctx-call", method: "recordMonitorAlert", args: ["$nodeId"] },
+    }]);
+  });
+
+  it("respects config.on — ignores non-matching message types", () => {
+    const msg = createMessage({ type: "probe-noise", origin: "A" });
+    const result = invoke("report", { on: "alert", call: "recordMonitorAlert" }, {}, msg);
+    assert.equal(result.events?.length ?? 0, 0);
+  });
+
+  it("ignores tick messages", () => {
+    const msg = createMessage({ type: "tick", origin: "__system__" });
+    const result = invoke("report", { call: "recordMonitorAlert" }, {}, msg);
+    assert.equal(result.events?.length ?? 0, 0);
+  });
+
+  it("is a no-op when config.call is missing", () => {
+    const msg = createMessage({ type: "alert", origin: "A" });
+    const result = invoke("report", { on: "alert" }, {}, msg);
+    assert.equal(result.events?.length ?? 0, 0);
+  });
+});

--- a/js/core/node-graph/runtime.test.js
+++ b/js/core/node-graph/runtime.test.js
@@ -19,131 +19,47 @@ function makeSpyNode(id) {
 }
 
 // ---------------------------------------------------------------------------
-// 1. IDS relay chain
+// 1. IDS relay chain — alert relays to the monitor, gated by forwardingEnabled
 // ---------------------------------------------------------------------------
 describe("IDS relay chain", () => {
-  it("alert sent to IDS arrives at monitor via relay", () => {
-    const graph = new NodeGraph({
-      nodes: [
-        { id: "ids-1", type: "ids", attributes: { forwardingEnabled: true }, operators: [{ name: "relay", filter: "alert" }] },
-        { id: "monitor", type: "security-monitor", attributes: { receivedAlert: false }, operators: [
-          // A custom operator to record receipt — we use latch to flip a flag
-          { name: "latch" }
-        ]},
-      ],
-      edges: [["ids-1", "monitor"]],
-    });
-
-    graph.sendMessage("ids-1", createMessage({ type: "alert", origin: "probe", payload: {} }));
-    // monitor receives the message; latch only reacts to set/reset, so we check
-    // via a trigger instead
-    // Re-test with a direct relay check: inject the message and observe monitor state
-    // via a trigger that sets a flag.
-  });
-
-  it("relay forwards alert to connected monitor", () => {
-    const ctx = mockCtx();
-    const graph = new NodeGraph({
-      nodes: [
-        { id: "ids", type: "ids", attributes: { forwardingEnabled: true }, operators: [{ name: "relay", filter: "alert" }] },
-        { id: "mon", type: "monitor", attributes: {}, operators: [] },
-      ],
-      edges: [["ids", "mon"]],
-      triggers: [{
-        id: "mon-received",
-        when: { type: "node-attr", nodeId: "mon", attr: "alerted", eq: true },
-        then: [{ effect: "ctx-call", method: "log", args: ["monitor alerted"] }],
-      }],
-    }, ctx);
-
-    // Inject alert — relay on ids forwards to mon, but mon has no operator to set alerted.
-    // Let's use set-node-attr effect instead: trigger when mon receives via operator.
-    // Simpler approach: use a trigger on ids being alerted, then check mon via relay + trigger.
-    // Actually the cleanest test: verify trigger fires after manual state update.
-    // For relay specifically, test by observing the mon node gets a message delivered.
-    // We'll do this via a tick-0 trigger pattern.
-
-    graph.sendMessage("ids", createMessage({ type: "alert", origin: "probe", payload: {} }));
-    // The relay on ids forwards the alert to mon. Mon has no operators so no state change.
-    // Verify by checking ids forwarding still works at the operator level (covered in operators.test.js).
-    // This integration test verifies the full path: sendMessage → operator → outgoing → deliver to neighbor.
-    assert.ok(true); // relay chain exercised without error
-  });
-
-  it("forwardingEnabled:false blocks relay to monitor", () => {
-    const ctx = mockCtx();
-    // Use a trigger on monitor to detect if it received an alert
-    const graph = new NodeGraph({
-      nodes: [
-        { id: "ids", type: "ids", attributes: { forwardingEnabled: false }, operators: [{ name: "relay", filter: "alert" }] },
-        { id: "mon", type: "monitor", attributes: { alerted: false },
-          operators: [{ name: "latch" }],
-          actions: [],
-        },
-      ],
-      edges: [["ids", "mon"]],
-      triggers: [{
-        id: "mon-alerted",
-        when: { type: "node-attr", nodeId: "mon", attr: "latched", eq: true },
-        then: [{ effect: "ctx-call", method: "log", args: ["monitor alerted"] }],
-      }],
-    }, ctx);
-
-    graph.sendMessage("ids", createMessage({ type: "set", origin: "probe", payload: {} }));
-    // ids has relay(filter:alert) — set message won't be relayed anyway.
-    // Let's use a direct alert to show forwarding is blocked:
-    graph.sendMessage("ids", createMessage({ type: "alert", origin: "probe", payload: {} }));
-    assert.equal(ctx.calls.log, undefined); // monitor never alerted
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Cleaner IDS test using a flag-setting operator workaround
-// ---------------------------------------------------------------------------
-describe("IDS relay — flag via trigger", () => {
+  // ids relays alert messages; monitor flags `alerted` when one arrives.
   function makeAlertChainGraph(forwardingEnabled) {
-    const ctx = mockCtx();
-    const graph = new NodeGraph({
+    return new NodeGraph({
       nodes: [
-        {
-          id: "ids", type: "ids",
-          attributes: { forwardingEnabled },
-          operators: [{ name: "relay", filter: "alert" }],
-        },
-        {
-          id: "mon", type: "monitor",
-          attributes: { alertCount: 0 },
-          operators: [],
-        },
+        { id: "ids", type: "ids", attributes: { forwardingEnabled },
+          operators: [{ name: "relay", filter: "alert" }] },
+        { id: "mon", type: "security-monitor", attributes: { alerted: false, sawNoise: false },
+          operators: [
+            { name: "flag", on: "alert", attr: "alerted", value: true },
+            // Would flip if the relay wrongly forwarded a non-alert message — lets the
+            // "only forwards alert" test actually observe the relay's filtering.
+            { name: "flag", on: "probe-noise", attr: "sawNoise", value: true },
+          ] },
       ],
       edges: [["ids", "mon"]],
-      triggers: [{
-        id: "mon-triggered",
-        when: { type: "quality-gte", name: "monAlerts", value: 1 },
-        then: [{ effect: "ctx-call", method: "log", args: ["monitor received alert"] }],
-      }],
-    }, ctx);
-    return { graph, ctx };
+    });
   }
 
-  it("alert reaches monitor when forwardingEnabled is true", () => {
-    // Since mon has no operators to set a flag, we verify via manual quality set after:
-    // The real integration value is that the graph doesn't throw and the relay fires.
-    const { graph } = makeAlertChainGraph(true);
-    // No error = relay executed correctly
-    assert.doesNotThrow(() => {
-      graph.sendMessage("ids", createMessage({ type: "alert", origin: "probe", payload: {} }));
-    });
+  it("relay forwards an alert to the connected monitor (forwardingEnabled:true)", () => {
+    const graph = makeAlertChainGraph(true);
+    assert.equal(graph.getNodeState("mon").alerted, false);
+    graph.sendMessage("ids", createMessage({ type: "alert", origin: "probe", payload: {} }));
+    assert.equal(graph.getNodeState("mon").alerted, true, "alert must reach the monitor via relay");
   });
 
-  it("no propagation when forwardingEnabled is false", () => {
-    const { graph } = makeAlertChainGraph(false);
-    assert.doesNotThrow(() => {
-      graph.sendMessage("ids", createMessage({ type: "alert", origin: "probe", payload: {} }));
-    });
-    // Verify ids attributes unchanged (no relay side-effects)
-    const idsState = graph.getNodeState("ids");
-    assert.equal(idsState.forwardingEnabled, false);
+  it("forwardingEnabled:false severs the relay — monitor never alerted", () => {
+    const graph = makeAlertChainGraph(false);
+    graph.sendMessage("ids", createMessage({ type: "alert", origin: "probe", payload: {} }));
+    assert.equal(graph.getNodeState("mon").alerted, false, "a subverted IDS must not forward the alert");
+  });
+
+  it("relay only forwards matching message types (alert), not others", () => {
+    const graph = makeAlertChainGraph(true);
+    graph.sendMessage("ids", createMessage({ type: "probe-noise", origin: "probe", payload: {} }));
+    // The monitor flags `sawNoise` on probe-noise, so if the relay had forwarded it this
+    // would be true. It stays false → the relay correctly filtered the non-alert message.
+    assert.equal(graph.getNodeState("mon").sawNoise, false, "relay must not forward non-alert messages");
+    assert.equal(graph.getNodeState("mon").alerted, false, "non-alert messages must not flag the monitor");
   });
 });
 

--- a/js/core/node-graph/traits.js
+++ b/js/core/node-graph/traits.js
@@ -269,20 +269,19 @@ registerTrait("security", {
   attributes: {
     alerted: false,
     alertState: "green",
+    alertCount: 0,
   },
   operators: [
     { name: "flag", on: "alert", attr: "alerted", value: true },
+    // Each alert that reaches the monitor reports to the global alert layer, which
+    // accumulates and climbs the ladder to trace (recordMonitorAlert). The monitor is
+    // reached only via an un-corrupted IDS relay, so corrupting the IDS severs this sensor.
+    { name: "report", on: "alert", call: "recordMonitorAlert" },
   ],
   actions: [ACTION_TEMPLATES.CANCEL_TRACE],
   triggers: [
-    {
-      id: "alert-escalate",
-      when: { type: "node-attr", attr: "alerted", eq: true },
-      then: [
-        { effect: "ctx-call", method: "setGlobalAlert", args: ["yellow"] },
-        { effect: "ctx-call", method: "log", args: ["Security monitor: intrusion alert raised"] },
-      ],
-    },
+    // (alert-escalate removed: escalation now flows per-alert through the report operator
+    //  → recordMonitorAlert, which climbs green→yellow→red→trace by accumulated count.)
     {
       // Repeating, not one-shot: owning the monitor must cancel a trace even if the
       // node was owned BEFORE the trace started (a one-shot would fire once into a

--- a/js/core/node-graph/types.js
+++ b/js/core/node-graph/types.js
@@ -33,7 +33,8 @@
  * @property {Record<string, number>} [ticksTable]  - delay / debounce: grade → ticks
  * @property {number} [n]             - counter: emit after N triggers
  * @property {MessageDescriptor} [emits] - counter: message to emit when threshold reached
- * @property {string} [on]            - flag / tally / debounce: message type to react to
+ * @property {string} [on]            - flag / tally / debounce / report: message type to react to
+ * @property {string} [call]          - report: ctx method name to invoke (with the node id)
  * @property {Record<string, any>} [when] - flag: payload key=value pairs that must match
  * @property {string} [attr]          - flag: node attribute name to set
  * @property {any} [value]            - flag: value to assign (default: true)
@@ -248,6 +249,7 @@
  * @typedef {Object} CtxInterface
  * @property {() => void} startTrace
  * @property {() => void} cancelTrace
+ * @property {(nodeId: string) => void} recordMonitorAlert
  * @property {(amount: number) => void} giveReward
  * @property {(nodeId: string) => void} spawnICE
  * @property {() => void} [stopIce]

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -22,7 +22,7 @@ export {
 export {
   setNodeVisible, setNodeAccessLevel, setNodeProbed, setNodeAlertState,
   setNodeRead, collectMacguffins, setNodeLooted, setNodeRebooting,
-  setNodeEventForwarding, setNodeVulnHidden, setNodeGraph, isObscured,
+  setNodeVulnHidden, setNodeGraph, isObscured,
 } from "./state/node.js";
 
 export {

--- a/js/core/state/node.js
+++ b/js/core/state/node.js
@@ -178,14 +178,6 @@ export function setNodeSigAlias(nodeId, alias) {
   syncToGraph(nodeId, "sigAlias", alias);
 }
 
-/** Sets node.eventForwardingDisabled. */
-export function setNodeEventForwarding(nodeId, disabled) {
-  mutate((s) => {
-    const node = s.nodes[nodeId];
-    if (node) node.eventForwardingDisabled = disabled;
-  });
-  syncToGraph(nodeId, "eventForwardingDisabled", disabled);
-}
 
 /** Sets hidden flag on a specific vulnerability by index. */
 export function setNodeVulnHidden(nodeId, vulnIndex, hidden) {

--- a/js/core/state/node.test.js
+++ b/js/core/state/node.test.js
@@ -8,7 +8,7 @@ import { clearAll } from "../timers.js";
 import {
   setNodeVisible, setNodeAccessLevel, setNodeProbed, setNodeAlertState,
   setNodeRead, collectMacguffins, setNodeLooted, setNodeRebooting,
-  setNodeEventForwarding, setNodeVulnHidden, isObscured,
+  setNodeVulnHidden, isObscured,
 } from "./node.js";
 
 describe("state/node — node mutations", () => {
@@ -82,16 +82,6 @@ describe("state/node — node mutations", () => {
     assert.equal(getState().nodes["gateway"].rebooting, true);
     setNodeRebooting("gateway", false);
     assert.equal(getState().nodes["gateway"].rebooting, false);
-  });
-
-  it("setNodeEventForwarding sets eventForwardingDisabled", () => {
-    // Find an IDS node that has eventForwardingDisabled
-    const s = getState();
-    const idsNode = Object.values(s.nodes).find((n) => n.type === "ids");
-    if (!idsNode) return;
-
-    setNodeEventForwarding(idsNode.id, true);
-    assert.equal(getState().nodes[idsNode.id].eventForwardingDisabled, true);
   });
 
   it("setNodeVulnHidden sets vulnerability hidden flag", () => {

--- a/scripts/lib/headless-engine.js
+++ b/scripts/lib/headless-engine.js
@@ -15,7 +15,7 @@
 import { initGame, getState, serializeState, deserializeState } from "../../js/core/state.js";
 import { buildActionContext, initActionDispatcher } from "../../js/core/actions/action-context.js";
 import { startIce, handleIceTick, handleIceDetect, initIceHandlers } from "../../js/core/ice.js";
-import { handleTraceTick, initAlertHandlers } from "../../js/core/alert.js";
+import { handleTraceTick } from "../../js/core/alert.js";
 import { initNavigationCancelHandler } from "../../js/core/node-graph/game-ctx.js";
 import { initGraphBridge } from "../../js/core/graph-bridge.js";
 import { initDynamicActions } from "../../js/core/console-commands/dynamic-actions.js";
@@ -63,7 +63,6 @@ export function wireRunHandlers() {
   // Game-logic listeners that are normally auto-registered at module import.
   // clearHandlers() wiped those, so re-register them explicitly per run.
   initIceHandlers();
-  initAlertHandlers();
   initNavigationCancelHandler();
   initGraphBridge();
   initDynamicActions();

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -306,37 +306,10 @@ describe("Trace: startTraceCountdown drives global alert to trace", () => {
   });
 });
 
-// ── Alert flow ────────────────────────────────────────────────────────────────
-
-describe("Alert flow: ids alert escalates global alert", () => {
-  beforeEach(() => {
-    clearAll();
-    initGame(() => buildAlertLAN(), "itest-6");
-  });
-
-  it("NODE_ALERT_RAISED on ids (with raised alertState) escalates global alert", () => {
-    // In the graph path, NODE_ALERT_RAISED triggers recomputeGlobalAlert(),
-    // which reads all IDS/monitor alertStates to compute the global level.
-    const s = getState();
-    assert.equal(s.globalAlert, "green");
-    s.nodes["ids-1"].alertState = "yellow";
-    emitEvent(E.NODE_ALERT_RAISED, { nodeId: "ids-1", label: "ids-1" });
-    assert.ok(
-      ["yellow", "red", "trace"].includes(s.globalAlert),
-      `expected alert to escalate, got: ${s.globalAlert}`
-    );
-  });
-
-  it("NODE_ALERT_RAISED does NOT escalate when forwarding disabled", () => {
-    // When eventForwardingDisabled is set, recomputeGlobalAlert skips the detector.
-    const s = getState();
-    s.nodes["ids-1"].eventForwardingDisabled = true;
-    s.nodes["ids-1"].alertState = "yellow";
-    emitEvent(E.NODE_ALERT_RAISED, { nodeId: "ids-1", label: "ids-1" });
-    assert.equal(s.globalAlert, "green",
-      "global alert must not escalate when forwarding is disabled");
-  });
-});
+// (The legacy "Alert flow: ids alert escalates global alert" suite was removed in #173 —
+//  it injected alertState/eventForwardingDisabled directly to exercise the retired
+//  recomputeGlobalAlert path. The honest replacement is the "security grid: IDS->monitor
+//  escalation" suite, which drives the real relay→monitor→recordMonitorAlert chain.)
 
 // ── Action availability ───────────────────────────────────────────────────────
 
@@ -1186,6 +1159,53 @@ describe("timed-action cancel clears the operator's real progress attr (B2)", ()
     assert.equal(after.reading, false, "navigation must cancel the dump");
     assert.equal(after._ta_dump_progress, 0,
       "cancel must reset the operator's real progress attr, not a phantom _ta_read_progress");
+  });
+});
+
+describe("security grid: IDS->monitor escalation (#173)", () => {
+  beforeEach(() => { clearAll(); });
+
+  // Drive the graph chain directly: an alert arriving at the IDS relays to its monitor
+  // (the bridge's job in real play — verified separately via playtest/census).
+  const sendAlert = (graph) => graph.sendMessage("sp/ids", { type: "alert", payload: {} });
+  // Send alerts until the trace starts (threshold is grade-scaled — don't hardcode it).
+  const alertUntilTrace = (graph) => {
+    for (let i = 0; i < 30 && getState().traceSecondsRemaining === null; i++) sendAlert(graph);
+  };
+
+  it("alerts through an un-corrupted IDS climb the global alert to trace", () => {
+    initGame(() => buildSetPieceMiniNetwork("idsRelayChain"), "grid-seed-1");
+    const graph = getState().nodeGraph;
+    assert.equal(getState().globalAlert, "green");
+
+    sendAlert(graph);
+    assert.notEqual(getState().globalAlert, "green", "first alert should climb the ladder");
+
+    alertUntilTrace(graph);
+    assert.notEqual(getState().traceSecondsRemaining, null,
+      "repeated alerts through the monitor must start the trace");
+  });
+
+  it("corrupting the IDS severs the chain — no escalation, no trace", () => {
+    initGame(() => buildSetPieceMiniNetwork("idsRelayChain"), "grid-seed-2");
+    const graph = getState().nodeGraph;
+    graph.setNodeAttr("sp/ids", "accessLevel", "owned");
+    graph.executeAction("sp/ids", "corrupt");
+    assert.equal(graph.getNodeState("sp/ids").forwardingEnabled, false, "corrupt should disable forwarding");
+
+    for (let i = 0; i < 30; i++) sendAlert(graph); // far past any grade threshold
+    assert.equal(getState().globalAlert, "green", "a corrupted IDS must not escalate the global alert");
+    assert.equal(getState().traceSecondsRemaining, null, "a corrupted IDS must not start a trace");
+  });
+
+  it("owning the monitor cancels an in-flight grid trace", () => {
+    initGame(() => buildSetPieceMiniNetwork("idsRelayChain"), "grid-seed-3");
+    const graph = getState().nodeGraph;
+    alertUntilTrace(graph);
+    assert.notEqual(getState().traceSecondsRemaining, null, "trace should be running first");
+
+    graph.setNodeAttr("sp/monitor", "accessLevel", "owned"); // owned-cancel-trace (repeating)
+    assert.equal(getState().traceSecondsRemaining, null, "owning the monitor cancels the trace");
   });
 });
 


### PR DESCRIPTION
## What

Reconciles the alert layer per the 2026-06-11 deep audit (#173). The IDS→monitor "two-layer ladder" the manual described was vestigial in graph mode; this makes it real and retires the dead legacy machinery that shadowed it.

**Two sensors, one ladder.** Global alert (`green → yellow → red → trace`) is now driven by two independent sensors sharing the same ladder and trace clock:

- **Security grid (passive)** — the clock for ICE-less LANs. A *failed* exploit broadcasts an `alert` to every IDS (`graph-bridge`, on `ACTION_RESOLVED` XPLOIT `success:false` — routine probing no longer trips it). Each un-corrupted IDS relays to its `security-monitor`; the new `report` operator calls `recordMonitorAlert`, which accumulates per-monitor and climbs the ladder, starting the trace at a grade-scaled count (`MONITOR_TRACE_THRESHOLD`). Grid-wide sensing, subversion-scoped: corrupt an IDS (`forwardingEnabled:false`) to blind its monitor.
- **ICE (active)** — `recordIceDetection`, unchanged.

## Changes

- **New escalation path**: `report` operator (`operators.js`), `recordMonitorAlert` (`alert.js`, mirrors `recordIceDetection`), ctx wiring (`ctx.js`/`types.js`/`game-ctx.js`), security trait (`report` op, `alertCount`, removed the one-shot `alert-escalate`), bridge broadcast on exploit failure.
- **Retired legacy layer**: `recomputeGlobalAlert`, `propagateAlertEvent`, `raiseGlobalAlert`, `DETECTOR/MONITOR_TYPES`, the `initAlertHandlers` hooks (+ headless wiring), `eventForwardingDisabled` attr + `setNodeEventForwarding`.
- **Cruft fix**: removed a redundant inline `relay` on 5 set-piece IDS nodes (the `detectable` trait already provides it; the duplicate double-counted alerts at the monitor).
- **Status fix**: `cmd-status` reads `forwardingEnabled` — it read the removed `eventForwardingDisabled`, so it always showed "enabled" regardless of subversion.
- **Test honesty**: rewrote the `assert.ok(true)` IDS-relay tests and the injected-state integration tests to drive the real relay→monitor→escalation chain; added a grid-escalation integration suite (climb to trace, corrupt severs, own-monitor cancels).
- **Docs**: MANUAL.md "Detection" + CLAUDE.md alert section describe the shipped two-sensor model; removed the #173 known-gap caveat.

## Difficulty (census, 25 seeds/grade)

| | threat C (ICE-less) | threat B (ICE + grid) |
|---|---|---|
| main | 0.32 success / 0.76 trace | 0.32 / 0.76 |
| this PR | 0.28 / 0.76 | 0.24 / 0.84 |

At threat C the grid is the *only* clock and lands at ~main's difficulty (a real, forgiving-ish passive failure mode where before there was none). At threat B it's slightly harder — the intended cost of a second sensor. Threshold table is the tuning knob; cooldown levers (#174) will add relief.

## Verification

`make check` green — 1027 tests, 0 failures, lint clean. Bridge verified end-to-end (an alert raised on the gateway escalates the grid to trace); IDS subversion + own-monitor-cancel covered by tests.

## References

- Closes #173.
- Follow-up: #174 (alert cooldown levers — "lie low" EXEC + "scrub logs" action; depends on this).
- Spec / plan / notes: `docs/dev-sessions/2026-06-11-2241-alert-layer-reconcile/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
