### PR TITLE
Split combat.js launchExploit into pure resolve + apply (#168)

### DIFF
--- a/js/core/alert.js
+++ b/js/core/alert.js
@@ -8,17 +8,10 @@ import { setGlobalAlert, setTraceCountdown, setTraceTimerId, decrementTraceCount
 import { setIceDetectedAt, incrementIceDetectionCount, activeIceInstances } from "./state/ice.js";
 import { emitEvent, E } from "./events.js";
 import { scheduleRepeating, cancelEvent, TIMER } from "./timers.js";
+import { DETECTION_TRACE_THRESHOLD, MONITOR_TRACE_THRESHOLD, TRACE_SECONDS } from "./balance.js";
 
 /** @type {GlobalAlertLevel[]} */
 const GLOBAL_ALERT_ORDER = ["green", "yellow", "red", "trace"];
-
-// Detection thresholds: cumulative detections before trace starts, by ICE grade
-const DETECTION_TRACE_THRESHOLD = { S: 1, A: 1, B: 2, C: 2, D: 3, F: 3 };
-
-// Security-grid trace gate: accumulated monitor alerts before trace starts, by network grade.
-// Mirrors DETECTION_TRACE_THRESHOLD (ICE) but kept separate so the passive grid and the active
-// ICE pursuit can be tuned independently.
-const MONITOR_TRACE_THRESHOLD = { S: 4, A: 5, B: 7, C: 9, D: 12, F: 15 };
 
 // Global alert escalation now flows entirely through the two sensors:
 //   - recordIceDetection (active ICE pursuit), below
@@ -26,11 +19,10 @@ const MONITOR_TRACE_THRESHOLD = { S: 4, A: 5, B: 7, C: 9, D: 12, F: 15 };
 // plus set-piece startTrace alarms. The legacy node-type-counting layer
 // (recomputeGlobalAlert / propagateAlertEvent / raiseGlobalAlert, gated on
 // alertState + eventForwardingDisabled) was retired in #173.
+// Trace thresholds (DETECTION_/MONITOR_TRACE_THRESHOLD) and the countdown
+// durations (TRACE_SECONDS) are tuning knobs — see js/core/balance.js (#169).
 
 // ── Trace countdown ───────────────────────────────────────
-
-/** Trace countdown duration scales with network threat grade. */
-const TRACE_SECONDS = { S: 30, A: 40, B: 45, C: 60, D: 75, F: 90 };
 
 export function startTraceCountdown() {
   const s = getState();

--- a/js/core/balance.js
+++ b/js/core/balance.js
@@ -1,0 +1,91 @@
+// @ts-check
+// Centralized game-balance / tuning constants (#169).
+//
+// These knobs drive the difficulty curve and were previously scattered across
+// combat.js, alert.js, and ice/runtime.js. Collecting them here makes the whole
+// tuning surface legible in one place — useful alongside census work. Each module
+// imports the constants it needs; the comments explaining WHY each value is what
+// it is travel with the values. (Structural constants — e.g. the alert ladder
+// order — stay with their subsystems; only tuning numbers live here.)
+
+// ── Combat: exploit resolution ───────────────────────────────────────────────
+
+// Success chance modifier by node security grade.
+export const GRADE_MODIFIER = {
+  S: 0.05,
+  A: 0.15,
+  B: 0.30,
+  C: 0.50,
+  D: 0.70,
+  F: 0.90,
+};
+
+/** Flat bonus when exploit targets a known vulnerability on the node. */
+export const MATCH_BONUS = 0.4;
+
+/** Hard cap on exploit success probability. */
+export const SUCCESS_CAP = 0.95;
+
+// Disclosure chance on failure by grade (higher grade = more likely to detect and disclose).
+export const DISCLOSURE_CHANCE = {
+  S: 0.85,
+  A: 0.70,
+  B: 0.50,
+  C: 0.30,
+  D: 0.15,
+  F: 0.05,
+};
+
+// Skip-to-owned floor and quality scaling. The chance a successful exploit
+// jumps locked → owned in one shot is driven by card QUALITY, not rarity:
+//   0.08 + quality * 0.55
+// This lifts the floor across the board (a fresh common skips ~19–38% of the
+// time, up from the old ~2–6%) while still rewarding the best cards most —
+// rare cards skip more only because they carry higher quality, not because of
+// a separate multiplier. Tops out near 0.60 for a best-in-class rare (q≈0.95);
+// never approaches certainty.
+export const SKIP_TO_OWNED_FLOOR = 0.08;
+export const SKIP_TO_OWNED_QUALITY_SCALE = 0.55;
+
+// Patch lag in turns by grade (how quickly vulns get patched after disclosure).
+export const PATCH_LAG = {
+  S: 1,
+  A: 2,
+  B: 3,
+  C: 4,
+  D: 6,
+  F: 8,
+};
+
+// ── Alert / trace ────────────────────────────────────────────────────────────
+
+// Detection thresholds: cumulative detections before trace starts, by ICE grade.
+export const DETECTION_TRACE_THRESHOLD = { S: 1, A: 1, B: 2, C: 2, D: 3, F: 3 };
+
+// Security-grid trace gate: accumulated monitor alerts before trace starts, by network grade.
+// Mirrors DETECTION_TRACE_THRESHOLD (ICE) but kept separate so the passive grid and the active
+// ICE pursuit can be tuned independently.
+export const MONITOR_TRACE_THRESHOLD = { S: 4, A: 5, B: 7, C: 9, D: 12, F: 15 };
+
+/** Trace countdown duration (seconds) scales with network threat grade. */
+export const TRACE_SECONDS = { S: 30, A: 40, B: 45, C: 60, D: 75, F: 90 };
+
+// ── ICE movement / detection ─────────────────────────────────────────────────
+
+// Grade → movement interval (ms); must be longer than the corresponding DWELL_TIMES entry.
+// A/S slowed from 2500/3000 to give players a narrow window for exploit completion.
+export const MOVE_INTERVALS = { S: 4000, A: 5000, B: 6000, C: 7000, D: 12000, F: 14000 };
+
+// Grade → dwell time before detection (ms).
+// S/A get very short dwells — tight but evadable with fast reactions.
+// C/B bumped from 4500/3500 to give players a window to complete exploits.
+export const DWELL_TIMES = { S: 800, A: 1500, B: 4500, C: 5500, D: 9000, F: 10000 };
+
+// Grade → noise tick at which ICE first responds to an executing exploit.
+// Exploit emits ticks 1–9 at 10%–90% of duration; 10% intervals.
+export const ICE_NOISE_THRESHOLD = { S: 1, A: 2, B: 3, C: 5, D: 7, F: 9 };
+
+// Delay before detection starts when ICE arrives via movement (ms).
+// Matches the ICE movement animation duration so the visual and the
+// detection timer stay in sync — player sees ICE arrive, then countdown starts.
+export const ARRIVAL_DELAY_MS = 400;

--- a/js/core/combat.js
+++ b/js/core/combat.js
@@ -98,9 +98,12 @@ export const PATCH_LAG = {
  */
 
 /**
- * Resolve an exploit attempt against a node.
+ * Resolve an exploit attempt against a node — the pure combat roll only.
  *
- * Returns a result object describing what happened.
+ * Returns a result object describing what happened (success, flavor, rolls).
+ * @param {ExploitCard} exploit
+ * @param {NodeState} node
+ * @returns {ExploitResult}
  */
 export function resolveExploit(exploit, node) {
   const knownVulns = node.vulnerabilities.filter((v) => !v.patched && !v.hidden);
@@ -213,8 +216,129 @@ function pickFailFlavor(exploit, disclosed, matchingVulns) {
 // ── Launch action ─────────────────────────────────────────
 
 /**
- * Launch an exploit card against a node.
- * Resolves combat, applies card decay, mutates access/alert state, and emits events.
+ * Resolve an exploit launch into a complete, side-effect-free PLAN: the combat
+ * roll (resolveExploit) plus the decided access-level transition, alert raise, and
+ * staged-vuln surfacing. Consumes RNG — success, flavor/disclosure, and (on a
+ * successful exploit FROM "locked") the skip-to-owned roll — but performs NO state
+ * mutation or event emission; applyCombatResult does that. Pure given the RNG
+ * stream + node reads, so the resolution logic is unit-testable without side
+ * effects (#168).
+ *
+ * The skip roll moves ahead of applyCardDecay's partial-burn roll, but the two are
+ * on mutually exclusive paths (success vs detected failure), so the RNG.COMBAT
+ * sequence per path is unchanged (see the roll-consumption note above).
+ * @param {ExploitCard} exploit
+ * @param {NodeState} node
+ * @returns {ExploitResult}
+ */
+export function resolveCombat(exploit, node) {
+  const result = resolveExploit(exploit, node);
+
+  if (result.success) {
+    result.levelChanged = false;
+    result.prevAccess = node.accessLevel;
+
+    if (node.accessLevel === "locked") {
+      // High-quality/rare exploits can skip compromised → owned in one shot
+      const skipRoll = random(RNG.COMBAT);
+      if (skipRoll <= skipToOwnedChance(exploit)) {
+        result.nextAccess = "owned";
+        result.skippedToOwned = true;
+        result.revealNeighbors = true;
+      } else {
+        result.nextAccess = "compromised";
+        result.revealNeighbors = (node.gateAccess ?? "probed") !== "owned";
+      }
+      result.levelChanged = true;
+    } else if (node.accessLevel === "compromised") {
+      result.nextAccess = "owned";
+      result.revealNeighbors = true;
+      result.levelChanged = true;
+    }
+
+    // Staged vulnerabilities the used exploit's target types unlock — surfaced on apply.
+    const usedTypes = exploit.targetVulnTypes;
+    result.vulnsToSurface = [];
+    node.vulnerabilities.forEach((v, idx) => {
+      if (v.hidden && v.unlockedBy && usedTypes.includes(v.unlockedBy)) {
+        result.vulnsToSurface.push(idx);
+      }
+    });
+  } else {
+    result.prevAlert = node.alertState;
+    result.nextAlert = nextAlertLevel(node.alertState);
+  }
+
+  return result;
+}
+
+/**
+ * Apply a resolved combat plan to game state: mutate access / alert / probed /
+ * disturbance, surface staged vulns, and emit ACTION_RESOLVED / NODE_ACCESSED /
+ * NODE_ALERT_RAISED / EXPLOIT_* events. All RNG was consumed in resolveCombat;
+ * applyCardDecay (which sets result.partialBurn) must run before this.
+ * @param {string} nodeId
+ * @param {ExploitCard} exploit
+ * @param {ExploitResult} result
+ */
+export function applyCombatResult(nodeId, exploit, result) {
+  const node = getState().nodes[nodeId];
+  const detail = { exploitName: exploit.name, flavor: result.flavor, roll: result.roll,
+    successChance: result.successChance, matchingVulns: result.matchingVulns };
+
+  if (result.success) {
+    if (result.nextAccess) {
+      setNodeAccessLevel(nodeId, result.nextAccess);
+      setNodeAlertState(nodeId, "green");
+      // Transitions FROM locked also reveal the node itself.
+      if (result.prevAccess === "locked") setNodeVisible(nodeId, "accessible");
+      if (result.revealNeighbors) revealNeighbors(nodeId);
+    }
+
+    // A successful exploit means you're inside — treat the node as probed (reveals vulns
+    // and engages the picker's match filter), so a blind gamble that lands also counts
+    // as a probe. Idempotent if the node was already probed.
+    setNodeProbed(nodeId);
+
+    // A clean exploit: clear the disturbance so ICE doesn't chase a ghost signal.
+    setLastDisturbedNode(null);
+
+    emitEvent(E.ACTION_RESOLVED, { action: A.XPLOIT, nodeId, label: node.label, success: true, detail });
+
+    if (result.levelChanged) {
+      emitEvent(E.NODE_ACCESSED, { nodeId, label: node.label, prev: result.prevAccess, next: node.accessLevel });
+    }
+
+    // Reveal staged vulnerabilities unlocked by the exploit's target types
+    (result.vulnsToSurface ?? []).forEach((idx) => {
+      setNodeVulnHidden(nodeId, idx, false);
+      emitEvent(E.EXPLOIT_SURFACE, { nodeId, label: node.label });
+    });
+  } else {
+    // Raise node alert on failure
+    if (result.nextAlert !== result.prevAlert) {
+      setNodeAlertState(nodeId, /** @type {import('./types.js').NodeAlertLevel} */ (result.nextAlert));
+    }
+
+    setLastDisturbedNode(nodeId);
+
+    emitEvent(E.ACTION_RESOLVED, { action: A.XPLOIT, nodeId, label: node.label, success: false, detail });
+
+    if (result.nextAlert !== result.prevAlert) {
+      emitEvent(E.NODE_ALERT_RAISED, { nodeId, label: node.label, prev: result.prevAlert, next: result.nextAlert });
+    }
+
+    if (result.disclosed && !result.partialBurn) {
+      emitEvent(E.EXPLOIT_DISCLOSED, { exploitName: exploit.name });
+    } else if (result.partialBurn) {
+      emitEvent(E.EXPLOIT_PARTIAL_BURN, { exploitName: exploit.name, usesRemaining: exploit.usesRemaining });
+    }
+  }
+}
+
+/**
+ * Launch an exploit card against a node. Orchestrates the pure resolution
+ * (resolveCombat) → card decay → state mutation + events (applyCombatResult).
  * @returns {ExploitResult|null}
  */
 export function launchExploit(nodeId, exploitId) {
@@ -228,90 +352,9 @@ export function launchExploit(nodeId, exploitId) {
     return null;
   }
 
-  const result = resolveExploit(exploit, node);
+  const result = resolveCombat(exploit, node);
   applyCardDecay(exploit, result);
-
-  if (result.success) {
-    result.levelChanged = false;
-    const prevAccess = node.accessLevel;
-
-    if (node.accessLevel === "locked") {
-      // High-quality/rare exploits can skip compromised → owned in one shot
-      const skipChance = skipToOwnedChance(exploit);
-      const skipRoll = random(RNG.COMBAT);
-      if (skipRoll <= skipChance) {
-        setNodeAccessLevel(nodeId, "owned");
-        setNodeAlertState(nodeId, "green");
-        setNodeVisible(nodeId, "accessible");
-        revealNeighbors(nodeId);
-        result.levelChanged = true;
-        result.skippedToOwned = true;
-      } else {
-        setNodeAccessLevel(nodeId, "compromised");
-        setNodeAlertState(nodeId, "green");
-        setNodeVisible(nodeId, "accessible");
-        if ((node.gateAccess ?? "probed") !== "owned") revealNeighbors(nodeId);
-        result.levelChanged = true;
-      }
-    } else if (node.accessLevel === "compromised") {
-      setNodeAccessLevel(nodeId, "owned");
-      setNodeAlertState(nodeId, "green");
-      revealNeighbors(nodeId);
-      result.levelChanged = true;
-    }
-
-    // A successful exploit means you're inside — treat the node as probed (reveals vulns
-    // and engages the picker's match filter), so a blind gamble that lands also counts
-    // as a probe. Idempotent if the node was already probed.
-    setNodeProbed(nodeId);
-
-    // A clean exploit: clear the disturbance so ICE doesn't chase a ghost signal.
-    setLastDisturbedNode(null);
-
-    emitEvent(E.ACTION_RESOLVED, {
-      action: A.XPLOIT, nodeId, label: node.label, success: true,
-      detail: { exploitName: exploit.name, flavor: result.flavor, roll: result.roll,
-        successChance: result.successChance, matchingVulns: result.matchingVulns },
-    });
-
-    if (result.levelChanged) {
-      emitEvent(E.NODE_ACCESSED, { nodeId, label: node.label, prev: prevAccess, next: node.accessLevel });
-    }
-
-    // Reveal staged vulnerabilities unlocked by the exploit's target types
-    const usedTypes = exploit.targetVulnTypes;
-    node.vulnerabilities.forEach((v, idx) => {
-      if (v.hidden && v.unlockedBy && usedTypes.includes(v.unlockedBy)) {
-        setNodeVulnHidden(nodeId, idx, false);
-        emitEvent(E.EXPLOIT_SURFACE, { nodeId, label: node.label });
-      }
-    });
-  } else {
-    // Raise node alert on failure
-    const prevAlert = node.alertState;
-    const raised = nextAlertLevel(node.alertState);
-    if (raised !== prevAlert) {
-      setNodeAlertState(nodeId, raised);
-    }
-
-    setLastDisturbedNode(nodeId);
-
-    emitEvent(E.ACTION_RESOLVED, {
-      action: A.XPLOIT, nodeId, label: node.label, success: false,
-      detail: { exploitName: exploit.name, flavor: result.flavor, roll: result.roll,
-        successChance: result.successChance, matchingVulns: result.matchingVulns },
-    });
-
-    if (node.alertState !== prevAlert) {
-      emitEvent(E.NODE_ALERT_RAISED, { nodeId, label: node.label, prev: prevAlert, next: node.alertState });
-    }
-
-    if (result.disclosed && !result.partialBurn) {
-      emitEvent(E.EXPLOIT_DISCLOSED, { exploitName: exploit.name });
-    } else if (result.partialBurn) {
-      emitEvent(E.EXPLOIT_PARTIAL_BURN, { exploitName: exploit.name, usesRemaining: exploit.usesRemaining });
-    }
-  }
+  applyCombatResult(nodeId, exploit, result);
 
   return result;
 }

--- a/js/core/combat.js
+++ b/js/core/combat.js
@@ -15,43 +15,14 @@ import { setLastDisturbedNode } from "./state/ice.js";
 import { applyCardDecay as applyCardDecayState } from "./state/player.js";
 import { emitEvent, E } from "./events.js";
 import { A } from "./action-ids.js";
+import {
+  GRADE_MODIFIER, MATCH_BONUS, SUCCESS_CAP, DISCLOSURE_CHANCE,
+  SKIP_TO_OWNED_FLOOR, SKIP_TO_OWNED_QUALITY_SCALE, PATCH_LAG,
+} from "./balance.js";
 
-// Success chance modifier by node security grade
-export const GRADE_MODIFIER = {
-  S: 0.05,
-  A: 0.15,
-  B: 0.30,
-  C: 0.50,
-  D: 0.70,
-  F: 0.90,
-};
-
-/** Flat bonus when exploit targets a known vulnerability on the node. */
-export const MATCH_BONUS = 0.4;
-
-/** Hard cap on exploit success probability. */
-export const SUCCESS_CAP = 0.95;
-
-// Disclosure chance on failure by grade (higher grade = more likely to detect and disclose)
-const DISCLOSURE_CHANCE = {
-  S: 0.85,
-  A: 0.70,
-  B: 0.50,
-  C: 0.30,
-  D: 0.15,
-  F: 0.05,
-};
-
-// Skip-to-owned floor and quality scaling. The chance a successful exploit
-// jumps locked → owned in one shot is driven by card QUALITY, not rarity:
-//   0.08 + quality * 0.55
-// This lifts the floor across the board (a fresh common skips ~19–38% of the
-// time, up from the old ~2–6%) while still rewarding the best cards most —
-// rare cards skip more only because they carry higher quality, not because of
-// a separate multiplier. Tops out near 0.60 for a best-in-class rare (q≈0.95);
-// never approaches certainty.
-const SKIP_TO_OWNED_FLOOR = 0.08;
-const SKIP_TO_OWNED_QUALITY_SCALE = 0.55;
+// Re-export combat-balance constants so existing `import … from "./combat.js"`
+// sites keep working; the values now live in balance.js (#169).
+export { GRADE_MODIFIER, MATCH_BONUS, SUCCESS_CAP, PATCH_LAG };
 
 /**
  * Chance that a successful exploit jumps from locked directly to owned,
@@ -62,16 +33,6 @@ const SKIP_TO_OWNED_QUALITY_SCALE = 0.55;
 export function skipToOwnedChance(exploit) {
   return SKIP_TO_OWNED_FLOOR + exploit.quality * SKIP_TO_OWNED_QUALITY_SCALE;
 }
-
-// Patch lag in turns by grade (how quickly vulns get patched after disclosure)
-export const PATCH_LAG = {
-  S: 1,
-  A: 2,
-  B: 3,
-  C: 4,
-  D: 6,
-  F: 8,
-};
 
 /**
  * RNG.COMBAT roll consumption per launchExploit() code path.

--- a/js/core/combat.test.js
+++ b/js/core/combat.test.js
@@ -1,7 +1,9 @@
 // @ts-check
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { skipToOwnedChance } from "./combat.js";
+import { skipToOwnedChance, resolveCombat } from "./combat.js";
+import { RNG, initRng, _forceNext } from "./rng.js";
+import { on, off, E } from "./events.js";
 
 /** Minimal exploit card — only the fields skipToOwnedChance reads. */
 function card(quality, rarity = "common") {
@@ -45,5 +47,96 @@ describe("skipToOwnedChance", () => {
   test("never exceeds a sane ceiling for the best cards", () => {
     // Best possible rare (quality 0.95) tops out around 0.60, never near certainty.
     assert.ok(skipToOwnedChance(card(0.95, "rare")) < 0.65);
+  });
+});
+
+// resolveCombat is the pure half of the launchExploit split (#168): it consumes
+// RNG and decides the full effect plan, but must NOT mutate node state or emit
+// events — applyCombatResult does that. These tests pin that purity.
+
+/** Minimal node fixture — resolveCombat only reads these fields. */
+function lockedNode() {
+  return /** @type {any} */ ({
+    accessLevel: "locked",
+    alertState: "green",
+    gateAccess: "probed",
+    grade: "C",
+    vulnerabilities: [{ id: "AuthBypass", name: "Auth Bypass", patched: false, hidden: false }],
+  });
+}
+function matchingExploit() {
+  return /** @type {any} */ ({ name: "TestKit", quality: 0.8, targetVulnTypes: ["AuthBypass"] });
+}
+
+describe("resolveCombat (pure resolution)", () => {
+  test("decides the locked→compromised plan without mutating the node or emitting", () => {
+    initRng("combat-test-1");
+    // From-locked success consumes three RNG.COMBAT rolls: success, flavor, skip.
+    _forceNext(RNG.COMBAT, 0);     // success
+    _forceNext(RNG.COMBAT, 0);     // flavor pick
+    _forceNext(RNG.COMBAT, 0.99);  // skip-to-owned bypass → stay at compromised
+
+    const node = lockedNode();
+    const before = { accessLevel: node.accessLevel, alertState: node.alertState };
+
+    let emitted = 0;
+    const bump = () => { emitted++; };
+    on(E.ACTION_RESOLVED, bump);
+    on(E.NODE_ACCESSED, bump);
+
+    const result = resolveCombat(matchingExploit(), node);
+
+    off(E.ACTION_RESOLVED, bump);
+    off(E.NODE_ACCESSED, bump);
+
+    // Plan is fully decided…
+    assert.equal(result.success, true);
+    assert.equal(result.prevAccess, "locked");
+    assert.equal(result.nextAccess, "compromised");
+    assert.equal(result.levelChanged, true);
+    assert.equal(result.revealNeighbors, true); // gateAccess "probed" !== "owned"
+    assert.ok(Array.isArray(result.vulnsToSurface));
+
+    // …but nothing was applied: node untouched, no events fired.
+    assert.equal(node.accessLevel, before.accessLevel, "node access not mutated");
+    assert.equal(node.alertState, before.alertState, "node alert not mutated");
+    assert.equal(emitted, 0, "no events emitted during resolution");
+  });
+
+  test("a from-locked success that wins the skip roll plans owned + skippedToOwned", () => {
+    initRng("combat-test-2");
+    _forceNext(RNG.COMBAT, 0);    // success
+    _forceNext(RNG.COMBAT, 0);    // flavor pick
+    _forceNext(RNG.COMBAT, 0);    // skip-to-owned wins
+
+    const result = resolveCombat(matchingExploit(), lockedNode());
+    assert.equal(result.nextAccess, "owned");
+    assert.equal(result.skippedToOwned, true);
+    assert.equal(result.revealNeighbors, true);
+  });
+
+  test("a failure plans the alert raise without mutating or emitting", () => {
+    initRng("combat-test-3");
+    _forceNext(RNG.COMBAT, 0.99); // success roll fails (above any chance)
+    _forceNext(RNG.COMBAT, 0.99); // disclosure roll
+    _forceNext(RNG.COMBAT, 0);    // fail-flavor pick
+
+    const node = lockedNode();
+    let emitted = 0;
+    const bump = () => { emitted++; };
+    on(E.NODE_ALERT_RAISED, bump);
+
+    const result = resolveCombat(
+      /** @type {any} */ ({ name: "Dud", quality: 0.01, targetVulnTypes: [] }),
+      node,
+    );
+
+    off(E.NODE_ALERT_RAISED, bump);
+
+    assert.equal(result.success, false);
+    assert.equal(result.prevAlert, "green");
+    assert.equal(result.nextAlert, "yellow"); // green → yellow
+    assert.equal(node.alertState, "green", "node alert not mutated");
+    assert.equal(emitted, 0, "no events emitted during resolution");
   });
 });

--- a/js/core/ice/runtime.js
+++ b/js/core/ice/runtime.js
@@ -15,6 +15,7 @@ import { A } from "../action-ids.js";
 import { RNG, randomPick } from "../rng.js";
 import { getType, getEffect } from "./index.js";
 import { damagePlayerHealth, damagePlayerDeck } from "../player-orchestration.js";
+import { MOVE_INTERVALS, DWELL_TIMES, ICE_NOISE_THRESHOLD, ARRIVAL_DELAY_MS } from "../balance.js";
 
 // Called whenever an ICE instance vacates a node for any reason: normal movement,
 // eject, or reboot. Cancels that instance's pending detection dwell and releases
@@ -27,18 +28,8 @@ function handleIceDeparture(iceId) {
   setIceDetectedAt(null, iceId);
 }
 
-// Grade → movement interval (ms); must be longer than the corresponding DWELL_TIMES entry.
-// A/S slowed from 2500/3000 to give players a narrow window for exploit completion.
-const MOVE_INTERVALS = { S: 4000, A: 5000, B: 6000, C: 7000, D: 12000, F: 14000 };
-
-// Grade → dwell time before detection (ms).
-// S/A get very short dwells — tight but evadable with fast reactions.
-// C/B bumped from 4500/3500 to give players a window to complete exploits.
-const DWELL_TIMES = { S: 800, A: 1500, B: 4500, C: 5500, D: 9000, F: 10000 };
-
-// Grade → noise tick at which ICE first responds to an executing exploit.
-// Exploit emits ticks 1–9 at 10%–90% of duration; 10% intervals.
-const ICE_NOISE_THRESHOLD = { S: 1, A: 2, B: 3, C: 5, D: 7, F: 9 };
+// ICE movement intervals, dwell times, noise thresholds, and the arrival delay
+// are tuning knobs — see js/core/balance.js (#169).
 
 export function startIce() {
   const s = getState();
@@ -214,11 +205,6 @@ function moveInstance(ice, s) {
   // Each instance drives its own per-id dwell timer on arrival.
   checkIceDetection(ice, nextNode, { justArrived: true });
 }
-
-// Delay before detection starts when ICE arrives via movement (ms).
-// Matches the ICE movement animation duration so the visual and the
-// detection timer stay in sync — player sees ICE arrive, then countdown starts.
-const ARRIVAL_DELAY_MS = 400;
 
 function checkIceDetection(ice, nodeId, { justArrived = false } = {}) {
   const s = getState();

--- a/js/core/types.js
+++ b/js/core/types.js
@@ -64,8 +64,10 @@
  */
 
 /**
- * Result of resolveExploit(). levelChanged and partialBurn are added by state.js
- * after the initial result is constructed.
+ * Result of resolveExploit() / resolveCombat(). The first six fields are the pure
+ * combat outcome; the rest form the side-effect-free PLAN that resolveCombat decides
+ * and applyCombatResult executes (access transition, alert raise, staged-vuln
+ * surfacing). partialBurn is set later by applyCardDecay.
  * @typedef {{
  *   success: boolean,
  *   disclosed: boolean,
@@ -75,6 +77,13 @@
  *   flavor: string,
  *   levelChanged?: boolean,
  *   partialBurn?: boolean,
+ *   skippedToOwned?: boolean,
+ *   prevAccess?: AccessLevel,
+ *   nextAccess?: AccessLevel,
+ *   revealNeighbors?: boolean,
+ *   vulnsToSurface?: number[],
+ *   prevAlert?: NodeAlertLevel,
+ *   nextAlert?: NodeAlertLevel,
  * }} ExploitResult
  */
 


### PR DESCRIPTION
Closes #168.

`launchExploit` mixed three concerns — deterministic combat resolution, state mutation, and event emission. Split into:

- **`resolveCombat(exploit, node)`** — pure: runs the existing `resolveExploit` roll, then decides the full effect **plan** (access transition incl. the skip-to-owned roll, alert raise, staged-vuln surfacing). Consumes RNG but performs **no** mutation or emission, so resolution is unit-testable without side effects.
- **`applyCombatResult(nodeId, exploit, result)`** — executes the plan: `setNode*` mutations, `revealNeighbors`, and the `ACTION_RESOLVED` / `NODE_ACCESSED` / `NODE_ALERT_RAISED` / `EXPLOIT_*` events.
- **`launchExploit`** — orchestrator: validate → `resolveCombat` → `applyCardDecay` → `applyCombatResult`.

## RNG order preserved
The skip-to-owned roll moves into `resolveCombat` (ahead of `applyCardDecay`), but it and the partial-burn roll are on mutually exclusive paths (success vs detected failure), so the per-path `RNG.COMBAT` sequence is unchanged. The effect-plan fields are documented on the `ExploitResult` typedef.

## Verification
- New `combat.test.js` cases pin `resolveCombat` purity (no node mutation, no events) for locked→compromised, locked→owned skip, and failure paths.
- `make check` green (1062 tests, lint clean).
- **`make census SEEDS=20` is byte-identical to `main`** (same successRate 0.35 / traceFiredRate 0.70 / avgCash / avgNodesOwned / avgCardsUsed) — confirming no behavioral drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)