### PR TITLE
Overlay time mode: managed, disconnect-safe cadence loop (jank sweep A)

### DIFF
--- a/docs/dev-sessions/2026-06-12-1210-overlay-time-mode/plan.md
+++ b/docs/dev-sessions/2026-06-12-1210-overlay-time-mode/plan.md
@@ -1,0 +1,38 @@
+# Plan — overlay time mode (jank sweep A)
+
+**Goal:** Managed, disconnect-safe time loop in `NodeOverlay`; convert `loot-rings` + zaps onto it.
+
+**Approach:** One slice — add the loop to the base, adopt in the two overlays, browser-verify.
+
+---
+
+## Phase 1: NodeOverlay time loop + adopt + verify
+
+**Files:**
+- Modify: `js/ui/overlays/node-overlay.js`
+  - Fields: `_timeRaf = null`, `_timeLast = 0`.
+  - `startTimeLoop()` — idempotent; kicks the rAF. `stopTimeLoop()` — cancels + resets.
+  - `_timeFrameLoop(now)` — compute `dt` (seed 16ms on first frame), call `_timeFrame(now, dt)`,
+    reschedule unless the hook stopped it.
+  - `_timeFrame(now, dtMs)` — empty subclass hook (documented).
+  - `disconnectedCallback()` and `clear()` also call `stopTimeLoop()`.
+- Modify: `js/ui/overlays/loot-rings.js` — drop `_timer`/`_tick`/`setTimeout`; `sync()` calls
+  `startTimeLoop()`; add `_timeFrame(now, dt)` accumulating toward `SPAWN_MIN_MS +
+  progress*SPAWN_PROGRESS_MS`, spawning + resetting the accumulator when due; `clear()` calls
+  `stopTimeLoop()` (drop the manual timer clear). Per-ring expansion rAF unchanged.
+- Modify: `js/ui/overlays/exploit-brackets.js` — drop `_zapIntervalId`/`setInterval`; `_startZaps`
+  → `startTimeLoop()`, `_stopZaps` → `stopTimeLoop()` + zap-hide; move `_tickZaps` body into
+  `_timeFrame(now, dt)` accumulating ms toward a 30–90 ms gap. Keep the smoothing loop for the
+  brackets; both stop on clear/disconnect.
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes (full suite green — no regression)
+
+**Verification — manual (browser, real game — DOM/cy-coupled, no node unit tests):**
+- [ ] Instantiate `loot-rings-overlay`: feed `sync()` over time, confirm rings spawn at the
+  expected cadence (denser at low progress), then `remove()` (no `clear()`) → time loop stops
+  (`_timeRaf === null`), no orphaned rAF, no console errors.
+- [ ] Instantiate `exploit-brackets-overlay`: confirm zaps fire while synced; `remove()` stops
+  the loop; brackets still converge/rotate (smoothing intact).
+- [ ] Sanity: a normal probe/xploit/fetch in a live run still shows the effects unchanged.

