### PR TITLE
Centralize node-graph timed-action registry + attr-name helper (#170)

### DIFF
--- a/js/core/node-graph/game-ctx.js
+++ b/js/core/node-graph/game-ctx.js
@@ -36,6 +36,12 @@ import { getState } from "../state.js";
 import { setNodeProbed, setNodeAlertState, setNodeRead, collectMacguffins, setNodeLooted, incrementMineAttempts, setMineExhausted } from "../state/node.js";
 import { setLastDisturbedNode } from "../state/ice.js";
 import { launchExploit } from "../combat.js";
+import { getTimedActionAttrNames } from "./timed-actions.js";
+
+/** Convenience: `_ta_<action>_progress` for the given timed action. */
+const progressAttr = (action) => getTimedActionAttrNames(action).progressAttr;
+/** Convenience: `_ta_<action>_duration` for the given timed action. */
+const durationAttr = (action) => getTimedActionAttrNames(action).durationAttr;
 
 /**
  * Build the real CtxInterface for game integration.
@@ -96,8 +102,8 @@ export function buildGameCtx(opts = {}) {
       if (ctx._graph) {
         ctx._graph.setNodeAttr(nodeId, "exploiting", true);
         ctx._graph.setNodeAttr(nodeId, "activeExploitId", exploitId);
-        ctx._graph.setNodeAttr(nodeId, "_ta_xploit_progress", 0);
-        ctx._graph.setNodeAttr(nodeId, "_ta_xploit_duration", durationTicks);
+        ctx._graph.setNodeAttr(nodeId, progressAttr("xploit"), 0);
+        ctx._graph.setNodeAttr(nodeId, durationAttr("xploit"), durationTicks);
       }
       // Emit start feedback immediately (operator skips start for pre-set durations)
       emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.XPLOIT, phase: "start", progress: 0, durationTicks });
@@ -111,8 +117,8 @@ export function buildGameCtx(opts = {}) {
       if (!exploitingNode) return;
       if (ctx._graph) {
         ctx._graph.setNodeAttr(exploitingNode.id, "exploiting", false);
-        ctx._graph.setNodeAttr(exploitingNode.id, "_ta_xploit_progress", 0);
-        ctx._graph.setNodeAttr(exploitingNode.id, "_ta_xploit_duration", 0);
+        ctx._graph.setNodeAttr(exploitingNode.id, progressAttr("xploit"), 0);
+        ctx._graph.setNodeAttr(exploitingNode.id, durationAttr("xploit"), 0);
         ctx._graph.setNodeAttr(exploitingNode.id, "activeExploitId", null);
       }
       emitEvent(E.ACTION_FEEDBACK, { nodeId: exploitingNode.id, action: A.XPLOIT, phase: "cancel", progress: 0 });
@@ -180,8 +186,8 @@ export function buildGameCtx(opts = {}) {
       const durationTicks = 10 + Math.round(random(RNG.WORLD) * 20);
       if (ctx._graph) {
         ctx._graph.setNodeAttr(nodeId, "rebooting", true);
-        ctx._graph.setNodeAttr(nodeId, "_ta_reboot_progress", 0);
-        ctx._graph.setNodeAttr(nodeId, "_ta_reboot_duration", durationTicks);
+        ctx._graph.setNodeAttr(nodeId, progressAttr("reboot"), 0);
+        ctx._graph.setNodeAttr(nodeId, durationAttr("reboot"), durationTicks);
       }
 
       emitEvent(E.ACTION_RESOLVED, { action: "reboot-start", nodeId, label: node.label, detail: { durationMs: durationTicks * 100 } });
@@ -384,39 +390,39 @@ export function initNavigationCancelHandler() {
     // overlay/log un-armed. (XPLOIT already cleared its ctx-set duration below.)
     if (attrs.probing) {
       graph.setNodeAttr(nodeId, "probing", false);
-      graph.setNodeAttr(nodeId, "_ta_probe_progress", 0);
-      graph.setNodeAttr(nodeId, "_ta_probe_duration", 0);
+      graph.setNodeAttr(nodeId, progressAttr("probe"), 0);
+      graph.setNodeAttr(nodeId, durationAttr("probe"), 0);
       emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.PROBE, phase: "cancel", progress: 0 });
     }
     if (attrs.exploiting) {
       graph.setNodeAttr(nodeId, "exploiting", false);
-      graph.setNodeAttr(nodeId, "_ta_xploit_progress", 0);
-      graph.setNodeAttr(nodeId, "_ta_xploit_duration", 0);
+      graph.setNodeAttr(nodeId, progressAttr("xploit"), 0);
+      graph.setNodeAttr(nodeId, durationAttr("xploit"), 0);
       graph.setNodeAttr(nodeId, "activeExploitId", null);
       emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.XPLOIT, phase: "cancel", progress: 0 });
     }
     if (attrs.reading) {
       graph.setNodeAttr(nodeId, "reading", false);
-      graph.setNodeAttr(nodeId, "_ta_dump_progress", 0);
-      graph.setNodeAttr(nodeId, "_ta_dump_duration", 0);
+      graph.setNodeAttr(nodeId, progressAttr("dump"), 0);
+      graph.setNodeAttr(nodeId, durationAttr("dump"), 0);
       emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.DUMP, phase: "cancel", progress: 0 });
     }
     if (attrs.looting) {
       graph.setNodeAttr(nodeId, "looting", false);
-      graph.setNodeAttr(nodeId, "_ta_fetch_progress", 0);
-      graph.setNodeAttr(nodeId, "_ta_fetch_duration", 0);
+      graph.setNodeAttr(nodeId, progressAttr("fetch"), 0);
+      graph.setNodeAttr(nodeId, durationAttr("fetch"), 0);
       emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.FETCH, phase: "cancel", progress: 0 });
     }
     if (attrs.mining) {
       graph.setNodeAttr(nodeId, "mining", false);
-      graph.setNodeAttr(nodeId, "_ta_mine_progress", 0);
-      graph.setNodeAttr(nodeId, "_ta_mine_duration", 0);
+      graph.setNodeAttr(nodeId, progressAttr("mine"), 0);
+      graph.setNodeAttr(nodeId, durationAttr("mine"), 0);
       emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.MINE, phase: "cancel", progress: 0 });
     }
     if (attrs.lyingLow) {
       graph.setNodeAttr(nodeId, "lyingLow", false);
-      graph.setNodeAttr(nodeId, "_ta_lie-low_progress", 0);
-      graph.setNodeAttr(nodeId, "_ta_lie-low_duration", 0);
+      graph.setNodeAttr(nodeId, progressAttr("lie-low"), 0);
+      graph.setNodeAttr(nodeId, durationAttr("lie-low"), 0);
       emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.LIE_LOW, phase: "cancel", progress: 0 });
     }
   }

--- a/js/core/node-graph/game-types.js
+++ b/js/core/node-graph/game-types.js
@@ -13,14 +13,15 @@
 
 import { A } from "../action-ids.js";
 import { getExploitChoices, getExploitEmptyReason } from "../exploits.js";
+import { ABORTABLE_FLAGS, getTimedActionAttrNames } from "./timed-actions.js";
 
 // ── Shared action templates ──────────────────────────────────
 
-// activeAttr flag for each player-initiated timed action. This is the single
-// source of truth for the abortable timed-action set: ABORT shows when any of
-// these is true, and NOT_BUSY (below) requires all of them false. When adding a
-// new timed action, add its activeAttr here — both lists stay in sync.
-const TIMED_ACTION_FLAGS = ["probing", "exploiting", "reading", "looting", "mining", "lyingLow"];
+// activeAttr flags for the player-initiated, abortable timed actions, sourced
+// from the TIMED_ACTIONS registry (timed-actions.js): ABORT shows when any is
+// true, and NOT_BUSY (below) requires all of them false. Add new timed actions
+// to the registry, not here.
+const TIMED_ACTION_FLAGS = ABORTABLE_FLAGS;
 
 // A node may run at most ONE timed action at a time. Every startable action
 // requires the node be idle: no timed action in flight, and not rebooting.
@@ -48,7 +49,7 @@ const PROBE_ACTION = {
   ],
   effects: [
     { effect: "set-attr", attr: "probing", value: true },
-    { effect: "set-attr", attr: "_ta_probe_progress", value: 0 },
+    { effect: "set-attr", attr: getTimedActionAttrNames("probe").progressAttr, value: 0 },
   ],
 };
 
@@ -123,9 +124,8 @@ const DUMP_ACTION = {
   ],
   effects: [
     { effect: "set-attr", attr: "reading", value: true },
-    // Must match the dump timed-action operator's progress attr (_ta_dump_progress,
-    // derived from action:"dump"), not a phantom _ta_read_progress.
-    { effect: "set-attr", attr: "_ta_dump_progress", value: 0 },
+    // Derived from the registry so it always matches the dump operator's progress attr.
+    { effect: "set-attr", attr: getTimedActionAttrNames("dump").progressAttr, value: 0 },
   ],
 };
 
@@ -144,9 +144,8 @@ const FETCH_ACTION = {
   ],
   effects: [
     { effect: "set-attr", attr: "looting", value: true },
-    // Must match the fetch timed-action operator's progress attr (_ta_fetch_progress,
-    // derived from action:"fetch"), not a phantom _ta_loot_progress.
-    { effect: "set-attr", attr: "_ta_fetch_progress", value: 0 },
+    // Derived from the registry so it always matches the fetch operator's progress attr.
+    { effect: "set-attr", attr: getTimedActionAttrNames("fetch").progressAttr, value: 0 },
   ],
 };
 
@@ -164,7 +163,7 @@ const MINE_ACTION = {
   ],
   effects: [
     { effect: "set-attr", attr: "mining", value: true },
-    { effect: "set-attr", attr: "_ta_mine_progress", value: 0 },
+    { effect: "set-attr", attr: getTimedActionAttrNames("mine").progressAttr, value: 0 },
   ],
 };
 
@@ -267,7 +266,7 @@ const LIE_LOW_ACTION = {
   ],
   effects: [
     { effect: "set-attr", attr: "lyingLow", value: true },
-    { effect: "set-attr", attr: "_ta_lie-low_progress", value: 0 },
+    { effect: "set-attr", attr: getTimedActionAttrNames("lie-low").progressAttr, value: 0 },
   ],
 };
 

--- a/js/core/node-graph/operators.js
+++ b/js/core/node-graph/operators.js
@@ -17,6 +17,8 @@
  * @typedef {(config: OperatorConfig, nodeAttributes: Record<string, any>, message: Message | null, ctx: CtxInterface) => OperatorResult} OperatorFn
  */
 
+import { getTimedActionAttrNames } from "./timed-actions.js";
+
 /**
  * Resolve a timing value from a grade table or fall back to a fixed value.
  * Operators can declare e.g. `periodTable: { S: 20, A: 25, B: 30, C: 40, D: 50, F: 60 }`
@@ -374,8 +376,9 @@ registerOperator("timed-action", (config, attrs, message, _ctx) => {
   const activeAttr = config.activeAttr;
   if (!activeAttr) return {};
 
-  const progressAttr = config.progressAttr ?? `_ta_${action}_progress`;
-  const durationAttr = config.durationAttr ?? `_ta_${action}_duration`;
+  const names = getTimedActionAttrNames(action);
+  const progressAttr = config.progressAttr ?? names.progressAttr;
+  const durationAttr = config.durationAttr ?? names.durationAttr;
 
   const isActive = attrs[activeAttr];
   const progress = attrs[progressAttr] ?? 0;

--- a/js/core/node-graph/runtime.js
+++ b/js/core/node-graph/runtime.js
@@ -15,6 +15,10 @@ import { fillConditionNodeId } from "./conditions.js";
 import { applyEffect } from "./effects.js";
 import { nullCtx } from "./ctx.js";
 import { resolveTraits } from "./traits.js";
+import { getTimedActionAttrNames } from "./timed-actions.js";
+
+// Re-exported so callers can reach the timed-action attr-name helper via runtime.
+export { getTimedActionAttrNames } from "./timed-actions.js";
 
 /**
  * @typedef {Object} NodeGraphDef
@@ -219,11 +223,12 @@ export class NodeGraph {
       const activeAttr = op.activeAttr;
       if (!activeAttr || !node.attributes[activeAttr]) continue;
       const action = op.action ?? "unknown";
+      const names = getTimedActionAttrNames(action);
       return {
         action,
         activeAttr,
-        progressAttr: op.progressAttr ?? `_ta_${action}_progress`,
-        durationAttr: op.durationAttr ?? `_ta_${action}_duration`,
+        progressAttr: op.progressAttr ?? names.progressAttr,
+        durationAttr: op.durationAttr ?? names.durationAttr,
       };
     }
     return null;

--- a/js/core/node-graph/timed-actions.js
+++ b/js/core/node-graph/timed-actions.js
@@ -1,0 +1,53 @@
+// @ts-check
+// Single source of truth for the timed-action set (#170).
+//
+// A timed action is an async node operation driven by the "timed-action" operator
+// (operators.js): it sets an `activeAttr` true, ticks a `_ta_<action>_progress`
+// attribute toward `_ta_<action>_duration`, then fires its onComplete. The action
+// id, the (irregular) activeAttr flag, and whether ABORT can cancel it were
+// previously enumerated independently across traits.js, game-types.js, and
+// game-ctx.js — adding one meant touching all three by hand. They derive from this
+// registry now: game-types builds ABORT/NOT_BUSY from ABORTABLE_FLAGS, game-ctx and
+// runtime build attribute names via getTimedActionAttrNames, and a test
+// (timed-actions.test.js) asserts the traits.js operator configs still match.
+
+/**
+ * @typedef {Object} TimedActionDef
+ * @property {string} action      timed-action id (drives the _ta_<action>_* attr names)
+ * @property {string} activeAttr  boolean "in progress" attribute (mapped explicitly — irregular)
+ * @property {boolean} abortable  whether ABORT can cancel it (reboot is involuntary, so no)
+ */
+
+/** @type {TimedActionDef[]} */
+export const TIMED_ACTIONS = [
+  { action: "probe",   activeAttr: "probing",    abortable: true },
+  { action: "xploit",  activeAttr: "exploiting", abortable: true },
+  { action: "dump",    activeAttr: "reading",    abortable: true },
+  { action: "fetch",   activeAttr: "looting",    abortable: true },
+  { action: "mine",    activeAttr: "mining",     abortable: true },
+  { action: "lie-low", activeAttr: "lyingLow",   abortable: true },
+  { action: "reboot",  activeAttr: "rebooting",  abortable: false },
+];
+
+/**
+ * activeAttr flags for the ABORTABLE timed actions. ABORT shows when any is true;
+ * NOT_BUSY (game-types.js) requires all of them — plus `rebooting` — false.
+ * @type {string[]}
+ */
+export const ABORTABLE_FLAGS = TIMED_ACTIONS.filter((t) => t.abortable).map((t) => t.activeAttr);
+
+/**
+ * The standard attribute names for a timed action, derived from its id. Operators
+ * may override progress/duration via config; this returns the conventional
+ * defaults plus the registered activeAttr (undefined for an unknown action).
+ * @param {string} action
+ * @returns {{ activeAttr: string|undefined, progressAttr: string, durationAttr: string }}
+ */
+export function getTimedActionAttrNames(action) {
+  const def = TIMED_ACTIONS.find((t) => t.action === action);
+  return {
+    activeAttr: def?.activeAttr,
+    progressAttr: `_ta_${action}_progress`,
+    durationAttr: `_ta_${action}_duration`,
+  };
+}

--- a/js/core/node-graph/timed-actions.test.js
+++ b/js/core/node-graph/timed-actions.test.js
@@ -1,0 +1,70 @@
+// The TIMED_ACTIONS registry (#170) is the single source of truth for the
+// timed-action set. These tests assert the traits.js operator configs and the
+// attr-name helper stay consistent with it — so adding a timed action to one
+// place without the registry fails CI instead of drifting silently.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { TIMED_ACTIONS, ABORTABLE_FLAGS, getTimedActionAttrNames } from "./timed-actions.js";
+import { getTrait } from "./traits.js";
+import { LIE_LOW_OPERATOR } from "./game-types.js";
+
+// Importing traits.js registers the built-in traits at module load.
+const TRAITS_WITH_TIMED_ACTIONS = ["hackable", "lootable", "rebootable"];
+
+/**
+ * Every (action, activeAttr) from a timed-action operator the game defines —
+ * across the built-in traits plus the standalone LIE_LOW_OPERATOR in game-types.js
+ * (lie-low is a WAN action, not a trait). This is the set the registry must mirror.
+ */
+function definedTimedActions() {
+  const found = [];
+  for (const name of TRAITS_WITH_TIMED_ACTIONS) {
+    const trait = getTrait(name);
+    for (const op of trait?.operators ?? []) {
+      if (op.name === "timed-action") found.push({ action: op.action, activeAttr: op.activeAttr });
+    }
+  }
+  if (LIE_LOW_OPERATOR?.name === "timed-action") {
+    found.push({ action: LIE_LOW_OPERATOR.action, activeAttr: LIE_LOW_OPERATOR.activeAttr });
+  }
+  return found;
+}
+
+describe("TIMED_ACTIONS registry", () => {
+  test("getTimedActionAttrNames derives the conventional _ta_<action>_* names", () => {
+    assert.deepEqual(getTimedActionAttrNames("xploit"), {
+      activeAttr: "exploiting",
+      progressAttr: "_ta_xploit_progress",
+      durationAttr: "_ta_xploit_duration",
+    });
+    // Unknown action: still derives the attr names, activeAttr undefined.
+    assert.deepEqual(getTimedActionAttrNames("nope"), {
+      activeAttr: undefined,
+      progressAttr: "_ta_nope_progress",
+      durationAttr: "_ta_nope_duration",
+    });
+  });
+
+  test("ABORTABLE_FLAGS excludes reboot (involuntary, ABORT can't cancel it)", () => {
+    assert.ok(!ABORTABLE_FLAGS.includes("rebooting"));
+    assert.deepEqual(ABORTABLE_FLAGS, ["probing", "exploiting", "reading", "looting", "mining", "lyingLow"]);
+  });
+
+  test("every defined timed-action operator matches a registry entry (action + activeAttr)", () => {
+    const byAction = new Map(TIMED_ACTIONS.map((t) => [t.action, t]));
+    for (const { action, activeAttr } of definedTimedActions()) {
+      const def = byAction.get(action);
+      assert.ok(def, `a timed-action operator declares "${action}" missing from TIMED_ACTIONS`);
+      assert.equal(def.activeAttr, activeAttr, `activeAttr mismatch for "${action}"`);
+    }
+  });
+
+  test("every registry action is backed by a defined operator (no phantom entries)", () => {
+    const definedActions = new Set(definedTimedActions().map((t) => t.action));
+    for (const { action } of TIMED_ACTIONS) {
+      assert.ok(definedActions.has(action), `TIMED_ACTIONS lists "${action}" with no operator`);
+    }
+  });
+});

--- a/js/core/node-graph/traits.js
+++ b/js/core/node-graph/traits.js
@@ -25,6 +25,8 @@
  * @property {import('./types.js').TriggerDef[]} [triggers]
  */
 
+import { getTimedActionAttrNames } from "./timed-actions.js";
+
 /** @type {Map<string, TraitDef>} */
 const _registry = new Map();
 
@@ -354,8 +356,8 @@ registerTrait("encrypted", {
     ],
     effects: [
       { effect: "set-attr", attr: "reading", value: true },
-      // Matches the lootable dump operator's progress attr (_ta_dump_progress).
-      { effect: "set-attr", attr: "_ta_dump_progress", value: 0 },
+      // Derived from the registry so it always matches the dump operator's progress attr.
+      { effect: "set-attr", attr: getTimedActionAttrNames("dump").progressAttr, value: 0 },
     ],
   }],
 });


