### PR TITLE
Drag-resizable UI regions (sidebar width, log height, hand height)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -63,6 +63,12 @@ at the end of this manual.
 
 **HUD** — Top bar shows global alert level (as a vector lamp whose shape encodes the level: hexagon = safe, point-up triangle = warning, inverted triangle = danger/trace), your current cash balance, and your two resource meters: **HEALTH** and **DECK INTEGRITY**, drawn as vector-CRT vital traces that sweep left-to-right with a fading phosphor trail. HEALTH is a green ECG/heartbeat (PQRST) complex — as health falls the beat speeds up and decays through escalating ECG abnormalities (ST/T-wave changes, then premature and skipped beats), breaking into a chaotic fibrillation flutter near death before flatlining at zero. DECK INTEGRITY is a violet symmetric CPU-clock pulse — as deck integrity falls its edges develop deepening ringing, overshoot and timing/amplitude glitches (the amplitude itself stays roughly constant); it flatlines at zero. Hover either trace to see the exact value as a percentage.
 
+**Resizing the layout** — Three borders are drag-resizable: the sidebar's left
+edge (its width), the border above the log/console (graph vs. log height), and
+the border above the exploit hand (hand vs. node-info height). Grab a border and
+drag; **double-click a border to reset that split** to its default. Your chosen
+sizes persist across reloads. The header bar is fixed.
+
 **Seed** — Each run is generated from a seed string, shown in the status display.
 Sharing a seed lets someone else play the same network layout, vulnerabilities,
 and exploit hand. Use `status summary` to see your current seed.

--- a/css/style.css
+++ b/css/style.css
@@ -100,12 +100,13 @@ html, body {
 }
 
 #log-pane {
-  flex: 0 0 auto;
+  flex: 0 0 var(--log-h, 260px);
   display: flex;
   flex-direction: column;
   background: var(--bg-panel);
   border-top: 1px solid var(--border);
   overflow: hidden;
+  min-height: 0;
 }
 
 #log-header {
@@ -113,12 +114,13 @@ html, body {
 }
 
 #log-entries {
-  flex: 0 0 14rem;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
   overflow-y: auto;
   padding: 0.3rem 1rem 0.3rem 1rem;
+  min-height: 0;
 }
 
 #console-row {
@@ -179,12 +181,57 @@ html, body {
 }
 
 #sidebar {
-  flex: 0 0 400px;
+  flex: 0 0 var(--sidebar-w, 400px);
   display: flex;
   flex-direction: column;
   background: var(--bg-panel);
   border-left: 1px solid var(--border);
   overflow: hidden;
+}
+
+/* ── Resize splitters ───────────────────────────────────────
+   Thin flex-participating bars between resizable panes. Stroke-only, no fill:
+   a hairline (::before) that brightens to a cyan phosphene glow on hover/drag,
+   inside a wider transparent hit zone so it stays easy to grab. */
+.splitter {
+  flex: 0 0 auto;
+  position: relative;
+  z-index: 4;            /* above panel chrome, below modals (store/level-select z10) */
+  background: transparent;
+  touch-action: none;    /* let Pointer Events own the drag gesture on touch */
+}
+.splitter::before {
+  content: "";
+  position: absolute;
+  background: var(--border);
+  transition: background 120ms, box-shadow 120ms;
+}
+.splitter:hover::before,
+.splitter.dragging::before {
+  background: var(--cyan);
+  box-shadow: 0 0 6px var(--cyan);
+}
+
+/* Vertical bar between two side-by-side panes (sidebar split). */
+.splitter--col {
+  width: 10px;
+  cursor: col-resize;
+  align-self: stretch;
+}
+.splitter--col::before {
+  top: 0; bottom: 0; left: 50%;
+  width: 1px; transform: translateX(-0.5px);
+}
+
+/* Horizontal bar between two stacked panes (log split, hand split). */
+.splitter--row {
+  height: 10px;
+  cursor: row-resize;
+  align-self: stretch;
+}
+.splitter--row::before {
+  left: 0; right: 0; top: 50%;
+  height: 1px; transform: translateY(-0.5px);
 }
 
 #sidebar-mission {
@@ -224,13 +271,11 @@ html, body {
   min-height: 0;
 }
 
-/* The hand sizes to its cards but is capped so a full deck can't crowd out the
-   node panel (the vital-sign stack already claims the top of the sidebar). Past
-   the cap it scrolls internally rather than pushing the middle status area
-   into a scroll. */
+/* Height owned by the --hand-h var + the resizer's clamp (see resizers.js); the
+   clamp's max (~60% of the sidebar) preserves the "don't crowd the node panel"
+   intent that the old max-height: 33% served. */
 #hand-strip {
-  flex: 0 0 auto;
-  max-height: 33%;
+  flex: 0 0 var(--hand-h, 200px);
   overflow-y: auto;
   border-top: 1px solid var(--border);
   background: var(--bg-panel);

