### PR TITLE
Centralize balance/tuning constants into one module (#169)

### DIFF
--- a/js/core/alert.js
+++ b/js/core/alert.js
@@ -8,17 +8,10 @@ import { setGlobalAlert, setTraceCountdown, setTraceTimerId, decrementTraceCount
 import { setIceDetectedAt, incrementIceDetectionCount, activeIceInstances } from "./state/ice.js";
 import { emitEvent, E } from "./events.js";
 import { scheduleRepeating, cancelEvent, TIMER } from "./timers.js";
+import { DETECTION_TRACE_THRESHOLD, MONITOR_TRACE_THRESHOLD, TRACE_SECONDS } from "./balance.js";
 
 /** @type {GlobalAlertLevel[]} */
 const GLOBAL_ALERT_ORDER = ["green", "yellow", "red", "trace"];
-
-// Detection thresholds: cumulative detections before trace starts, by ICE grade
-const DETECTION_TRACE_THRESHOLD = { S: 1, A: 1, B: 2, C: 2, D: 3, F: 3 };
-
-// Security-grid trace gate: accumulated monitor alerts before trace starts, by network grade.
-// Mirrors DETECTION_TRACE_THRESHOLD (ICE) but kept separate so the passive grid and the active
-// ICE pursuit can be tuned independently.
-const MONITOR_TRACE_THRESHOLD = { S: 4, A: 5, B: 7, C: 9, D: 12, F: 15 };
 
 // Global alert escalation now flows entirely through the two sensors:
 //   - recordIceDetection (active ICE pursuit), below
@@ -26,11 +19,10 @@ const MONITOR_TRACE_THRESHOLD = { S: 4, A: 5, B: 7, C: 9, D: 12, F: 15 };
 // plus set-piece startTrace alarms. The legacy node-type-counting layer
 // (recomputeGlobalAlert / propagateAlertEvent / raiseGlobalAlert, gated on
 // alertState + eventForwardingDisabled) was retired in #173.
+// Trace thresholds (DETECTION_/MONITOR_TRACE_THRESHOLD) and the countdown
+// durations (TRACE_SECONDS) are tuning knobs — see js/core/balance.js (#169).
 
 // ── Trace countdown ───────────────────────────────────────
-
-/** Trace countdown duration scales with network threat grade. */
-const TRACE_SECONDS = { S: 30, A: 40, B: 45, C: 60, D: 75, F: 90 };
 
 export function startTraceCountdown() {
   const s = getState();

--- a/js/core/balance.js
+++ b/js/core/balance.js
@@ -1,0 +1,91 @@
+// @ts-check
+// Centralized game-balance / tuning constants (#169).
+//
+// These knobs drive the difficulty curve and were previously scattered across
+// combat.js, alert.js, and ice/runtime.js. Collecting them here makes the whole
+// tuning surface legible in one place — useful alongside census work. Each module
+// imports the constants it needs; the comments explaining WHY each value is what
+// it is travel with the values. (Structural constants — e.g. the alert ladder
+// order — stay with their subsystems; only tuning numbers live here.)
+
+// ── Combat: exploit resolution ───────────────────────────────────────────────
+
+// Success chance modifier by node security grade.
+export const GRADE_MODIFIER = {
+  S: 0.05,
+  A: 0.15,
+  B: 0.30,
+  C: 0.50,
+  D: 0.70,
+  F: 0.90,
+};
+
+/** Flat bonus when exploit targets a known vulnerability on the node. */
+export const MATCH_BONUS = 0.4;
+
+/** Hard cap on exploit success probability. */
+export const SUCCESS_CAP = 0.95;
+
+// Disclosure chance on failure by grade (higher grade = more likely to detect and disclose).
+export const DISCLOSURE_CHANCE = {
+  S: 0.85,
+  A: 0.70,
+  B: 0.50,
+  C: 0.30,
+  D: 0.15,
+  F: 0.05,
+};
+
+// Skip-to-owned floor and quality scaling. The chance a successful exploit
+// jumps locked → owned in one shot is driven by card QUALITY, not rarity:
+//   0.08 + quality * 0.55
+// This lifts the floor across the board (a fresh common skips ~19–38% of the
+// time, up from the old ~2–6%) while still rewarding the best cards most —
+// rare cards skip more only because they carry higher quality, not because of
+// a separate multiplier. Tops out near 0.60 for a best-in-class rare (q≈0.95);
+// never approaches certainty.
+export const SKIP_TO_OWNED_FLOOR = 0.08;
+export const SKIP_TO_OWNED_QUALITY_SCALE = 0.55;
+
+// Patch lag in turns by grade (how quickly vulns get patched after disclosure).
+export const PATCH_LAG = {
+  S: 1,
+  A: 2,
+  B: 3,
+  C: 4,
+  D: 6,
+  F: 8,
+};
+
+// ── Alert / trace ────────────────────────────────────────────────────────────
+
+// Detection thresholds: cumulative detections before trace starts, by ICE grade.
+export const DETECTION_TRACE_THRESHOLD = { S: 1, A: 1, B: 2, C: 2, D: 3, F: 3 };
+
+// Security-grid trace gate: accumulated monitor alerts before trace starts, by network grade.
+// Mirrors DETECTION_TRACE_THRESHOLD (ICE) but kept separate so the passive grid and the active
+// ICE pursuit can be tuned independently.
+export const MONITOR_TRACE_THRESHOLD = { S: 4, A: 5, B: 7, C: 9, D: 12, F: 15 };
+
+/** Trace countdown duration (seconds) scales with network threat grade. */
+export const TRACE_SECONDS = { S: 30, A: 40, B: 45, C: 60, D: 75, F: 90 };
+
+// ── ICE movement / detection ─────────────────────────────────────────────────
+
+// Grade → movement interval (ms); must be longer than the corresponding DWELL_TIMES entry.
+// A/S slowed from 2500/3000 to give players a narrow window for exploit completion.
+export const MOVE_INTERVALS = { S: 4000, A: 5000, B: 6000, C: 7000, D: 12000, F: 14000 };
+
+// Grade → dwell time before detection (ms).
+// S/A get very short dwells — tight but evadable with fast reactions.
+// C/B bumped from 4500/3500 to give players a window to complete exploits.
+export const DWELL_TIMES = { S: 800, A: 1500, B: 4500, C: 5500, D: 9000, F: 10000 };
+
+// Grade → noise tick at which ICE first responds to an executing exploit.
+// Exploit emits ticks 1–9 at 10%–90% of duration; 10% intervals.
+export const ICE_NOISE_THRESHOLD = { S: 1, A: 2, B: 3, C: 5, D: 7, F: 9 };
+
+// Delay before detection starts when ICE arrives via movement (ms).
+// Matches the ICE movement animation duration so the visual and the
+// detection timer stay in sync — player sees ICE arrive, then countdown starts.
+export const ARRIVAL_DELAY_MS = 400;

--- a/js/core/combat.js
+++ b/js/core/combat.js
@@ -15,43 +15,14 @@ import { setLastDisturbedNode } from "./state/ice.js";
 import { applyCardDecay as applyCardDecayState } from "./state/player.js";
 import { emitEvent, E } from "./events.js";
 import { A } from "./action-ids.js";
+import {
+  GRADE_MODIFIER, MATCH_BONUS, SUCCESS_CAP, DISCLOSURE_CHANCE,
+  SKIP_TO_OWNED_FLOOR, SKIP_TO_OWNED_QUALITY_SCALE, PATCH_LAG,
+} from "./balance.js";
 
-// Success chance modifier by node security grade
-export const GRADE_MODIFIER = {
-  S: 0.05,
-  A: 0.15,
-  B: 0.30,
-  C: 0.50,
-  D: 0.70,
-  F: 0.90,
-};
-
-/** Flat bonus when exploit targets a known vulnerability on the node. */
-export const MATCH_BONUS = 0.4;
-
-/** Hard cap on exploit success probability. */
-export const SUCCESS_CAP = 0.95;
-
-// Disclosure chance on failure by grade (higher grade = more likely to detect and disclose)
-const DISCLOSURE_CHANCE = {
-  S: 0.85,
-  A: 0.70,
-  B: 0.50,
-  C: 0.30,
-  D: 0.15,
-  F: 0.05,
-};
-
-// Skip-to-owned floor and quality scaling. The chance a successful exploit
-// jumps locked → owned in one shot is driven by card QUALITY, not rarity:
-//   0.08 + quality * 0.55
-// This lifts the floor across the board (a fresh common skips ~19–38% of the
-// time, up from the old ~2–6%) while still rewarding the best cards most —
-// rare cards skip more only because they carry higher quality, not because of
-// a separate multiplier. Tops out near 0.60 for a best-in-class rare (q≈0.95);
-// never approaches certainty.
-const SKIP_TO_OWNED_FLOOR = 0.08;
-const SKIP_TO_OWNED_QUALITY_SCALE = 0.55;
+// Re-export combat-balance constants so existing `import … from "./combat.js"`
+// sites keep working; the values now live in balance.js (#169).
+export { GRADE_MODIFIER, MATCH_BONUS, SUCCESS_CAP, PATCH_LAG };
 
 /**
  * Chance that a successful exploit jumps from locked directly to owned,
@@ -62,16 +33,6 @@ const SKIP_TO_OWNED_QUALITY_SCALE = 0.55;
 export function skipToOwnedChance(exploit) {
   return SKIP_TO_OWNED_FLOOR + exploit.quality * SKIP_TO_OWNED_QUALITY_SCALE;
 }
-
-// Patch lag in turns by grade (how quickly vulns get patched after disclosure)
-export const PATCH_LAG = {
-  S: 1,
-  A: 2,
-  B: 3,
-  C: 4,
-  D: 6,
-  F: 8,
-};
 
 /**
  * RNG.COMBAT roll consumption per launchExploit() code path.

--- a/js/core/ice/runtime.js
+++ b/js/core/ice/runtime.js
@@ -15,6 +15,7 @@ import { A } from "../action-ids.js";
 import { RNG, randomPick } from "../rng.js";
 import { getType, getEffect } from "./index.js";
 import { damagePlayerHealth, damagePlayerDeck } from "../player-orchestration.js";
+import { MOVE_INTERVALS, DWELL_TIMES, ICE_NOISE_THRESHOLD, ARRIVAL_DELAY_MS } from "../balance.js";
 
 // Called whenever an ICE instance vacates a node for any reason: normal movement,
 // eject, or reboot. Cancels that instance's pending detection dwell and releases
@@ -27,18 +28,8 @@ function handleIceDeparture(iceId) {
   setIceDetectedAt(null, iceId);
 }
 
-// Grade → movement interval (ms); must be longer than the corresponding DWELL_TIMES entry.
-// A/S slowed from 2500/3000 to give players a narrow window for exploit completion.
-const MOVE_INTERVALS = { S: 4000, A: 5000, B: 6000, C: 7000, D: 12000, F: 14000 };
-
-// Grade → dwell time before detection (ms).
-// S/A get very short dwells — tight but evadable with fast reactions.
-// C/B bumped from 4500/3500 to give players a window to complete exploits.
-const DWELL_TIMES = { S: 800, A: 1500, B: 4500, C: 5500, D: 9000, F: 10000 };
-
-// Grade → noise tick at which ICE first responds to an executing exploit.
-// Exploit emits ticks 1–9 at 10%–90% of duration; 10% intervals.
-const ICE_NOISE_THRESHOLD = { S: 1, A: 2, B: 3, C: 5, D: 7, F: 9 };
+// ICE movement intervals, dwell times, noise thresholds, and the arrival delay
+// are tuning knobs — see js/core/balance.js (#169).
 
 export function startIce() {
   const s = getState();
@@ -214,11 +205,6 @@ function moveInstance(ice, s) {
   // Each instance drives its own per-id dwell timer on arrival.
   checkIceDetection(ice, nextNode, { justArrived: true });
 }
-
-// Delay before detection starts when ICE arrives via movement (ms).
-// Matches the ICE movement animation duration so the visual and the
-// detection timer stay in sync — player sees ICE arrive, then countdown starts.
-const ARRIVAL_DELAY_MS = 400;
 
 function checkIceDetection(ice, nodeId, { justArrived = false } = {}) {
   const s = getState();


### PR DESCRIPTION
Closes #169. **Stacked on #168** (#199) — base retargets to `main` once that merges.

Game-balance tuning values were scattered across three modules. Consolidated into `js/core/balance.js`, exported as named constants and imported where needed (the comments explaining each value travel with it):

- **Combat** (`combat.js`): `GRADE_MODIFIER`, `MATCH_BONUS`, `SUCCESS_CAP`, `DISCLOSURE_CHANCE`, `SKIP_TO_OWNED_FLOOR`/`_QUALITY_SCALE`, `PATCH_LAG`
- **Alert/trace** (`alert.js`): `DETECTION_TRACE_THRESHOLD`, `MONITOR_TRACE_THRESHOLD`, `TRACE_SECONDS`
- **ICE** (`ice/runtime.js`): `MOVE_INTERVALS`, `DWELL_TIMES`, `ICE_NOISE_THRESHOLD`, `ARRIVAL_DELAY_MS`

`combat.js` re-exports its four formerly-public constants so any external import site keeps working. Structural constants (the alert-ladder order) stay with their subsystems — only tuning numbers moved.

Behavior-preserving (values unchanged). `make check` green (1062 tests); `make census SEEDS=20` byte-identical to the #168 base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)