### PR TITLE
Decompose graph.js: shared pulse animator + BFS pathfinder (#165)

### DIFF
--- a/js/ui/graph-path.js
+++ b/js/ui/graph-path.js
@@ -1,0 +1,49 @@
+// Pure breadth-first pathfinding over a Cytoscape graph's edges.
+//
+// Extracted from graph.js's two near-identical BFS walks (flashIcePath /
+// drawIceTrace) per issue #165. Returns the ordered node-id list; each caller
+// keeps its own styling. Kept dependency-free (only the `cy.edges()` +
+// `edge.data()` surface) so it's unit-testable with a tiny mock.
+
+/**
+ * Find the shortest path between two nodes, treating edges as undirected.
+ *
+ * @param {{ edges: () => Iterable<{ data: (key: string) => string }> }} cy
+ * @param {string} fromId
+ * @param {string} toId
+ * @returns {string[] | null} ordered node ids from `fromId` to `toId`
+ *   (inclusive), or `null` if `toId` is unreachable from `fromId`. A
+ *   degenerate `fromId === toId` returns `null` (no traversable path),
+ *   matching the original walks.
+ */
+export function findPath(cy, fromId, toId) {
+  const prev = new Map([[fromId, null]]); // node id → predecessor id (null at root)
+  const queue = [fromId];
+  let found = false;
+
+  while (queue.length && !found) {
+    const cur = queue.shift();
+    for (const edge of cy.edges()) {
+      const s = edge.data("source");
+      const t = edge.data("target");
+      let neighbor = null;
+      if (s === cur && !prev.has(t)) neighbor = t;
+      else if (t === cur && !prev.has(s)) neighbor = s;
+      if (neighbor !== null) {
+        prev.set(neighbor, cur);
+        if (neighbor === toId) { found = true; break; }
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  if (!found) return null;
+
+  const path = [];
+  let cur = toId;
+  while (cur !== null) {
+    path.unshift(cur);
+    cur = prev.get(cur);
+  }
+  return path;
+}

--- a/js/ui/graph-path.test.js
+++ b/js/ui/graph-path.test.js
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { findPath } from "./graph-path.js";
+
+// Build a mock `cy` whose edges() yields objects with the same `.data()`
+// surface findPath consumes. Edges are undirected pairs [source, target].
+function mockCy(edges) {
+  return {
+    edges: () =>
+      edges.map(([source, target]) => ({
+        data: (key) => (key === "source" ? source : target),
+      })),
+  };
+}
+
+test("findPath returns the ordered node list including both endpoints", () => {
+  // a — b — c — d
+  const cy = mockCy([["a", "b"], ["b", "c"], ["c", "d"]]);
+  assert.deepEqual(findPath(cy, "a", "d"), ["a", "b", "c", "d"]);
+});
+
+test("findPath traverses edges as undirected (target → source too)", () => {
+  // edges stored as a→b, c→b — path a..c must walk c→b backwards
+  const cy = mockCy([["a", "b"], ["c", "b"]]);
+  assert.deepEqual(findPath(cy, "a", "c"), ["a", "b", "c"]);
+});
+
+test("findPath returns the shortest path when multiple exist", () => {
+  // a—b—d and a—c—d both length 2; a—e—f—d is longer. BFS picks a length-2 path.
+  const cy = mockCy([
+    ["a", "b"], ["b", "d"],
+    ["a", "c"], ["c", "d"],
+    ["a", "e"], ["e", "f"], ["f", "d"],
+  ]);
+  const path = findPath(cy, "a", "d");
+  assert.equal(path.length, 3);
+  assert.equal(path[0], "a");
+  assert.equal(path[2], "d");
+});
+
+test("findPath returns null when the target is unreachable", () => {
+  const cy = mockCy([["a", "b"], ["c", "d"]]);
+  assert.equal(findPath(cy, "a", "d"), null);
+});
+
+test("findPath returns null for a degenerate from === to (no traversable path)", () => {
+  const cy = mockCy([["a", "b"]]);
+  assert.equal(findPath(cy, "a", "a"), null);
+});

--- a/js/ui/graph.js
+++ b/js/ui/graph.js
@@ -5,6 +5,7 @@ import { isIceVisible, isObscured } from "../core/state.js";
 import { CONTAINER_POLYGON_POINTS, nodeFaceDataUri } from "./node-glyphs.js";
 import { iceStrikeCage } from "./ice-glyphs.js";
 import { ringPoints } from "./overlays/facet.js";
+import { findPath } from "./graph-path.js";
 
 // Still playing with what might be the best default here
 // const DEFAULT_LAYOUT_ALGO = "breadthfirst";
@@ -44,93 +45,69 @@ const pulsingNodes = new Set();       // nodeIds running red-alert pulse
 const yellowPulsingNodes = new Set(); // nodeIds running yellow-alert pulse
 const rebootingNodes = new Set();     // nodeIds running reboot opacity pulse
 
-function startRedPulse(node) {
-  const id = node.id();
-  if (pulsingNodes.has(id)) return;
-  pulsingNodes.add(id);
-  runRedPulse(node);
-}
-
-function stopRedPulse(node) {
-  pulsingNodes.delete(node.id());
-  node.stop();
-  node.removeStyle("border-color border-width");
+// Build a looping node-style pulse. All three pulses share the same shape —
+// start → add to a membership Set → chain `frames` forever, re-checking
+// membership before every animate so stop() halts the loop cleanly. They differ
+// only in the Set, the looped frames, and which style props stop() clears.
+//
+// @param {object} opts
+// @param {Set<string>} opts.set       membership Set keyed by node id
+// @param {{ style: object, duration: number }[]} opts.frames  looped in order
+// @param {string} opts.clearStyle     space-separated props removed on stop()
+function createPulseAnimator({ set, frames, clearStyle }) {
+  function step(node, id, i) {
+    if (!set.has(id)) return;
+    const frame = frames[i % frames.length];
+    node.animate(
+      { style: frame.style },
+      { duration: frame.duration, complete: () => step(node, id, i + 1) }
+    );
+  }
+  return {
+    start(node) {
+      const id = node.id();
+      if (set.has(id)) return;
+      set.add(id);
+      step(node, id, 0);
+    },
+    stop(node) {
+      set.delete(node.id());
+      node.stop();
+      node.removeStyle(clearStyle);
+    },
+  };
 }
 
 // Thin strobe blink (not a fattening breathe): a thin constant-width border that
 // flickers bright→dim, so under the global bloom it reads as a vector alarm
 // strobe rather than a throbbing halo. Red strobes fast (urgent).
-function runRedPulse(node) {
-  const id = node.id();
-  if (!pulsingNodes.has(id)) return;
-  node.animate(
-    { style: { "border-color": "#ff3030", "border-width": 1.5 } },
-    { duration: 220, complete: () => {
-      if (!pulsingNodes.has(id)) return;
-      node.animate(
-        { style: { "border-color": "#5a1010", "border-width": 1.5 } },
-        { duration: 420, complete: () => runRedPulse(node) }
-      );
-    }}
-  );
-}
-
-function startYellowPulse(node) {
-  const id = node.id();
-  if (yellowPulsingNodes.has(id)) return;
-  yellowPulsingNodes.add(id);
-  runYellowPulse(node);
-}
-
-function stopYellowPulse(node) {
-  yellowPulsingNodes.delete(node.id());
-  node.stop();
-  node.removeStyle("border-color border-width");
-}
+const redPulse = createPulseAnimator({
+  set: pulsingNodes,
+  clearStyle: "border-color border-width",
+  frames: [
+    { style: { "border-color": "#ff3030", "border-width": 1.5 }, duration: 220 },
+    { style: { "border-color": "#5a1010", "border-width": 1.5 }, duration: 420 },
+  ],
+});
 
 // Yellow strobes slower/softer than red (lower urgency), same thin-blink idea.
-function runYellowPulse(node) {
-  const id = node.id();
-  if (!yellowPulsingNodes.has(id)) return;
-  node.animate(
-    { style: { "border-color": "#ffcc00", "border-width": 1.5 } },
-    { duration: 480, complete: () => {
-      if (!yellowPulsingNodes.has(id)) return;
-      node.animate(
-        { style: { "border-color": "#4a3800", "border-width": 1.5 } },
-        { duration: 720, complete: () => runYellowPulse(node) }
-      );
-    }}
-  );
-}
+const yellowPulse = createPulseAnimator({
+  set: yellowPulsingNodes,
+  clearStyle: "border-color border-width",
+  frames: [
+    { style: { "border-color": "#ffcc00", "border-width": 1.5 }, duration: 480 },
+    { style: { "border-color": "#4a3800", "border-width": 1.5 }, duration: 720 },
+  ],
+});
 
-function startRebootPulse(node) {
-  const id = node.id();
-  if (rebootingNodes.has(id)) return;
-  rebootingNodes.add(id);
-  runRebootPulse(node);
-}
-
-function stopRebootPulse(node) {
-  rebootingNodes.delete(node.id());
-  node.stop();
-  node.removeStyle("opacity");
-}
-
-function runRebootPulse(node) {
-  const id = node.id();
-  if (!rebootingNodes.has(id)) return;
-  node.animate(
-    { style: { opacity: 0.2 } },
-    { duration: 1000, complete: () => {
-      if (!rebootingNodes.has(id)) return;
-      node.animate(
-        { style: { opacity: 0.55 } },
-        { duration: 1200, complete: () => runRebootPulse(node) }
-      );
-    }}
-  );
-}
+const rebootPulse = createPulseAnimator({
+  set: rebootingNodes,
+  clearStyle: "opacity",
+  frames: [
+    { style: { opacity: 0.2 }, duration: 1000 },
+    { style: { opacity: 0.55 }, duration: 1200 },
+  ],
+});
 
 // Full network topology — stored for deferred node addition.
 // Nodes are only added to Cytoscape when they become visible.
@@ -548,10 +525,10 @@ export function updateNodeStyle(nodeId, nodeState) {
   // Rebooting state
   if (nodeState.rebooting) {
     node.addClass("rebooting");
-    startRebootPulse(node);
+    rebootPulse.start(node);
   } else {
     node.removeClass("rebooting");
-    stopRebootPulse(node);
+    rebootPulse.stop(node);
   }
 
   // Visibility class
@@ -584,14 +561,14 @@ export function updateNodeStyle(nodeId, nodeState) {
 
     // Alert pulse animations (shadow-blur is invalid in Cytoscape; use bg/border instead)
     if (nodeState.alertState === "red") {
-      if (yellowPulsingNodes.has(nodeId)) stopYellowPulse(node);
-      startRedPulse(node);
+      if (yellowPulsingNodes.has(nodeId)) yellowPulse.stop(node);
+      redPulse.start(node);
     } else if (nodeState.alertState === "yellow") {
-      if (pulsingNodes.has(nodeId)) stopRedPulse(node);
-      startYellowPulse(node);
+      if (pulsingNodes.has(nodeId)) redPulse.stop(node);
+      yellowPulse.start(node);
     } else {
-      if (pulsingNodes.has(nodeId)) stopRedPulse(node);
-      if (yellowPulsingNodes.has(nodeId)) stopYellowPulse(node);
+      if (pulsingNodes.has(nodeId)) redPulse.stop(node);
+      if (yellowPulsingNodes.has(nodeId)) yellowPulse.stop(node);
     }
 
     // Glyph by node type — but an obscured node shows the bare dodecagon (no
@@ -814,105 +791,60 @@ function clearIceTrace() {
   cy.edges(".ice-trace").removeClass("ice-trace");
 }
 
-// Flash edges along the BFS path from fromId to toId, staggered per hop.
-// Only flashes edges that are currently visible (respects fog of war).
-function flashIcePath(fromId, toId) {
-  // BFS: find shortest path, recording edge objects
-  const visited = new Map([[fromId, { prev: null, edge: null }]]);
-  const queue = [fromId];
-  let found = false;
-
-  outer: while (queue.length) {
-    const cur = queue.shift();
-    for (const edge of cy.edges()) {
-      const s = edge.data("source");
-      const t = edge.data("target");
-      let neighbor = null;
-      if (s === cur && !visited.has(t)) neighbor = t;
-      else if (t === cur && !visited.has(s)) neighbor = s;
-      if (neighbor !== null) {
-        visited.set(neighbor, { prev: cur, edge });
-        if (neighbor === toId) { found = true; break outer; }
-        queue.push(neighbor);
-      }
-    }
-  }
-
-  if (!found) return;
-
-  // Reconstruct ordered edge list (from → to direction)
-  const pathEdges = [];
-  let cur = toId;
-  while (cur !== fromId) {
-    const { prev, edge } = visited.get(cur);
-    pathEdges.unshift(edge);
-    cur = prev;
-  }
-
-  // Flash each edge in sequence; skip edges not in player-controlled territory.
-  // Requires at least one endpoint to be compromised or owned (not just visible).
-  pathEdges.forEach((edge, i) => {
-    if (edge.hasClass("hidden")) return;
-    const src = cy.getElementById(edge.data("source"));
-    const tgt = cy.getElementById(edge.data("target"));
-    const srcControlled = src.hasClass("compromised") || src.hasClass("owned");
-    const tgtControlled = tgt.hasClass("compromised") || tgt.hasClass("owned");
-    if (!srcControlled && !tgtControlled) return;
-    setTimeout(() => {
-      edge.animate(
-        { style: { "line-color": "#ff00aa", width: 3, opacity: 1 } },
-        { duration: 150, complete: () => edge.animate(
-          { style: { "line-color": "#440033", width: 1.5, opacity: 0.4 } },
-          { duration: 400, complete: () => edge.removeStyle("line-color width opacity") }
-        )}
-      );
-    }, i * 100);
+// Edges connecting two node ids (undirected); usually one, but tolerant of
+// parallel edges. Used to recover edge objects from findPath's node list.
+function edgesBetween(a, b) {
+  return cy.edges().filter((e) => {
+    const s = e.data("source");
+    const t = e.data("target");
+    return (s === a && t === b) || (s === b && t === a);
   });
 }
 
-function drawIceTrace(fromId, toId, nodeStates) {
-  // BFS to find shortest path from attention focus back to resident node
-  const visited = new Map([[fromId, null]]); // node → predecessor
-  const queue = [fromId];
-  let found = false;
+// Flash edges along the shortest path from fromId to toId, staggered per hop.
+// Only flashes edges that are currently visible (respects fog of war).
+function flashIcePath(fromId, toId) {
+  const path = findPath(cy, fromId, toId);
+  if (!path) return;
 
-  while (queue.length && !found) {
-    const cur = queue.shift();
-    for (const edge of cy.edges()) {
-      const s = edge.data("source");
-      const t = edge.data("target");
-      let neighbor = null;
-      if (s === cur && !visited.has(t)) neighbor = t;
-      else if (t === cur && !visited.has(s)) neighbor = s;
-      if (neighbor !== null) {
-        visited.set(neighbor, cur);
-        if (neighbor === toId) { found = true; break; }
-        queue.push(neighbor);
-      }
-    }
+  // Flash each hop's edge in sequence; skip edges not in player-controlled
+  // territory. Requires at least one endpoint compromised/owned (not just visible).
+  for (let hop = 1; hop < path.length; hop++) {
+    const delay = (hop - 1) * 100;
+    edgesBetween(path[hop - 1], path[hop]).forEach((edge) => {
+      if (edge.hasClass("hidden")) return;
+      const src = cy.getElementById(edge.data("source"));
+      const tgt = cy.getElementById(edge.data("target"));
+      const srcControlled = src.hasClass("compromised") || src.hasClass("owned");
+      const tgtControlled = tgt.hasClass("compromised") || tgt.hasClass("owned");
+      if (!srcControlled && !tgtControlled) return;
+      setTimeout(() => {
+        edge.animate(
+          { style: { "line-color": "#ff00aa", width: 3, opacity: 1 } },
+          { duration: 150, complete: () => edge.animate(
+            { style: { "line-color": "#440033", width: 1.5, opacity: 0.4 } },
+            { duration: 400, complete: () => edge.removeStyle("line-color width opacity") }
+          )}
+        );
+      }, delay);
+    });
   }
+}
 
-  if (!found) return;
+function drawIceTrace(fromId, toId, nodeStates) {
+  const path = findPath(cy, fromId, toId);
+  if (!path) return;
 
-  // Walk path from toId back to fromId, marking waypoints and edges
-  let cur = toId;
-  while (cur && cur !== fromId) {
+  // Walk waypoints from toId back toward (but not including) fromId, marking
+  // hidden nodes as traced and every hop's edge as part of the trace.
+  for (let hop = path.length - 1; hop > 0; hop--) {
+    const cur = path[hop];
     const cyNode = cy.getElementById(cur);
-    if (cyNode.length > 0) {
-      if (cyNode.hasClass("hidden")) {
-        // Reveal hidden nodes along the path as traced waypoints
-        cyNode.addClass("ice-traced");
-      }
+    if (cyNode.length > 0 && cyNode.hasClass("hidden")) {
+      // Reveal hidden nodes along the path as traced waypoints
+      cyNode.addClass("ice-traced");
     }
-    const prev = visited.get(cur);
-    if (prev !== undefined && prev !== null) {
-      cy.edges().filter((e) => {
-        const s = e.data("source");
-        const t = e.data("target");
-        return (s === prev && t === cur) || (s === cur && t === prev);
-      }).addClass("ice-trace");
-    }
-    cur = prev;
+    edgesBetween(path[hop - 1], cur).addClass("ice-trace");
   }
 
   // Mark the resident node distinctly


### PR DESCRIPTION
Closes #165.

Behavior-preserving decomposition of two duplicated clusters in `js/ui/graph.js`.

## Pulse animators
`startRedPulse`/`startYellowPulse`/`startRebootPulse` (+ their stop/run partners) shared one start→add-to-Set→run-loop→remove-on-stop shape, differing only in colors/durations/cleared style. Replaced with a single `createPulseAnimator({ set, frames, clearStyle })` factory; the three pulses are now data:

- `redPulse` — fast border strobe (220/420ms)
- `yellowPulse` — slower/softer border strobe (480/720ms)
- `rebootPulse` — opacity breathe (1000/1200ms)

Membership is still re-checked before every `animate()`, so `stop()` halts the loop exactly as before.

## Pathfinder
`flashIcePath` and `drawIceTrace` each reimplemented breadth-first search with their own queue/reconstruction. Extracted a pure `findPath(cy, fromId, toId)` into `js/ui/graph-path.js` returning the ordered node list (or `null`). Each caller recovers edge objects via a small `edgesBetween()` helper and keeps its own styling. The degenerate `from === to` returns `null`, matching the original walks (and the callers never hit it).

## Tests
New `js/ui/graph-path.test.js` covers ordering, undirected traversal, shortest-of-many, unreachable, and the degenerate case — the traversal logic is now unit-testable without a browser.

`make check` green (1064 tests, lint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)