### PR TITLE
Cap exploit-hand height so it scrolls instead of crowding the node panel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -219,13 +219,18 @@ html, body {
 }
 
 #sidebar-node {
-  flex: 1 1 50%;
+  flex: 1 1 auto;
   overflow-y: auto;
   min-height: 0;
 }
 
+/* The hand sizes to its cards but is capped so a full deck can't crowd out the
+   node panel (the vital-sign stack already claims the top of the sidebar). Past
+   the cap it scrolls internally rather than pushing the middle status area
+   into a scroll. */
 #hand-strip {
-  flex: 0 0 50%;
+  flex: 0 0 auto;
+  max-height: 33%;
   overflow-y: auto;
   border-top: 1px solid var(--border);
   background: var(--bg-panel);


### PR DESCRIPTION
The sidebar gained a vital-sign stack (health/deck waveforms) at the top, which ate into the layout budget. The exploit hand was pinned at a rigid `flex: 0 0 50%` that refused to shrink, so the loss fell entirely on the middle status area (`#sidebar-node`) — forcing it to scroll under normal content.

## What changed (CSS only)

- `#hand-strip` now sizes to its cards with a `max-height: 33%` cap and scrolls internally past that, instead of rigidly claiming half the sidebar.
- `#sidebar-node` gets `flex: 1 1 auto`, reclaiming the freed space so the middle status area stops scrolling under normal content.

## Testing

- Previewed in-browser: the hand is shorter, scrolls when the deck is large, and the node panel no longer scrolls under typical content.

## Follow-up

Per-region drag-resizable layout (terminal/graph split, sidebar width, sidebar section heights) is filed as #181 — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)