### PR TITLE
Move dev FPS meter to upper-left (clear of JACK OUT)

### DIFF
--- a/js/ui/fps-meter.js
+++ b/js/ui/fps-meter.js
@@ -102,7 +102,7 @@ function buildEl() {
   const panel = document.createElement("div");
   panel.id = "fps-meter";
   Object.assign(panel.style, {
-    position: "fixed", top: "8px", right: "8px", zIndex: "9999",
+    position: "fixed", top: "8px", left: "8px", zIndex: "9999",
     padding: "6px 8px", font: "11px / 1.3 monospace", color: "#39ff14",
     background: "rgba(10,10,15,0.72)", border: "1px solid rgba(57,255,20,0.4)",
     pointerEvents: "none", letterSpacing: "0.5px",


### PR DESCRIPTION
The `cheat fps` frame-time / FPS meter (#192) is fixed-positioned at `top: 8px; right: 8px`, which sits over the `[ JACK OUT ]` button in the HUD header.

This moves it to `top: 8px; left: 8px` so it parks over the non-interactive `★ STARNET` title instead. The panel is `pointerEvents: none`, so the change only affects visual occlusion — clicks were never blocked, but the button was hidden behind the readout.

One-line change in `js/ui/fps-meter.js` `buildEl()`. `make check` passes (lint + 1105 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)