### PR DESCRIPTION
Closes #170.

The timed-action system was stringly-coupled and spread across files: `game-ctx.js` hand-built magic attribute names like `_ta_xploit_progress`, and the action set (probe/xploit/dump/fetch/mine/**lie-low**/reboot ↔ activeAttr probing/exploiting/reading/looting/mining/**lyingLow**/rebooting) was enumerated independently in `traits.js` operator configs, `game-types.js` (ABORT `requires` / NOT_BUSY + `LIE_LOW_OPERATOR`), and `game-ctx.js`.

## Registry
New `js/core/node-graph/timed-actions.js` is the single source of truth:
- **`TIMED_ACTIONS`** — `{ action, activeAttr, abortable }` per timed action.
- **`getTimedActionAttrNames(action)`** → `{ activeAttr, progressAttr, durationAttr }`, re-exported from `runtime.js`.
- **`ABORTABLE_FLAGS`** — derived (excludes `reboot`, which is involuntary).

## Rewired consumers
- `operators.js` + `runtime.getActiveTimedAction`: default `_ta_*` names via the helper.
- `game-ctx.js`: every `_ta_<action>_progress/_duration` literal → helper (incl. the `lie-low` cancel branch; preserves the cancel-resets-duration fix from #189).
- `game-types.js`: `TIMED_ACTION_FLAGS = ABORTABLE_FLAGS`; PROBE/DUMP/FETCH/MINE + the `lie-low` action effect attrs via the helper. `traits.js` dump effect likewise.

## Consistency test
New `timed-actions.test.js` asserts the registry and every **defined** timed-action operator stay consistent (action + activeAttr, both directions) — across the hackable/lootable/rebootable traits **and** the standalone `LIE_LOW_OPERATOR` — so adding a timed action in one place without the registry fails CI.

Behavior-preserving (attr names unchanged). Redone in a worktree on top of current `main`, absorbing the `lie-low` timed action that landed via #186. `make check` green (1099 tests, lint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)