### PR TITLE
Share overlay init between visual-renderer.js and preview.js (#167)

### DIFF
--- a/js/ui/overlays/index.js
+++ b/js/ui/overlays/index.js
@@ -11,6 +11,8 @@ import "./loot-rings.js";
 import "./exploit-brackets.js";
 import "./ice-detect.js";
 import { OVERLAY_DESCRIPTORS } from "./registry.js";
+import { onViewport, setReticleOverlay } from "../graph.js";
+import { mountReticle } from "./selection-reticle.js";
 
 /**
  * @param {HTMLElement} container
@@ -26,4 +28,25 @@ export function mountOverlays(container) {
     if (d.driver === "action-feedback" && d.action) byAction.set(d.action, el);
   }
   return { byKey, byAction };
+}
+
+/**
+ * Bring up the graph overlay layer, shared by the game (visual-renderer) and the
+ * preview harness so new overlays work in both automatically (#167): mount the
+ * registry overlays + the selection reticle into the overlay container, register
+ * the reticle with graph.js, and wire both to re-anchor on every pan/zoom.
+ * @param {HTMLElement} [layer] overlay container; defaults to #overlay-layer
+ * @returns {{ overlays: ReturnType<typeof mountOverlays>, reticle: any }}
+ */
+export function initializeGraphOverlays(
+  layer = /** @type {HTMLElement} */ (document.getElementById("overlay-layer")),
+) {
+  const overlays = mountOverlays(layer);
+  onViewport(() => overlays.byKey.forEach((o) => o.reposition()));
+
+  const reticle = mountReticle(layer);
+  setReticleOverlay(reticle);
+  onViewport(() => reticle.reposition());
+
+  return { overlays, reticle };
 }

--- a/js/ui/preview.js
+++ b/js/ui/preview.js
@@ -10,10 +10,8 @@ import {
   flashNode,
   updateNodeStyle,
   onViewport,
-  setReticleOverlay,
 } from "./graph.js";
-import { mountOverlays } from "./overlays/index.js";
-import { mountReticle } from "./overlays/selection-reticle.js";
+import { initializeGraphOverlays } from "./overlays/index.js";
 import { OVERLAY_DESCRIPTORS } from "./overlays/registry.js";
 import { mountCardGallery, mountVulnSwatches, mountIndicatorSwatches } from "./preview-cards.js";
 import { ALL_GLYPH_TYPES } from "./node-glyphs.js";
@@ -141,15 +139,11 @@ cy.fit(undefined, 40);
 cy.userZoomingEnabled(true);
 cy.userPanningEnabled(true);
 
-// Mount overlay animations from the registry and re-anchor them on pan/zoom.
+// Mount the registry overlays + selection reticle and wire them to re-anchor on
+// pan/zoom — shared with the game via initializeGraphOverlays (#167). The layer
+// element is kept for the preview-only ICE-presence demo node mounted below.
 const overlayLayer = document.getElementById("overlay-layer");
-const overlays = mountOverlays(overlayLayer);
-onViewport(() => overlays.byKey.forEach((o) => o.reposition()));
-
-// Selection reticle (selection-driven; toggled below via syncSelection).
-const reticle = mountReticle(overlayLayer);
-setReticleOverlay(reticle);
-onViewport(() => reticle.reposition());
+const { overlays } = initializeGraphOverlays(overlayLayer);
 
 // ── Animation helpers ────────────────────────────────────────
 

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -12,9 +12,8 @@ import { A } from "../core/action-ids.js";
 import { getState as _getState } from "../core/state.js";
 import { getAvailableActions } from "../core/actions/node-actions.js";
 import { isScriptAction } from "../core/actions/scripts.js";
-import { updateNodeStyle, getCy, flashNode, addIceNode, syncIceGraph, syncSelection, onViewport, setReticleOverlay } from "./graph.js";
-import { mountOverlays } from "./overlays/index.js";
-import { mountReticle } from "./overlays/selection-reticle.js";
+import { updateNodeStyle, getCy, flashNode, addIceNode, syncIceGraph, syncSelection } from "./graph.js";
+import { initializeGraphOverlays } from "./overlays/index.js";
 import { dispatchActionFeedback } from "./overlays/dispatch.js";
 import { getVisibleTimers } from "../core/timers.js";
 import { exploitSortKey } from "../core/exploits.js";
@@ -73,15 +72,10 @@ export function initVisualRenderer() {
   // Mount overlay animations into the graph's overlay layer and drive them from
   // the registry. visual-renderer no longer knows individual effects — it maps
   // action id → overlay element and calls the sync/clear/reposition contract.
-  const layer = /** @type {HTMLElement} */ (document.getElementById("overlay-layer"));
-  const overlays = mountOverlays(layer);
-  onViewport(() => overlays.byKey.forEach((o) => o.reposition()));
-
-  // Selection reticle — a NodeOverlay too, but selection-driven (graph.js calls
-  // it from syncSelection) rather than action-driven.
-  const reticle = mountReticle(layer);
-  setReticleOverlay(reticle);
-  onViewport(() => reticle.reposition());
+  // Shared with the preview harness via initializeGraphOverlays (#167): mounts
+  // the registry overlays + the selection reticle (graph.js drives the latter
+  // from syncSelection) and wires both to re-anchor on pan/zoom.
+  const { overlays } = initializeGraphOverlays();
 
   // action id → node id of the in-flight animation (tracked across feedback events)
   const activeNodeIds = new Map();


### PR DESCRIPTION
Closes #167.

`visual-renderer.js` (game) and `preview.js` (harness) both repeated the same overlay bring-up, differing only in their data source: `getElementById("overlay-layer")` → `mountOverlays` → `onViewport(reposition)` → `mountReticle` → `setReticleOverlay` → `onViewport(reposition)`. Every new overlay had to be wired in both places.

Extracted `initializeGraphOverlays(layer?)` into `js/ui/overlays/index.js` (defaults `layer` to `#overlay-layer`). It mounts the registry overlays + the selection reticle, registers the reticle with `graph.js`, and wires both to re-anchor on pan/zoom, returning `{ overlays, reticle }`. Both entry points now call it, dropping their now-unused `mountOverlays`/`mountReticle`/`setReticleOverlay` imports.

Future overlay additions work in game + preview automatically. Behavior-preserving; `make check` green (1059 tests, lint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)