### PR TITLE
Network-gen cleanups: tree-utils extraction + fillSlot options object (#171)

### DIFF
--- a/js/core/network/skeleton.js
+++ b/js/core/network/skeleton.js
@@ -13,6 +13,7 @@
 /** @typedef {import('./set-pieces.js').SetPieceDef} SetPieceDef */
 
 import { gradeToNumber, maxDepth, TAG_WEIGHTS, costBudget, wingCount, hierarchicalBudget, lanGradeOffset, applyGradeOffset, minWingSlots } from "./budget.js";
+import { walkSlots } from "./tree-utils.js";
 
 /** @typedef {import('./set-pieces.js').SubBiomeDef} SubBiomeDef */
 /** @typedef {import('./set-pieces.js').RecipeDef} RecipeDef */
@@ -295,16 +296,12 @@ function ensureTagEarly(root, tag, coverage) {
 }
 
 /**
- * Collect all slots from a skeleton tree.
+ * Collect all slots from a skeleton tree (pre-order).
  * @param {SkeletonSlot} slot
  * @returns {SkeletonSlot[]}
  */
 function collectAll(slot) {
-  const result = [slot];
-  for (const child of slot.children) {
-    result.push(...collectAll(child));
-  }
-  return result;
+  return walkSlots(slot);
 }
 
 /**
@@ -329,8 +326,7 @@ function ensureTreasureLeaf(root, coverage) {
  * @returns {SkeletonSlot[]}
  */
 function collectLeaves(slot) {
-  if (slot.children.length === 0) return [slot];
-  return slot.children.flatMap(c => collectLeaves(c));
+  return walkSlots(slot, s => s.children.length === 0);
 }
 
 /**
@@ -543,14 +539,7 @@ function countChildren(slot) {
 
 /** Collect slots that can accept new children (depth < maxD, sorted shallowest first). */
 function collectExpandable(root, maxD) {
-  const result = [];
-  function walk(slot) {
-    if (slot.depth < maxD - 1) result.push(slot);
-    for (const child of slot.children) walk(child);
-  }
-  walk(root);
-  result.sort((a, b) => a.depth - b.depth);
-  return result;
+  return walkSlots(root, slot => slot.depth < maxD - 1).sort((a, b) => a.depth - b.depth);
 }
 
 // ---------------------------------------------------------------------------

--- a/js/core/network/slot-filler.js
+++ b/js/core/network/slot-filler.js
@@ -18,6 +18,7 @@
 
 import { instantiate } from "./set-pieces.js";
 import { gradeToNumber, costBudget } from "./budget.js";
+import { walkSlots } from "./tree-utils.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -87,7 +88,13 @@ export function fillSkeleton(skeleton, biome, spec, rng, opts = {}) {
   const preAssigned = preAssignRequired(requiredPieceIds, skeleton, biome);
 
   // Pass 1: fill all skeleton slots
-  const ok = fillSlot(skeleton, null, biome, spec, rng, pieces, crossEdges, placed, { budget: budgetRemaining }, usedPieceIds, scatterObligations, piecePalette, preAssigned, skipSubBiome);
+  /** @type {FillContext} */
+  const fillContext = {
+    biome, rng, pieces, crossEdges, placed,
+    state: { budget: budgetRemaining },
+    usedPieceIds, scatterObligations, piecePalette, preAssigned, skipSubBiome,
+  };
+  const ok = fillSlot(skeleton, null, fillContext);
   if (!ok) return { pieces, crossEdges, ok: false };
 
   // Pass 2: place scattered nodes (unless caller wants to handle them)
@@ -100,24 +107,35 @@ export function fillSkeleton(skeleton, biome, spec, rng, opts = {}) {
 }
 
 /**
+ * Shared context threaded through a single fillSkeleton pass — the config + the
+ * mutable accumulators every fillSlot call reads and writes. Constant across the
+ * whole recursion, so it's bundled into one object rather than 12 positional args.
+ * @typedef {Object} FillContext
+ * @property {BiomeDef} biome
+ * @property {() => number} rng
+ * @property {PlacedPiece[]} pieces                 accumulator: placed pieces
+ * @property {[string, string][]} crossEdges        accumulator: inter-piece edges
+ * @property {Map<string, PlacedPiece>} placed      slotId → placed piece
+ * @property {{ budget: number }} state             remaining cost budget (mutated)
+ * @property {Set<string>} usedPieceIds             diversity tracking
+ * @property {ScatterObligation[]} scatterObligations accumulator for pass 2
+ * @property {Set<string>|null} piecePalette        allowed piece ids, or null for all
+ * @property {Map<string, SetPieceDef>} preAssigned slotId → required piece
+ * @property {boolean} [skipSubBiome]               skip wing-entry slots (backbone-only fill)
+ */
+
+/**
  * Recursively fill a slot and its children.
  * @param {SkeletonSlot} slot
  * @param {PlacedPiece|null} parentPiece
- * @param {BiomeDef} biome
- * @param {NetworkSpec} spec
- * @param {() => number} rng
- * @param {PlacedPiece[]} pieces
- * @param {[string, string][]} crossEdges
- * @param {Map<string, PlacedPiece>} placed
- * @param {{ budget: number }} state
- * @param {Set<string>} usedPieceIds
- * @param {ScatterObligation[]} scatterObligations
- * @param {Set<string>|null} piecePalette
- * @param {Map<string, SetPieceDef>} preAssigned
- * @param {boolean} [skipSubBiome]
+ * @param {FillContext} ctx
  * @returns {boolean}
  */
-function fillSlot(slot, parentPiece, biome, spec, rng, pieces, crossEdges, placed, state, usedPieceIds, scatterObligations, piecePalette, preAssigned, skipSubBiome = false) {
+function fillSlot(slot, parentPiece, ctx) {
+  const {
+    biome, rng, pieces, crossEdges, placed, state,
+    usedPieceIds, scatterObligations, piecePalette, preAssigned, skipSubBiome = false,
+  } = ctx;
   // Skip wing entry slots when filling backbone only
   if (skipSubBiome && slot.subBiomeId) return true;
 
@@ -212,7 +230,7 @@ function fillSlot(slot, parentPiece, biome, spec, rng, pieces, crossEdges, place
 
   // 8. Fill children
   for (const child of slot.children) {
-    if (!fillSlot(child, piece, biome, spec, rng, pieces, crossEdges, placed, state, usedPieceIds, scatterObligations, piecePalette, preAssigned, skipSubBiome)) {
+    if (!fillSlot(child, piece, ctx)) {
       return false;
     }
   }
@@ -381,7 +399,7 @@ function preAssignRequired(requiredPieceIds, skeleton, biome) {
   if (requiredPieceIds.length === 0) return assignments;
 
   const catalogMap = new Map(biome.catalog.map(p => [p.id, p]));
-  const allSlots = collectSlots(skeleton);
+  const allSlots = walkSlots(skeleton);
   const usedSlots = new Set();
 
   for (const pieceId of requiredPieceIds) {
@@ -407,23 +425,6 @@ function preAssignRequired(requiredPieceIds, skeleton, biome) {
     }
   }
   return assignments;
-}
-
-/**
- * Collect all slots from a skeleton tree into a flat array.
- * @param {SkeletonSlot} root
- * @returns {SkeletonSlot[]}
- */
-function collectSlots(root) {
-  /** @type {SkeletonSlot[]} */
-  const result = [];
-  /** @param {SkeletonSlot} slot */
-  function walk(slot) {
-    result.push(slot);
-    for (const child of slot.children) walk(child);
-  }
-  walk(root);
-  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/js/core/network/tree-utils.js
+++ b/js/core/network/tree-utils.js
@@ -1,0 +1,26 @@
+// @ts-check
+// Shared pre-order traversal for skeleton slot trees. skeleton.js's collectors
+// (collectAll / collectLeaves / collectExpandable) and slot-filler.js's
+// collectSlots were near-identical recursive walks; they're now all defined in
+// terms of walkSlots (#171).
+
+/** @typedef {import('./skeleton.js').SkeletonSlot} SkeletonSlot */
+
+/**
+ * Pre-order depth-first walk over a slot tree, collecting every slot for which
+ * `predicate` returns true (defaults to all slots).
+ * @param {SkeletonSlot} root
+ * @param {(slot: SkeletonSlot) => boolean} [predicate]
+ * @returns {SkeletonSlot[]}
+ */
+export function walkSlots(root, predicate = () => true) {
+  /** @type {SkeletonSlot[]} */
+  const result = [];
+  /** @param {SkeletonSlot} slot */
+  function visit(slot) {
+    if (predicate(slot)) result.push(slot);
+    for (const child of slot.children) visit(child);
+  }
+  visit(root);
+  return result;
+}


### PR DESCRIPTION
Closes #171. Two behavior-preserving maintainability cleanups in the procedural generator (generation snapshots unchanged → byte-identical output).

## 1. Shared tree traversal
`collectAll` / `collectLeaves` / `collectExpandable` (`skeleton.js`) and `collectSlots` (`slot-filler.js`) were near-identical pre-order recursive walks. Extracted `js/core/network/tree-utils.js` with a single `walkSlots(root, predicate)`:

- `collectAll(slot)` → `walkSlots(slot)`
- `collectLeaves(slot)` → `walkSlots(slot, s => s.children.length === 0)`
- `collectExpandable(root, maxD)` → `walkSlots(root, s => s.depth < maxD - 1).sort(...)`
- `slot-filler`s `collectSlots` dropped in favor of `walkSlots` directly.

## 2. `fillSlot` 14 positional params → options object
The 11 params that are constant across the whole recursion (biome, rng, the mutable accumulators, palette, preAssigned, skipSubBiome) are now a documented `FillContext`: `fillSlot(slot, parentPiece, ctx)`. The recursive call just forwards `ctx`. Also drops the dead `spec` param (unused in `fillSlot`s body and by everything it called).

`make check` green (1059 tests incl. generation snapshots, lint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)