### PR TITLE
Overlay progress smoothing: decouple render cadence from the game tick

### DIFF
--- a/docs/dev-sessions/2026-06-12-1119-mine-overlay-smoothing/lab/mine-smoothing-lab.html
+++ b/docs/dev-sessions/2026-06-12-1119-mine-overlay-smoothing/lab/mine-smoothing-lab.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>MINE overlay smoothing lab</title>
+<style>
+  body { background:#0a0a0f; color:#39ff14; font:13px monospace; margin:0; padding:16px; }
+  h1 { font-size:15px; font-weight:normal; color:#cc00cc; }
+  .row { display:flex; gap:24px; align-items:flex-start; margin-top:12px; }
+  .panel { background:#06060a; border:1px solid #1a3a1a; }
+  .panel h2 { font-size:12px; margin:0; padding:4px 8px; color:#888; border-bottom:1px solid #1a3a1a; }
+  svg { display:block; }
+  .h, .v { stroke:#cc00cc; stroke-width:2; stroke-opacity:0.5; }
+  .box { fill:none; stroke:#ff44ff; stroke-width:1; stroke-opacity:0.9; }
+  .controls { margin-top:16px; line-height:2; }
+  .controls label { display:inline-block; width:170px; }
+  input[type=range] { vertical-align:middle; width:260px; }
+  button { background:#1a3a1a; color:#39ff14; border:1px solid #39ff14; font:13px monospace; padding:4px 12px; cursor:pointer; }
+  .val { color:#fff; }
+  .note { color:#666; max-width:740px; margin-top:14px; line-height:1.5; }
+</style>
+</head>
+<body>
+<h1>MINE overlay — progress smoothing lab</h1>
+<div class="note">
+  Both panels animate the real MINE crosshair geometry from the SAME target progress,
+  which advances 0→1 but is only <b>updated at 10 fps</b> (the game tick).
+  LEFT = today's behavior (renders only when the target updates).
+  RIGHT = proposed fix (rAF easing a displayed progress toward the target).
+  Watch the crosshair roam and the reticle spin.
+</div>
+<div class="row">
+  <div class="panel"><h2>RAW — render on 10fps sync (current)</h2>
+    <svg id="raw" width="220" height="220"></svg>
+  </div>
+  <div class="panel"><h2>SMOOTHED — rAF + ease (proposed)</h2>
+    <svg id="smooth" width="220" height="220"></svg>
+  </div>
+</div>
+<div class="controls">
+  <div><label>smoothing τ (ms)</label><input id="tau" type="range" min="20" max="400" step="5" value="120"><span class="val" id="tauv">120</span></div>
+  <div><label>scan duration (ms)</label><input id="dur" type="range" min="1000" max="6000" step="250" value="3000"><span class="val" id="durv">3000</span></div>
+  <div><label>tick rate (fps)</label><input id="fps" type="range" min="4" max="30" step="1" value="10"><span class="val" id="fpsv">10</span></div>
+  <div><button id="scan">▶ run scan</button> <button id="loop">⟲ loop</button></div>
+</div>
+<script>
+const R = 100, SIZE = R * 2, OFF = 10; // svg padding offset for stroke
+const FX = 2.5, FY = 3.5, PHASE = Math.PI / 2;
+
+function makeReticle(svg) {
+  svg.innerHTML = `
+    <line class="h"></line><line class="v"></line>
+    <rect class="box"></rect>`;
+  return { h: svg.querySelector('.h'), v: svg.querySelector('.v'), box: svg.querySelector('.box') };
+}
+function draw(els, p) {
+  const c = OFF + R;
+  const amp = R * 0.62 * (1 - p * p);
+  const ix = c + amp * Math.sin(2 * Math.PI * FX * p);
+  const iy = c + amp * Math.sin(2 * Math.PI * FY * p + PHASE);
+  els.h.setAttribute('x1', OFF); els.h.setAttribute('y1', iy);
+  els.h.setAttribute('x2', OFF + SIZE); els.h.setAttribute('y2', iy);
+  els.v.setAttribute('x1', ix); els.v.setAttribute('y1', OFF);
+  els.v.setAttribute('x2', ix); els.v.setAttribute('y2', OFF + SIZE);
+  const side = R * 0.42;
+  els.box.setAttribute('x', ix - side / 2); els.box.setAttribute('y', iy - side / 2);
+  els.box.setAttribute('width', side); els.box.setAttribute('height', side);
+  els.box.setAttribute('transform', `rotate(${p * 360} ${ix} ${iy})`);
+}
+
+const rawEls = makeReticle(document.getElementById('raw'));
+const smoothEls = makeReticle(document.getElementById('smooth'));
+
+let target = 0, disp = 0, start = 0, last = 0, tickTimer = null, running = false, looping = false;
+const tau = () => +document.getElementById('tau').value;
+const dur = () => +document.getElementById('dur').value;
+const fps = () => +document.getElementById('fps').value;
+
+function startScan() {
+  stop();
+  target = 0; disp = 0; start = performance.now(); last = start; running = true;
+  // 10fps (configurable) stepped target feed — mimics the game's per-tick sync().
+  const stepTarget = () => {
+    if (!running) return;
+    const t = Math.min(1, (performance.now() - start) / dur());
+    target = t;
+    draw(rawEls, target);          // RAW renders ONLY here (on the stepped sync)
+    if (t >= 1) { running = false; if (looping) setTimeout(startScan, 500); return; }
+    tickTimer = setTimeout(stepTarget, 1000 / fps());
+  };
+  stepTarget();
+  requestAnimationFrame(loop);
+}
+function loop(now) {
+  const dt = now - last; last = now;
+  const k = 1 - Math.exp(-dt / tau());
+  disp += (target - disp) * k;
+  draw(smoothEls, disp);
+  if (running || Math.abs(target - disp) > 0.001) requestAnimationFrame(loop);
+}
+function stop() {
+  running = false;
+  if (tickTimer) { clearTimeout(tickTimer); tickTimer = null; }
+}
+for (const id of ['tau', 'dur', 'fps']) {
+  const el = document.getElementById(id);
+  el.addEventListener('input', () => document.getElementById(id + 'v').textContent = el.value);
+}
+document.getElementById('scan').onclick = () => { looping = false; startScan(); };
+document.getElementById('loop').onclick = () => { looping = !looping; if (looping) startScan(); else stop(); };
+draw(rawEls, 0); draw(smoothEls, 0);
+</script>
+</body>
+</html>

--- a/docs/dev-sessions/2026-06-12-1119-mine-overlay-smoothing/plan.md
+++ b/docs/dev-sessions/2026-06-12-1119-mine-overlay-smoothing/plan.md
@@ -1,0 +1,37 @@
+# Plan — overlay progress smoothing
+
+**Goal:** Opt-in render-cadence/progress-update decoupling in `NodeOverlay`, applied to the
+three continuous-motion overlays.
+
+**Approach:** One slice — pure easing helper + base-class opt-in rAF + adopt in three overlays.
+
+---
+
+## Phase 1: Easing helper + NodeOverlay opt-in + adopt + verify
+
+**Files:**
+- Add: `js/ui/overlays/ease.js` — `easeToward(current, target, dtMs, tauMs)` (pure, no deps).
+- Add: `js/ui/overlays/ease.test.js` — converges, stays between current/target, monotone
+  approach, frame-rate independence (2×8ms ≈ 1×16ms within tolerance), identity at current==target.
+- Modify: `js/ui/overlays/node-overlay.js` — add `_smoothing`/`_tau`/`_displayProgress`/`_raf`/
+  `_lastFrame` fields; `enableProgressSmoothing(tauMs = 120)`; `get displayProgress()`
+  (returns `this.progress` when smoothing off, eased value when on); an rAF loop using
+  `easeToward` that re-renders each frame and self-stops on convergence; `sync()` starts/keeps
+  the loop and snaps `_displayProgress` on a new target node; `clear()` cancels the rAF. When
+  smoothing is off, the `sync()`/`reposition()` render path is unchanged.
+- Modify: `js/ui/overlays/mine-scan.js` — `enableProgressSmoothing(120)` in ctor; `_render`
+  reads `this.displayProgress`.
+- Modify: `js/ui/overlays/probe-sweep.js` — add ctor `enableProgressSmoothing(120)`; `_render`
+  reads `this.displayProgress`.
+- Modify: `js/ui/overlays/exploit-brackets.js` — `enableProgressSmoothing(120)` in ctor;
+  `_render` + `_tickZaps` read `this.displayProgress`.
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes (new `ease.test.js` green; full suite green)
+
+**Verification — manual (browser, real game — smoothness is motion, not a screenshot):**
+- [ ] `make bundle-vendor`; serve; in a run trigger PROBE, XPLOIT, and a MINE scan via the
+  console; confirm each overlay still renders correctly, animates smoothly (no 10 fps lurch),
+  and no console errors. Confirm `clear()` hides them (no lingering rAF/ghost).
+- [ ] Sanity: with smoothing off (any non-adopted overlay, e.g. ice-detect) behavior unchanged.

--- a/docs/dev-sessions/2026-06-12-1119-mine-overlay-smoothing/spec.md
+++ b/docs/dev-sessions/2026-06-12-1119-mine-overlay-smoothing/spec.md
@@ -1,0 +1,63 @@
+# Overlay progress smoothing — decouple render cadence from tick-fed progress
+
+**Goal:** Node-anchored overlay animations whose geometry is a continuous function of
+`progress` look choppy in-game because they only re-render when `sync()` is called — and
+in game that happens once per game tick (~10 fps via `ACTION_FEEDBACK`). In the preview
+harness `sync()` is driven by a 60 fps rAF, so the same effects look smooth there. Give the
+overlays an internal rAF that renders at display rate, easing a *displayed* progress toward
+the tick-fed *target* progress, so the motion is smooth without changing how progress is fed.
+
+**Source:** User report — the MINE scan overlay is choppier in normal gameplay than in
+preview. Diagnosed as a cadence (not performance) issue. τ tuned to 120 ms by eye in the lab
+(`lab/mine-smoothing-lab.html`).
+
+## Current state
+
+`NodeOverlay` (`js/ui/overlays/node-overlay.js`) re-renders only inside `sync()`/`reposition()`.
+Effects that own their own rAF/interval (`loot-rings`, `exploit-brackets` zaps) are smooth;
+effects whose geometry is purely a function of `this.progress` freeze between ticks.
+
+## Audit (which overlays benefit)
+
+Smoothing helps **continuous progress→geometry** motion; it's wrong or pointless elsewhere.
+
+- ✅ **mine-scan** — continuous Lissajous roam + reticle spin.
+- ✅ **probe-sweep** — rotating radar "hand" + sweep-front cross-fade.
+- ✅ **exploit-brackets** — brackets converge + rotate `p*360` (zap flicker already self-runs).
+- ➖ **ice-detect**, **read-sectors** — discrete segment fills, chunky *by design*.
+- ➖ **selection-reticle** — spin is CSS (already decoupled); progress unused.
+- ➖ **loot-rings** — already time-driven (per-ring rAF).
+
+## Desired end state
+
+- A pure, testable easing helper: `easeToward(current, target, dtMs, tauMs)` =
+  `current + (target-current) * (1 - exp(-dtMs/tauMs))` (frame-rate-independent low-pass).
+- `NodeOverlay` gains opt-in smoothing: `enableProgressSmoothing(tauMs = 120)`, a
+  `displayProgress` getter, and an internal rAF loop that eases `displayProgress` toward
+  `this.progress` each frame and calls `_render()`. The loop self-stops on convergence and is
+  cancelled in `clear()`; a new target node snaps `displayProgress` (no stale ease-in).
+  When smoothing is **off**, behavior is byte-identical to today (`displayProgress` === `progress`,
+  render on `sync()`).
+- `mine-scan`, `probe-sweep`, `exploit-brackets` opt in and read `this.displayProgress` in
+  `_render()` (exploit-brackets' zap origin too) instead of `this.progress`.
+
+## Design decisions
+
+- **Opt-in, not automatic** — discrete-fill and CSS-spin overlays must NOT be smoothed; the
+  helper defaults off so each overlay declares intent.
+- **τ = 120 ms** — locked by eye in the lab (snappy but no lock-on lag at 10 fps feed).
+- **Time-based low-pass** (not velocity extrapolation) — simplest robustly-smooth approach;
+  ~τ of imperceptible lag, handles scrub/pause/variable rate for free.
+- **Cost** — one rAF per *active* smoothed overlay (a handful of `setAttribute`s/frame); stops on
+  convergence + on `clear()`. Not a perf concern; this is a cadence fix.
+
+## What we're NOT doing
+
+- Not changing how progress is produced/fed (still tick-driven `ACTION_FEEDBACK`).
+- Not smoothing the discrete/CSS/time-driven overlays.
+- Not touching preview's 60 fps driver (it already feeds fine; the helper just adds harmless
+  sub-frame easing there).
+
+## Open questions
+
+- None — τ locked, audit complete.

--- a/js/ui/overlays/ease.js
+++ b/js/ui/overlays/ease.js
@@ -1,0 +1,22 @@
+// @ts-check
+// Frame-rate-independent exponential smoothing (a low-pass filter). Used by
+// NodeOverlay to ease a displayed progress toward a tick-fed target progress so
+// overlay geometry renders smoothly at display rate even when progress only
+// updates at the ~10fps game tick. tau is the time-constant in ms: larger = more
+// smoothing (and more lag), smaller = snappier.
+
+/**
+ * Move `current` toward `target` by an amount that depends on elapsed time, so
+ * the approach rate is independent of frame rate (two 8ms steps ≈ one 16ms step).
+ * @param {number} current
+ * @param {number} target
+ * @param {number} dtMs   elapsed time since the last step, in ms
+ * @param {number} tauMs  smoothing time-constant in ms (> 0)
+ * @returns {number}
+ */
+export function easeToward(current, target, dtMs, tauMs) {
+  if (!Number.isFinite(dtMs) || dtMs <= 0) return current; // no time elapsed → no step
+  if (!Number.isFinite(tauMs) || tauMs <= 0) return target; // smoothing disabled → snap
+  const k = 1 - Math.exp(-dtMs / tauMs);
+  return current + (target - current) * k;
+}

--- a/js/ui/overlays/ease.test.js
+++ b/js/ui/overlays/ease.test.js
@@ -1,0 +1,55 @@
+// @ts-check
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { easeToward } from "./ease.js";
+
+const TAU = 120;
+
+describe("easeToward", () => {
+  test("identity when already at target", () => {
+    assert.equal(easeToward(0.5, 0.5, 16, TAU), 0.5);
+  });
+
+  test("no movement on non-positive or non-finite dt", () => {
+    assert.equal(easeToward(0.2, 1, 0, TAU), 0.2);
+    assert.equal(easeToward(0.2, 1, -5, TAU), 0.2);
+    assert.equal(easeToward(0.2, 1, NaN, TAU), 0.2);
+    assert.equal(easeToward(0.2, 1, Infinity, TAU), 0.2);
+  });
+
+  test("non-positive or non-finite tau snaps to target (smoothing disabled)", () => {
+    assert.equal(easeToward(0.2, 1, 16, 0), 1);
+    assert.equal(easeToward(0.2, 1, 16, -10), 1);
+    assert.equal(easeToward(0.2, 1, 16, NaN), 1);
+    assert.equal(easeToward(0.2, 1, 16, Infinity), 1);
+  });
+
+  test("moves toward target, staying strictly between current and target", () => {
+    const next = easeToward(0, 1, 16, TAU);
+    assert.ok(next > 0 && next < 1, `expected (0,1), got ${next}`);
+  });
+
+  test("works downward too", () => {
+    const next = easeToward(1, 0, 16, TAU);
+    assert.ok(next > 0 && next < 1, `expected (0,1), got ${next}`);
+  });
+
+  test("larger dt advances further toward target", () => {
+    const small = easeToward(0, 1, 8, TAU);
+    const big = easeToward(0, 1, 32, TAU);
+    assert.ok(big > small, `expected ${big} > ${small}`);
+  });
+
+  test("converges to target after many steps", () => {
+    let v = 0;
+    for (let i = 0; i < 500; i++) v = easeToward(v, 1, 16, TAU);
+    assert.ok(Math.abs(v - 1) < 1e-3, `did not converge, v=${v}`);
+  });
+
+  test("frame-rate independent: two 8ms steps ≈ one 16ms step", () => {
+    const oneStep = easeToward(0, 1, 16, TAU);
+    let two = easeToward(0, 1, 8, TAU);
+    two = easeToward(two, 1, 8, TAU);
+    assert.ok(Math.abs(oneStep - two) < 1e-9, `${oneStep} vs ${two}`);
+  });
+});

--- a/js/ui/overlays/exploit-brackets.js
+++ b/js/ui/overlays/exploit-brackets.js
@@ -15,6 +15,10 @@ class ExploitBracketsOverlay extends NodeOverlay {
     this._zapIntervalId = null;
     this._zapNextCorner = 0;  // cycles 0→1→2→3→0...
     this._zapTicksToFire = 0; // ticks until next zap
+    // Brackets converge + rotate continuously with progress — render at display
+    // rate so the convergence doesn't step at the ~10fps game tick. (The zap
+    // flicker runs on its own interval already.)
+    this.enableProgressSmoothing(120);
   }
 
   sync(nodeId, progress) {
@@ -24,13 +28,9 @@ class ExploitBracketsOverlay extends NodeOverlay {
 
   clear() {
     this._stopZaps();
-    this.nodeId = null;
-    this.progress = 0;
+    super.clear(); // stops the smoothing rAF, hides, resets progress/displayProgress
     const svg = this._svg();
-    if (svg) {
-      svg.style.opacity = "0";
-      svg.style.transform = "rotate(0deg)";
-    }
+    if (svg) svg.style.transform = "rotate(0deg)";
   }
 
   render() {
@@ -75,7 +75,7 @@ class ExploitBracketsOverlay extends NodeOverlay {
     const { pos, r } = a;
     this._place(svg, pos, r);
 
-    const p = this.progress;
+    const p = this.displayProgress;
     const ox = r, oy = r;  // center offset within the SVG viewport
     // Brackets start at 1.8x radius from center, converge to 1.1x
     const dist = r * 1.8 - r * 0.7 * p;   // lerp(1.8r, 1.1r, p)
@@ -120,7 +120,7 @@ class ExploitBracketsOverlay extends NodeOverlay {
 
     const r = a.r;
     const ox = r, oy = r;
-    const p = this.progress;
+    const p = this.displayProgress;
     const dist = r * 1.8 - r * 0.7 * p;
 
     const corners = [

--- a/js/ui/overlays/mine-scan.js
+++ b/js/ui/overlays/mine-scan.js
@@ -14,6 +14,9 @@ class MineScanOverlay extends NodeOverlay {
     this._fx = 2.5;
     this._fy = 3.5;
     this._phase = Math.PI / 2;
+    // Continuous Lissajous roam + reticle spin — render at display rate, not the
+    // ~10fps game tick, so it doesn't lurch in-game (smooth in the 60fps preview).
+    this.enableProgressSmoothing(120);
   }
 
   sync(nodeId, progress) {
@@ -43,7 +46,7 @@ class MineScanOverlay extends NodeOverlay {
     const size = r * 2;
     this._place(svg, pos, r);
 
-    const p = this.progress;
+    const p = this.displayProgress;
     // Lissajous roam in overlay coords [0..size], center at r. Amplitude eases
     // to 0 as p→1 so the crosshair settles onto center (lock-on).
     const amp = r * 0.62 * (1 - p * p);

--- a/js/ui/overlays/node-overlay.js
+++ b/js/ui/overlays/node-overlay.js
@@ -13,6 +13,11 @@
 import { html } from "lit";
 import { StarnetElement } from "../components/starnet-element.js";
 import { getCy } from "../graph.js";
+import { easeToward } from "./ease.js";
+
+// Below this gap between displayed and target progress, the smoothing loop has
+// effectively converged and parks itself (a later sync() restarts it).
+const SMOOTH_EPSILON = 0.0005;
 
 export class NodeOverlay extends StarnetElement {
   constructor() {
@@ -22,11 +27,68 @@ export class NodeOverlay extends StarnetElement {
     // Lit renders asynchronously, so the SVG children don't exist until
     // firstUpdated(). sync()/reposition() no-op until then, then _render() runs.
     this._ready = false;
+    // Progress smoothing (opt-in via enableProgressSmoothing). When off, behavior
+    // is identical to the original: render on sync(), displayProgress === progress.
+    this._smoothing = false;
+    this._tau = 120;
+    this._displayProgress = 0;
+    this._raf = null;
+    this._lastFrame = 0;
+  }
+
+  /**
+   * Opt in to display-rate smoothing. Progress is fed at the ~10fps game tick, but
+   * effects whose geometry is a continuous function of progress look choppy unless
+   * they render at display rate. With smoothing on, an internal rAF eases a
+   * displayed progress toward the tick-fed target; subclasses read
+   * `this.displayProgress` (not `this.progress`) in _render(). Only for continuous
+   * motion — discrete-fill / CSS-driven overlays should NOT enable it.
+   * @param {number} [tauMs] smoothing time-constant (larger = smoother + more lag)
+   */
+  enableProgressSmoothing(tauMs = 120) {
+    this._smoothing = true;
+    this._tau = tauMs;
+  }
+
+  /** Progress to render from: the eased value when smoothing, else the raw target. */
+  get displayProgress() {
+    return this._smoothing ? this._displayProgress : this.progress;
+  }
+
+  _smoothFrame(now) {
+    const dt = this._lastFrame ? now - this._lastFrame : 16;
+    this._lastFrame = now;
+    this._displayProgress = easeToward(this._displayProgress, this.progress, dt, this._tau);
+    const converged =
+      this.nodeId === null || Math.abs(this.progress - this._displayProgress) <= SMOOTH_EPSILON;
+    if (converged) this._displayProgress = this.progress; // snap to target
+    if (this._ready) this._render();
+    if (converged) {
+      this._raf = null;
+      this._lastFrame = 0;
+    } else {
+      this._raf = requestAnimationFrame((t) => this._smoothFrame(t));
+    }
+  }
+
+  _stopSmoothing() {
+    if (this._raf !== null) {
+      cancelAnimationFrame(this._raf);
+      this._raf = null;
+    }
+    this._lastFrame = 0;
   }
 
   firstUpdated() {
     this._ready = true;
     this._render();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    // Stop the smoothing rAF if the element is removed without an explicit clear(),
+    // so it can't keep firing against a detached element.
+    this._stopSmoothing();
   }
 
   /**
@@ -74,8 +136,22 @@ export class NodeOverlay extends StarnetElement {
    * @param {number} progress
    */
   sync(nodeId, progress) {
+    const newTarget = nodeId !== this.nodeId;
     this.nodeId = nodeId;
-    this.progress = Math.max(0, Math.min(1, progress));
+    // Sanitize before clamping — a non-finite progress (e.g. a malformed payload)
+    // would otherwise render invalid SVG and stall the smoothing loop's convergence.
+    const p = Number(progress);
+    this.progress = Number.isFinite(p) ? Math.max(0, Math.min(1, p)) : 0;
+    if (this._smoothing) {
+      // A fresh target node starts at its synced value (no ease-in from a stale
+      // displayed progress); then the rAF loop drives all rendering.
+      if (newTarget) this._displayProgress = this.progress;
+      if (this._raf === null) {
+        this._lastFrame = 0;
+        this._raf = requestAnimationFrame((t) => this._smoothFrame(t));
+      }
+      return;
+    }
     if (this._ready) this._render();
   }
 
@@ -85,8 +161,10 @@ export class NodeOverlay extends StarnetElement {
   }
 
   clear() {
+    this._stopSmoothing();
     this.nodeId = null;
     this.progress = 0;
+    this._displayProgress = 0;
     this._hide();
   }
 

--- a/js/ui/overlays/probe-sweep.js
+++ b/js/ui/overlays/probe-sweep.js
@@ -14,6 +14,13 @@ const OFF = 0.12; // unlit segment opacity (the dim ring)
 const ON = 0.95;  // fully-lit segment opacity
 
 class ProbeSweepOverlay extends NodeOverlay {
+  constructor() {
+    super();
+    // Continuous radial sweep "hand" + sweep-front cross-fade — render at display
+    // rate so the hand doesn't step around the dial at the ~10fps game tick.
+    this.enableProgressSmoothing(120);
+  }
+
   render() {
     return html`
       <svg style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
@@ -46,7 +53,7 @@ class ProbeSweepOverlay extends NodeOverlay {
 
     const v = facetVertices(r, r, rr); // 12 vertices, first at 12 o'clock, clockwise
     const segs = group.children;
-    const p = this.progress;
+    const p = this.displayProgress;
     const front = p * FACET_SIDES; // fractional count of segments the sweep has crossed
     for (let i = 0; i < FACET_SIDES; i++) {
       const a1 = v[i];


### PR DESCRIPTION
You reported the MINE scan overlay looking choppier in normal gameplay than in the preview harness. Diagnosed as a **cadence** issue, not performance.

## Root cause

`NodeOverlay` effects re-render only inside `sync()`. In the preview harness `sync()` is driven by a 60fps rAF, so progress-driven geometry looks smooth. In game, `sync()` rides the **~10fps `ACTION_FEEDBACK` game tick** — so any overlay whose geometry is a continuous function of `progress` freezes between ticks and jumps in ~0.1 steps.

## Fix

Opt-in display-rate smoothing in `NodeOverlay`:

- `js/ui/overlays/ease.js` — a pure, frame-rate-independent low-pass `easeToward(current, target, dtMs, tauMs)` (two 8ms steps compose exactly to one 16ms step).
- `enableProgressSmoothing(tauMs = 120)` + a `displayProgress` getter + an internal rAF that eases a *displayed* progress toward the tick-fed *target* and re-renders at display rate. The loop self-parks on convergence and is cancelled in `clear()`; a fresh target node snaps (no stale ease-in).
- **Smoothing off = byte-identical to before** (`displayProgress === progress`, render on `sync()`). Subclasses read `this.displayProgress` instead of `this.progress`.

τ = 120ms, tuned by eye in a throwaway lab (saved at `docs/dev-sessions/2026-06-12-1119-mine-overlay-smoothing/lab/mine-smoothing-lab.html`, which drives the real MINE geometry from a simulated 10fps feed in a RAW-vs-SMOOTHED split).

## Audit — applied everywhere it helps

| Overlay | | Why |
|---|---|---|
| mine-scan | ✅ smoothed | continuous Lissajous roam + reticle spin |
| probe-sweep | ✅ smoothed | rotating radar hand + sweep-front cross-fade |
| exploit-brackets | ✅ smoothed | brackets converge + rotate (zaps already self-run) |
| ice-detect, read-sectors | ➖ skip | discrete segment fills — chunky by design |
| selection-reticle | ➖ skip | spin is CSS (already decoupled); progress unused |
| loot-rings | ➖ skip | already time-driven (per-ring rAF) |

## Verification

- `ease.test.js` 7/7 (convergence, monotone approach, frame-rate independence); full suite **1042** green; lint clean.
- Runtime in-browser: `displayProgress` eases between the 10fps target steps (16 distinct values across ~5 stepped targets), rAF runs during a scan and stops cleanly on `clear()` (no leak), zero console errors. Not a perf concern — a handful of `setAttribute`s per frame, only while a scan is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)