### PR TITLE
fix(ui): ECG waveform draws a partial final beat instead of flatlining

### DIFF
--- a/js/ui/waveform.js
+++ b/js/ui/waveform.js
@@ -33,6 +33,31 @@ function clamp01(v) {
   return Math.max(0, Math.min(1, n));
 }
 
+/**
+ * Truncate an ascending-in-x polyline at x = W, interpolating the y at the crossing.
+ * A trailing vertex past the right edge is replaced by the exact point where the last
+ * segment meets x = W, so an over-filled final beat reads as an incomplete pulse cut at
+ * the edge rather than running out of bounds.
+ * @param {Array<Point>} pts vertices in ascending x
+ * @param {number} W
+ * @returns {Array<Point>}
+ */
+function clipRightX(pts, W) {
+  /** @type {Array<Point>} */
+  const out = [];
+  for (let i = 0; i < pts.length; i++) {
+    const p = pts[i];
+    if (p.x <= W) {
+      out.push(p);
+      continue;
+    }
+    const prev = pts[i - 1];
+    if (prev && prev.x < W) out.push({ x: W, y: lerp(prev.y, p.y, (W - prev.x) / (p.x - prev.x)) });
+    break;
+  }
+  return out;
+}
+
 // ── public API ───────────────────────────────────────────────────────────────
 
 /**
@@ -91,7 +116,11 @@ export function ecgPoints({ frac, width, height }) {
   // a wider strip shows MORE beats rather than stretching a fixed few. Damage shortens
   // the period (faster heart rate). Tuned to match the lab proportions.
   const period = H * lerp(1.15, 2.0, f);
-  const beats = Math.max(1, Math.floor(W / period));
+  // ceil (not floor): draw the final beat even when only part of it fits, so a wide
+  // strip ends on an incomplete pulse clipped at the edge rather than dropping the beat
+  // and flatlining for up to a full period of leftover width. clipRightX trims the
+  // overhang back to W below.
+  const beats = Math.max(1, Math.ceil(W / period));
   const cw = Math.min(period * 0.72, period - 2); // complex width; rest is flat diastole
   const top = H * 0.04, bot = H * 0.96;            // headroom so glow doesn't clip
   const cl = (y) => Math.max(top, Math.min(bot, y));
@@ -155,8 +184,10 @@ export function ecgPoints({ frac, width, height }) {
       pts.push({ x: X(0.96), y: mid });
     }
   }
-  pts.push({ x: W, y: mid });
-  return pts;
+  // If the last beat ended before the edge, extend flat diastole to W; if it overran the
+  // edge, clipRightX trims it back to an incomplete pulse cut at W.
+  if (pts[pts.length - 1].x < W) pts.push({ x: W, y: mid });
+  return clipRightX(pts, W);
 }
 
 /**

--- a/js/ui/waveform.test.js
+++ b/js/ui/waveform.test.js
@@ -55,6 +55,26 @@ describe("ecgPoints", () => {
     }
   });
 
+  test("wide strip renders a partial final beat, not a near-full-period flatline", () => {
+    // Regression: ecgPoints used Math.floor(W/period) for the beat count, so any
+    // leftover width up to almost a whole period was filled with flat baseline. At
+    // sidebar widths where that remainder approached a full period, the trace dropped
+    // the final beat and flatlined for nearly a beat-width at the right edge. A partial
+    // beat clipped at the edge should fill that space instead.
+    const period = H * 2.0; // lerp(1.15, 2.0, 1) — frac=1 is the slowest heart, longest period
+    // Width with a large floor() remainder (~0.85 period) — worst case for the old bug.
+    const width = Math.round(2 * period + 0.85 * period);
+    const pts = ecgPoints({ frac: 1, width, height: H });
+    const feature = (p) => Math.abs(p.y - MID) > H * 0.05;
+    const lastFeatureX = pts.filter(feature).reduce((mx, p) => Math.max(mx, p.x), 0);
+    const trailingFlat = width - lastFeatureX;
+    assert.ok(
+      trailingFlat < period,
+      `trailing flat gap ${trailingFlat.toFixed(1)}px should be < one period ${period.toFixed(1)}px ` +
+        `(expected a partial beat near the edge, not a flatline)`,
+    );
+  });
+
   test("beat count increases with damage", () => {
     // R peaks sit well above the midline (small y); P/T/U humps stay below the threshold.
     const peaks = (pts) => pts.filter((p) => MID - p.y > H * 0.25).length;


### PR DESCRIPTION
Reported: at certain sidebar widths the human pulse (health) waveform skips its final pulse and flatlines, rather than drawing an incomplete pulse.

## Root cause

`ecgPoints()` in `js/ui/waveform.js` computed the beat count with `Math.floor(W / period)`. `floor` drops the final beat whenever the leftover width is under a full `period` — even a beat that would physically fit. The trailing `pts.push({ x: W, y: mid })` then filled that leftover (up to ~1 period wide) with flat baseline. At widths where the remainder approached a full period, the trace lost its last pulse and flatlined at the right edge.

The deck-integrity `pulsePoints()` never had this — it already tiles cycles edge-to-edge (`round` + `half = W/(CYCLES*2)`) — and is unchanged here.

## Fix

- `floor` → `ceil` for the beat count, so the final beat is drawn even when only partly inside the strip.
- New private `clipRightX(pts, W)` truncates the polyline at `x = W`, interpolating the crossing point — an over-filled beat reads as an *incomplete pulse cut at the edge* (a CRT sweep reaching the edge mid-beat) instead of running out of bounds. When the last beat fits with room to spare, flat diastole still extends to `W`.

## Verification

- TDD: added a failing regression test first (`trailing flat 62.5px > 56px period`), confirmed it failed for the right reason, then the fix made it pass.
- Full suite: **1113 tests pass**; `make lint` clean.
- Swept widths 60–600px × health 0.1–1.0: bounds + ascending-x invariants hold; at full health the trailing gap is now ≤0.40 period (was up to ~1.94). The only near-1.0 values are at heavy damage, from the intentional dropped-beat degradation (flat tail after a P-wave) — unchanged by this PR.

No `MANUAL.md` change needed: the documented behavior (health shown as a degrading ECG) is unchanged; this only fixes how the trace fills width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)