### PR TITLE
fix(ui): skip select-and-fit when viewport already frames the selection

### DIFF
--- a/js/ui/graph.js
+++ b/js/ui/graph.js
@@ -6,6 +6,7 @@ import { CONTAINER_POLYGON_POINTS, nodeFaceDataUri } from "./node-glyphs.js";
 import { iceStrikeCage } from "./ice-glyphs.js";
 import { ringPoints } from "./overlays/facet.js";
 import { findPath } from "./graph-path.js";
+import { viewportMatchesFit } from "./viewport-fit.js";
 
 // Still playing with what might be the best default here
 // const DEFAULT_LAYOUT_ALGO = "breadthfirst";
@@ -773,9 +774,16 @@ export function syncSelection(nodeId, forceRefit = false) {
       const hop2 = neighborhood.neighborhood(visible);
       neighborhood = neighborhood.add(hop2);
       if (neighborhood.length > 0) {
+        // Skip the fit when the viewport is already framing this neighborhood: an
+        // imperceptible animation would still emit pan/zoom and flash the bloom off
+        // (it's suspended during viewport motion) just as the action menu appears.
+        // Real reframes still animate — and still suspend bloom — as before.
+        const FIT_PADDING = 50;
+        const target = cy.getFitViewport(neighborhood, FIT_PADDING);
+        if (viewportMatchesFit({ zoom: cy.zoom(), pan: cy.pan() }, target)) return;
         cy.stop();
         cy.animate({
-          fit: { eles: neighborhood, padding: 50 },
+          fit: { eles: neighborhood, padding: FIT_PADDING },
           duration: 400,
           easing: "ease-in-out-cubic",
         });

--- a/js/ui/viewport-fit.js
+++ b/js/ui/viewport-fit.js
@@ -1,0 +1,35 @@
+// @ts-check
+// Pure viewport-fit comparison — no DOM, no Cytoscape.
+//
+// The select-and-fit in graph.js pans/zooms to frame the selected node's neighborhood.
+// That animation emits pan/zoom events every frame, which suspend the CRT bloom (a perf
+// measure for real gestures). When the viewport is ALREADY framing the selection, the
+// fit moves nothing yet still animates — flashing the bloom off and back on as the action
+// menu appears. graph.js asks Cytoscape what fit() would produce (cy.getFitViewport) and
+// uses this predicate to skip the animation when it would be imperceptible, so the bloom
+// only dims for fits that actually move the view.
+
+/**
+ * @typedef {{ zoom: number, pan: { x: number, y: number } }} Viewport
+ */
+
+/**
+ * Is the current viewport already at the fit target, within tolerance?
+ *
+ * Zoom is compared relatively (a fixed absolute zoom delta is more noticeable at low zoom
+ * than high), pan as straight-line rendered-pixel distance.
+ *
+ * @param {Viewport} current  the live viewport (cy.zoom() / cy.pan())
+ * @param {Viewport | null | undefined} target  what fit would produce (cy.getFitViewport)
+ * @param {{ zoomTol?: number, panTol?: number }} [tol]
+ *   zoomTol — max relative zoom difference (default 0.02 = 2%)
+ *   panTol  — max pan distance in rendered px (default 3)
+ * @returns {boolean} true if a fit to `target` would be imperceptible and can be skipped
+ */
+export function viewportMatchesFit(current, target, { zoomTol = 0.02, panTol = 3 } = {}) {
+  if (!current || !target) return false;
+  const base = Math.abs(current.zoom) || 1;
+  const relZoom = Math.abs(target.zoom - current.zoom) / base;
+  const panDist = Math.hypot(target.pan.x - current.pan.x, target.pan.y - current.pan.y);
+  return relZoom <= zoomTol && panDist <= panTol;
+}

--- a/js/ui/viewport-fit.test.js
+++ b/js/ui/viewport-fit.test.js
@@ -1,0 +1,41 @@
+// @ts-check
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { viewportMatchesFit } from "./viewport-fit.js";
+
+describe("viewportMatchesFit", () => {
+  const at = (zoom, x, y) => ({ zoom, pan: { x, y } });
+
+  test("exact match → true (a re-fit to the same framing is a no-op)", () => {
+    assert.equal(viewportMatchesFit(at(1.5, 100, 200), at(1.5, 100, 200)), true);
+  });
+
+  test("sub-pixel pan + tiny zoom drift still counts as matched", () => {
+    assert.equal(viewportMatchesFit(at(1.5, 100, 200), at(1.503, 101, 201)), true);
+  });
+
+  test("a real reframe (large pan) → false, so the fit still animates", () => {
+    assert.equal(viewportMatchesFit(at(1.5, 100, 200), at(1.5, 260, 200)), false);
+  });
+
+  test("a real zoom change (>2%) → false", () => {
+    assert.equal(viewportMatchesFit(at(1.0, 100, 200), at(1.2, 100, 200)), false);
+  });
+
+  test("zoom delta is relative to current zoom, not absolute", () => {
+    // 0.05 absolute is 2.5% of zoom 2.0 → exceeds the 2% default → not matched
+    assert.equal(viewportMatchesFit(at(2.0, 0, 0), at(2.05, 0, 0)), false);
+    // same 0.05 absolute is well within tolerance at a higher zoom baseline
+    assert.equal(viewportMatchesFit(at(10.0, 0, 0), at(10.05, 0, 0)), true);
+  });
+
+  test("tolerances are configurable", () => {
+    assert.equal(viewportMatchesFit(at(1.5, 100, 200), at(1.5, 140, 200), { panTol: 50 }), true);
+    assert.equal(viewportMatchesFit(at(1.5, 100, 200), at(1.5, 102, 200), { panTol: 1 }), false);
+  });
+
+  test("null/missing target → false (fall through to animating the fit)", () => {
+    assert.equal(viewportMatchesFit(at(1.5, 100, 200), null), false);
+    assert.equal(viewportMatchesFit(at(1.5, 100, 200), undefined), false);
+  });
+});


### PR DESCRIPTION
Reported: summoning the node action menu dims the CRT bloom, which should only happen on graph movement.

## Root cause

Selecting a node both summons the action menu and schedules a **select-and-fit** `cy.animate({ fit: …, duration: 400 })` (`graph.js` `syncSelection`) that pans+zooms to frame the node + its 2-hop neighborhood. That animation emits `pan`/`zoom` events every frame, and `cy.on("pan zoom", _suspendBloomDuringViewport)` drops the `#cy` bloom to `filter:none` for the duration + restore delay, then ramps it back. So whenever selection changes — exactly when the menu appears — the bloom flashes off and back on, even when the fit barely moves the view.

The bloom-suspend is a real perf win for genuine viewport motion, so we keep it. The waste is the **no-op fits**: re-framing a neighborhood the viewport already shows.

## Fix

Before animating, ask Cytoscape what `fit()` would produce — `cy.getFitViewport(neighborhood, padding)`, the same call `animate({fit})` uses internally — and skip the animation when that target is within tolerance of the current viewport. No animation → no pan/zoom events → no bloom dim. Genuine reframes still animate and still suspend bloom, so the perf benefit is intact.

The tolerance comparison (relative zoom delta + pan distance) lives in a new pure, unit-tested module `js/ui/viewport-fit.js`, matching the project pattern of pure geometry/logic modules consumed by `graph.js`.

## Verification

- TDD: `viewport-fit.test.js` (7 cases) written first against the missing module (RED), then implemented (GREEN). Full suite **1120 pass**, `make lint` clean.
- Wiring verified in the running app (puppeteer + system Chrome), driving selection through the real console→state→`syncSelection` path:
  - Forced a non-matching zoom, then selected a node → fit animates **and** bloom suspends (`filter:none` observed) — perf path intact.
  - With the view already framing the neighborhood, selected a node → fit **skipped**, bloom **does not** dim; menu still summoned.
  - Post-settle, `getFitViewport` target == current viewport exactly, confirming the already-framed classification on live data.

No preview-harness change needed — this suppresses a dim on existing behavior, not a new visual effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)