### PR TITLE
Access-level UX: rename compromised → open + inspector chevron glyph

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,8 @@ Rules:
 1. Player starts at gateway node (accessible); neighbors revealed as `???`
 2. **Probe** a node → reveals vulnerabilities, raises local alert
 3. **Xploit** → pick a card → resolve success/failure vs node grade + vuln match
-4. On success: node access level rises (locked → compromised → owned)
-5. **Dump** a compromised/owned node → reveals macguffins
+4. On success: node access level rises (locked → open → owned)
+5. **Dump** an open/owned node → reveals macguffins
 6. **Fetch** from an owned node → collects macguffins, adds cash to wallet
 7. **Corrupt** an IDS node → disables alert event forwarding to security monitor
 8. Global alert rises as detection nodes fire events to security monitors
@@ -166,7 +166,7 @@ alarms). There is no node-`alertState`-counting global recompute — that legacy
 retired in #173. (Node `alertState` is now purely the per-node visual alert glow.)
 
 **Cooldown (grid-only, below-trace; #174).** The grid can be pushed back down via `coolGrid` in
-`alert.js`: `scrubLogs(monitorId)` (a `scrub-logs` action on a compromised monitor — resets that
+`alert.js`: `scrubLogs(monitorId)` (a `scrub-logs` action on an open monitor — resets that
 monitor's `alertCount`, eases the level one step) and `lieLow(wanNodeId)` (a timed `lie-low` action
 on every WAN node via the shared `LIE_LOW_OPERATOR`/`LIE_LOW_ATTRS` — fully calms the grid to green,
 limited to a couple of uses/run via `lieLowUsesRemaining`/`lieLowExhausted`). Both no-op at trace and

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -113,7 +113,7 @@ Each node in the LAN has a **type** that determines what it does and why you wan
 |-------------------|-------------------|--------------|---------------------------------------------------|
 | **WAN**           | Globe             | Probe        | The network boundary — your tether to the outside. Access the darknet broker here. |
 | **Gateway**       | Portal arch       | Probe        | Entry point. Your foothold into the LAN.          |
-| **Router**        | Four-way arrows   | Compromised  | Routes traffic. Bridges to deeper nodes. Must compromise to see connections. |
+| **Router**        | Four-way arrows   | Open         | Routes traffic. Bridges to deeper nodes. Must open it to see connections. |
 | **Firewall**      | Brick wall        | Owned        | High-security chokepoint. Must fully own to reveal what's beyond. |
 | **Workstation**   | Monitor           | Probe        | User machines. Often soft targets with loose data.|
 | **File Server**   | Rack stack        | Probe        | Where documents live. Usually where your mission target is. |
@@ -125,10 +125,10 @@ Every node is drawn as a 12-sided container holding a small glyph of the device
 it represents, rendered as a glowing vector outline. The glyph (and its color)
 tells you *what kind* of node it is; the container's border plus a fence-hatch
 pattern inside it tell you its *state* — the hatching gets denser as a node goes
-from locked to compromised to owned, and the border color/pulse shows alert.
+from locked to open to owned, and the border color/pulse shows alert.
 
 The **Gate** column shows when a node reveals its connections to neighboring nodes.
-"Probe" means probing the node is enough to see what's connected. "Compromised" or
+"Probe" means probing the node is enough to see what's connected. "Open" or
 "Owned" means you must reach that access level before the node reveals what's beyond it.
 Security infrastructure and chokepoints gate their connections — you can't just scan
 them to map the network.
@@ -160,17 +160,17 @@ specific macguffin, it won't be sitting in a trap node.
 Every node starts **locked**. To use a node you must work through its access levels:
 
 ```
-LOCKED  →  COMPROMISED  →  OWNED
+LOCKED  →  OPEN  →  OWNED
 ```
 
 **Locked** — No access. You can probe it to reveal vulnerabilities.
 
-**Compromised** — Partial access. You can read contents and attempt to escalate.
+**Open** — Partial access. You can read contents and attempt to escalate.
 An IDS at this level can be corrupted to stop forwarding alerts.
 
 **Owned** — Full control. You can fetch macguffins, reboot the node, or kick ICE.
 
-A clean exploit on a **locked** node usually lands you at *compromised*, but a
+A clean exploit on a **locked** node usually lands you at *open*, but a
 high-quality card can punch straight through to **owned** in a single shot,
 skipping the middle step. The better the card, the more often this happens.
 
@@ -285,7 +285,7 @@ improves your odds significantly.
 
 - Base success chance scales with **card quality** (the tick-meter) vs **node grade**
 - A **matching vulnerability** boosts your odds considerably
-- Success: node access level rises (locked → compromised, compromised → owned).
+- Success: node access level rises (locked → open, open → owned).
   A high-quality card can skip the middle step, jumping a locked node straight to
   owned — more likely the better the card's quality meter
 - Success also **counts as a probe** — the node's vulnerabilities are revealed, so a
@@ -298,7 +298,7 @@ improves your odds significantly.
 > dump
 ```
 
-On a compromised or owned node, `dump` extracts data from the node's filesystem —
+On an open or owned node, `dump` extracts data from the node's filesystem —
 data packages, files, anything of value. This takes time, scaled by node grade.
 The node's 12 facets light up in random order as data is extracted. You can cancel
 with `abort`, and navigating away cancels automatically.
@@ -570,7 +570,7 @@ which stays perfectly legible.
 
 ### Subverting the IDS
 
-If you can compromise and then **corrupt** an IDS node:
+If you can open and then **corrupt** an IDS node:
 
 ```
 > exec corrupt
@@ -586,7 +586,7 @@ worth the detour, especially on an ICE-less LAN where the grid is your only cloc
 The security grid climbs, but — below trace — you can also push it back down. Two relief levers
 (both **grid only**: they don't touch ICE, which keeps hunting):
 
-- **Scrub logs** (`exec scrub-logs`) — on a **compromised** security-monitor. Wipes that monitor's
+- **Scrub logs** (`exec scrub-logs`) — on an **open** security-monitor. Wipes that monitor's
   accumulated alerts and eases the global alert one level. Cheap and repeatable.
 - **Lie low** (`exec lie-low`) — at the **WAN node**. You go quiet and *wait* (a timed action — ICE
   keeps moving while you sit). A clock face spins on the WAN node, its edges lighting up as the wait
@@ -626,7 +626,7 @@ your exploit resolves, it will start routing. Cancelling mid-run leaves that sig
 ### ICE Movement
 
 ICE moves every few seconds, traversing the network graph. You can only see ICE when it
-enters a node you **control** (compromised or owned) — it's invisible in the dark territory
+enters a node you **control** (open or owned) — it's invisible in the dark territory
 of unowned nodes. When it moves onto a node you control, a red diamond appears on the graph
 and the log reports its arrival. When a LAN has multiple ICE, each moves on its own
 cadence (set by its grade) and a node you control can be visited by more than one at a time.
@@ -727,14 +727,14 @@ Actions depend on the selected node's type and access level:
 | `probe`           | Node is locked and unprobed                   | Timed scan — reveals vulnerabilities, raises local alert |
 | `abort`           | Timed action in progress on targeted node      | Aborts the current action (probe, xploit, dump, or fetch) |
 | `xploit` (menu) / `xploit <n>` (console) | Node is accessible and not currently exploiting | Opens a node-anchored card picker. Unprobed → all usable cards (blind); probed → only cards matching revealed vulns; disabled with a reason when no card applies. Not offered at all on an already-owned node. The hand strip and `xploit <n>` console command stay full-agency (play any usable card). Raises access level on success. |
-| `dump`         | Node is compromised or owned, unread           | Timed scan — reveals macguffins |
+| `dump`         | Node is open or owned, unread                  | Timed scan — reveals macguffins |
 | `fetch`        | Node is owned + has uncollected macguffins     | Timed extraction — collects macguffins for cash |
 | `mine`         | Node is owned and not exhausted                | Timed data-mining — rolls a yield chance for one exploit card targeting the node's own vuln classes; yield decays per attempt; disappears when the node is exhausted |
-| `exec <script>` | A compromised/owned node exposes node scripts | Lists/runs the node's scripts (corrupt, spoof, unlock-vault, cancel-trace, access-darknet, …) |
-| `corrupt`      | IDS node is compromised or owned               | Severs event forwarding to security monitor (run via `exec`) |
-| `scrub-logs`   | Security-monitor, compromised or owned         | Wipes that monitor's accumulated alerts, eases the global alert one level (below trace; run via `exec`) |
+| `exec <script>` | An open/owned node exposes node scripts       | Lists/runs the node's scripts (corrupt, spoof, unlock-vault, cancel-trace, access-darknet, …) |
+| `corrupt`      | IDS node is open or owned                      | Severs event forwarding to security monitor (run via `exec`) |
+| `scrub-logs`   | Security-monitor, open or owned                | Wipes that monitor's accumulated alerts, eases the global alert one level (below trace; run via `exec`) |
 | `lie-low`      | WAN node, uses remaining this run              | Timed wait that calms the whole grid to green (below trace); limited per run (run via `exec`) |
-| `spoof`        | Security-monitor node, compromised or owned    | Recalibrates security monitor (run via `exec`) |
+| `spoof`        | Security-monitor node, open or owned           | Recalibrates security monitor (run via `exec`) |
 | `kick`         | Owned node + ICE is present here               | Boots ICE to adjacent node |
 | `reboot`       | Owned node, not currently rebooting            | Forces ICE home, node offline briefly |
 | `cancel-trace` | Owned security-monitor + trace active          | Cancels the trace countdown (run via `exec`) |
@@ -802,12 +802,12 @@ vulnerability can mean the difference between a 30% and a 65% success chance.
 
 **Firewalls hide what's behind them.** You won't see any connections beyond a
 firewall, IDS, or security monitor until you own it. Routers require at least
-compromised access. Plan your route — sometimes the soft path through a workstation
+open access. Plan your route — sometimes the soft path through a workstation
 reveals more of the network than hammering on a hardened chokepoint.
 
 **Watch the IDS chain.** Before you start hammering on nodes deep in the network,
 find the IDS nodes and figure out which security monitor they feed. If you can
-compromise and corrupt the IDS first, you can work quietly behind it.
+open and corrupt the IDS first, you can work quietly behind it.
 
 **ICE is predictable once you understand its grade.** A grade-C ICE is drawn to
 disturbances — it will come to where the action is. If you're making noise in one

--- a/css/style.css
+++ b/css/style.css
@@ -841,6 +841,12 @@ html, body {
   vertical-align: middle;
 }
 
+.access-glyph {
+  width: 12px;
+  height: 14px;
+  vertical-align: middle;
+}
+
 .nd-vuln.patched .vuln-name { text-decoration: line-through; color: var(--text-dim); }
 
 .vuln-name  { color: var(--green); }

--- a/data/biomes/corporate-pieces.js
+++ b/data/biomes/corporate-pieces.js
@@ -1185,7 +1185,7 @@ export const serverBank = {
       id: "hub",
       type: "router",
       traits: ["graded", "hackable", "rebootable", "gate"],
-      attributes: { accessLevel: "locked", gateAccess: "compromised" },
+      attributes: { accessLevel: "locked", gateAccess: "open" },
       operators: [{ name: "relay" }],
       actions: [],
     },
@@ -1298,7 +1298,7 @@ export const largeServerBank = {
   id: "large-server-bank",
   description: "Cluster of five lootable fileservers connected to a hub. Rich harvest.",
   nodes: [
-    { id: "hub", type: "router", traits: ["graded", "hackable", "rebootable", "gate"], attributes: { accessLevel: "locked", gateAccess: "compromised" }, operators: [{ name: "relay" }], actions: [] },
+    { id: "hub", type: "router", traits: ["graded", "hackable", "rebootable", "gate"], attributes: { accessLevel: "locked", gateAccess: "open" }, operators: [{ name: "relay" }], actions: [] },
     { id: "server-1", type: "fileserver", traits: ["graded", "hackable", "rebootable", "lootable", "gate"], attributes: { accessLevel: "locked" }, operators: [], actions: [] },
     { id: "server-2", type: "fileserver", traits: ["graded", "hackable", "rebootable", "lootable", "gate"], attributes: { accessLevel: "locked" }, operators: [], actions: [] },
     { id: "server-3", type: "fileserver", traits: ["graded", "hackable", "rebootable", "lootable", "gate"], attributes: { accessLevel: "locked" }, operators: [], actions: [] },
@@ -1494,7 +1494,7 @@ export const dataCenter = {
   id: "data-center",
   description: "Hub connected to six fileservers. Major loot haul for deep runs.",
   nodes: [
-    { id: "hub", type: "router", traits: ["graded", "hackable", "rebootable", "gate"], attributes: { accessLevel: "locked", gateAccess: "compromised" }, operators: [{ name: "relay" }], actions: [] },
+    { id: "hub", type: "router", traits: ["graded", "hackable", "rebootable", "gate"], attributes: { accessLevel: "locked", gateAccess: "open" }, operators: [{ name: "relay" }], actions: [] },
     { id: "server-1", type: "fileserver", traits: ["graded", "hackable", "rebootable", "lootable", "gate"], attributes: { accessLevel: "locked" }, operators: [], actions: [] },
     { id: "server-2", type: "fileserver", traits: ["graded", "hackable", "rebootable", "lootable", "gate"], attributes: { accessLevel: "locked" }, operators: [], actions: [] },
     { id: "server-3", type: "fileserver", traits: ["graded", "hackable", "rebootable", "lootable", "gate"], attributes: { accessLevel: "locked" }, operators: [], actions: [] },
@@ -1894,18 +1894,18 @@ export const entryPoint = {
 
 /**
  * Single router — spine node with multiple outbound ports for branching.
- * Compromise to reveal the network beyond.
+ * Open it to reveal the network beyond.
  * @type {SetPieceDef}
  */
 export const singleRouter = {
   id: "single-router",
-  description: "Router node: compromise to reveal connected segments.",
+  description: "Router node: open it to reveal connected segments.",
   nodes: [
     {
       id: "router",
       type: "router",
       traits: ["graded", "hackable", "rebootable", "gate"],
-      attributes: { accessLevel: "locked", gateAccess: "compromised" },
+      attributes: { accessLevel: "locked", gateAccess: "open" },
       operators: [{ name: "relay" }],
       actions: [],
     },
@@ -2026,7 +2026,7 @@ export const workstationArray = {
       id: "hub",
       type: "router",
       traits: ["graded", "hackable", "rebootable", "gate"],
-      attributes: { accessLevel: "locked", gateAccess: "compromised" },
+      attributes: { accessLevel: "locked", gateAccess: "open" },
       operators: [{ name: "relay" }],
       actions: [],
     },
@@ -2195,7 +2195,7 @@ export const backboneRouter = {
       id: "router",
       type: "router",
       traits: ["graded", "hackable", "rebootable", "gate"],
-      attributes: { accessLevel: "locked", gateAccess: "compromised" },
+      attributes: { accessLevel: "locked", gateAccess: "open" },
       operators: [{ name: "relay" }],
       actions: [],
     },
@@ -2254,7 +2254,7 @@ export const backboneHub = {
       id: "hub",
       type: "router",
       traits: ["graded", "hackable", "rebootable", "gate"],
-      attributes: { accessLevel: "locked", gateAccess: "compromised" },
+      attributes: { accessLevel: "locked", gateAccess: "open" },
       operators: [{ name: "relay" }],
       actions: [],
     },

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -125,7 +125,7 @@ dumb bot hits 0% at A/A without upgrades, but the mechanical levers (deck
 speed, stealth) would directly address the exploit-duration vs ICE-dwell race.
 
 ### Adversarial / ICE
-- **Defender ICE** — instead of detecting and triggering alert, this ICE variant reverses access levels (owned → compromised → locked) as it dwells on a node; creates territory-holding pressure that complements the existing detection model. Would need new ICE behavior type, reverse-access state mutation, and visual feedback distinct from current ICE presence indicator.
+- **Defender ICE** — instead of detecting and triggering alert, this ICE variant reverses access levels (owned → open → locked) as it dwells on a node; creates territory-holding pressure that complements the existing detection model. Would need new ICE behavior type, reverse-access state mutation, and visual feedback distinct from current ICE presence indicator.
 - **ICE reaches into the deck — burns exploits mid-run** — an ICE variant that, on detection/dwell, doesn't just raise alert but attacks the player's *loadout*: it disables or "burns" an exploit card mid-run (the graduated, in-run cousin of capture-burns-loadout). Extends the existing failure-driven `disclose` mechanic in `combat.js`, but ICE-driven rather than player-failure-driven. Pairs with the persistent exploit inventory (see `docs/dev-sessions/2026-06-10-1516-overworld-meta-state/`): once cards are durable inventory instances with stable ids, burning a specific card has lasting cost. Fits the multi-instance / variant-ICE direction in `docs/ICE.md`. _Raised 2026-06-10; future iteration, depends on the meta-state inventory landing first._
 - **Bot player: eject and reboot** — the bot currently never uses eject (push
   ICE to adjacent node) or reboot (force ICE to resident, node goes offline).
@@ -134,13 +134,13 @@ speed, stealth) would directly address the exploit-duration vs ICE-dwell race.
   (requires planning about which node and when) and may be too complex for
   the dumb bot. Both require tracking ICE position (`iceCurrentNode`).
 - **`cheat ice-move <node>`** — cheat command to teleport ICE directly to a node for testing detection scenarios without waiting for ticks
-- **ICE path tracing via traffic analysis daemon** — ICE movements currently invisible until dwell fires; a "traffic analysis daemon" installed on a compromised node could reveal ICE movement logs as events _(part of the log-verbosity-as-mechanic idea below)_
+- **ICE path tracing via traffic analysis daemon** — ICE movements currently invisible until dwell fires; a "traffic analysis daemon" installed on an open node could reveal ICE movement logs as events _(part of the log-verbosity-as-mechanic idea below)_
 - **ICE status readout on owned-node crossings** — when ICE moves through a node you own, the log reports its path but not its behavioral state. A brief status tag (e.g. `[PATROLLING]`, `[ALERTED]`, `[HUNTING]`) in the movement log entry would let the player read ICE intent at a glance — useful for deciding whether to deselect and go dark or commit to an action. Status maps naturally to the existing grade-behavior tiers: D/F = patrolling, B/C with a disturbance target = alerted, A/S or B/C chasing player = hunting.
 
 ### Information Asymmetry (Log Verbosity as Game Mechanic)
 From session-5 design discussion — reframe log verbosity as something the player *earns*:
-- **Traffic analysis daemon** — installed on a compromised node; reveals ICE movements through visible territory in the log
-- **Alert propagation logs** — requires subverting/compromising an IDS; once owned, you see alert events as they propagate to monitors
+- **Traffic analysis daemon** — installed on an open node; reveals ICE movements through visible territory in the log
+- **Alert propagation logs** — requires subverting/opening an IDS; once owned, you see alert events as they propagate to monitors
 - **Deep network telemetry** — high-tier readable nodes contain network maps, revealing hidden nodes or edges without traversal
 - This reframes information asymmetry as diegetic and earned, not a UI toggle
 
@@ -395,7 +395,7 @@ Locked nodes that are accessible show background fill `#080810`, nearly identica
 container background `#0a0a0f`. On most monitors these are visually indistinguishable.
 Consider increasing the fill lightness for locked/accessible nodes to make their presence
 more readable on the graph — without losing the "dark and unowned" feel relative to
-compromised/owned nodes.
+open/owned nodes.
 
 ### Effects (out of scope, recurring)
 - Screenshake on jack-out

--- a/docs/ICE.md
+++ b/docs/ICE.md
@@ -72,7 +72,7 @@ Three atom types, all living in the registry at `js/core/ice/`:
   `cancel-action`, `accelerate`, `broadcast-alert-adjacent`, ...
 
 Effect atoms receive a selector when they need to pick a target. Selector
-grammar: `self-host`, `player-selected`, `random-owned`, `random-compromised`,
+grammar: `self-host`, `player-selected`, `random-owned`, `random-open`,
 `random-revealed`, `adjacent-to-self`, `farthest-from-player`, `stash-tagged`.
 
 ### Catalog
@@ -112,7 +112,7 @@ The graph uses two distinct markers:
 - **Attention cursor** (red diamond) — roaming ICE's current patrol location.
   Follows the ICE as it moves.
 
-Counter-play: `scan-for-ice` action on owned/compromised nodes reveals ICE
+Counter-play: `scan-for-ice` action on owned/open nodes reveals ICE
 without triggering it. Reveals typeId, focus, and pattern; does not reveal
 effects.
 
@@ -165,7 +165,7 @@ with per-ICE actions. Verbs:
 | Verb | Availability | Effect |
 |---|---|---|
 | `uninstall-ice` | Owned host | Removes the instance entirely |
-| `disable-ice` | Compromised host, type-gated | Disables for a short timer (type declares `canTempDisable`) |
+| `disable-ice` | Open host, type-gated | Disables for a short timer (type declares `canTempDisable`) |
 | `swap-pattern` | Owned host, type-gated | Swap behavior pattern from an allowed set |
 | `reprogram-effects` | Owned host, type-gated | Swap effect atoms from an allowed set |
 

--- a/docs/PROCGEN.md
+++ b/docs/PROCGEN.md
@@ -310,7 +310,7 @@ ensures the forced piece is reachable.
 **More set pieces.** The careless-user piece demonstrates the concept but one piece is a
 thin library. Candidates: honeypot (appears to be a juicy target but triggers silent
 alert), network tap (hidden router branch, suggests a second party is already inside),
-air-gap bridge (isolated subnet accessible only through a specific compromised node).
+air-gap bridge (isolated subnet accessible only through a specific open node).
 
 **Biome blending.** The layer-processor is strictly sequential, but nothing prevents a
 layer from referencing roles defined in a "mixin" bundle. A corporate network with a

--- a/docs/superpowers/plans/2026-06-13-access-level-chevron-glyph.md
+++ b/docs/superpowers/plans/2026-06-13-access-level-chevron-glyph.md
@@ -1,0 +1,367 @@
+# Access-level Chevron Glyph Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a stroke-only chevron glyph to the node inspector header that encodes access tier (locked/open/owned) by lit-chevron count, colored to match the node fence ramp, making access glance-legible.
+
+**Architecture:** A new pure SVG generator (`accessGlyphSvg`) in `js/ui/indicator-glyphs.js` alongside the existing alert-lamp/tick-meter generators, following their exact conventions (stroke-only, baked-in glow, deterministic, no DOM). The context-menu inspector header renders it as a data-URI `<img>` next to the existing access text label. A preview-harness swatch row lets us tune it without playing to the right game state.
+
+**Tech Stack:** Vanilla ES modules, JSDoc `@ts-check`, Lit (light-DOM component), `node:test` unit tests.
+
+**Spec:** `docs/superpowers/specs/2026-06-13-access-level-chevron-glyph-design.md` · **Approved mockup:** `…-mockup.html` (Treatment A — unified color).
+
+**Branch & PR:** Work continues on the current branch `worktree-rename-compromised-cracked`. This feature builds directly on the `compromised → open` rename (it lights chevrons for the value `"open"`) and is in the same access-level UX area, so it extends PR #211 rather than opening a stacked PR. The final step broadens the PR title/body to cover both changes. (If you'd rather keep PRs single-concern, branch off here instead — noted at handoff.)
+
+---
+
+## File structure
+
+- `js/ui/indicator-glyphs.js` — **modify**: add `ACCESS` palette, `ACCESS_LIT` count map, `CHEVRONS` geometry, `accessGlyphSvg`, `accessGlyphDataUri`. (Owns all stroke-only indicator geometry.)
+- `js/ui/indicator-glyphs.test.js` — **modify**: add an `accessGlyphSvg` describe block.
+- `js/ui/components/starnet-context-menu.js` — **modify**: import `accessGlyphDataUri`; render it in the `insp-meta` row.
+- `css/style.css` — **modify**: add `.access-glyph` sizing rule.
+- `js/ui/preview-cards.js` — **modify**: import `accessGlyphDataUri`; add an "Access level" swatch row.
+
+---
+
+## Task 1: `accessGlyphSvg` / `accessGlyphDataUri` generator (TDD)
+
+**Files:**
+- Modify: `js/ui/indicator-glyphs.js`
+- Test: `js/ui/indicator-glyphs.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+In `js/ui/indicator-glyphs.test.js`, add the two new names to the existing import block (top of file):
+
+```js
+import {
+  alertLampSvg,
+  alertLampDataUri,
+  connStatusSvg,
+  connStatusDataUri,
+  tickMeterSvg,
+  tickMeterDataUri,
+  missionMarkSvg,
+  missionMarkDataUri,
+  accessGlyphSvg,
+  accessGlyphDataUri,
+} from "./indicator-glyphs.js";
+```
+
+Then add this describe block just before the final `// ── dataUri helpers` describe (the helper functions `countOccurrences`, `countPoints` already exist at the top of the file):
+
+```js
+  // ── accessGlyphSvg ────────────────────────────────────────────────────────────
+
+  describe("accessGlyphSvg", () => {
+    /** lit chevrons render at stroke-width 1.8; dim at 1.4. */
+    const litCount = (svg) => countOccurrences(svg, `stroke-width="1.8"`);
+
+    test("always renders exactly 3 chevron polylines", () => {
+      for (const lvl of ["locked", "open", "owned", "—", "nonsense"]) {
+        assert.equal(countOccurrences(accessGlyphSvg(lvl), "<polyline"), 3,
+          `expected 3 polylines for "${lvl}"`);
+      }
+    });
+
+    test("locked → 1 lit chevron", () => {
+      assert.equal(litCount(accessGlyphSvg("locked")), 1);
+    });
+    test("open → 2 lit chevrons", () => {
+      assert.equal(litCount(accessGlyphSvg("open")), 2);
+    });
+    test("owned → 3 lit chevrons", () => {
+      assert.equal(litCount(accessGlyphSvg("owned")), 3);
+    });
+    test("unknown / obscured (—) → 0 lit chevrons", () => {
+      assert.equal(litCount(accessGlyphSvg("—")), 0);
+      assert.equal(litCount(accessGlyphSvg("nonsense")), 0);
+    });
+
+    test("locked lit hue is teal #45c4c4", () => {
+      assert.ok(accessGlyphSvg("locked").includes("#45c4c4"));
+    });
+    test("open lit hue is azure #36a6e0", () => {
+      assert.ok(accessGlyphSvg("open").includes("#36a6e0"));
+    });
+    test("owned lit hue is green-teal #2ad17a", () => {
+      assert.ok(accessGlyphSvg("owned").includes("#2ad17a"));
+    });
+
+    test("unreached chevrons use the dim color #2a3a55", () => {
+      // locked has 2 dim chevrons, open has 1.
+      assert.ok(accessGlyphSvg("locked").includes("#2a3a55"));
+      assert.ok(accessGlyphSvg("open").includes("#2a3a55"));
+    });
+    test("owned has no dim chevrons (no #2a3a55)", () => {
+      assert.ok(!accessGlyphSvg("owned").includes("#2a3a55"));
+    });
+
+    test("stroke-only: top-level fill=none, no shape fill in body", () => {
+      const svg = accessGlyphSvg("open");
+      assert.ok(svg.includes(`fill="none"`));
+      const body = svg.slice(svg.indexOf(">") + 1);
+      assert.ok(!body.includes(`fill="#`), `body has a shape fill: ${body}`);
+    });
+
+    test("deterministic: identical args → identical string", () => {
+      assert.equal(accessGlyphSvg("open"), accessGlyphSvg("open"));
+    });
+
+    test("accessGlyphDataUri starts with data:image/svg+xml,", () => {
+      assert.ok(accessGlyphDataUri("owned").startsWith("data:image/svg+xml,"));
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `node --test js/ui/indicator-glyphs.test.js`
+Expected: FAIL — `accessGlyphSvg`/`accessGlyphDataUri` are `undefined` (import resolves to undefined; calling them throws "is not a function").
+
+- [ ] **Step 3: Implement the generator**
+
+In `js/ui/indicator-glyphs.js`, add this block after the `missionMarkSvg`/`missionMarkDataUri` section (near the end of the file, before any trailing export aggregation if present). It reuses the module-level `DIM` constant and the `dataUri` helper already defined at the top of the file:
+
+```js
+// ── accessGlyphSvg ────────────────────────────────────────────────────────────
+// Three stacked point-up chevrons; lit-from-the-bottom count encodes the access
+// tier (colorblind-safe: count is the primary channel). Lit chevrons take the
+// current level's hue — the glance-legible bright sibling of the node fence ramp
+// in node-glyphs.js (which is intentionally dimmed so the node border stays
+// brightest). Deliberately NOT the alert green/amber/red ramp, so it never reads
+// as alert state even sitting beside the alert lamp.
+
+/** Bright header hues, by access level. @type {Record<string, string>} */
+const ACCESS = {
+  locked: "#45c4c4", // bright teal
+  open:   "#36a6e0", // bright azure
+  owned:  "#2ad17a", // bright green-teal (kept teal-ward to stay clear of alert green)
+};
+
+/** Lit-chevron count, by access level. @type {Record<string, number>} */
+const ACCESS_LIT = { locked: 1, open: 2, owned: 3 };
+
+/** Chevron polylines (viewBox 0 0 16 18), ordered bottom → top. */
+const CHEVRONS = [
+  "3,16.5 8,13 13,16.5",
+  "3,11.5 8,8 13,11.5",
+  "3,6.5 8,3 13,6.5",
+];
+
+/**
+ * Access-level indicator: 3 stacked chevrons, lit from the bottom up by tier.
+ *   locked → 1 lit · open → 2 lit · owned → 3 lit · anything else → 0 lit.
+ * Lit chevrons use the level hue (stroke 1.8 + glow); unreached use DIM (stroke 1.4).
+ *
+ * @param {string} accessLevel
+ * @returns {string} standalone SVG markup
+ */
+export function accessGlyphSvg(accessLevel) {
+  const lit = ACCESS_LIT[accessLevel] ?? 0;
+  const color = ACCESS[accessLevel] ?? DIM;
+  let body = "";
+  for (let i = 0; i < CHEVRONS.length; i++) {
+    const isLit = i < lit;
+    body += `<polyline points="${CHEVRONS[i]}"`
+          + ` stroke="${isLit ? color : DIM}"`
+          + ` stroke-width="${isLit ? 1.8 : 1.4}"/>`;
+  }
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 18" fill="none" stroke-linecap="round" stroke-linejoin="round">`
+    + `<defs><filter id="g" x="-50%" y="-50%" width="200%" height="200%"><feDropShadow dx="0" dy="0" stdDeviation="1.4" flood-color="${color}"/></filter></defs>`
+    + `<g filter="url(#g)">${body}</g></svg>`;
+}
+
+/**
+ * Access glyph as an `<img src>`-ready data URI.
+ * @param {string} accessLevel
+ * @returns {string}
+ */
+export function accessGlyphDataUri(accessLevel) {
+  return dataUri(accessGlyphSvg(accessLevel));
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `node --test js/ui/indicator-glyphs.test.js`
+Expected: PASS — all new `accessGlyphSvg` tests green, existing tests unaffected.
+
+- [ ] **Step 5: Lint**
+
+Run: `make lint`
+Expected: no errors (the `@type {Record<string, …>}` annotations let tsc accept the string-indexed lookups).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add js/ui/indicator-glyphs.js js/ui/indicator-glyphs.test.js
+git commit -m 'Add accessGlyphSvg: 3-chevron access-level indicator' \
+  -m 'Stroke-only stacked chevrons, lit bottom-up by tier (locked=1/open=2/owned=3),
+colored to match the node fence ramp; deliberately not the alert ramp. Pure
+deterministic generator alongside the other indicator glyphs.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>'
+```
+
+---
+
+## Task 2: Render the glyph in the inspector header
+
+**Files:**
+- Modify: `js/ui/components/starnet-context-menu.js:16` (import) and `:124` (markup)
+- Modify: `css/style.css` (after `.nd-lamp`, ~line 842)
+
+- [ ] **Step 1: Add the import**
+
+In `js/ui/components/starnet-context-menu.js`, change line 16 from:
+
+```js
+import { alertLampDataUri } from "../indicator-glyphs.js";
+```
+
+to:
+
+```js
+import { alertLampDataUri, accessGlyphDataUri } from "../indicator-glyphs.js";
+```
+
+- [ ] **Step 2: Add the glyph to the access cell**
+
+In the `_renderHeader` method, replace the access `<span>` (line 124):
+
+```js
+            <span class="im-val">${(node.accessLevel || "—").toUpperCase()}</span>
+```
+
+with (glyph before the label, mirroring the alert-lamp cell two lines below it):
+
+```js
+            <span class="im-val"><img class="access-glyph" alt="" src=${accessGlyphDataUri(node.accessLevel)}> ${(node.accessLevel || "—").toUpperCase()}</span>
+```
+
+- [ ] **Step 3: Add the CSS rule**
+
+In `css/style.css`, add immediately after the `.nd-lamp { … }` block (which ends at line 842):
+
+```css
+.access-glyph {
+  width: 12px;
+  height: 14px;
+  vertical-align: middle;
+}
+```
+
+- [ ] **Step 4: Lint**
+
+Run: `make lint`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/ui/components/starnet-context-menu.js css/style.css
+git commit -m 'Show access-level chevron glyph in the inspector header' \
+  -m 'Renders accessGlyphDataUri(node.accessLevel) beside the access label in the
+insp-meta row, mirroring the adjacent alert lamp. Text label retained for
+console/LLM-legibility.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>'
+```
+
+---
+
+## Task 3: Add the glyph to the preview harness
+
+**Files:**
+- Modify: `js/ui/preview-cards.js` (import block ~lines 12-16, and `mountIndicatorSwatches`)
+
+- [ ] **Step 1: Add the import**
+
+In `js/ui/preview-cards.js`, add `accessGlyphDataUri` to the existing import from `./indicator-glyphs.js`:
+
+```js
+import {
+  alertLampDataUri,
+  connStatusDataUri,
+  tickMeterDataUri,
+  missionMarkDataUri,
+  accessGlyphDataUri,
+} from "./indicator-glyphs.js";
+```
+
+- [ ] **Step 2: Add an "Access level" swatch row**
+
+In `mountIndicatorSwatches`, add this block at the end of the function (after the "Mission marks" loop, before the closing `}`):
+
+```js
+  // Access level — 3-chevron tier badge (lit bottom-up by tier)
+  row("Access level");
+  for (const level of ["locked", "open", "owned"]) {
+    container.appendChild(cell(accessGlyphDataUri(level), level));
+  }
+```
+
+- [ ] **Step 3: Lint**
+
+Run: `make lint`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add js/ui/preview-cards.js
+git commit -m 'Add access-level glyph swatches to the preview harness' \
+  -m 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>'
+```
+
+---
+
+## Task 4: Verify (tests + visual) and finalize
+
+**Files:** none (verification + PR update)
+
+- [ ] **Step 1: Full check**
+
+Run: `make check`
+Expected: lint clean; all tests pass (1137 prior + the new `accessGlyphSvg` cases).
+
+- [ ] **Step 2: Visual check in the preview harness**
+
+Run: `make bundle-vendor` (if not already built), then open `http://localhost:35345/preview.html` (the dev server from `make dev` is already running; the port may differ — check the server output).
+Expected: the **Indicators** panel shows an "Access level" row with three chevron badges — locked (1 teal chevron + 2 dim), open (2 azure + 1 dim), owned (3 green-teal). Confirm at widget size the chevrons are crisp, the glow reads, and the three states are distinguishable by count alone (squint test).
+
+- [ ] **Step 3: Visual check in the live inspector header**
+
+Open `http://localhost:35345/` (the game). Probe then exploit a node to reach `open` (or use the playtest harness flow). Click the node to open the context menu / inspector header.
+Expected: the `GRADE · ACCESS · ALERT` row shows the chevron glyph immediately left of the access word (`OPEN`), in the access hue, visibly distinct from the green/amber/red alert lamp at the end of the row. Verify a `locked` (unprobed-but-revealed) node shows 1 lit chevron and an obscured node shows the all-dim glyph without error.
+
+- [ ] **Step 4: Tune if needed, then commit any adjustment**
+
+If the visual check calls for a tweak (hue, `width/height` in `.access-glyph`, glow `stdDeviation`, chevron spacing), make the smallest change, re-run `make check`, and commit:
+
+```bash
+git add -A
+git commit -m 'Tune access-glyph sizing/hue after visual check' \
+  -m 'Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>'
+```
+
+If no tweak is needed, skip this commit.
+
+- [ ] **Step 5: Push and broaden PR #211**
+
+```bash
+git push
+gh pr edit 211 --title 'Access-level UX: rename "compromised" → "open" + inspector chevron glyph'
+```
+
+Add a section to the PR body summarizing the glyph feature (link the spec + mockup), or post a comment noting the added commits. Confirm CI is green.
+
+---
+
+## Self-review
+
+- **Spec coverage:** generator (Task 1) ✓; header integration + label retained (Task 2) ✓; `.access-glyph` CSS (Task 2) ✓; preview harness (Task 3) ✓; tests for count/hue/dim/stroke-only/unknown (Task 1) ✓; obscured = all-dim, no new log/event, fence unchanged (Tasks 1/2 + non-goals honored — no graph.js/node-glyphs.js edits) ✓; visual verification incl. alert-lamp distinctness and obscured case (Task 4) ✓.
+- **Placeholder scan:** none — every code step shows complete code; every command has expected output.
+- **Type consistency:** `accessGlyphSvg` / `accessGlyphDataUri` names match across the generator, tests, context-menu import, and preview-cards import. `ACCESS`, `ACCESS_LIT`, `CHEVRONS`, `DIM`, `dataUri` all defined/available in `indicator-glyphs.js`. Lit-detection in tests (`stroke-width="1.8"`) matches the implementation's emitted attribute exactly.

--- a/docs/superpowers/specs/2026-06-13-access-level-chevron-glyph-design.md
+++ b/docs/superpowers/specs/2026-06-13-access-level-chevron-glyph-design.md
@@ -1,0 +1,135 @@
+# Access-level chevron glyph in the inspector header — Design
+
+**Date:** 2026-06-13
+**Status:** Approved (design); pending implementation plan
+**Branch context:** follows the `compromised → open` rename (PR #211)
+**Approved mockup:** [`2026-06-13-access-level-chevron-glyph-mockup.html`](./2026-06-13-access-level-chevron-glyph-mockup.html) (Treatment A selected)
+
+## Motivation
+
+The node inspector header (`starnet-context-menu.js`, the `insp-meta` row) shows access
+level as plain uppercase text — `GRADE C · OPEN · ▲ GREEN`. Access level is the single most
+important "where am I in breaking this node" signal, but as bare text it's not glance-legible.
+We want a small stroke-only vector glyph beside the label that encodes the access tier and how
+much headroom remains, consistent with the game's existing indicator vocabulary.
+
+## Decisions (settled during brainstorming)
+
+1. **Glyph = three stacked, point-up chevrons.** Reached levels are lit; not-yet-reached levels
+   are dim — so the player can see the *ceiling* they can still climb to.
+   - `locked` → bottom chevron lit, top two dim
+   - `open` → bottom two lit, top dim
+   - `owned` → all three lit
+   - obscured / unknown access → all three dim
+2. **Color = the node's own fence ramp (unified treatment "A").** Lit chevrons all take the
+   *current level's* single hue — the glance-legible bright sibling of the node fence color.
+   This reuses the access color language already on the graph node and deliberately avoids the
+   green/amber/red **alert** ramp shown by the lamp immediately to its right (no semantic clash).
+   Shape (chevron count) is the primary colorblind-safe channel; color reinforces.
+3. **Integration point = the context-menu inspector header only.** The graph node's fence-hatch
+   encoding is unchanged; the HUD is unchanged. (`starnet-node-panel.js` does not exist / does not
+   render access, so there is a single integration site.)
+4. **The text label stays.** The glyph is reinforcement; keeping the word `OPEN` preserves
+   console/LLM-legibility and GUI/console symmetry. No new game event or log line is introduced —
+   this visualizes the existing `accessLevel`, whose changes already log via the exploit flow.
+
+## Detailed design
+
+### New pure functions — `js/ui/indicator-glyphs.js`
+
+Add alongside the existing `alertLampSvg` / `tickMeterSvg`, following the same conventions
+(stroke-only, `fill="none"`, baked-in phosphene drop-shadow glow, no DOM, deterministic):
+
+```
+accessGlyphSvg(accessLevel: string): string        // standalone SVG markup
+accessGlyphDataUri(accessLevel: string): string     // <img src>-ready data URI
+```
+
+**Access palette** — add bright siblings of the node fence ramp (the fence colors in
+`node-glyphs.js` are intentionally dimmed "so the border stays brightest"; the header indicator
+must pop). Documented as the bright counterpart so the two ramps stay in the same hue family:
+
+| level   | lit chevrons | hue            |
+|---------|--------------|----------------|
+| locked  | 1            | `#45c4c4` teal |
+| open    | 2            | `#36a6e0` blue |
+| owned   | 3            | `#2ad17a` green-teal |
+| (other) | 0            | — (all dim)    |
+
+`owned` leans green-*teal* rather than pure green to keep visual distance from the alert lamp's
+pure green (`#39ff7a`); the differing shape (3 chevrons vs hexagon) is the real disambiguator.
+
+Dim chevrons reuse the existing `DIM = #2a3a55` constant at a thinner stroke, no glow.
+
+**Geometry** (viewBox `0 0 16 18`, three point-up chevrons, filled bottom-up):
+
+```
+top    (level 3): polyline "3,6.5  8,3  13,6.5"
+mid    (level 2): polyline "3,11.5 8,8  13,11.5"
+bottom (level 1): polyline "3,16.5 8,13 13,16.5"
+```
+
+Lit stroke width ~1.8 with a `drop-shadow`/`feDropShadow` glow in the level hue; dim stroke ~1.4,
+no glow. Built manually (like `tickMeterSvg`) to allow per-chevron stroke colors under one glow
+filter colored by the current level's hue.
+
+**Lit count mapping** — a small internal `{ locked: 1, open: 2, owned: 3 }` lookup; anything else
+(including the obscured placeholder `"—"`) → 0 lit. This is the only place that encodes the ladder
+order; keep it adjacent to the palette.
+
+### Integration — `js/ui/components/starnet-context-menu.js`
+
+In the `insp-meta` row, the access `<span>` becomes an image + label, mirroring the adjacent
+alert-lamp markup (`<img class="nd-lamp" …> GREEN`):
+
+```html
+<img class="access-glyph" alt="" src=${accessGlyphDataUri(node.accessLevel)}>
+<span class="im-val">${(node.accessLevel || "—").toUpperCase()}</span>
+```
+
+Obscured nodes (where `accessLevel` is absent/`"—"`) render the all-dim glyph — consistent with
+the existing `"—"` text fallback.
+
+### CSS — `css/style.css`
+
+Add `.access-glyph` mirroring `.nd-lamp` (style.css:838) for inline sizing/vertical-alignment.
+
+### Preview harness — `preview.html` / `js/ui/preview.js`
+
+Per the project rule that new visual effects go in the preview harness: add the three access-glyph
+states (locked / open / owned) plus the obscured all-dim state so the chevron geometry and glow can
+be tuned without playing to the right game state. Render via the same `accessGlyphSvg` so the harness
+and live UI never drift.
+
+### Tests — `js/ui/indicator-glyphs.test.js`
+
+Extend the existing suite (pure function, deterministic output):
+
+- lit-chevron count per level: `locked` → 1 lit, `open` → 2, `owned` → 3, unknown/`"—"` → 0
+- correct lit hue per level (teal / blue / green-teal)
+- dim chevrons use `#2a3a55`
+- stroke-only: no `fill` other than `none`
+- output is a well-formed standalone `<svg>` (matches the shape of `alertLampSvg` assertions)
+
+## Non-goals
+
+- No change to the graph node's fence-hatch access encoding.
+- No change to the HUD.
+- No new game event, state field, or log line (visualizes existing `accessLevel`).
+- No change to the access ladder order or values.
+
+## Risks / edge cases
+
+- **Color proximity to alert green** — handled by hue choice (green-teal vs pure green) and, more
+  importantly, by shape (chevrons vs hexagon). Verify in the running game, not just the mockup.
+- **Obscured nodes** — must render the all-dim glyph, not crash or show a stray lit chevron.
+- **Drift between harness and live UI** — both must call the same `accessGlyphSvg`; never hand-author
+  the SVG twice.
+
+## Files touched
+
+- `js/ui/indicator-glyphs.js` — new `accessGlyphSvg` / `accessGlyphDataUri` + `ACCESS` palette
+- `js/ui/indicator-glyphs.test.js` — new tests
+- `js/ui/components/starnet-context-menu.js` — header integration
+- `css/style.css` — `.access-glyph`
+- `preview.html` / `js/ui/preview.js` — harness demo

--- a/docs/superpowers/specs/2026-06-13-access-level-chevron-glyph-mockup.html
+++ b/docs/superpowers/specs/2026-06-13-access-level-chevron-glyph-mockup.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Access-level chevron glyph — approved mockup (Treatment A)</title>
+<style>
+  :root { color-scheme: dark; }
+  body {
+    background:#08080d; color:#9fc; font-family:ui-monospace,Menlo,monospace;
+    margin:0; padding:32px; line-height:1.5;
+  }
+  .wrap { max-width:820px; margin:0 auto; }
+  h2 { color:#8fe6d6; font-weight:600; letter-spacing:.03em; }
+  h3 { color:#a9e6da; margin:0 0 6px; }
+  .subtitle { color:#5a7d78; }
+  code { background:#11202a; padding:1px 5px; border-radius:3px; color:#7fd6c9; }
+  .note { color:#c9a23a; }
+  .cards { display:flex; gap:20px; flex-wrap:wrap; margin-top:18px; }
+  .card { flex:1 1 340px; border:1px solid #16343a; border-radius:6px; overflow:hidden; background:#0c0c12; }
+  .card.chosen { border-color:#2ad17a; box-shadow:0 0 0 1px #2ad17a44; }
+  .card-image { padding:14px; }
+  .card-body { padding:12px 14px; border-top:1px solid #16343a; }
+  .card-body p { color:#7a9c97; margin:6px 0 0; font-size:13px; }
+  .cap { color:#5a7d78; font-size:12px; margin:0 0 10px; }
+  .ins {
+    background:#0a0a0f; border:1px solid #16343a; border-radius:4px;
+    padding:10px 14px; margin:8px 0; display:flex; align-items:center; gap:10px;
+    font-size:14px; letter-spacing:.06em;
+  }
+  .ins .k{ color:#3a6b6b; } .ins .sep{ color:#2a4444; } .ins .val{ color:#a9e6da; }
+  .ins svg{ vertical-align:middle; }
+  .lvl{ display:inline-block; min-width:78px; }
+  .tag { display:inline-block; font-size:11px; color:#2ad17a; border:1px solid #2ad17a55;
+         border-radius:3px; padding:1px 6px; margin-left:8px; vertical-align:middle; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h2>Access-level chevron glyph — inspector header <span class="tag">APPROVED: Treatment A</span></h2>
+  <p class="subtitle">Companion mockup archived from the 2026-06-13 brainstorming session. Three stacked
+  chevrons, reached levels lit in the current level's hue, unreached dim — shown in the real
+  <code>GRADE · ACCESS · ALERT</code> row beside the alert lamp on the game's <code>#0a0a0f</code> background.
+  Treatment A (unified color) was selected. Treatment B (per-tier hue) is recorded below for context.</p>
+
+  <div class="cards">
+
+    <!-- Treatment A — selected -->
+    <div class="card chosen">
+      <div class="card-image">
+        <div class="cap">A · UNIFIED — all lit chevrons share the current level's color (SELECTED)</div>
+
+        <div class="ins">
+          <span class="k">GRADE</span><span class="val">C</span><span class="sep">·</span>
+          <svg width="20" height="22" viewBox="0 0 16 18" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3,6.5 8,3 13,6.5"    stroke="#2a3a55" stroke-width="1.4"/>
+            <polyline points="3,11.5 8,8 13,11.5"  stroke="#2a3a55" stroke-width="1.4"/>
+            <polyline points="3,16.5 8,13 13,16.5" stroke="#45c4c4" stroke-width="1.8" style="filter:drop-shadow(0 0 2px #45c4c4)"/>
+          </svg>
+          <span class="val lvl">LOCKED</span><span class="sep">·</span>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><polygon points="8,1.6 13.5,4.8 13.5,11.2 8,14.4 2.5,11.2 2.5,4.8" stroke="#39ff7a" stroke-width="1.8" style="filter:drop-shadow(0 0 1.6px #39ff7a)"/></svg>
+          <span style="color:#39ff7a">GREEN</span>
+        </div>
+
+        <div class="ins">
+          <span class="k">GRADE</span><span class="val">C</span><span class="sep">·</span>
+          <svg width="20" height="22" viewBox="0 0 16 18" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3,6.5 8,3 13,6.5"    stroke="#2a3a55" stroke-width="1.4"/>
+            <polyline points="3,11.5 8,8 13,11.5"  stroke="#36a6e0" stroke-width="1.8" style="filter:drop-shadow(0 0 2px #36a6e0)"/>
+            <polyline points="3,16.5 8,13 13,16.5" stroke="#36a6e0" stroke-width="1.8" style="filter:drop-shadow(0 0 2px #36a6e0)"/>
+          </svg>
+          <span class="val lvl">OPEN</span><span class="sep">·</span>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><polygon points="8,2.5 13.5,13.5 2.5,13.5" stroke="#c9d11e" stroke-width="1.8" style="filter:drop-shadow(0 0 1.6px #c9d11e)"/></svg>
+          <span style="color:#c9d11e">YELLOW</span>
+        </div>
+
+        <div class="ins">
+          <span class="k">GRADE</span><span class="val">C</span><span class="sep">·</span>
+          <svg width="20" height="22" viewBox="0 0 16 18" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3,6.5 8,3 13,6.5"    stroke="#2ad17a" stroke-width="1.8" style="filter:drop-shadow(0 0 2px #2ad17a)"/>
+            <polyline points="3,11.5 8,8 13,11.5"  stroke="#2ad17a" stroke-width="1.8" style="filter:drop-shadow(0 0 2px #2ad17a)"/>
+            <polyline points="3,16.5 8,13 13,16.5" stroke="#2ad17a" stroke-width="1.8" style="filter:drop-shadow(0 0 2px #2ad17a)"/>
+          </svg>
+          <span class="val lvl">OWNED</span><span class="sep">·</span>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><polygon points="2.5,2.5 13.5,2.5 8,13.5" stroke="#ff5a4d" stroke-width="1.8" style="filter:drop-shadow(0 0 1.6px #ff5a4d)"/></svg>
+          <span style="color:#ff5a4d">RED</span>
+        </div>
+      </div>
+      <div class="card-body">
+        <h3>A · Unified color</h3>
+        <p>The whole badge takes on the current level's hue (teal→blue→green-teal). Count shows progress;
+        one color reads cleanly at 16px. Matches how the tick-meter colors all lit ticks one tier color.</p>
+      </div>
+    </div>
+
+    <!-- Treatment B — not selected, kept for context -->
+    <div class="card">
+      <div class="card-image">
+        <div class="cap">B · PER-TIER — each chevron has a fixed hue; dim until reached (not selected)</div>
+
+        <div class="ins">
+          <span class="k">GRADE</span><span class="val">C</span><span class="sep">·</span>
+          <svg width="20" height="22" viewBox="0 0 16 18" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3,6.5 8,3 13,6.5"    stroke="#2a3a55" stroke-width="1.4"/>
+            <polyline points="3,11.5 8,8 13,11.5"  stroke="#2a3a55" stroke-width="1.4"/>
+            <polyline points="3,16.5 8,13 13,16.5" stroke="#45c4c4" stroke-width="1.8" style="filter:drop-shadow(0 0 2px #45c4c4)"/>
+          </svg>
+          <span class="val lvl">LOCKED</span><span class="sep">·</span>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><polygon points="8,1.6 13.5,4.8 13.5,11.2 8,14.4 2.5,11.2 2.5,4.8" stroke="#39ff7a" stroke-width="1.8" style="filter:drop-shadow(0 0 1.6px #39ff7a)"/></svg>
+          <span style="color:#39ff7a">GREEN</span>
+        </div>
+
+        <div class="ins">
+          <span class="k">GRADE</span><span class="val">C</span><span class="sep">·</span>
+          <svg width="20" height="22" viewBox="0 0 16 18" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3,6.5 8,3 13,6.5"    stroke="#2a3a55" stroke-width="1.4"/>
+            <polyline points="3,11.5 8,8 13,11.5"  stroke="#36a6e0" stroke-width="1.8" style="filter:drop-shadow(0 0 2px #36a6e0)"/>
+            <polyline points="3,16.5 8,13 13,16.5" stroke="#45c4c4" stroke-width="1.8" style="filter:drop-shadow(0 0 2px #45c4c4)"/>
+          </svg>
+          <span class="val lvl">OPEN</span><span class="sep">·</span>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><polygon points="8,2.5 13.5,13.5 2.5,13.5" stroke="#c9d11e" stroke-width="1.8" style="filter:drop-shadow(0 0 1.6px #c9d11e)"/></svg>
+          <span style="color:#c9d11e">YELLOW</span>
+        </div>
+
+        <div class="ins">
+          <span class="k">GRADE</span><span class="val">C</span><span class="sep">·</span>
+          <svg width="20" height="22" viewBox="0 0 16 18" fill="none" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="3,6.5 8,3 13,6.5"    stroke="#2ad17a" stroke-width="1.8" style="filter:drop-shadow(0 0 2px #2ad17a)"/>
+            <polyline points="3,11.5 8,8 13,11.5"  stroke="#36a6e0" stroke-width="1.8" style="filter:drop-shadow(0 0 2px #36a6e0)"/>
+            <polyline points="3,16.5 8,13 13,16.5" stroke="#45c4c4" stroke-width="1.8" style="filter:drop-shadow(0 0 2px #45c4c4)"/>
+          </svg>
+          <span class="val lvl">OWNED</span><span class="sep">·</span>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><polygon points="2.5,2.5 13.5,2.5 8,13.5" stroke="#ff5a4d" stroke-width="1.8" style="filter:drop-shadow(0 0 1.6px #ff5a4d)"/></svg>
+          <span style="color:#ff5a4d">RED</span>
+        </div>
+      </div>
+      <div class="card-body">
+        <h3>B · Per-tier hue</h3>
+        <p>Bottom chevron always teal, middle always blue, top always green-teal — the "frontier" is where
+        it goes dim. More information per glance, but busier and the ramp is subtle at 16px.</p>
+      </div>
+    </div>
+
+  </div>
+
+  <p class="subtitle" style="margin-top:20px;">See the companion design doc:
+  <code>docs/superpowers/specs/2026-06-13-access-level-chevron-glyph-design.md</code></p>
+</div>
+</body>
+</html>

--- a/js/core/alert.js
+++ b/js/core/alert.js
@@ -184,7 +184,7 @@ function coolGrid(monitorIds, mode) {
 }
 
 /**
- * Scrub one compromised monitor's logs: reset its accumulated alertCount and ease the global
+ * Scrub one open monitor's logs: reset its accumulated alertCount and ease the global
  * alert one level. Below-trace only. (Player relief lever — see #174.)
  * @param {string} monitorId
  */

--- a/js/core/combat.js
+++ b/js/core/combat.js
@@ -26,7 +26,7 @@ export { GRADE_MODIFIER, MATCH_BONUS, SUCCESS_CAP, PATCH_LAG };
 
 /**
  * Chance that a successful exploit jumps from locked directly to owned,
- * skipping the compromised step. Driven by exploit quality.
+ * skipping the open step. Driven by exploit quality.
  * @param {ExploitCard} exploit
  * @returns {number} probability 0-1
  */
@@ -52,7 +52,7 @@ export function skipToOwnedChance(exploit) {
  *     4. partial-burn roll                             (detected failure, uses > 1)
  *
  * So "force a successful exploit from a locked node" needs THREE forced rolls:
- *   success (low), flavor pick (any), skip-to-owned (high → stay at "compromised").
+ *   success (low), flavor pick (any), skip-to-owned (high → stay at "open").
  * Forcing only the first two leaves the skip roll seeded — see issue #109.
  * Tests MUST pass an explicit seed to initGame() so any unforced roll is at least
  * deterministic rather than Math.random()-derived.
@@ -200,18 +200,18 @@ export function resolveCombat(exploit, node) {
     result.prevAccess = node.accessLevel;
 
     if (node.accessLevel === "locked") {
-      // High-quality/rare exploits can skip compromised → owned in one shot
+      // High-quality/rare exploits can skip open → owned in one shot
       const skipRoll = random(RNG.COMBAT);
       if (skipRoll <= skipToOwnedChance(exploit)) {
         result.nextAccess = "owned";
         result.skippedToOwned = true;
         result.revealNeighbors = true;
       } else {
-        result.nextAccess = "compromised";
+        result.nextAccess = "open";
         result.revealNeighbors = (node.gateAccess ?? "probed") !== "owned";
       }
       result.levelChanged = true;
-    } else if (node.accessLevel === "compromised") {
+    } else if (node.accessLevel === "open") {
       result.nextAccess = "owned";
       result.revealNeighbors = true;
       result.levelChanged = true;

--- a/js/core/combat.test.js
+++ b/js/core/combat.test.js
@@ -69,12 +69,12 @@ function matchingExploit() {
 }
 
 describe("resolveCombat (pure resolution)", () => {
-  test("decides the locked→compromised plan without mutating the node or emitting", () => {
+  test("decides the locked→open plan without mutating the node or emitting", () => {
     initRng("combat-test-1");
     // From-locked success consumes three RNG.COMBAT rolls: success, flavor, skip.
     _forceNext(RNG.COMBAT, 0);     // success
     _forceNext(RNG.COMBAT, 0);     // flavor pick
-    _forceNext(RNG.COMBAT, 0.99);  // skip-to-owned bypass → stay at compromised
+    _forceNext(RNG.COMBAT, 0.99);  // skip-to-owned bypass → stay at open
 
     const node = lockedNode();
     const before = { accessLevel: node.accessLevel, alertState: node.alertState };
@@ -92,7 +92,7 @@ describe("resolveCombat (pure resolution)", () => {
     // Plan is fully decided…
     assert.equal(result.success, true);
     assert.equal(result.prevAccess, "locked");
-    assert.equal(result.nextAccess, "compromised");
+    assert.equal(result.nextAccess, "open");
     assert.equal(result.levelChanged, true);
     assert.equal(result.revealNeighbors, true); // gateAccess "probed" !== "owned"
     assert.ok(Array.isArray(result.vulnsToSurface));

--- a/js/core/ice/runtime.js
+++ b/js/core/ice/runtime.js
@@ -105,7 +105,7 @@ initIceHandlers();
 
 
 function isPlayerVisible(nodeState) {
-  return nodeState?.accessLevel === "compromised" || nodeState?.accessLevel === "owned";
+  return nodeState?.accessLevel === "open" || nodeState?.accessLevel === "owned";
 }
 
 // BFS: returns the first hop on the shortest path from src toward dst.

--- a/js/core/node-graph/game-types.js
+++ b/js/core/node-graph/game-types.js
@@ -115,7 +115,7 @@ const DUMP_ACTION = {
   requires: [
     {
       type: "any-of", conditions: [
-        { type: "node-attr", attr: "accessLevel", eq: "compromised" },
+        { type: "node-attr", attr: "accessLevel", eq: "open" },
         { type: "node-attr", attr: "accessLevel", eq: "owned" },
       ],
     },
@@ -203,7 +203,7 @@ const RECONFIGURE_ACTION = {
   requires: [
     {
       type: "any-of", conditions: [
-        { type: "node-attr", attr: "accessLevel", eq: "compromised" },
+        { type: "node-attr", attr: "accessLevel", eq: "open" },
         { type: "node-attr", attr: "accessLevel", eq: "owned" },
       ],
     },
@@ -257,7 +257,7 @@ const SCRUB_LOGS_ACTION = {
   desc: "Wipe this monitor's accumulated alert logs, easing the global alert one level.",
   requires: [{
     type: "any-of", conditions: [
-      { type: "node-attr", attr: "accessLevel", eq: "compromised" },
+      { type: "node-attr", attr: "accessLevel", eq: "open" },
       { type: "node-attr", attr: "accessLevel", eq: "owned" },
     ],
   }],
@@ -344,7 +344,7 @@ export function createRouter(id, config = {}) {
     attributes: {
       label: config.label || id,
       grade: config.grade || "D",
-      gateAccess: "compromised",
+      gateAccess: "open",
       ...config.attributes,
     },
   };

--- a/js/core/node-graph/game-types.test.js
+++ b/js/core/node-graph/game-types.test.js
@@ -194,8 +194,8 @@ describe("action availability", () => {
     assert.ok(!actions.some(a => a.id === "xploit"));
   });
 
-  it("exploit still available on compromised node", () => {
-    const gw = createGateway("gw", { attributes: { visibility: "accessible", accessLevel: "compromised" } });
+  it("exploit still available on open node", () => {
+    const gw = createGateway("gw", { attributes: { visibility: "accessible", accessLevel: "open" } });
     const graph = new NodeGraph({ nodes: [gw], edges: [] });
     const actions = graph.getAvailableActions("gw");
     assert.ok(actions.some(a => a.id === "xploit"));
@@ -208,9 +208,9 @@ describe("action availability", () => {
     assert.ok(!actions.some(a => a.id === "xploit"));
   });
 
-  it("dump available on compromised unread fileserver", () => {
+  it("dump available on open unread fileserver", () => {
     const fs = createFileserver("fs", {
-      attributes: { visibility: "accessible", accessLevel: "compromised" },
+      attributes: { visibility: "accessible", accessLevel: "open" },
     });
     const graph = new NodeGraph({ nodes: [fs], edges: [] });
     const actions = graph.getAvailableActions("fs");
@@ -235,9 +235,9 @@ describe("action availability", () => {
     assert.ok(!actions.some(a => a.id === "fetch"));
   });
 
-  it("corrupt available on compromised IDS with forwarding enabled", () => {
+  it("corrupt available on open IDS with forwarding enabled", () => {
     const ids = createIDS("ids-1", {
-      attributes: { visibility: "accessible", accessLevel: "compromised" },
+      attributes: { visibility: "accessible", accessLevel: "open" },
     });
     const graph = new NodeGraph({ nodes: [ids], edges: [] });
     const actions = graph.getAvailableActions("ids-1");

--- a/js/core/node-graph/traits.js
+++ b/js/core/node-graph/traits.js
@@ -346,7 +346,7 @@ registerTrait("encrypted", {
     desc: "Scan encrypted node contents (requires decryption key).",
     requires: [
       { type: "any-of", conditions: [
-        { type: "node-attr", attr: "accessLevel", eq: "compromised" },
+        { type: "node-attr", attr: "accessLevel", eq: "open" },
         { type: "node-attr", attr: "accessLevel", eq: "owned" },
       ]},
       { type: "node-attr", attr: "read", eq: false },

--- a/js/core/state/index.js
+++ b/js/core/state/index.js
@@ -338,7 +338,7 @@ export function isIceVisible(ice, nodes, selectedNodeId = null) {
   if (!ice?.active) return false;
   if (selectedNodeId && ice.attentionNodeId === selectedNodeId) return true;
   const atAccess = nodes[ice.attentionNodeId]?.accessLevel;
-  return atAccess === "compromised" || atAccess === "owned";
+  return atAccess === "open" || atAccess === "owned";
 }
 
 // ── Store / card acquisition ──────────────────────────────

--- a/js/core/state/node.js
+++ b/js/core/state/node.js
@@ -49,7 +49,7 @@ export function setNodeVisible(nodeId, visibility) {
   syncToGraph(nodeId, "visibility", visibility);
 }
 
-/** Sets node.accessLevel ('locked' | 'compromised' | 'owned'). */
+/** Sets node.accessLevel ('locked' | 'open' | 'owned'). */
 export function setNodeAccessLevel(nodeId, level) {
   mutate((s) => {
     const node = s.nodes[nodeId];
@@ -70,12 +70,12 @@ export function setNodeProbed(nodeId) {
 /**
  * True when a node's identity (id, label, type, grade) should stay hidden behind
  * its sig-N alias. A node is obscured while it has a signal alias, is still `locked`,
- * and has not yet been probed. Once you're inside a node (compromised or owned) you
+ * and has not yet been probed. Once you're inside a node (open or owned) you
  * know what it is — "own it = know it" — so any non-locked node reveals, even without
  * a probe. This matters for owned-by-default bait like the honey-pot (accessLevel:
  * "owned", probed: false), which PROBE can never touch (PROBE requires `locked`);
  * without the access-level clause it would stay a permanent sig-N mystery.
- * A successful blind exploit also sets `probed`, so the normal locked→compromised
+ * A successful blind exploit also sets `probed`, so the normal locked→open
  * path reveals too. `sigAlias` is assigned only on hidden→revealed, so foothold nodes
  * (no alias) are never obscured. Read-only predicate; consulted by the graph, console,
  * and sidebar.

--- a/js/core/state/node.test.js
+++ b/js/core/state/node.test.js
@@ -26,8 +26,8 @@ describe("state/node — node mutations", () => {
 
   it("setNodeAccessLevel changes accessLevel and bumps version", () => {
     const v = getVersion();
-    setNodeAccessLevel("gateway", "compromised");
-    assert.equal(getState().nodes["gateway"].accessLevel, "compromised");
+    setNodeAccessLevel("gateway", "open");
+    assert.equal(getState().nodes["gateway"].accessLevel, "open");
     assert.equal(getVersion(), v + 1);
   });
 
@@ -133,9 +133,9 @@ describe("state/node — isObscured", () => {
     );
   });
 
-  it("compromised-but-unprobed node is NOT obscured (you're inside it)", () => {
+  it("open-but-unprobed node is NOT obscured (you're inside it)", () => {
     assert.equal(
-      isObscured({ sigAlias: "sig-1", accessLevel: "compromised", probed: false }),
+      isObscured({ sigAlias: "sig-1", accessLevel: "open", probed: false }),
       false
     );
   });

--- a/js/core/types.js
+++ b/js/core/types.js
@@ -6,7 +6,7 @@
 // ── String union types ────────────────────────────────────
 
 /** @typedef {"hidden"|"revealed"|"accessible"} Visibility */
-/** @typedef {"locked"|"compromised"|"owned"} AccessLevel */
+/** @typedef {"locked"|"open"|"owned"} AccessLevel */
 /** @typedef {"green"|"yellow"|"red"} NodeAlertLevel */
 /** @typedef {"green"|"yellow"|"red"|"trace"} GlobalAlertLevel */
 /** @typedef {"fresh"|"worn"|"disclosed"} DecayState */
@@ -298,7 +298,7 @@
  *   lootConfig?:    { count: number[] },
  *   combatConfig?:  CombatConfig,
  *   vulnConfig?:    VulnConfig,
- *   gateAccess?:    "probed"|"compromised"|"owned",
+ *   gateAccess?:    "probed"|"open"|"owned",
  *   gradeOverrides?: Partial<Record<Grade, GradeOverride>>,
  * }} NodeTypeDef
  */

--- a/js/ui/components/starnet-context-menu.js
+++ b/js/ui/components/starnet-context-menu.js
@@ -13,7 +13,7 @@ import { html, nothing } from "lit";
 import { StarnetElement } from "./starnet-element.js";
 import { isObscured } from "../../core/state.js";
 import { vulnGlyphDataUri } from "../vuln-glyphs.js";
-import { alertLampDataUri } from "../indicator-glyphs.js";
+import { alertLampDataUri, accessGlyphDataUri } from "../indicator-glyphs.js";
 
 class StarnetContextMenu extends StarnetElement {
   static properties = {
@@ -121,7 +121,7 @@ class StarnetContextMenu extends StarnetElement {
             <span class="im-key">GRADE</span>
             <span class="im-val grade-${obscured ? "" : (node.grade || "")}">${grade}</span>
             <span class="im-sep">·</span>
-            <span class="im-val">${(node.accessLevel || "—").toUpperCase()}</span>
+            <span class="im-val"><img class="access-glyph" alt="" src=${accessGlyphDataUri(node.accessLevel)}> ${(node.accessLevel || "—").toUpperCase()}</span>
             <span class="im-sep">·</span>
             <span class="im-val" style="color:${alertColor}"><img class="nd-lamp" alt="" src=${alertLampDataUri(alertState)}> ${alertState.toUpperCase()}</span>
           </div>

--- a/js/ui/components/starnet-end-screen.js
+++ b/js/ui/components/starnet-end-screen.js
@@ -11,7 +11,7 @@ class StarnetEndScreen extends StarnetElement {
     cash: { type: Number },
     missionComplete: { type: Boolean },
     hasMission: { type: Boolean },
-    nodesCompromised: { type: Number },
+    nodesAccessed: { type: Number },
     nodesOwned: { type: Number },
     macguffinsLooted: { type: Number },
     isCheating: { type: Boolean },
@@ -24,7 +24,7 @@ class StarnetEndScreen extends StarnetElement {
     this.cash = 0;
     this.missionComplete = false;
     this.hasMission = false;
-    this.nodesCompromised = 0;
+    this.nodesAccessed = 0;
     this.nodesOwned = 0;
     this.macguffinsLooted = 0;
     this.isCheating = false;
@@ -75,8 +75,8 @@ class StarnetEndScreen extends StarnetElement {
           </div>
         ` : nothing}
         <div class="end-row">
-          <span class="end-key">NODES COMPROMISED</span>
-          <span class="end-val">${this.nodesCompromised}</span>
+          <span class="end-key">NODES ACCESSED</span>
+          <span class="end-val">${this.nodesAccessed}</span>
         </div>
         <div class="end-row">
           <span class="end-key">NODES OWNED</span>

--- a/js/ui/graph.js
+++ b/js/ui/graph.js
@@ -650,7 +650,7 @@ export function updateNodeStyle(nodeId, nodeState) {
 
   if (nodeState.visibility === "accessible") {
     // Access level
-    node.removeClass("compromised owned");
+    node.removeClass("open owned");
     if (nodeState.accessLevel !== "locked") {
       node.addClass(nodeState.accessLevel);
     }
@@ -916,15 +916,15 @@ function flashIcePath(fromId, toId) {
   if (!path) return;
 
   // Flash each hop's edge in sequence; skip edges not in player-controlled
-  // territory. Requires at least one endpoint compromised/owned (not just visible).
+  // territory. Requires at least one endpoint open/owned (not just visible).
   for (let hop = 1; hop < path.length; hop++) {
     const delay = (hop - 1) * 100;
     edgesBetween(path[hop - 1], path[hop]).forEach((edge) => {
       if (edge.hasClass("hidden")) return;
       const src = cy.getElementById(edge.data("source"));
       const tgt = cy.getElementById(edge.data("target"));
-      const srcControlled = src.hasClass("compromised") || src.hasClass("owned");
-      const tgtControlled = tgt.hasClass("compromised") || tgt.hasClass("owned");
+      const srcControlled = src.hasClass("open") || src.hasClass("owned");
+      const tgtControlled = tgt.hasClass("open") || tgt.hasClass("owned");
       if (!srcControlled && !tgtControlled) return;
       setTimeout(() => {
         edge.animate(

--- a/js/ui/indicator-glyphs.js
+++ b/js/ui/indicator-glyphs.js
@@ -206,3 +206,60 @@ export function missionMarkSvg(state) {
 export function missionMarkDataUri(state) {
   return dataUri(missionMarkSvg(state));
 }
+
+// ── accessGlyphSvg ────────────────────────────────────────────────────────────
+// Three stacked point-up chevrons; lit-from-the-bottom count encodes the access
+// tier (colorblind-safe: count is the primary channel). Lit chevrons take the
+// current level's hue — the glance-legible bright sibling of the node fence ramp
+// in node-glyphs.js (which is intentionally dimmed so the node border stays
+// brightest). Deliberately NOT the alert green/amber/red ramp, so it never reads
+// as alert state even sitting beside the alert lamp.
+
+/** Bright header hues, by access level. @type {Record<string, string>} */
+const ACCESS = {
+  locked: "#45c4c4", // bright teal
+  open:   "#36a6e0", // bright azure
+  owned:  "#2ad17a", // bright green-teal (kept teal-ward to stay clear of alert green)
+};
+
+/** Lit-chevron count, by access level. @type {Record<string, number>} */
+const ACCESS_LIT = { locked: 1, open: 2, owned: 3 };
+
+/** Chevron polylines (viewBox 0 0 16 18), ordered bottom → top. */
+const CHEVRONS = [
+  "3,16.5 8,13 13,16.5",
+  "3,11.5 8,8 13,11.5",
+  "3,6.5 8,3 13,6.5",
+];
+
+/**
+ * Access-level indicator: 3 stacked chevrons, lit from the bottom up by tier.
+ *   locked → 1 lit · open → 2 lit · owned → 3 lit · anything else → 0 lit.
+ * Lit chevrons use the level hue (stroke 1.8 + glow); unreached use DIM (stroke 1.4).
+ *
+ * @param {string} accessLevel
+ * @returns {string} standalone SVG markup
+ */
+export function accessGlyphSvg(accessLevel) {
+  const lit = ACCESS_LIT[accessLevel] ?? 0;
+  const color = ACCESS[accessLevel] ?? DIM;
+  let body = "";
+  for (let i = 0; i < CHEVRONS.length; i++) {
+    const isLit = i < lit;
+    body += `<polyline points="${CHEVRONS[i]}"`
+          + ` stroke="${isLit ? color : DIM}"`
+          + ` stroke-width="${isLit ? 1.8 : 1.4}"/>`;
+  }
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 18" fill="none" stroke-linecap="round" stroke-linejoin="round">`
+    + `<defs><filter id="g" x="-50%" y="-50%" width="200%" height="200%"><feDropShadow dx="0" dy="0" stdDeviation="1.4" flood-color="${color}"/></filter></defs>`
+    + `<g filter="url(#g)">${body}</g></svg>`;
+}
+
+/**
+ * Access glyph as an `<img src>`-ready data URI.
+ * @param {string} accessLevel
+ * @returns {string}
+ */
+export function accessGlyphDataUri(accessLevel) {
+  return dataUri(accessGlyphSvg(accessLevel));
+}

--- a/js/ui/indicator-glyphs.test.js
+++ b/js/ui/indicator-glyphs.test.js
@@ -10,6 +10,8 @@ import {
   tickMeterDataUri,
   missionMarkSvg,
   missionMarkDataUri,
+  accessGlyphSvg,
+  accessGlyphDataUri,
 } from "./indicator-glyphs.js";
 
 /** Count non-overlapping occurrences of a substring in a string. */
@@ -246,6 +248,68 @@ describe("indicator-glyphs — stroke-only SVG", () => {
     });
     test("identical args → identical string for missionMarkSvg", () => {
       assert.equal(missionMarkSvg("complete"), missionMarkSvg("complete"));
+    });
+  });
+
+  // ── accessGlyphSvg ────────────────────────────────────────────────────────────
+
+  describe("accessGlyphSvg", () => {
+    /** lit chevrons render at stroke-width 1.8; dim at 1.4. */
+    const litCount = (svg) => countOccurrences(svg, `stroke-width="1.8"`);
+
+    test("always renders exactly 3 chevron polylines", () => {
+      for (const lvl of ["locked", "open", "owned", "—", "nonsense"]) {
+        assert.equal(countOccurrences(accessGlyphSvg(lvl), "<polyline"), 3,
+          `expected 3 polylines for "${lvl}"`);
+      }
+    });
+
+    test("locked → 1 lit chevron", () => {
+      assert.equal(litCount(accessGlyphSvg("locked")), 1);
+    });
+    test("open → 2 lit chevrons", () => {
+      assert.equal(litCount(accessGlyphSvg("open")), 2);
+    });
+    test("owned → 3 lit chevrons", () => {
+      assert.equal(litCount(accessGlyphSvg("owned")), 3);
+    });
+    test("unknown / obscured (—) → 0 lit chevrons", () => {
+      assert.equal(litCount(accessGlyphSvg("—")), 0);
+      assert.equal(litCount(accessGlyphSvg("nonsense")), 0);
+    });
+
+    test("locked lit hue is teal #45c4c4", () => {
+      assert.ok(accessGlyphSvg("locked").includes("#45c4c4"));
+    });
+    test("open lit hue is azure #36a6e0", () => {
+      assert.ok(accessGlyphSvg("open").includes("#36a6e0"));
+    });
+    test("owned lit hue is green-teal #2ad17a", () => {
+      assert.ok(accessGlyphSvg("owned").includes("#2ad17a"));
+    });
+
+    test("unreached chevrons use the dim color #2a3a55", () => {
+      // locked has 2 dim chevrons, open has 1.
+      assert.ok(accessGlyphSvg("locked").includes("#2a3a55"));
+      assert.ok(accessGlyphSvg("open").includes("#2a3a55"));
+    });
+    test("owned has no dim chevrons (no #2a3a55)", () => {
+      assert.ok(!accessGlyphSvg("owned").includes("#2a3a55"));
+    });
+
+    test("stroke-only: top-level fill=none, no shape fill in body", () => {
+      const svg = accessGlyphSvg("open");
+      assert.ok(svg.includes(`fill="none"`));
+      const body = svg.slice(svg.indexOf(">") + 1);
+      assert.ok(!body.includes(`fill="#`), `body has a shape fill: ${body}`);
+    });
+
+    test("deterministic: identical args → identical string", () => {
+      assert.equal(accessGlyphSvg("open"), accessGlyphSvg("open"));
+    });
+
+    test("accessGlyphDataUri starts with data:image/svg+xml,", () => {
+      assert.ok(accessGlyphDataUri("owned").startsWith("data:image/svg+xml,"));
     });
   });
 

--- a/js/ui/node-glyphs.js
+++ b/js/ui/node-glyphs.js
@@ -111,7 +111,7 @@ const FACE_POLYGON_POINTS = (() => {
  */
 const FENCE = {
   locked:      { gap: 11,  color: "#246060" },
-  compromised: { gap: 7,   color: "#1c6a85" },
+  open: { gap: 7,   color: "#1c6a85" },
   owned:       { gap: 4.5, color: "#1c8a4a" },
 };
 const FENCE_OPACITY = 0.42;

--- a/js/ui/preview-cards.js
+++ b/js/ui/preview-cards.js
@@ -13,6 +13,7 @@ import {
   connStatusDataUri,
   tickMeterDataUri,
   missionMarkDataUri,
+  accessGlyphDataUri,
 } from "./indicator-glyphs.js";
 
 const RARITIES = /** @type {const} */ (["common", "uncommon", "rare"]);
@@ -151,6 +152,12 @@ export function mountIndicatorSwatches(container) {
   row("Mission mark");
   for (const state of ["complete", "failed"]) {
     container.appendChild(cell(missionMarkDataUri(state), state));
+  }
+
+  // Access level — 3-chevron tier badge (lit bottom-up by tier)
+  row("Access level");
+  for (const level of ["locked", "open", "owned"]) {
+    container.appendChild(cell(accessGlyphDataUri(level), level));
   }
 }
 

--- a/js/ui/preview.js
+++ b/js/ui/preview.js
@@ -73,11 +73,11 @@ const ALERT_NODES = [
   { id: "alert-reboot",  label: "REBOOT",   type: "router", grade: "C", x: 750, y: 720 },
 ];
 
-// Access-state demo nodes — show fence density across locked/compromised/owned
+// Access-state demo nodes — show fence density across locked/open/owned
 // so the vector-CRT fence treatment can be tuned in isolation.
 const ACCESS_NODES = [
   { id: "acc-locked",      label: "LOCKED",      type: "fileserver", grade: "C", x: 150, y: 850 },
-  { id: "acc-compromised", label: "COMPROMISED", type: "fileserver", grade: "C", x: 380, y: 850 },
+  { id: "acc-open", label: "OPEN", type: "fileserver", grade: "C", x: 380, y: 850 },
   { id: "acc-owned",       label: "OWNED",       type: "fileserver", grade: "C", x: 610, y: 850 },
 ];
 
@@ -138,7 +138,7 @@ updateNodeStyle("alert-reboot", { visibility: "accessible", accessLevel: "owned"
 
 // Access-state demo overrides (the generic loop above set every node to "owned")
 updateNodeStyle("acc-locked",      { visibility: "accessible", accessLevel: "locked",      alertState: "green", rebooting: false });
-updateNodeStyle("acc-compromised", { visibility: "accessible", accessLevel: "compromised", alertState: "green", rebooting: false });
+updateNodeStyle("acc-open", { visibility: "accessible", accessLevel: "open", alertState: "green", rebooting: false });
 updateNodeStyle("acc-owned",       { visibility: "accessible", accessLevel: "owned",       alertState: "green", rebooting: false });
 
 // Fit the view to show all nodes

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -518,7 +518,7 @@ function renderEndScreen(state) {
   endEl.cash = state.player.cash;
   endEl.hasMission = !!state.mission;
   endEl.missionComplete = state.mission?.complete ?? false;
-  endEl.nodesCompromised = Object.values(state.nodes).filter(
+  endEl.nodesAccessed = Object.values(state.nodes).filter(
     (n) => n.accessLevel !== "locked"
   ).length;
   endEl.nodesOwned = Object.values(state.nodes).filter(

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -320,10 +320,10 @@ describe("Action availability: corrupt on ids", () => {
     initGame(() => buildAlertLAN(), "itest-7");
   });
 
-  it("available when compromised and forwarding enabled", () => {
+  it("available when open and forwarding enabled", () => {
     const s = getState();
     const graph = s.nodeGraph;
-    graph.setNodeAttr("ids-1", "accessLevel", "compromised");
+    graph.setNodeAttr("ids-1", "accessLevel", "open");
     graph.setNodeAttr("ids-1", "forwardingEnabled", true);
     const actionIds = getAvailableActions(s.nodes["ids-1"], s).map((a) => a.id);
     assert.ok(actionIds.includes("corrupt"));
@@ -332,7 +332,7 @@ describe("Action availability: corrupt on ids", () => {
   it("not available when forwardingEnabled is false", () => {
     const s = getState();
     const graph = s.nodeGraph;
-    graph.setNodeAttr("ids-1", "accessLevel", "compromised");
+    graph.setNodeAttr("ids-1", "accessLevel", "open");
     graph.setNodeAttr("ids-1", "forwardingEnabled", false);
     const actionIds = getAvailableActions(s.nodes["ids-1"], s).map((a) => a.id);
     assert.ok(!actionIds.includes("corrupt"));
@@ -657,10 +657,10 @@ describe("isIceVisible: ICE visible on selected locked node", () => {
     assert.equal(isIceVisible(firstIce(), s.nodes, s.selectedNodeId), true);
   });
 
-  it("ICE IS visible on a compromised node regardless of selection", () => {
+  it("ICE IS visible on a open node regardless of selection", () => {
     const s = getState();
     teleportIce("gateway");
-    s.nodes["gateway"].accessLevel = "compromised";
+    s.nodes["gateway"].accessLevel = "open";
     s.selectedNodeId = null;
     assert.equal(isIceVisible(firstIce(), s.nodes, s.selectedNodeId), true);
   });
@@ -774,14 +774,14 @@ describe("Exploit success: neighbor visibility", () => {
     // RNG.COMBAT is consumed three times on a from-locked success:
     //   1) success roll, 2) success-flavor pick, 3) skipToOwnedChance roll.
     // Force the third > skipChance so the access level lands on
-    // 'compromised', not 'owned'.
+    // 'open', not 'owned'.
     _forceNext(RNG.COMBAT, 0);    // success
     _forceNext(RNG.COMBAT, 0);    // flavor pick
     _forceNext(RNG.COMBAT, 0.99); // bypass skip-to-owned
     launchExploit("gateway", s.player.hand[0].id);
 
-    assert.equal(gateway.accessLevel, "compromised",
-      "Gateway should be compromised after successful exploit");
+    assert.equal(gateway.accessLevel, "open",
+      "Gateway should be open after successful exploit");
 
     // Neighbors should be "revealed" (showing as ???), NOT "accessible"
     for (const nid of neighbors) {
@@ -801,9 +801,9 @@ describe("Exploit success: neighbor visibility", () => {
     _forceNext(RNG.COMBAT, 0.99);
     launchExploit("gateway", s.player.hand[0].id);
 
-    assert.equal(gateway.accessLevel, "compromised");
+    assert.equal(gateway.accessLevel, "open");
     assert.equal(gateway.probed, true,
-      "a successful exploit should count as a probe (compromised ⇒ probed)");
+      "a successful exploit should count as a probe (open ⇒ probed)");
   });
 });
 
@@ -829,7 +829,7 @@ function buildFirewallGateLAN({ startCash = 0 } = {}) {
 }
 
 /**
- * LAN with a router (gateAccess: "compromised") between gateway and a fileserver.
+ * LAN with a router (gateAccess: "open") between gateway and a fileserver.
  * gateway → router → fileserver
  */
 function buildRouterGateLAN({ startCash = 0 } = {}) {
@@ -861,36 +861,36 @@ describe("gate-access: nodes behind gates are inaccessible until conditions met"
         "fileserver behind firewall should start hidden");
     });
 
-    it("compromising the firewall does NOT reveal nodes behind it", () => {
+    it("opening the firewall does NOT reveal nodes behind it", () => {
       const s = getState();
       // RNG.COMBAT is consumed three times on a from-locked success:
       //   1) success roll, 2) success-flavor pick, 3) skipToOwnedChance roll.
       // Force the third > skipChance so the access level lands on
-      // 'compromised', not 'owned'.
+      // 'open', not 'owned'.
       _forceNext(RNG.COMBAT, 0);    // success
       _forceNext(RNG.COMBAT, 0);    // flavor pick
       _forceNext(RNG.COMBAT, 0.99); // bypass skip-to-owned
       launchExploit("firewall-1", s.player.hand[0].id);
 
-      assert.equal(s.nodes["firewall-1"].accessLevel, "compromised",
-        "firewall should be compromised after first successful exploit");
+      assert.equal(s.nodes["firewall-1"].accessLevel, "open",
+        "firewall should be open after first successful exploit");
       assert.equal(s.nodes["hidden-fs"].visibility, "hidden",
-        "fileserver behind owned-gated firewall must remain hidden when firewall is only compromised");
+        "fileserver behind owned-gated firewall must remain hidden when firewall is only open");
     });
 
     it("owning the firewall DOES reveal nodes behind it", () => {
       const s = getState();
 
-      // First exploit: locked → compromised (block skip-to-owned with third roll)
+      // First exploit: locked → open (block skip-to-owned with third roll)
       _forceNext(RNG.COMBAT, 0);    // success
       _forceNext(RNG.COMBAT, 0);    // flavor pick
       _forceNext(RNG.COMBAT, 0.99); // bypass skip-to-owned
       launchExploit("firewall-1", s.player.hand[0].id);
-      assert.equal(s.nodes["firewall-1"].accessLevel, "compromised");
+      assert.equal(s.nodes["firewall-1"].accessLevel, "open");
       assert.equal(s.nodes["hidden-fs"].visibility, "hidden",
-        "precondition: still hidden after compromised");
+        "precondition: still hidden after open");
 
-      // Second exploit: compromised → owned (no skip roll on this transition)
+      // Second exploit: open → owned (no skip roll on this transition)
       _forceNext(RNG.COMBAT, 0);    // success
       _forceNext(RNG.COMBAT, 0);    // flavor pick
       launchExploit("firewall-1", s.player.hand[1].id);
@@ -901,7 +901,7 @@ describe("gate-access: nodes behind gates are inaccessible until conditions met"
     });
   });
 
-  describe("router gate (gateAccess: 'compromised')", () => {
+  describe("router gate (gateAccess: 'open')", () => {
     beforeEach(() => {
       clearAll();
       initGame(() => buildRouterGateLAN(), "itest-22");
@@ -913,22 +913,22 @@ describe("gate-access: nodes behind gates are inaccessible until conditions met"
         "fileserver behind router should start hidden");
     });
 
-    it("compromising the router reveals nodes behind it", () => {
+    it("opening the router reveals nodes behind it", () => {
       const s = getState();
 
       // RNG.COMBAT is consumed three times on a from-locked success:
       //   1) success roll, 2) success-flavor pick, 3) skipToOwnedChance roll.
       // Force the third > skipChance so the access level lands on
-      // 'compromised', not 'owned'.
+      // 'open', not 'owned'.
       _forceNext(RNG.COMBAT, 0);    // success
       _forceNext(RNG.COMBAT, 0);    // flavor pick
       _forceNext(RNG.COMBAT, 0.99); // bypass skip-to-owned
       launchExploit("router-gate", s.player.hand[0].id);
 
-      assert.equal(s.nodes["router-gate"].accessLevel, "compromised",
-        "router should be compromised after first successful exploit");
+      assert.equal(s.nodes["router-gate"].accessLevel, "open",
+        "router should be open after first successful exploit");
       assert.equal(s.nodes["behind-router"].visibility, "revealed",
-        "fileserver behind compromised-gated router should be revealed on compromise");
+        "fileserver behind open-gated router should be revealed on open");
     });
   });
 
@@ -1285,7 +1285,7 @@ describe("security grid cooldown: scrub logs (#174)", () => {
   const ORDER = ["green", "yellow", "red", "trace"];
   const sendAlert = (graph) => graph.sendMessage("sp/ids", { type: "alert", payload: {} });
 
-  it("scrubbing a compromised monitor resets its alertCount and eases the global alert one level", () => {
+  it("scrubbing a open monitor resets its alertCount and eases the global alert one level", () => {
     initGame(() => buildSetPieceMiniNetwork("idsRelayChain"), "scrub-1");
     const graph = getState().nodeGraph;
     sendAlert(graph); sendAlert(graph); sendAlert(graph); // 3 alerts (grade C): climbs to red
@@ -1293,7 +1293,7 @@ describe("security grid cooldown: scrub logs (#174)", () => {
     assert.notEqual(before, "green", "grid should have climbed");
     assert.ok(graph.getNodeState("sp/monitor").alertCount > 0, "monitor should have accumulated");
 
-    graph.setNodeAttr("sp/monitor", "accessLevel", "compromised");
+    graph.setNodeAttr("sp/monitor", "accessLevel", "open");
     graph.executeAction("sp/monitor", "scrub-logs");
 
     assert.equal(graph.getNodeState("sp/monitor").alertCount, 0, "scrub resets the monitor's count");
@@ -1308,7 +1308,7 @@ describe("security grid cooldown: scrub logs (#174)", () => {
     assert.equal(getState().globalAlert, "trace", "should be at trace");
     const countAtTrace = graph.getNodeState("sp/monitor").alertCount;
 
-    graph.setNodeAttr("sp/monitor", "accessLevel", "compromised");
+    graph.setNodeAttr("sp/monitor", "accessLevel", "open");
     graph.executeAction("sp/monitor", "scrub-logs");
 
     assert.equal(getState().globalAlert, "trace", "scrub must not cool an active trace");
@@ -1541,7 +1541,7 @@ describe("status ice: enumerates all active ICE instances", () => {
   it("lists one line per active instance when there are multiple", () => {
     const s = getState();
     // Make both instances visible: ice-1's attention node is selected; ice-2's
-    // attention node is owned (isIceVisible passes for owned/compromised nodes).
+    // attention node is owned (isIceVisible passes for owned/open nodes).
     s.selectedNodeId = "gateway";
     s.nodes["gateway"].accessLevel = "owned";
     s.nodes["router-a"].accessLevel = "owned";

--- a/tests/node-glyphs.test.js
+++ b/tests/node-glyphs.test.js
@@ -64,8 +64,8 @@ test("gallery type list (ALL_GLYPH_TYPES) includes every mapped type for the pre
 });
 
 test("fenceYs density increases with access level", () => {
-  assert.ok(fenceYs("locked").length < fenceYs("compromised").length);
-  assert.ok(fenceYs("compromised").length < fenceYs("owned").length);
+  assert.ok(fenceYs("locked").length < fenceYs("open").length);
+  assert.ok(fenceYs("open").length < fenceYs("owned").length);
 });
 
 test("fenceYs is empty for an unknown access level", () => {
@@ -88,7 +88,7 @@ test("nodeFaceSvg for an unknown access level draws the glyph but no fence group
 });
 
 test("nodeFaceDataUri returns an encoded svg data uri (no raw #)", () => {
-  const uri = nodeFaceDataUri("mine", "compromised");
+  const uri = nodeFaceDataUri("mine", "open");
   assert.ok(uri.startsWith("data:image/svg+xml,"));
   assert.ok(!uri.slice("data:image/svg+xml,".length).includes("#"), "hex # must be percent-encoded");
 });


### PR DESCRIPTION
## What

Renames the mid-tier access level **`compromised` → `open`** (`locked → open → owned`).

The 11-char word "compromised" was causing UI layout issues (node labels, context menu, end screen). `open` (4 chars) fixes that with no collision.

## Scope (deliberately narrow)

Only the **mid-tier `accessLevel` enum value** changed. We considered a bigger realignment (`owned → rooted` + unifying the vault `open`/`opened`/`cracked` vocab) but deferred it — it's ~400 touch points, doesn't help the layout problem (`rooted` is longer than `owned`), and the vault vocab needs its own careful pass. Tracked in #210.

### Changed
- `accessLevel`/`gateAccess` value `"compromised"` → `"open"` across `js/core/`, `js/core/node-graph/`, `data/biomes/`, and the derived graph CSS classes (`hasClass`/`removeClass` in `graph.js`).
- End-screen stat relabeled **NODES COMPROMISED → NODES ACCESSED** (it counts all non-locked nodes — open *and* owned — so a generic term is accurate); property `nodesCompromised` → `nodesAccessed`.
- Tests + living docs (`MANUAL.md`, `CLAUDE.md`, `SPEC`/`ICE`/`PROCGEN`/`BACKLOG`) updated to match.

### Intentionally left alone
- Generic-English flavor that isn't the access tier: `loot.js` ("Highly compromising"), `exploits.js:91` ("channel compromised"), `SPEC.md:112` ("Compromising documents").
- Historical records: `docs/dev-sessions/**`, `docs/superpowers/plans/**`, speculative `docs/VISION-*.md`.

## Verification
- `make check` — 1137 tests green, lint clean.
- Harness smoke: a successful exploit escalates the gateway to `access: open`.
- `make census SEEDS=10` — no regression (successRate 0.3, avgNodesOwned 4.2, traceFiredRate 0.8).

Follow-up: #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