--- a/docs/dev-sessions/2026-06-12-1210-overlay-time-mode/spec.md
+++ b/docs/dev-sessions/2026-06-12-1210-overlay-time-mode/spec.md
@@ -1,0 +1,58 @@
+# Overlay time mode — managed, disconnect-safe cadence loop (jank sweep A)
+
+**Goal:** First slice of the jank-elimination sweep (#179, part A — driver consolidation).
+`NodeOverlay` already owns a managed **progress-smoothing** rAF (from #178, PR #178). The
+**time-driven** half is still hand-rolled per overlay: `loot-rings` runs a self-rescheduling
+`setTimeout` spawn chain, `exploit-brackets` runs a `setInterval` zap loop. Both duplicate
+lifecycle bookkeeping and — like the smoothing rAF before its fix — **neither is cancelled on
+`disconnectedCallback`**, so a removed element keeps its cadence loop firing. Give `NodeOverlay`
+a managed, disconnect-safe **time loop** and convert both onto it.
+
+**Source:** #179 part A. No visible behavior change intended — same spawn cadence, same zaps;
+this is code-health + latent-leak prevention + foundation for the (B) particle emitter.
+
+## Current state
+
+- `loot-rings`: `sync()` → `_tick()` self-reschedules via `setTimeout(_tick, SPAWN_MIN_MS +
+  progress*SPAWN_PROGRESS_MS)`; each `_tick` spawns a ring that self-animates on its own rAF.
+  `clear()` clears the timer.
+- `exploit-brackets`: `_startZaps()` sets `setInterval(_tickZaps, ZAP_TICK_MS=30)`; `_tickZaps`
+  counts ticks and fires a zap when due. `_stopZaps()` clears.
+- Neither `setTimeout`/`setInterval` is stopped in `disconnectedCallback`.
+
+## Desired end state
+
+- `NodeOverlay` gains: `startTimeLoop()` / `stopTimeLoop()` (idempotent) and a per-frame hook
+  `_timeFrame(now, dtMs)` driven by a managed `requestAnimationFrame`. The loop is auto-stopped
+  by `clear()` **and** `disconnectedCallback()` (alongside the existing smoothing stop).
+- `loot-rings` expresses its spawn cadence inside `_timeFrame` (accumulate `dtMs`; spawn when the
+  accumulator reaches the progress-scaled delay; reset). No `setTimeout`.
+- `exploit-brackets` expresses its zap cadence inside `_timeFrame` (accumulate `dtMs`; fire when
+  due; pick next 30–90 ms delay). No `setInterval`. (It also keeps the smoothing loop for the
+  brackets — the two managed loops coexist; both stopped on clear/disconnect.)
+- The per-ring expansion rAF and per-zap one-frame fade are **unchanged** (that's (B)).
+
+## Design decisions
+
+- **One managed time loop, separate from the smoothing loop.** They model different concerns
+  (ease progress vs drive cadence) and an overlay may use both (exploit-brackets). Keeping them
+  separate is clearer than merging; both are lifecycle-managed by the base.
+- **rAF, not setTimeout/setInterval.** Display-rate frame loop with internal time accumulation —
+  consistent with the smoothing loop, naturally throttles in a backgrounded tab, and is trivially
+  disconnect-safe via one cancel path.
+- **No behavior change.** Cadence values (`SPAWN_MIN_MS`, `SPAWN_PROGRESS_MS`, 30–90 ms zap gap)
+  are preserved; verification is "still looks/behaves the same, and now stops on disconnect."
+
+## What we're NOT doing
+
+- Not unifying the per-particle animations into a shared emitter (that's #179 part B).
+- Not touching the progress-smoothing path, or any overlay that isn't time-driven.
+
+## Verification
+
+- `make check` green (no regression; these overlays have no node unit tests — DOM/cy-coupled).
+- Browser: rings still spawn at the same cadence, zaps still fire; removing the element stops
+  the loop (no orphaned rAF) — the latent-leak fix; no console errors.
+
+## Open questions
+- None.

--- a/js/ui/overlays/exploit-brackets.js
+++ b/js/ui/overlays/exploit-brackets.js
@@ -7,28 +7,32 @@
 import { html } from "lit";
 import { NodeOverlay } from "./node-overlay.js";
 
-const ZAP_TICK_MS = 30;
+const ZAP_MIN_GAP_MS = 30;          // shortest gap between zaps
+const ZAP_GAP_STEPS = 3;            // gaps are 30 / 60 / 90 ms (rapid corner cycling)
 
 class ExploitBracketsOverlay extends NodeOverlay {
   constructor() {
     super();
-    this._zapIntervalId = null;
-    this._zapNextCorner = 0;  // cycles 0→1→2→3→0...
-    this._zapTicksToFire = 0; // ticks until next zap
+    this._zapNextCorner = 0; // which corner the next zap fires from
+    this._zapAcc = 0;        // ms accumulated toward the next zap
+    this._zapDelay = ZAP_MIN_GAP_MS; // gap before the first zap
     // Brackets converge + rotate continuously with progress — render at display
-    // rate so the convergence doesn't step at the ~10fps game tick. (The zap
-    // flicker runs on its own interval already.)
+    // rate so the convergence doesn't step at the ~10fps game tick. The zap
+    // flicker runs on the base class's managed time loop.
     this.enableProgressSmoothing(120);
   }
 
   sync(nodeId, progress) {
     super.sync(nodeId, progress);
-    this._startZaps();
+    this.startTimeLoop(); // idempotent; drives the zap cadence
   }
 
   clear() {
-    this._stopZaps();
-    super.clear(); // stops the smoothing rAF, hides, resets progress/displayProgress
+    super.clear(); // stops the smoothing + time loops, hides, resets progress
+    this._hideZaps();
+    this._zapNextCorner = 0;
+    this._zapAcc = 0;
+    this._zapDelay = ZAP_MIN_GAP_MS;
     const svg = this._svg();
     if (svg) svg.style.transform = "rotate(0deg)";
   }
@@ -95,29 +99,21 @@ class ExploitBracketsOverlay extends NodeOverlay {
     this._setLine("b-bl-v", ox - dist, oy + dist, ox - dist,       oy + dist - arm);
   }
 
-  _startZaps() {
-    if (this._zapIntervalId !== null) return;
-    this._zapNextCorner = 0;
-    this._zapTicksToFire = 1;
-    this._zapIntervalId = setInterval(() => this._tickZaps(), ZAP_TICK_MS);
-  }
-
-  _stopZaps() {
-    if (this._zapIntervalId !== null) {
-      clearInterval(this._zapIntervalId);
-      this._zapIntervalId = null;
-    }
-    const zaps = this._svg()?.querySelectorAll(".zap");
-    if (zaps) zaps.forEach((el) => el.setAttribute("stroke-opacity", "0"));
-  }
-
-  _tickZaps() {
+  // Managed time-loop hook: fire a zap once the gap has elapsed; the loop stops
+  // itself (and hides the zaps) if the anchor is lost, and is stopped on
+  // clear()/disconnect by the base class.
+  _timeFrame(now, dtMs) {
     const a = this._anchor();
-    if (!a) { this._stopZaps(); return; }
+    if (!a) { this.stopTimeLoop(); this._hideZaps(); return; }
+    this._zapAcc += dtMs;
+    if (this._zapAcc < this._zapDelay) return;
+    this._zapAcc = 0;
+    this._fireZap(a);
+    // 30 / 60 / 90 ms until the next zap — rapid cycling through corners.
+    this._zapDelay = ZAP_MIN_GAP_MS * (1 + Math.floor(Math.random() * ZAP_GAP_STEPS));
+  }
 
-    this._zapTicksToFire--;
-    if (this._zapTicksToFire > 0) return;
-
+  _fireZap(a) {
     const r = a.r;
     const ox = r, oy = r;
     const p = this.displayProgress;
@@ -153,8 +149,11 @@ class ExploitBracketsOverlay extends NodeOverlay {
     }
 
     this._zapNextCorner = Math.floor(Math.random() * 4);
-    // 1-3 ticks between zaps (30-90ms) — rapid cycling through corners
-    this._zapTicksToFire = 1 + Math.floor(Math.random() * 3);
+  }
+
+  _hideZaps() {
+    const zaps = this._svg()?.querySelectorAll(".zap");
+    if (zaps) zaps.forEach((el) => el.setAttribute("stroke-opacity", "0"));
   }
 }
 

--- a/js/ui/overlays/loot-rings.js
+++ b/js/ui/overlays/loot-rings.js
@@ -17,33 +17,33 @@ const PAD = 20; // ripples travel this far past the node rim
 class LootRingsOverlay extends NodeOverlay {
   constructor() {
     super();
-    this._timer = null;
-    this._running = false;
+    this._spawnAcc = 0;   // ms accumulated toward the next ring
+    this._nextDelay = 0;  // 0 → spawn on the first frame after sync
   }
 
   sync(nodeId, progress) {
     super.sync(nodeId, progress);
-    if (!this._running) {
-      this._running = true;
-      this._tick();
+    this.startTimeLoop(); // idempotent; the managed loop drives spawn cadence
+  }
+
+  // Spawn a ring once the accumulated time reaches the progress-scaled delay
+  // (dense when the node is full, sparser as it drains). The base loop stops
+  // itself on clear()/disconnect, so there's no timer to leak.
+  _timeFrame(now, dtMs) {
+    this._spawnAcc += dtMs;
+    if (this._spawnAcc >= this._nextDelay) {
+      this._spawn();
+      this._spawnAcc = 0;
+      this._nextDelay = SPAWN_MIN_MS + this.progress * SPAWN_PROGRESS_MS;
     }
   }
 
-  _tick() {
-    if (!this._running) return;
-    this._spawn();
-    const delay = SPAWN_MIN_MS + this.progress * SPAWN_PROGRESS_MS;
-    this._timer = setTimeout(() => this._tick(), delay);
-  }
-
   clear() {
-    this._running = false;
-    if (this._timer !== null) { clearTimeout(this._timer); this._timer = null; }
-    this.nodeId = null;
-    this.progress = 0;
+    super.clear(); // stops the managed loop(s), resets, hides
+    this._spawnAcc = 0;
+    this._nextDelay = 0;
     const svg = this._svg();
     if (svg) {
-      svg.style.opacity = "0";
       setTimeout(() => {
         if (!this.nodeId && svg) svg.querySelectorAll("polygon").forEach((c) => c.remove());
       }, 200);

--- a/js/ui/overlays/node-overlay.js
+++ b/js/ui/overlays/node-overlay.js
@@ -34,6 +34,12 @@ export class NodeOverlay extends StarnetElement {
     this._displayProgress = 0;
     this._raf = null;
     this._lastFrame = 0;
+    // Time mode (opt-in via startTimeLoop): a managed per-frame loop for
+    // time-driven effects (spawn cadence, flicker), so subclasses don't hand-roll
+    // setTimeout/setInterval that leak on disconnect. Separate from the smoothing
+    // loop above; an overlay may run both.
+    this._timeRaf = null;
+    this._timeLast = 0;
   }
 
   /**
@@ -79,6 +85,44 @@ export class NodeOverlay extends StarnetElement {
     this._lastFrame = 0;
   }
 
+  /**
+   * Start the managed time loop: calls `_timeFrame(now, dtMs)` every frame until
+   * stopped. Idempotent. Auto-stopped by clear() and disconnectedCallback(), so a
+   * subclass never needs to hand-roll (or leak) a setTimeout/setInterval.
+   */
+  startTimeLoop() {
+    if (this._timeRaf !== null) return;
+    this._timeLast = 0;
+    this._timeRaf = requestAnimationFrame((t) => this._timeFrameLoop(t));
+  }
+
+  /** Stop the managed time loop. */
+  stopTimeLoop() {
+    if (this._timeRaf !== null) {
+      cancelAnimationFrame(this._timeRaf);
+      this._timeRaf = null;
+    }
+    this._timeLast = 0;
+  }
+
+  _timeFrameLoop(now) {
+    const dt = this._timeLast ? now - this._timeLast : 16;
+    this._timeLast = now;
+    this._timeFrame(now, dt);
+    // _timeFrame may have stopped the loop (e.g. lost its anchor); only reschedule
+    // if it's still meant to be running.
+    if (this._timeRaf !== null) {
+      this._timeRaf = requestAnimationFrame((t) => this._timeFrameLoop(t));
+    }
+  }
+
+  /**
+   * Subclass hook: per-frame work for time-driven effects (spawn cadence, flicker).
+   * @param {number} now    high-res timestamp (ms)
+   * @param {number} dtMs   ms since the previous frame
+   */
+  _timeFrame(now, dtMs) {} // eslint-disable-line no-unused-vars
+
   firstUpdated() {
     this._ready = true;
     this._render();
@@ -86,9 +130,10 @@ export class NodeOverlay extends StarnetElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    // Stop the smoothing rAF if the element is removed without an explicit clear(),
-    // so it can't keep firing against a detached element.
+    // Stop both managed loops if the element is removed without an explicit clear(),
+    // so neither keeps firing against a detached element.
     this._stopSmoothing();
+    this.stopTimeLoop();
   }
 
   /**
@@ -162,6 +207,7 @@ export class NodeOverlay extends StarnetElement {
 
   clear() {
     this._stopSmoothing();
+    this.stopTimeLoop();
     this.nodeId = null;
     this.progress = 0;
     this._displayProgress = 0;


### PR DESCRIPTION
First slice of the jank-elimination sweep (#179, part A — driver consolidation).

## Why

`NodeOverlay` already owns a managed **progress-smoothing** rAF (from #178). But the **time-driven** half was still hand-rolled per overlay:
- `loot-rings` — self-rescheduling `setTimeout` spawn chain
- `exploit-brackets` — `setInterval` zap loop

Both duplicated lifecycle bookkeeping, and **neither was cancelled on `disconnectedCallback`** — the exact latent leak class the #178 review flagged for the smoothing rAF (a removed element keeps its loop firing against a detached node).

## What

Add a managed **time loop** to `NodeOverlay`, sibling to the smoothing loop:
- `startTimeLoop()` / `stopTimeLoop()` (idempotent) + a per-frame `_timeFrame(now, dtMs)` hook driven by `requestAnimationFrame`.
- `clear()` **and** `disconnectedCallback()` now stop **both** managed loops — subclasses never hand-roll (or leak) a `setTimeout`/`setInterval` again.

Convert both overlays onto it, **no behavior change**:
- `loot-rings` accumulates `dt` toward the progress-scaled spawn delay (`SPAWN_MIN_MS + progress*SPAWN_PROGRESS_MS`).
- `exploit-brackets` accumulates `dt` toward a 30/60/90 ms zap gap; brackets keep the smoothing loop, so it now runs both managed loops (both stopped on clear/disconnect).

The per-ring expansion rAF and per-zap one-frame fade are **unchanged** — those are jank-sweep **part B** (the shared deterministic stroke particle emitter).

## Verification

These overlays are DOM/cy-coupled (no node unit tests), so verified in-browser:
- **Lifecycle/leak fix:** the time loop drives `_timeFrame` (23 frames/200ms), `sync()` is idempotent (no duplicate loop), and removing the element **without** `clear()` stops it (`_timeRaf: null`, no further frames).
- **Behavior intact:** in the preview harness against real nodes, loot rings still spawn at cadence (1→5 over 700ms) and exploit zaps still fire.
- No console errors. `make check` green (**1043** tests, lint clean).

Part of #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)