### PR TITLE
Reduce graph label text bloom via a wider dark text-outline buffer

### DIFF
--- a/js/ui/graph.js
+++ b/js/ui/graph.js
@@ -414,8 +414,11 @@ function buildStylesheet() {
         "font-weight": "bold",
         "text-valign": "bottom",
         "text-margin-y": 6,
+        // Wider dark buffer between glyph and the global bloom: the outline is
+        // background-dark, so under the bloom it surrounds the bright text and
+        // knocks back the halo at the glyph edges without dimming the text.
         "text-outline-color": "#0a0a0f",
-        "text-outline-width": 2,
+        "text-outline-width": 3,
       },
     },
     // Alert state: yellow — thin amber border (strobe-blinked by JS animation)


### PR DESCRIPTION
The node-label glow read as too hot under the global vector-CRT bloom.

## What changed (one value)

`text-outline-width` on the accessible-node label style goes from `2` → `3`.

The bloom is a single SVG filter over the whole `#cy` canvas, so node glyphs and labels bloom together — there is no text-only bloom knob. Widening the dark (background-colored) text-outline puts more dark immediately around each glyph, so under the bloom that ring buffers the halo at the text edges **without dimming the text** itself.

A dimmer label color was tried first (`#00ff41` → `#00c233`) but it hurt legibility without taming the halo much, so it was reverted in favor of the outline approach.

## Testing

- Previewed in-browser: label glow is noticeably tamer, text stays crisp and full-bright green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)