### PR TITLE
Enforce one timed action at a time per node

### DIFF
--- a/js/core/actions/node-actions.test.js
+++ b/js/core/actions/node-actions.test.js
@@ -6,6 +6,33 @@ import { initGame, getState } from "../state.js";
 import { buildNetwork as buildCorporateFoothold } from "../../../data/networks/corporate-foothold.js";
 import { A } from "../action-ids.js";
 
+describe("getAvailableActions — one timed action at a time per node", () => {
+  test("a node mid-PROBE offers neither PROBE nor XPLOIT, only ABORT", () => {
+    initGame(() => buildCorporateFoothold(), "one-at-a-time-seed");
+    const state = getState();
+    const node = Object.values(state.nodes).find(
+      (n) => n.visibility === "accessible" && n.accessLevel === "locked" && !n.probed
+    );
+    assert.ok(node, "expected an accessible, locked, unprobed node");
+
+    // Sanity: before any action, both PROBE and XPLOIT are offered.
+    const before = getAvailableActions(node, state).map((a) => a.id);
+    assert.ok(before.includes(A.PROBE), "PROBE should be available initially");
+    assert.ok(before.includes(A.XPLOIT), "XPLOIT should be available initially");
+
+    // Start a probe — sets the `probing` busy flag via the timed-action operator.
+    state.nodeGraph.executeAction(node.id, A.PROBE);
+
+    const during = getAvailableActions(node, state).map((a) => a.id);
+    assert.ok(!during.includes(A.PROBE), "PROBE should not be re-startable mid-probe");
+    assert.ok(
+      !during.includes(A.XPLOIT),
+      "XPLOIT must not be available while a probe is in progress"
+    );
+    assert.ok(during.includes(A.ABORT), "ABORT should be the escape hatch mid-probe");
+  });
+});
+
 describe("getAvailableActions — XPLOIT followup passthrough", () => {
   test("XPLOIT on an accessible node carries a followup with working choices", () => {
     initGame(() => buildCorporateFoothold());

--- a/js/core/node-graph/game-types.js
+++ b/js/core/node-graph/game-types.js
@@ -16,6 +16,26 @@ import { getExploitChoices, getExploitEmptyReason } from "../exploits.js";
 
 // ── Shared action templates ──────────────────────────────────
 
+// activeAttr flag for each player-initiated timed action. This is the single
+// source of truth for the abortable timed-action set: ABORT shows when any of
+// these is true, and NOT_BUSY (below) requires all of them false. When adding a
+// new timed action, add its activeAttr here — both lists stay in sync.
+const TIMED_ACTION_FLAGS = ["probing", "exploiting", "reading", "looting", "mining"];
+
+// A node may run at most ONE timed action at a time. Every startable action
+// requires the node be idle: no timed action in flight, and not rebooting.
+// `rebooting` is involuntary (forced offline after a failure) so it isn't in
+// TIMED_ACTION_FLAGS — ABORT can't cancel it — but it still blocks starting
+// anything new. Spread `...NOT_BUSY` into each startable action's requires.
+//
+// A flag means "busy" only when explicitly true, so we test `not (eq true)`
+// rather than `eq false`: some flags (e.g. reading/looting) aren't defined on
+// non-lootable node types, and undefined must read as idle, not busy.
+/** @type {import('./types.js').Condition[]} */
+const NOT_BUSY = [...TIMED_ACTION_FLAGS, "rebooting"].map(
+  (attr) => ({ type: "not", condition: { type: "node-attr", attr, eq: true } })
+);
+
 /** @type {ActionDef} */
 const PROBE_ACTION = {
   id: A.PROBE,
@@ -24,8 +44,7 @@ const PROBE_ACTION = {
   requires: [
     { type: "node-attr", attr: "accessLevel", eq: "locked" },
     { type: "node-attr", attr: "probed", eq: false },
-    { type: "node-attr", attr: "rebooting", eq: false },
-    { type: "node-attr", attr: "probing", eq: false },
+    ...NOT_BUSY,
   ],
   effects: [
     { effect: "set-attr", attr: "probing", value: true },
@@ -34,9 +53,8 @@ const PROBE_ACTION = {
 };
 
 // Abort: unified cancel for any timed action. The execution is generic
-// (queries timed-action operators at runtime), but the requires list must
-// enumerate activeAttr flags so the action system knows when to show it.
-// When adding a new timed action, add its activeAttr here.
+// (queries timed-action operators at runtime); the requires list shows it
+// whenever any abortable timed action is in flight (see TIMED_ACTION_FLAGS).
 /** @type {ActionDef} */
 const ABORT_ACTION = {
   id: A.ABORT,
@@ -44,13 +62,8 @@ const ABORT_ACTION = {
   desc: "Cancel the current timed action.",
   requires: [
     {
-      type: "any-of", conditions: [
-        { type: "node-attr", attr: "probing", eq: true },
-        { type: "node-attr", attr: "exploiting", eq: true },
-        { type: "node-attr", attr: "reading", eq: true },
-        { type: "node-attr", attr: "looting", eq: true },
-        { type: "node-attr", attr: "mining", eq: true },
-      ],
+      type: "any-of",
+      conditions: TIMED_ACTION_FLAGS.map((attr) => ({ type: "node-attr", attr, eq: true })),
     },
   ],
   effects: [
@@ -76,8 +89,7 @@ const EXPLOIT_ACTION = {
   desc: "Attack with an exploit card.",
   requires: [
     { type: "node-attr", attr: "visibility", eq: "accessible" },
-    { type: "node-attr", attr: "rebooting", eq: false },
-    { type: "node-attr", attr: "exploiting", eq: false },
+    ...NOT_BUSY,
     // Owned nodes are already at max access — don't offer XPLOIT at all (the
     // hand stays a full-agency override for a deliberate re-exploit).
     { type: "not", condition: { type: "node-attr", attr: "accessLevel", eq: "owned" } },
@@ -107,8 +119,7 @@ const DUMP_ACTION = {
       ],
     },
     { type: "node-attr", attr: "read", eq: false },
-    { type: "node-attr", attr: "rebooting", eq: false },
-    { type: "node-attr", attr: "reading", eq: false },
+    ...NOT_BUSY,
   ],
   effects: [
     { effect: "set-attr", attr: "reading", value: true },
@@ -128,9 +139,8 @@ const FETCH_ACTION = {
   requires: [
     { type: "node-attr", attr: "accessLevel", eq: "owned" },
     { type: "node-attr", attr: "read", eq: true },
-    { type: "node-attr", attr: "rebooting", eq: false },
     { type: "node-attr", attr: "looted", eq: false },
-    { type: "node-attr", attr: "looting", eq: false },
+    ...NOT_BUSY,
   ],
   effects: [
     { effect: "set-attr", attr: "looting", value: true },
@@ -149,9 +159,8 @@ const MINE_ACTION = {
   desc: "Data-mine for exploits.",
   requires: [
     { type: "node-attr", attr: "accessLevel", eq: "owned" },
-    { type: "node-attr", attr: "rebooting", eq: false },
-    { type: "node-attr", attr: "mining", eq: false },
     { type: "node-attr", attr: "mineExhausted", eq: false },
+    ...NOT_BUSY,
   ],
   effects: [
     { effect: "set-attr", attr: "mining", value: true },
@@ -179,7 +188,7 @@ const REBOOT_ACTION = {
   desc: "Force ICE home and take node offline 1-3s.",
   requires: [
     { type: "node-attr", attr: "accessLevel", eq: "owned" },
-    { type: "node-attr", attr: "rebooting", eq: false },
+    ...NOT_BUSY,
   ],
   effects: [
     // startReboot handles ICE eviction + deselect + setting rebooting + duration


### PR DESCRIPTION
## Problem

Clicking PROBE on a node left XPLOIT available, so both could run at once. The
root cause was general: each timed action's `requires` only blocked *itself* —
PROBE checked `probing:false`, XPLOIT checked `exploiting:false`, etc. So the
single-current-action model the manual already describes (abort cancels "the
current action"; navigating away cancels it) wasn't actually enforced. The same
gap existed symmetrically:

- a node mid-PROBE still offered XPLOIT
- a compromised node mid-XPLOIT still offered DUMP
- an owned node mid-MINE still offered DUMP / FETCH

## Fix

A shared `NOT_BUSY` guard spread into every startable timed action (PROBE,
XPLOIT, DUMP, FETCH, MINE, REBOOT), in `js/core/node-graph/game-types.js`.

- `TIMED_ACTION_FLAGS` is the single source of truth for the abortable timed
  set — it feeds both `NOT_BUSY` and `ABORT` so the two lists can't drift (the
  exact failure mode the old "remember to add it here too" comment warned about).
- `NOT_BUSY` tests `not (eq true)` rather than `eq false`, so flags that aren't
  defined on a node type (`reading` / `looting` on non-lootable nodes) read as
  idle, not busy. This was a regression I hit and fixed mid-change.
- `rebooting` blocks starting new actions but is **not** abortable (it's
  involuntary — forced offline after a failure), so it's in `NOT_BUSY` but not
  `TIMED_ACTION_FLAGS`.

## Behavior change to note

REBOOT is now also blocked while another timed action is in progress (you must
ABORT first). This is consistent with the one-action invariant and avoids
orphaned busy flags, but it's slightly beyond the literal PROBE/XPLOIT report.
An alternative design — REBOOT *interrupts* the in-progress action — is worth
considering if that feels better.

## Testing

- New failing test written first (reproduced the bug), now passing:
  `js/core/actions/node-actions.test.js` — "a node mid-PROBE offers neither
  PROBE nor XPLOIT, only ABORT".
- Full suite: 1046/1046 pass. `make lint` clean.
- Verified through the playtest harness: before probe → `probe` + `xploit`
  offered; during probe → only `abort`.
- `make census SEEDS=10` runs clean (bot never overlapped timed actions, so it's
  unaffected).

## Follow-up

#187 — make *most* node actions timed (CORRUPT, KICK, most set-piece scripts),
with a small deliberate instant-action exception set. This PR is the prerequisite
that establishes the mutual-exclusion scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