--- a/docs/dev-sessions/2026-06-12-1429-resizable-ui-regions/notes.md
+++ b/docs/dev-sessions/2026-06-12-1429-resizable-ui-regions/notes.md
@@ -1,0 +1,68 @@
+# Notes — Drag-resizable UI regions
+
+Issue: #181 · Branch: `resizable-ui-regions`
+
+## What shipped
+
+Three drag-resizable borders, each adjusting one CSS custom property on `#app`:
+
+- **Sidebar width** (`--sidebar-w`) — vertical splitter between graph-column and sidebar.
+- **Graph ↔ log height** (`--log-h`) — horizontal splitter above the log/console.
+- **Hand height** (`--hand-h`) — horizontal splitter above the exploit hand.
+
+Sizes persist to `localStorage["starnet:layout"]` via a new `layout-store.js`,
+kept deliberately OUT of the game state object (UI chrome, not gameplay).
+Double-click a splitter resets that axis to its default.
+
+## Files
+
+- `js/ui/layout-store.js` (new) — `DEFAULT_LAYOUT`, `SIZE_BOUNDS`, pure `clampSize`
+  + `normalizeLayout`, `loadLayout` / `saveLayout`. Unit-tested (`layout-store.test.js`, 10 tests).
+- `js/ui/resizers.js` (new) — `initResizers()`: applies the loaded layout, wires
+  the three splitters with Pointer Events (+ `setPointerCapture`), clamps to live
+  viewport-relative maxima, debounced save, `lostpointercapture` cleanup, double-click reset.
+- `css/style.css` — flex bases via the three vars; `#log-pane`/`#log-entries`
+  refactor (pane carries the basis, entries fill + scroll, console row pinned);
+  removed the `#hand-strip { max-height: 33% }` cap from #182 (the clamp's
+  ~60%-of-sidebar max now serves that "don't crowd the node panel" intent);
+  `.splitter` styles (stroke-only hairline, cyan glow on hover/drag, 10px hit zone).
+- `index.html` — three `<div class="splitter" data-resize="…">` elements.
+- `js/ui/main.js` — `initResizers()` called in `init()` after `initConsole()`.
+- `MANUAL.md` — THE INTERFACE section notes the resizable borders + double-click reset.
+
+## Defaults chosen
+
+`{ sidebarW: 400, logH: 260, handH: 200 }` px. `sidebarW: 400` matches the
+historical fixed width. Static persistence bounds: sidebar 280–1200, log 64–1200,
+hand 80–1200; live drag maxima are 50vw / 60vh / 60%-of-sidebar.
+
+## Process
+
+Brainstorm → spec → plan → subagent-driven execution (2 implementer units +
+two-stage spec/quality review each). The touch-cancel fix (`lostpointercapture`)
+came out of the code-quality review.
+
+## Follow-on bug fix folded in (deck-pulse stretch)
+
+Playtesting the splitters surfaced a real bug: the DECK vital waveform's pulse
+stretched as the sidebar widened. `pulsePoints` hardcoded `CYCLES = 4` across the
+strip width, whereas `ecgPoints` anchors its period to height (wider strip = more
+beats). Fixed `pulsePoints` the same way (`CYCLE_W = H * 2.05`, cycle count snapped
+to tile the width) — at default strip dimensions it still yields 4 cycles, so the
+look is unchanged; it just adds cycles when wider instead of stretching. Reproduced
+with a failing test first (`waveform.test.js`: a 4×-wider strip must yield more
+vertices). Folded into this branch because the splitter is the natural repro.
+(The waveform restart-on-drag flicker is separate autosize re-init — left as-is.)
+
+## Deferred / noted
+
+- Full 4-way sidebar section resize (vital-stack / mission / node) — the rest of #181.
+- `role="separator"` + `aria-*` on the splitters for screen-reader operability
+  (raised in review; out of this pass's spec — worth a small follow-up).
+- A global "reset all layout" affordance.
+
+## Verification
+
+`make check` clean (1055 tests). Live browser verification of the drag behavior
+done against a local server (Playwright Firefox won't launch in this environment,
+so the visual confirm was manual).

--- a/docs/dev-sessions/2026-06-12-1429-resizable-ui-regions/plan.md
+++ b/docs/dev-sessions/2026-06-12-1429-resizable-ui-regions/plan.md
@@ -1,0 +1,641 @@
+# Drag-resizable UI regions — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the player drag three borders — sidebar width, graph/log height, and hand height — to rebalance the layout, with sizes persisted across reloads.
+
+**Architecture:** Three CSS custom properties on `#app` (`--sidebar-w`, `--log-h`, `--hand-h`) drive the flex bases of `#sidebar`, `#log-pane`, and `#hand-strip`. Thin flex-participating `.splitter` bars between the panes capture pointer drags and update those vars. A small `layout-store.js` persists the sizes to `localStorage` (outside game state); `resizers.js` wires the drag/double-click behavior. Pure size-clamping and load-normalization logic is unit-tested; the DOM wiring is verified live in the browser.
+
+**Tech Stack:** Vanilla ES modules, Pointer Events API, CSS flexbox + custom properties, `node:test` for units. No new dependencies.
+
+---
+
+## File structure
+
+- **Create** `js/ui/layout-store.js` — `DEFAULT_LAYOUT`, `SIZE_BOUNDS`, pure `clampSize()` + `normalizeLayout()`, and `loadLayout()` / `saveLayout()` (localStorage). One responsibility: persistence + validation of layout sizes.
+- **Create** `js/ui/layout-store.test.js` — unit tests for `clampSize` and `normalizeLayout`.
+- **Create** `js/ui/resizers.js` — `initResizers()`: applies the loaded layout to CSS vars and wires the three dividers (pointer drag, clamp, debounced save, double-click reset).
+- **Modify** `css/style.css` — flex-basis via vars on `#sidebar` / `#log-pane` / `#hand-strip`, the `#log-pane`/`#log-entries` refactor, removal of the `#hand-strip` `max-height: 33%`, and `.splitter` styles.
+- **Modify** `index.html` — three `<div class="splitter">` elements at the pane borders.
+- **Modify** `js/ui/main.js` — call `initResizers()` in `init()`.
+
+---
+
+## Task 1: layout-store — defaults, bounds, and pure `clampSize`
+
+**Files:**
+- Create: `js/ui/layout-store.js`
+- Test: `js/ui/layout-store.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `js/ui/layout-store.test.js`:
+
+```js
+// @ts-check
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { clampSize, DEFAULT_LAYOUT, SIZE_BOUNDS } from "./layout-store.js";
+
+describe("clampSize", () => {
+  test("passes through an in-range value", () => {
+    assert.equal(clampSize(400, 280, 1200), 400);
+  });
+  test("clamps below min up to min", () => {
+    assert.equal(clampSize(100, 280, 1200), 280);
+  });
+  test("clamps above max down to max", () => {
+    assert.equal(clampSize(5000, 280, 1200), 1200);
+  });
+  test("non-finite falls back to min", () => {
+    assert.equal(clampSize(NaN, 280, 1200), 280);
+    assert.equal(clampSize(Infinity, 280, 1200), 280);
+    assert.equal(clampSize("nope", 280, 1200), 280);
+  });
+});
+
+describe("DEFAULT_LAYOUT / SIZE_BOUNDS", () => {
+  test("defaults are within their static bounds", () => {
+    for (const key of Object.keys(DEFAULT_LAYOUT)) {
+      const { min, max } = SIZE_BOUNDS[key];
+      const v = DEFAULT_LAYOUT[key];
+      assert.ok(v >= min && v <= max, `${key}=${v} out of [${min},${max}]`);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test js/ui/layout-store.test.js`
+Expected: FAIL — cannot find module `./layout-store.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `js/ui/layout-store.js`:
+
+```js
+// @ts-check
+// Persistence + validation for the resizable-layout sizes (sidebar width,
+// log-pane height, hand height). UI chrome — deliberately kept OUT of the game
+// state object so save/load of a run stays pure (see CLAUDE.md). Mirrors the
+// load/save/normalize idiom of profile-store.js.
+
+const LAYOUT_KEY = "starnet:layout";
+
+/** Default sizes in px. `sidebarW` matches the historical fixed 400px. */
+export const DEFAULT_LAYOUT = { sidebarW: 400, logH: 260, handH: 200 };
+
+/**
+ * Static sanity bounds used when normalizing a persisted payload. The live
+ * viewport-relative maximum (≈50vw / 60vh / 60% of sidebar) is enforced during
+ * drag in resizers.js; these just keep a stored value finite and on-screen.
+ */
+export const SIZE_BOUNDS = {
+  sidebarW: { min: 280, max: 1200 },
+  logH:     { min: 64,  max: 1200 },
+  handH:    { min: 80,  max: 1200 },
+};
+
+/**
+ * Clamp a size to [min, max]. Non-finite / non-number input falls back to min.
+ * @param {unknown} px
+ * @param {number} min
+ * @param {number} max
+ * @returns {number}
+ */
+export function clampSize(px, min, max) {
+  const n = typeof px === "number" ? px : NaN;
+  if (!Number.isFinite(n)) return min;
+  return Math.min(max, Math.max(min, n));
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test js/ui/layout-store.test.js`
+Expected: PASS (all 5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/ui/layout-store.js js/ui/layout-store.test.js
+git commit -m 'feat: layout-store defaults, bounds, and clampSize'
+```
+
+---
+
+## Task 2: layout-store — `normalizeLayout`, `loadLayout`, `saveLayout`
+
+**Files:**
+- Modify: `js/ui/layout-store.js`
+- Test: `js/ui/layout-store.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `js/ui/layout-store.test.js`:
+
+```js
+import { normalizeLayout } from "./layout-store.js";
+
+describe("normalizeLayout", () => {
+  test("non-object payload returns the defaults", () => {
+    assert.deepEqual(normalizeLayout(null), DEFAULT_LAYOUT);
+    assert.deepEqual(normalizeLayout("x"), DEFAULT_LAYOUT);
+    assert.deepEqual(normalizeLayout(42), DEFAULT_LAYOUT);
+  });
+  test("missing keys fall back to per-key defaults", () => {
+    assert.deepEqual(normalizeLayout({ sidebarW: 500 }), {
+      sidebarW: 500, logH: DEFAULT_LAYOUT.logH, handH: DEFAULT_LAYOUT.handH,
+    });
+  });
+  test("out-of-range values are clamped to static bounds", () => {
+    const out = normalizeLayout({ sidebarW: 99999, logH: 1, handH: 0 });
+    assert.equal(out.sidebarW, SIZE_BOUNDS.sidebarW.max);
+    assert.equal(out.logH, SIZE_BOUNDS.logH.min);
+    assert.equal(out.handH, SIZE_BOUNDS.handH.min);
+  });
+  test("ignores unknown keys", () => {
+    assert.deepEqual(normalizeLayout({ sidebarW: 400, bogus: 1 }), DEFAULT_LAYOUT);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test js/ui/layout-store.test.js`
+Expected: FAIL — `normalizeLayout` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `js/ui/layout-store.js`:
+
+```js
+/**
+ * Coerce an arbitrary parsed payload into a valid layout: every key from
+ * DEFAULT_LAYOUT is taken from `raw` (clamped to its static bounds) or falls
+ * back to the default. Unknown keys are dropped. Pure.
+ * @param {unknown} raw
+ * @returns {{ sidebarW: number, logH: number, handH: number }}
+ */
+export function normalizeLayout(raw) {
+  const src = raw && typeof raw === "object" ? /** @type {any} */ (raw) : {};
+  const out = /** @type {any} */ ({});
+  for (const key of /** @type {(keyof typeof DEFAULT_LAYOUT)[]} */ (Object.keys(DEFAULT_LAYOUT))) {
+    const { min, max } = SIZE_BOUNDS[key];
+    out[key] = key in src ? clampSize(src[key], min, max) : DEFAULT_LAYOUT[key];
+    // A present-but-invalid value clamps to min; if it was simply absent we used
+    // the default above. Treat a min-clamped *default-equal* as fine either way.
+  }
+  return out;
+}
+
+/**
+ * Load the layout from localStorage, normalized. Corrupt/absent payload →
+ * defaults. Never throws.
+ * @returns {{ sidebarW: number, logH: number, handH: number }}
+ */
+export function loadLayout() {
+  try {
+    const raw = localStorage.getItem(LAYOUT_KEY);
+    if (!raw) return { ...DEFAULT_LAYOUT };
+    return normalizeLayout(JSON.parse(raw));
+  } catch {
+    return { ...DEFAULT_LAYOUT };
+  }
+}
+
+/**
+ * Persist the layout (normalized first so we never store junk).
+ * @param {{ sidebarW: number, logH: number, handH: number }} layout
+ */
+export function saveLayout(layout) {
+  try {
+    localStorage.setItem(LAYOUT_KEY, JSON.stringify(normalizeLayout(layout)));
+  } catch {
+    // storage full / unavailable — non-fatal, sizes just won't persist
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test js/ui/layout-store.test.js`
+Expected: PASS (all tests, including the new `normalizeLayout` block).
+
+Note: `loadLayout`/`saveLayout` touch `localStorage` and are not unit-tested in node (no DOM); they are thin wrappers over the tested `normalizeLayout` and verified live in Task 7.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/ui/layout-store.js js/ui/layout-store.test.js
+git commit -m 'feat: layout-store normalizeLayout + load/save'
+```
+
+---
+
+## Task 3: CSS — flex-basis vars, log-pane refactor, hand cap removal, splitter styles
+
+**Files:**
+- Modify: `css/style.css` (`#log-pane` ~102, `#log-entries` ~115, `#sidebar` ~181, `#sidebar-node`/`#hand-strip` ~221-233)
+
+No unit test (pure presentation); verified live in Task 7.
+
+- [ ] **Step 1: Drive the three flex bases from CSS vars**
+
+In `css/style.css`, change `#sidebar` (currently `flex: 0 0 400px;`):
+
+```css
+#sidebar {
+  flex: 0 0 var(--sidebar-w, 400px);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel);
+  border-left: 1px solid var(--border);
+  overflow: hidden;
+}
+```
+
+Change `#log-pane` (currently `flex: 0 0 auto;`) to carry the basis, and let its
+contents fill:
+
+```css
+#log-pane {
+  flex: 0 0 var(--log-h, 260px);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel);
+  border-top: 1px solid var(--border);
+  overflow: hidden;
+  min-height: 0;
+}
+```
+
+Change `#log-entries` from `flex: 0 0 14rem;` to fill the pane (console row stays
+pinned by its own `flex: 0 0 auto` default):
+
+```css
+#log-entries {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  overflow-y: auto;
+  padding: 0.3rem 1rem 0.3rem 1rem;
+  min-height: 0;
+}
+```
+
+- [ ] **Step 2: Hand-strip — basis var, drop the max-height cap**
+
+Change `#hand-strip` (currently `flex: 0 0 auto; max-height: 33%;` plus the
+comment added in #182). Remove the `max-height` and its comment; the `--hand-h`
+basis + drag clamp now own the height:
+
+```css
+/* Height owned by the --hand-h var + the resizer's clamp (see resizers.js); the
+   clamp's max (~60% of the sidebar) preserves the "don't crowd the node panel"
+   intent that the old max-height: 33% served. */
+#hand-strip {
+  flex: 0 0 var(--hand-h, 200px);
+  overflow-y: auto;
+  border-top: 1px solid var(--border);
+  background: var(--bg-panel);
+  padding: 0.4rem 0.75rem;
+}
+```
+
+- [ ] **Step 3: Splitter styles**
+
+Add a new block (near the layout rules, e.g. after `#sidebar`):
+
+```css
+/* ── Resize splitters ───────────────────────────────────────
+   Thin flex-participating bars between resizable panes. Stroke-only, no fill:
+   a hairline (::before) that brightens to a cyan phosphene glow on hover/drag,
+   inside a wider transparent hit zone so it stays easy to grab. */
+.splitter {
+  flex: 0 0 auto;
+  position: relative;
+  z-index: 4;            /* above panel chrome, below modals (store/level-select z10) */
+  background: transparent;
+  touch-action: none;    /* let Pointer Events own the drag gesture on touch */
+}
+.splitter::before {
+  content: "";
+  position: absolute;
+  background: var(--border);
+  transition: background 120ms, box-shadow 120ms;
+}
+.splitter:hover::before,
+.splitter.dragging::before {
+  background: var(--cyan);
+  box-shadow: 0 0 6px var(--cyan);
+}
+
+/* Vertical bar between two side-by-side panes (sidebar split). */
+.splitter--col {
+  width: 10px;
+  cursor: col-resize;
+  align-self: stretch;
+}
+.splitter--col::before {
+  top: 0; bottom: 0; left: 50%;
+  width: 1px; transform: translateX(-0.5px);
+}
+
+/* Horizontal bar between two stacked panes (log split, hand split). */
+.splitter--row {
+  height: 10px;
+  cursor: row-resize;
+  align-self: stretch;
+}
+.splitter--row::before {
+  left: 0; right: 0; top: 50%;
+  height: 1px; transform: translateY(-0.5px);
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add css/style.css
+git commit -m 'feat: CSS vars for resizable panes + splitter styles'
+```
+
+---
+
+## Task 4: index.html — insert the three splitter elements
+
+**Files:**
+- Modify: `index.html`
+
+- [ ] **Step 1: Add the graph↔log splitter**
+
+Between `#graph-container` (closes at line 42) and `#log-pane` (line 43), insert:
+
+```html
+        <div class="splitter splitter--row" data-resize="logH" title="Drag to resize — double-click to reset"></div>
+```
+
+- [ ] **Step 2: Add the graph-column↔sidebar splitter**
+
+Between `#graph-column` (closes at line 50) and `<aside id="sidebar">` (line 52), insert:
+
+```html
+      <div class="splitter splitter--col" data-resize="sidebarW" title="Drag to resize — double-click to reset"></div>
+```
+
+- [ ] **Step 3: Add the node↔hand splitter**
+
+Between `<starnet-node-panel id="sidebar-node">` (line 64) and
+`<starnet-hand id="hand-strip">` (line 65), insert:
+
+```html
+        <div class="splitter splitter--row" data-resize="handH" title="Drag to resize — double-click to reset"></div>
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add index.html
+git commit -m 'feat: add resize splitter elements to layout'
+```
+
+---
+
+## Task 5: resizers.js — wire drag, clamp, persist, reset
+
+**Files:**
+- Create: `js/ui/resizers.js`
+
+This module is DOM-coupled; its correctness is verified live (Task 7). The
+numeric clamping it relies on is already covered by Task 1.
+
+- [ ] **Step 1: Write the module**
+
+Create `js/ui/resizers.js`:
+
+```js
+// @ts-check
+// Wires the three layout splitters (sidebar width, log height, hand height).
+// Each divider drags one CSS var on #app; the var drives a flex-basis (see
+// css/style.css). Sizes load from / save to layout-store (localStorage).
+//
+// Pointer Events cover mouse + touch with one code path. The numeric clamp is
+// clampSize() in layout-store (unit-tested); live viewport-relative maxima are
+// computed here at drag time.
+
+import { loadLayout, saveLayout, clampSize, DEFAULT_LAYOUT, SIZE_BOUNDS } from "./layout-store.js";
+
+/**
+ * Per-axis config. `cssVar` is set on #app; `delta(start, ev)` converts a
+ * pointer position into a new size (the resized pane is below/right of the
+ * divider, so moving toward it shrinks, away grows); `liveMax()` is the
+ * viewport-relative ceiling enforced during drag.
+ */
+function axisConfig() {
+  const sidebar = document.getElementById("sidebar");
+  return {
+    sidebarW: {
+      cssVar: "--sidebar-w",
+      vertical: false, // drag along X
+      // sidebar is the RIGHT pane: moving left (smaller clientX) grows it
+      sizeFrom: (startSize, startPos, pos) => startSize + (startPos - pos),
+      liveMin: () => SIZE_BOUNDS.sidebarW.min,
+      liveMax: () => Math.max(SIZE_BOUNDS.sidebarW.min, window.innerWidth * 0.5),
+    },
+    logH: {
+      cssVar: "--log-h",
+      vertical: true, // drag along Y
+      // log-pane is the BOTTOM pane: moving up (smaller clientY) grows it
+      sizeFrom: (startSize, startPos, pos) => startSize + (startPos - pos),
+      liveMin: () => SIZE_BOUNDS.logH.min,
+      liveMax: () => Math.max(SIZE_BOUNDS.logH.min, window.innerHeight * 0.6),
+    },
+    handH: {
+      cssVar: "--hand-h",
+      vertical: true,
+      // hand is the BOTTOM pane: moving up grows it
+      sizeFrom: (startSize, startPos, pos) => startSize + (startPos - pos),
+      liveMin: () => SIZE_BOUNDS.handH.min,
+      liveMax: () => {
+        const h = sidebar ? sidebar.clientHeight : window.innerHeight;
+        return Math.max(SIZE_BOUNDS.handH.min, h * 0.6);
+      },
+    },
+  };
+}
+
+/** Read the current px size for an axis from the applied CSS var (fallback to default). */
+function currentSize(app, cssVar, fallback) {
+  const raw = getComputedStyle(app).getPropertyValue(cssVar).trim();
+  const n = parseFloat(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/** Apply a full layout object to the #app CSS vars. */
+function applyLayout(app, layout) {
+  app.style.setProperty("--sidebar-w", `${layout.sidebarW}px`);
+  app.style.setProperty("--log-h", `${layout.logH}px`);
+  app.style.setProperty("--hand-h", `${layout.handH}px`);
+}
+
+/**
+ * Initialize the resizers: apply the saved layout, then wire each splitter.
+ * Idempotent enough for a single call from main.js init().
+ */
+export function initResizers() {
+  const app = document.getElementById("app");
+  if (!app) return;
+
+  const layout = loadLayout();
+  applyLayout(app, layout);
+
+  const cfg = axisConfig();
+  /** debounce timer for saves */
+  let saveTimer = null;
+  const scheduleSave = () => {
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      saveLayout({
+        sidebarW: currentSize(app, "--sidebar-w", DEFAULT_LAYOUT.sidebarW),
+        logH: currentSize(app, "--log-h", DEFAULT_LAYOUT.logH),
+        handH: currentSize(app, "--hand-h", DEFAULT_LAYOUT.handH),
+      });
+    }, 250);
+  };
+
+  for (const el of document.querySelectorAll(".splitter")) {
+    const axis = /** @type {HTMLElement} */ (el).dataset.resize;
+    const c = axis && cfg[axis];
+    if (!c) continue;
+
+    el.addEventListener("pointerdown", (/** @type {PointerEvent} */ ev) => {
+      ev.preventDefault();
+      const startPos = c.vertical ? ev.clientY : ev.clientX;
+      const startSize = currentSize(app, c.cssVar, DEFAULT_LAYOUT[axis]);
+      el.classList.add("dragging");
+      el.setPointerCapture(ev.pointerId);
+
+      const onMove = (/** @type {PointerEvent} */ mv) => {
+        const pos = c.vertical ? mv.clientY : mv.clientX;
+        const next = clampSize(c.sizeFrom(startSize, startPos, pos), c.liveMin(), c.liveMax());
+        app.style.setProperty(c.cssVar, `${next}px`);
+      };
+      const onUp = (/** @type {PointerEvent} */ up) => {
+        el.classList.remove("dragging");
+        el.releasePointerCapture(up.pointerId);
+        el.removeEventListener("pointermove", onMove);
+        el.removeEventListener("pointerup", onUp);
+        scheduleSave();
+      };
+      el.addEventListener("pointermove", onMove);
+      el.addEventListener("pointerup", onUp);
+    });
+
+    // Double-click resets just this axis to its default.
+    el.addEventListener("dblclick", () => {
+      app.style.setProperty(c.cssVar, `${DEFAULT_LAYOUT[axis]}px`);
+      scheduleSave();
+    });
+  }
+}
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `make lint`
+Expected: PASS (no new tsc errors). `resizers.js` is type-checked; `layout-store.js` is too.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add js/ui/resizers.js
+git commit -m 'feat: resizers.js — drag/persist/reset wiring for splitters'
+```
+
+---
+
+## Task 6: main.js — call `initResizers()` at startup
+
+**Files:**
+- Modify: `js/ui/main.js` (import near line 18; call inside `init()` near line 66)
+
+- [ ] **Step 1: Add the import**
+
+After the existing UI imports (e.g. after line 18 `import { initProfileRunCommit } from "./profile-store.js";`):
+
+```js
+import { initResizers } from "./resizers.js";
+```
+
+- [ ] **Step 2: Call it in `init()`**
+
+In `init()`, after `initConsole();` (line 66), add:
+
+```js
+  initResizers();  // apply saved layout + wire the resize splitters
+```
+
+- [ ] **Step 3: Lint**
+
+Run: `make lint`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add js/ui/main.js
+git commit -m 'feat: wire initResizers into app init'
+```
+
+---
+
+## Task 7: Verify live + full check
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Build vendor + serve (worktree has no dist/)**
+
+```bash
+make bundle-vendor
+npx serve . -l 4319
+```
+
+- [ ] **Step 2: Manual verification in the browser** at `http://localhost:4319/`
+
+Confirm each, then note results in `notes.md`:
+- Drag the **sidebar** border left/right — sidebar widens/narrows, graph reflows, stops at ~280px / ~50vw.
+- Drag the **log** border up/down — log area grows/shrinks, console row stays pinned, graph reflows, stops at min / ~60vh.
+- Drag the **hand** border up/down — hand grows/shrinks, node panel takes the rest, stops at min / ~60% sidebar.
+- Splitter hairline brightens cyan on hover/drag.
+- **Double-click** each splitter resets that axis.
+- Reload the page — all three sizes persist.
+- In DevTools, run `localStorage.removeItem("starnet:layout")` then reload — layout returns to defaults, no errors.
+
+- [ ] **Step 3: Full check**
+
+Run: `make check`
+Expected: lint clean; all tests pass (including the new `layout-store.test.js`).
+
+- [ ] **Step 4: Update MANUAL.md**
+
+Per CLAUDE.md, the manual must reflect new behavior. Add a short note (in the UI/interface section) that the sidebar, log, and hand borders are drag-resizable and double-click resets a divider. Then:
+
+```bash
+git add MANUAL.md
+git commit -m 'docs: note drag-resizable layout in the manual'
+```
+
+- [ ] **Step 5: Write session notes + open PR**
+
+Fill `docs/dev-sessions/2026-06-12-1429-resizable-ui-regions/notes.md` with a short retro (what shipped, default sizes chosen, anything deferred), commit it, push the branch, and open a PR referencing #181.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** sidebar/log/hand dividers (Tasks 3–5), CSS-var mechanism (Task 3), log-pane refactor (Task 3), hand `max-height` removal (Task 3), layout-store persistence outside game state (Tasks 1–2), pointer+touch via Pointer Events + `touch-action: none` (Tasks 3, 5), per-axis clamps (Tasks 1, 5), double-click reset (Task 5), `clampSize`/`normalizeLayout` unit tests (Tasks 1–2), manual update (Task 7). All spec sections map to a task.
+- **Type/name consistency:** `clampSize(px, min, max)`, `normalizeLayout(raw)`, `DEFAULT_LAYOUT` (`sidebarW`/`logH`/`handH`), `SIZE_BOUNDS`, `loadLayout`/`saveLayout`, `initResizers`, CSS vars `--sidebar-w`/`--log-h`/`--hand-h`, and `data-resize` keys all match across tasks.
+- **Constraint:** `data-resize` attribute values (`sidebarW`/`logH`/`handH`) are exactly the keys of `DEFAULT_LAYOUT`/`SIZE_BOUNDS`/`axisConfig()` — the lookup `cfg[axis]` depends on this.

--- a/docs/dev-sessions/2026-06-12-1429-resizable-ui-regions/spec.md
+++ b/docs/dev-sessions/2026-06-12-1429-resizable-ui-regions/spec.md
@@ -1,0 +1,123 @@
+# Spec — Drag-resizable UI regions
+
+Issue: #181
+Branch: `resizable-ui-regions`
+
+## Goal
+
+Let the player rebalance the main UI layout by dragging region borders, with the
+chosen sizes persisted across reloads. First pass covers three dividers; the
+header HUD stays fixed.
+
+## Scope (this pass)
+
+Three draggable dividers, each a simple two-side split that adjusts one size:
+
+1. **Graph ↔ log** — height of `#log-pane` inside `#graph-column`.
+2. **Graph-column ↔ sidebar** — width of `#sidebar` (currently fixed `flex: 0 0 400px`).
+3. **Sidebar-node ↔ hand** — height of `#hand-strip`. The vital-sign stack and
+   mission pane stay pinned at the top of the sidebar; the divider sits just
+   above the hand.
+
+**Out of scope (deferred):** resizing the vital-stack / mission / node sections
+relative to each other (the full 4-way sidebar split from #181), and resizing
+the HUD.
+
+## Design
+
+### Mechanism — CSS-variable-driven flex sizing
+
+Three custom properties on `#app` drive the flex bases:
+
+- `--sidebar-w`  → `#sidebar { flex-basis: var(--sidebar-w, 400px); }`
+- `--log-h`      → `#log-pane { flex-basis: var(--log-h, 260px); }`
+- `--hand-h`     → `#hand-strip { flex-basis: var(--hand-h, 200px); }`
+
+`DEFAULT_LAYOUT` = `{ sidebarW: 400, logH: 260, handH: 200 }` (px; tunable during build).
+
+Dragging a divider updates one variable. Declarative, no per-frame layout math.
+The graph's existing `ResizeObserver` (added in #180) already calls `cy.resize()`
+when `#graph-container` changes size, so the graph copes with live resize for free.
+
+**Log-pane refactor:** `#log-pane` currently sizes to content via a fixed
+`#log-entries { flex: 0 0 14rem }`. Flip it so `#log-pane` carries the basis
+(`--log-h`) and `#log-entries` becomes `flex: 1 1 auto` (scrolling), with the
+console row pinned. The divider then grows/shrinks the scrollable log area.
+
+**Hand-strip cap:** `#hand-strip` currently has `max-height: 33%` (from #182) so
+a full deck can't crowd the node panel. The `--hand-h` basis + the hand-axis
+clamp now own that height, so the `max-height: 33%` is removed to avoid two
+mechanisms fighting over the same dimension. The clamp's max (≈60% of sidebar)
+preserves the original "don't crowd the node panel" intent.
+
+### Splitters — thin flex-participating bars
+
+Three `<div class="splitter">` elements in `index.html`, each placed *between*
+its two panes as a thin (~6px) flex item:
+
+- Vertical bar, `cursor: col-resize`, between `#graph-column` and `#sidebar`.
+- Horizontal bar, `cursor: row-resize`, between `#graph-container` and `#log-pane`.
+- Horizontal bar, `cursor: row-resize`, between `#sidebar-node` and `#hand-strip`.
+
+No absolute positioning or `getBoundingClientRect` border math — the bars
+participate in the existing flex layout.
+
+**Aesthetic (vector vocabulary):** a hairline that is nearly invisible at rest
+and brightens to a cyan stroke + phosphene glow on hover/drag. A wider (~10px)
+transparent hit zone makes it grabbable without a fat visible bar. Stroke-only,
+no fill, no bitmap chrome. Exact look tuned live in the browser during build.
+
+### Modules
+
+- **`js/ui/layout-store.js`** — mirrors `profile-store.js`:
+  - `DEFAULT_LAYOUT` — default px sizes for the three axes.
+  - `loadLayout()` — read `localStorage["starnet:layout"]`, JSON-parse,
+    normalize-and-clamp every field (corrupt/stale/missing payload falls back to
+    defaults; never wedges the layout).
+  - `saveLayout(layout)` — persist JSON.
+  - `clampSize(axis, px)` — **pure**, the unit-tested core. Clamps a size to the
+    axis min/max.
+- **`js/ui/resizers.js`** — wires the three dividers:
+  - Pointer Events (`pointerdown` / `pointermove` / `pointerup` +
+    `setPointerCapture`) — covers mouse and touch uniformly.
+  - On drag: compute new size from the pointer delta, `clampSize`, write the CSS
+    var on `#app`.
+  - On release: debounced `saveLayout()`.
+  - Initializes the CSS vars from `loadLayout()` at startup.
+  - **Double-click a divider resets that axis** to its `DEFAULT_LAYOUT` value
+    (and saves).
+
+UI-prefs live OUTSIDE the game state object (CLAUDE.md state-encapsulation rule):
+layout is chrome, not gameplay, so save/load of a run stays pure.
+
+### Constraints (clamped per axis)
+
+| Axis         | Min                          | Max            |
+|--------------|------------------------------|----------------|
+| Sidebar width| ~280px (HUD/cards readable)  | ~50vw          |
+| Log height   | ~console row + one line       | ~60vh          |
+| Hand height  | ~one card row                | ~60% of sidebar |
+
+Final numbers tunable during build; intent is no pane collapses to zero or
+starves its neighbor.
+
+## Testing
+
+- `clampSize` — pure unit tests: in-range passthrough, below-min, above-max,
+  each axis.
+- `loadLayout` normalization — corrupt JSON, missing keys, out-of-range values,
+  non-object payload all return a clamped valid layout.
+- Drag wiring is DOM-coupled; per the `testing-ui-modules-in-node` note a
+  `globalThis.document` stub allows a smoke test, but the meaningful assertions
+  stay on the pure helpers.
+
+## Reset mechanism
+
+Double-click a divider → resets that one axis to its default. (No global
+"reset all" button this pass; can add later if wanted.)
+
+## Out of scope / future
+
+- Full 4-way sidebar section resize (#181 remainder).
+- Resizable/collapsible HUD.
+- A global "reset layout" affordance.

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
           <starnet-store id="darknet-store"></starnet-store>
           <starnet-level-select id="level-select"></starnet-level-select>
         </div>
+        <div class="splitter splitter--row" data-resize="logH" title="Drag to resize — double-click to reset"></div>
         <div id="log-pane">
           <starnet-log id="log-entries"></starnet-log>
           <div id="console-row">
@@ -48,6 +49,7 @@
           </div>
         </div>
       </div>
+      <div class="splitter splitter--col" data-resize="sidebarW" title="Drag to resize — double-click to reset"></div>
 
       <aside id="sidebar">
         <!-- Vital-sign traces: a stacked pair at the top of the sidebar. Canvas traces
@@ -62,6 +64,7 @@
         </div>
         <starnet-mission-pane id="sidebar-mission"></starnet-mission-pane>
         <starnet-node-panel id="sidebar-node"></starnet-node-panel>
+        <div class="splitter splitter--row" data-resize="handH" title="Drag to resize — double-click to reset"></div>
         <starnet-hand id="hand-strip"></starnet-hand>
       </aside>
     </main>

--- a/js/ui/layout-store.js
+++ b/js/ui/layout-store.js
@@ -1,0 +1,78 @@
+// @ts-check
+// Persistence + validation for the resizable-layout sizes (sidebar width,
+// log-pane height, hand height). UI chrome — deliberately kept OUT of the game
+// state object so save/load of a run stays pure (see CLAUDE.md). Mirrors the
+// load/save/normalize idiom of profile-store.js.
+
+const LAYOUT_KEY = "starnet:layout";
+
+/** Default sizes in px. `sidebarW` matches the historical fixed 400px. */
+export const DEFAULT_LAYOUT = { sidebarW: 400, logH: 260, handH: 200 };
+
+/**
+ * Static sanity bounds used when normalizing a persisted payload. The live
+ * viewport-relative maximum (≈50vw / 60vh / 60% of sidebar) is enforced during
+ * drag in resizers.js; these just keep a stored value finite and on-screen.
+ */
+export const SIZE_BOUNDS = {
+  sidebarW: { min: 280, max: 1200 },
+  logH:     { min: 64,  max: 1200 },
+  handH:    { min: 80,  max: 1200 },
+};
+
+/**
+ * Clamp a size to [min, max]. Non-finite / non-number input falls back to min.
+ * @param {unknown} px
+ * @param {number} min
+ * @param {number} max
+ * @returns {number}
+ */
+export function clampSize(px, min, max) {
+  const n = typeof px === "number" ? px : NaN;
+  if (!Number.isFinite(n)) return min;
+  return Math.min(max, Math.max(min, n));
+}
+
+/**
+ * Coerce an arbitrary parsed payload into a valid layout: every key from
+ * DEFAULT_LAYOUT is taken from `raw` (clamped to its static bounds) or falls
+ * back to the default. Unknown keys are dropped. Pure.
+ * @param {unknown} raw
+ * @returns {{ sidebarW: number, logH: number, handH: number }}
+ */
+export function normalizeLayout(raw) {
+  const src = raw && typeof raw === "object" ? /** @type {any} */ (raw) : {};
+  const out = /** @type {any} */ ({});
+  for (const key of /** @type {(keyof typeof DEFAULT_LAYOUT)[]} */ (Object.keys(DEFAULT_LAYOUT))) {
+    const { min, max } = SIZE_BOUNDS[key];
+    out[key] = key in src ? clampSize(src[key], min, max) : DEFAULT_LAYOUT[key];
+  }
+  return out;
+}
+
+/**
+ * Load the layout from localStorage, normalized. Corrupt/absent payload →
+ * defaults. Never throws.
+ * @returns {{ sidebarW: number, logH: number, handH: number }}
+ */
+export function loadLayout() {
+  try {
+    const raw = localStorage.getItem(LAYOUT_KEY);
+    if (!raw) return { ...DEFAULT_LAYOUT };
+    return normalizeLayout(JSON.parse(raw));
+  } catch {
+    return { ...DEFAULT_LAYOUT };
+  }
+}
+
+/**
+ * Persist the layout (normalized first so we never store junk).
+ * @param {{ sidebarW: number, logH: number, handH: number }} layout
+ */
+export function saveLayout(layout) {
+  try {
+    localStorage.setItem(LAYOUT_KEY, JSON.stringify(normalizeLayout(layout)));
+  } catch {
+    // storage full / unavailable — non-fatal, sizes just won't persist
+  }
+}

--- a/js/ui/layout-store.test.js
+++ b/js/ui/layout-store.test.js
@@ -1,0 +1,59 @@
+// @ts-check
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { clampSize, DEFAULT_LAYOUT, SIZE_BOUNDS, normalizeLayout } from "./layout-store.js";
+
+// loadLayout/saveLayout touch localStorage (absent under node:test); only the
+// pure helpers clampSize/normalizeLayout are covered here.
+
+describe("clampSize", () => {
+  test("passes through an in-range value", () => {
+    assert.equal(clampSize(400, 280, 1200), 400);
+  });
+  test("clamps below min up to min", () => {
+    assert.equal(clampSize(100, 280, 1200), 280);
+  });
+  test("clamps above max down to max", () => {
+    assert.equal(clampSize(5000, 280, 1200), 1200);
+  });
+  test("non-finite falls back to min", () => {
+    assert.equal(clampSize(NaN, 280, 1200), 280);
+    assert.equal(clampSize(Infinity, 280, 1200), 280);
+    assert.equal(clampSize("nope", 280, 1200), 280);
+  });
+});
+
+describe("DEFAULT_LAYOUT / SIZE_BOUNDS", () => {
+  test("defaults are within their static bounds", () => {
+    for (const key of Object.keys(DEFAULT_LAYOUT)) {
+      const { min, max } = SIZE_BOUNDS[key];
+      const v = DEFAULT_LAYOUT[key];
+      assert.ok(v >= min && v <= max, `${key}=${v} out of [${min},${max}]`);
+    }
+  });
+});
+
+describe("normalizeLayout", () => {
+  test("non-object payload returns the defaults", () => {
+    assert.deepEqual(normalizeLayout(null), DEFAULT_LAYOUT);
+    assert.deepEqual(normalizeLayout("x"), DEFAULT_LAYOUT);
+    assert.deepEqual(normalizeLayout(42), DEFAULT_LAYOUT);
+  });
+  test("missing keys fall back to per-key defaults", () => {
+    assert.deepEqual(normalizeLayout({ sidebarW: 500 }), {
+      sidebarW: 500, logH: DEFAULT_LAYOUT.logH, handH: DEFAULT_LAYOUT.handH,
+    });
+  });
+  test("out-of-range values are clamped to static bounds", () => {
+    const out = normalizeLayout({ sidebarW: 99999, logH: 1, handH: 0 });
+    assert.equal(out.sidebarW, SIZE_BOUNDS.sidebarW.max);
+    assert.equal(out.logH, SIZE_BOUNDS.logH.min);
+    assert.equal(out.handH, SIZE_BOUNDS.handH.min);
+  });
+  test("ignores unknown keys", () => {
+    assert.deepEqual(normalizeLayout({ sidebarW: 400, bogus: 1 }), DEFAULT_LAYOUT);
+  });
+  test("a null-valued key clamps to that axis min", () => {
+    assert.equal(normalizeLayout({ sidebarW: null }).sidebarW, SIZE_BOUNDS.sidebarW.min);
+  });
+});

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -16,6 +16,7 @@ import { initRng } from "../core/rng.js";
 import { toCytoscapeFormat } from "./run-control.js";
 import { openHub, initHub } from "./hub.js";
 import { initProfileRunCommit } from "./profile-store.js";
+import { initResizers } from "./resizers.js";
 import "./hub-commands.js";
 
 import { NAMED_NETWORKS, DEFAULT_NETWORK, buildGenerated } from "../../data/networks/index.js";
@@ -64,6 +65,7 @@ function init() {
     emitEvent("starnet:action", { actionId: "untarget" });
   });
   initConsole();
+  initResizers();  // apply saved layout + wire the resize splitters
   initVisualRenderer();  // must subscribe before initGame fires STATE_CHANGED
   initGraphBridge();
   initDynamicActions();

--- a/js/ui/resizers.js
+++ b/js/ui/resizers.js
@@ -1,0 +1,132 @@
+// @ts-check
+// Wires the three layout splitters (sidebar width, log height, hand height).
+// Each divider drags one CSS var on #app; the var drives a flex-basis (see
+// css/style.css). Sizes load from / save to layout-store (localStorage).
+//
+// Pointer Events cover mouse + touch with one code path. The numeric clamp is
+// clampSize() in layout-store (unit-tested); live viewport-relative maxima are
+// computed here at drag time.
+
+import { loadLayout, saveLayout, clampSize, DEFAULT_LAYOUT, SIZE_BOUNDS } from "./layout-store.js";
+
+/**
+ * Per-axis config. `cssVar` is set on #app; `sizeFrom()` converts a pointer
+ * position into a new size (the resized pane is below/right of the divider, so
+ * moving toward it shrinks, away grows); `liveMax()` is the viewport-relative
+ * ceiling enforced during drag.
+ */
+function axisConfig() {
+  return {
+    sidebarW: {
+      cssVar: "--sidebar-w",
+      vertical: false, // drag along X
+      // sidebar is the RIGHT pane: moving left (smaller clientX) grows it
+      sizeFrom: (startSize, startPos, pos) => startSize + (startPos - pos),
+      liveMin: () => SIZE_BOUNDS.sidebarW.min,
+      liveMax: () => Math.max(SIZE_BOUNDS.sidebarW.min, window.innerWidth * 0.5),
+    },
+    logH: {
+      cssVar: "--log-h",
+      vertical: true, // drag along Y
+      // log-pane is the BOTTOM pane: moving up (smaller clientY) grows it
+      sizeFrom: (startSize, startPos, pos) => startSize + (startPos - pos),
+      liveMin: () => SIZE_BOUNDS.logH.min,
+      liveMax: () => Math.max(SIZE_BOUNDS.logH.min, window.innerHeight * 0.6),
+    },
+    handH: {
+      cssVar: "--hand-h",
+      vertical: true,
+      // hand is the BOTTOM pane: moving up grows it
+      sizeFrom: (startSize, startPos, pos) => startSize + (startPos - pos),
+      liveMin: () => SIZE_BOUNDS.handH.min,
+      liveMax: () => {
+        const el = document.getElementById("sidebar");
+        const h = el ? el.clientHeight : window.innerHeight;
+        return Math.max(SIZE_BOUNDS.handH.min, h * 0.6);
+      },
+    },
+  };
+}
+
+/** Read the current px size for an axis from the applied CSS var (fallback to default). */
+function currentSize(app, cssVar, fallback) {
+  const raw = getComputedStyle(app).getPropertyValue(cssVar).trim();
+  const n = parseFloat(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/** Apply a full layout object to the #app CSS vars. */
+function applyLayout(app, layout) {
+  app.style.setProperty("--sidebar-w", `${layout.sidebarW}px`);
+  app.style.setProperty("--log-h", `${layout.logH}px`);
+  app.style.setProperty("--hand-h", `${layout.handH}px`);
+}
+
+/**
+ * Initialize the resizers: apply the saved layout, then wire each splitter.
+ * Safe to call once from main.js init().
+ */
+export function initResizers() {
+  const app = document.getElementById("app");
+  if (!app) return;
+
+  const layout = loadLayout();
+  applyLayout(app, layout);
+
+  const cfg = axisConfig();
+  let saveTimer = null;
+  const scheduleSave = () => {
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      saveLayout({
+        sidebarW: currentSize(app, "--sidebar-w", DEFAULT_LAYOUT.sidebarW),
+        logH: currentSize(app, "--log-h", DEFAULT_LAYOUT.logH),
+        handH: currentSize(app, "--hand-h", DEFAULT_LAYOUT.handH),
+      });
+    }, 250);
+  };
+
+  for (const el of document.querySelectorAll(".splitter")) {
+    const axis = /** @type {HTMLElement} */ (el).dataset.resize;
+    const c = axis && cfg[axis];
+    if (!c) continue;
+
+    el.addEventListener("pointerdown", (/** @type {PointerEvent} */ ev) => {
+      ev.preventDefault();
+      const startPos = c.vertical ? ev.clientY : ev.clientX;
+      const startSize = currentSize(app, c.cssVar, DEFAULT_LAYOUT[axis]);
+      el.classList.add("dragging");
+      el.setPointerCapture(ev.pointerId);
+
+      const onMove = (/** @type {PointerEvent} */ mv) => {
+        const pos = c.vertical ? mv.clientY : mv.clientX;
+        const next = clampSize(c.sizeFrom(startSize, startPos, pos), c.liveMin(), c.liveMax());
+        app.style.setProperty(c.cssVar, `${next}px`);
+      };
+      const cleanup = () => {
+        el.classList.remove("dragging");
+        el.removeEventListener("pointermove", onMove);
+        el.removeEventListener("pointerup", onUp);
+        el.removeEventListener("lostpointercapture", onLost);
+        scheduleSave();
+      };
+      const onUp = (/** @type {PointerEvent} */ up) => {
+        el.releasePointerCapture(up.pointerId);
+        cleanup();
+      };
+      // lostpointercapture fires on pointercancel / OS interruption (capture is
+      // auto-released by the browser); without this the splitter stays stuck in
+      // .dragging on touch. Guard against the explicit-release path double-firing.
+      const onLost = () => { if (el.classList.contains("dragging")) cleanup(); };
+      el.addEventListener("pointermove", onMove);
+      el.addEventListener("pointerup", onUp);
+      el.addEventListener("lostpointercapture", onLost);
+    });
+
+    // Double-click resets just this axis to its default.
+    el.addEventListener("dblclick", () => {
+      app.style.setProperty(c.cssVar, `${DEFAULT_LAYOUT[axis]}px`);
+      scheduleSave();
+    });
+  }
+}

--- a/js/ui/waveform.js
+++ b/js/ui/waveform.js
@@ -189,7 +189,12 @@ export function pulsePoints({ frac, width, height }) {
   const ramp = Math.pow(dmg, 0.4);
   const over = H * lerp(0.06, 0.34, ramp);      // edge overshoot, visible healthy → grows with damage
   const nw = Math.round(lerp(0, 4, ramp));      // extra damped ring wobbles from damage
-  const CYCLES = 4;                             // hi+lo cycles across the width (~W/8 plateaus)
+  // Cycle width is anchored to height (like ecgPoints' period) so a wider strip
+  // shows MORE clock cycles rather than stretching a fixed few to fill. CYCLE_W
+  // ≈ the old four-cycles-across-the-default-strip ratio; the count is snapped so
+  // plateaus tile the width edge-to-edge (a continuous clock).
+  const CYCLE_W = H * 2.05;                      // one hi+lo cycle, height-relative
+  const CYCLES = Math.max(1, Math.round(W / CYCLE_W));
   const half = W / (CYCLES * 2);                // one plateau (up OR down) — equal duty
   const eW = half * lerp(0.375, 0.6, ramp);     // ringing-edge region width
 

--- a/js/ui/waveform.test.js
+++ b/js/ui/waveform.test.js
@@ -174,6 +174,18 @@ describe("pulsePoints", () => {
       pulsePoints({ frac: 0.4, width: W, height: H }),
     );
   });
+
+  test("fixed cycle width: a wider strip shows MORE pulses, not stretched ones", () => {
+    // Cycle width is anchored to height (like ecgPoints' period), so widening the
+    // strip adds clock cycles rather than stretching a fixed few to fill. A 4×
+    // wider strip should yield substantially more vertices, not the same count.
+    const narrow = pulsePoints({ frac: 0.7, width: 200, height: H });
+    const wide = pulsePoints({ frac: 0.7, width: 800, height: H });
+    assert.ok(
+      wide.length > narrow.length * 2,
+      `expected wide (${wide.length}) >> narrow (${narrow.length}) — pulse appears width-stretched`,
+    );
+  });
 });
 
 describe("frac clamping (both)", () => {


### PR DESCRIPTION
Closes #181 (first pass).

Three UI borders are now drag-resizable, with sizes persisted across reloads.

## What you can resize

- **Sidebar width** — vertical splitter between the graph column and the sidebar (was a fixed `400px`).
- **Graph ↔ log height** — horizontal splitter above the log/console.
- **Hand ↔ node-info height** — horizontal splitter above the exploit hand.

Grab a border and drag; **double-click a border resets that split** to its default. The header HUD stays fixed.

## How it works

Three CSS custom properties on `#app` (`--sidebar-w`, `--log-h`, `--hand-h`) drive the flex bases of `#sidebar`, `#log-pane`, and `#hand-strip`. Thin flex-participating `.splitter` bars capture pointer drags (Pointer Events + `setPointerCapture`, so mouse and touch share one path) and update one var. Sizes load from / save to a new `layout-store.js` backed by `localStorage["starnet:layout"]` — kept **out of the game state object** per the CLAUDE.md state-encapsulation rule (layout is chrome, not gameplay). The graphs existing `ResizeObserver` (#180) handles `cy.resize()` on live resize for free.

## Files

- **New** `js/ui/layout-store.js` — `DEFAULT_LAYOUT`, `SIZE_BOUNDS`, pure `clampSize` + `normalizeLayout`, `loadLayout`/`saveLayout`. Unit-tested (`layout-store.test.js`, 10 tests).
- **New** `js/ui/resizers.js` — `initResizers()`: apply saved layout, wire splitters, clamp to live viewport maxima (50vw / 60vh / 60%-of-sidebar), debounced save, `lostpointercapture` cleanup, double-click reset.
- **Changed** `css/style.css` (vars + splitter styles + log-pane refactor), `index.html` (splitter elements), `js/ui/main.js` (init), `MANUAL.md`.
- **Removed** the `#hand-strip { max-height: 33% }` cap from #182 — the new `--hand-h` basis + clamp now own that height; the clamps ~60%-of-sidebar max preserves the "dont crowd the node panel" intent.

## Defaults

`{ sidebarW: 400, logH: 260, handH: 200 }` px (`sidebarW` matches the old fixed width).

## Testing

- `make check` clean — 1055 tests pass (incl. the new `layout-store` unit tests).
- Live browser verification of all three drags, double-click reset, persistence across reload, and corrupt/missing-payload reset.

## Deferred (noted in session notes)

- Full 4-way sidebar section resize (the remainder of #181).
- `role="separator"` + `aria-*` on the splitters for screen-reader operability.
- A global "reset all layout" affordance.
- **Deck-pulse fix (included):** dragging the sidebar wider stretched the DECK vital pulse — `pulsePoints` hardcoded a fixed cycle count across the width. Fixed to anchor cycle width to height (matching `ecgPoints`), with a failing test first; default look unchanged. The HEALTH/DECK waveforms still restart on each drag (autosize re-init) — left as-is.

Process: brainstorm → spec → plan → subagent-driven execution with spec + code-quality review per unit. Session docs in `docs/dev-sessions/2026-06-12-1429-resizable-ui-regions/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)