### PR TITLE
Fast-start past the overworld hub on a ?network= deep-link

### DIFF
--- a/js/ui/hub.js
+++ b/js/ui/hub.js
@@ -62,6 +62,32 @@ function showHub() {
   el.open = true;
 }
 
+/**
+ * Canned "hub start" for fast-start scenarios (e.g. a `?network=` deep-link): bootstrap/load
+ * the profile, auto-equip a default starter loadout (the profile's inventory, up to
+ * MAX_LOADOUT), and launch directly into the given prebuilt network — skipping the overworld
+ * hub UI entirely. Carries no cash. Reuses the same prepareLaunch → startRun path the hub uses,
+ * so the run is committed back to the profile on RUN_ENDED like any other.
+ * @param {{ graphDef: any, meta: any }} networkResult
+ * @returns {boolean} true if a run was launched; false if launch prep failed (caller should
+ *   fall back to the hub rather than leave the player in an unplayable/empty run).
+ */
+export function quickStartRun(networkResult) {
+  const p = loadProfile(); // bootstraps a fresh profile (starter inventory) if absent
+  const loadoutIds = p.inventory.slice(0, MAX_LOADOUT).map((c) => c.instanceId);
+  // prepareLaunch returns null only if the launch can't be prepared (e.g. a corrupt profile
+  // with a negative bank). Don't launch a loadout-less, unplayable run — bail and let the
+  // caller open the hub. (mirrors launchTarget's null handling.)
+  const launchMeta = prepareLaunch({ loadoutInstanceIds: loadoutIds, withdrawAmount: 0 });
+  if (!launchMeta) {
+    log("[HUB] Fast-start could not prepare a loadout — opening the hub instead.", "error");
+    return false;
+  }
+  log(`[HUB] Fast-start (overworld hub skipped) — ${networkResult.meta?.name ?? "network"}.`, "success");
+  startRun({ graphDef: networkResult.graphDef, meta: { ...networkResult.meta, ...launchMeta } });
+  return true;
+}
+
 /** Enter the hub fresh: roll a new target list, reset the selection, show it. */
 export function openHub() {
   const p = loadProfile();

--- a/js/ui/hub.test.js
+++ b/js/ui/hub.test.js
@@ -1,0 +1,48 @@
+// Tests for quickStartRun — the "canned hub start" used by ?network= deep-links and
+// other fast-start scenarios. Like run-control.test, startRun touches DOM/Cytoscape but
+// every graph fn guards on a null `cy`, so with a document stub it runs in node. hub.js
+// also reaches the profile via localStorage, so we stub that too (in-memory).
+
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+globalThis.document = globalThis.document ?? { getElementById: () => null };
+const _store = new Map();
+globalThis.localStorage = globalThis.localStorage ?? {
+  getItem: (k) => (_store.has(k) ? _store.get(k) : null),
+  setItem: (k, v) => _store.set(k, String(v)),
+  removeItem: (k) => _store.delete(k),
+};
+
+const { quickStartRun } = await import("./hub.js");
+const { getState } = await import("../core/state.js");
+const { buildNetwork } = await import("../../data/networks/generated.js");
+const { initRng } = await import("../core/rng.js");
+
+const PROFILE_KEY = "starnet:profile"; // mirror profile-store.js
+
+describe("quickStartRun — canned hub start (fast-start / deep-link)", () => {
+  // Reset the profile through the localStorage API (not the stub's internals) so this stays
+  // correct under any localStorage implementation / test ordering. main.js inits the RNG
+  // streams before either boot branch; mirror that (the profile bootstrap needs RNG).
+  beforeEach(() => { localStorage.removeItem(PROFILE_KEY); initRng("hub-test"); });
+
+  test("launches the given network directly into an active run", () => {
+    assert.equal(quickStartRun(buildNetwork({ seed: "qs-1" })), true, "should report a launch");
+    assert.ok(getState(), "a run should be active after a quick start");
+    assert.ok(Object.keys(getState().nodes).length > 0, "the run's network should be loaded");
+  });
+
+  test("equips a default starter loadout so the run is playable (non-empty hand)", () => {
+    quickStartRun(buildNetwork({ seed: "qs-2" }));
+    assert.ok(getState().player.hand.length > 0,
+      "fast-start must deal a starter hand, not launch with an empty loadout");
+  });
+
+  test("returns false (caller falls back to the hub) when the loadout can't be prepared", () => {
+    // Corrupt profile: negative bank makes withdraw(_, 0) fail → prepareLaunch returns null.
+    localStorage.setItem(PROFILE_KEY, JSON.stringify({ version: 1, bank: -1, inventory: [], _instanceSeq: 0 }));
+    assert.equal(quickStartRun(buildNetwork({ seed: "qs-3" })), false,
+      "a failed launch prep must report false rather than start an unplayable run");
+  });
+});

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -14,7 +14,7 @@ import { initGraphBridge } from "../core/graph-bridge.js";
 import { initDynamicActions } from "../core/console-commands/dynamic-actions.js";
 import { initRng } from "../core/rng.js";
 import { toCytoscapeFormat } from "./run-control.js";
-import { openHub, initHub } from "./hub.js";
+import { openHub, initHub, quickStartRun } from "./hub.js";
 import { initProfileRunCommit } from "./profile-store.js";
 import "./hub-commands.js";
 
@@ -140,8 +140,13 @@ function init() {
   on("starnet:action:run-again", returnToHub);
   document.getElementById("end-screen")?.addEventListener("run-again", returnToHub);
 
-  // Boot into the hub — the player launches the first run from there.
-  openHub();
+  // Boot. An explicit ?network= deep-link is a fast-start request — skip the overworld
+  // hub and jack straight into that network with a canned starter loadout. Otherwise (or
+  // if the fast-start can't prepare a loadout) boot into the hub.
+  const wantsFastStart = new URLSearchParams(location.search).has("network");
+  if (!(wantsFastStart && quickStartRun(buildNetworkFn()))) {
+    openHub();
+  }
 }
 
 document.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
## What

An explicit `?network=` deep-link now **fast-starts past the overworld hub** straight into that network, instead of dropping you in the hub. A dev/playtest convenience (deep-link a specific generated or named network and you're immediately in the run).

## How

Introduces a reusable **`quickStartRun(networkResult)`** in `hub.js` — a "canned hub start":

- bootstraps/loads the profile (fresh profile gets the usual starter inventory),
- auto-equips a **default starter loadout** (inventory up to `MAX_LOADOUT`, no carried cash),
- launches via the same `prepareLaunch → startRun` path the hub uses — so `RUN_ENDED` still commits back to the profile like any other run.

`main.js` boot: an explicit `?network=` param calls `quickStartRun(buildNetworkFn())`; no param still opens the hub. Works for both generated and named networks (same `{graphDef, meta}` shape).

This is deliberately a *reusable* helper, not inline deep-link logic — it can back other fast-start scenarios (headless/playtest) later.

## Verification

- `make check` green — **1047 tests**, lint clean.
- New `hub.test.js`: `quickStartRun` launches an active run and deals a non-empty starter hand (stubs `document` + `localStorage`, same pattern as `run-control.test`).
- **Verified live in a browser:** `?network=generated&threat=C` → hub closed, run active, 12-node network, 5-card hand, no console errors; the bare URL → hub opens, no run. (Playwright.)

## Notes

- Default loadout = the profile's starter inventory (capped at `MAX_LOADOUT`), no carried cash — the "fresh decker quick-play" default we agreed on.
- Independent of the open alert-cooldown PR (#186).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
