### PR TITLE
Eliminate top header; move status into a bar above the terminal

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -30,13 +30,13 @@ And when they find you, the clock starts.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│  HUD: ALERT · WALLET · MISSION · [ ☰ ]                       │
-├──────────────────────────────────────────────────────────────┤
 │                                                  ┌─────────┐ │
 │                  NETWORK GRAPH                   │ HEALTH  │ │
 │                                                  │  DECK   │ │
 │         [ node inspector popup ]                 │VISIT WAN│ │
 │                                                  └─────────┘ │
+├──────────────────────────────────────────────────────────────┤
+│  STATUS: LINK · ALERT · WALLET · MISSION              [ ☰ ]  │
 ├────────────────────────────────────┬─────────────────────────┤
 │  LOG                               │  EXPLOIT HAND  [ ▾ ]   │
 │  > CONSOLE INPUT                   │                         │
@@ -73,10 +73,11 @@ every ICE movement that crosses into your territory appears here.
 **Console** — Type commands directly. Tab-complete node names. Full command reference
 at the end of this manual.
 
-**HUD** — Top bar shows global alert level (as a vector lamp whose shape encodes the
-level: hexagon = safe, point-up triangle = warning, inverted triangle = danger/trace),
-your current cash balance, the active **mission** target and status, and a hamburger
-button `[ ☰ ]` that opens a dropdown panel with NEW RUN / PAUSE / SAVE / LOAD. Use the
+**Status bar** — A full-width strip directly above the terminal showing the connection
+status, the global alert level (as a vector lamp whose shape encodes the level: hexagon =
+safe, point-up triangle = warning, inverted triangle = danger/trace), your current cash
+balance, the active **mission** target and status, and — at its right end — a hamburger
+button `[ ☰ ]` that opens a dropdown panel (NEW RUN / PAUSE / SAVE / LOAD) upward. Use the
 `menu` console command to toggle the panel from the keyboard.
 
 **Vital traces** — HEALTH and DECK INTEGRITY float as an inset in the upper-right corner
@@ -97,7 +98,7 @@ counting down, it switches to a pulsing `[ JACK OUT ]` for instant disconnect.
 **Resizing the layout** — Two borders are drag-resizable: the border above the log/console
 (graph vs. log height) and the border between the log and the exploit hand (log vs. hand
 width). Grab a border and drag; **double-click a border to reset that split** to its
-default. Your chosen sizes persist across reloads. The header bar is fixed.
+default. Your chosen sizes persist across reloads. The status bar is fixed.
 
 **Seed** — Each run is generated from a seed string, shown in the status display.
 Sharing a seed lets someone else play the same network layout, vulnerabilities,
@@ -709,10 +710,10 @@ Counters are the same regardless of ICE type: untarget, eject, or reboot.
 
 Each run has an optional mission: retrieve a specific **macguffin** from somewhere in the
 network. The mission target and its status (ACTIVE / COMPLETE / FAILED) are shown in the
-HUD top bar.
+status bar.
 
 You won't know which node holds the target until you `dump` it. Once you fetch the mission
-target, the HUD marks the mission complete. Mission completion is tracked separately
+target, the status bar marks the mission complete. Mission completion is tracked separately
 from your cash score.
 
 ---
@@ -763,7 +764,7 @@ kick                   Push ICE off current node to adjacent node.
 reboot [node]          Force ICE home; node goes briefly offline.
 jackout                End run.
 
-menu                   Toggle the header controls panel (NEW RUN / PAUSE / SAVE / LOAD).
+menu                   Toggle the status-bar controls panel (NEW RUN / PAUSE / SAVE / LOAD).
 hand                   Toggle collapse of the exploit hand strip.
 
 darknet                List darknet broker catalog (requires WAN targeted).

--- a/css/style.css
+++ b/css/style.css
@@ -62,15 +62,17 @@ html, body {
   height: 100vh;
 }
 
+/* Status bar — a full-width strip below the graph splitter, above the terminal
+   + hand strip. (Formerly the top header; the title is gone and the graph now
+   reclaims that band.) */
 #hud {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
   gap: 1.5rem;
-  padding: 0.5rem 1rem;
+  padding: 0.25rem 1rem;
   background: var(--bg-panel);
-  border-bottom: 1px solid var(--border);
-  z-index: 10;
+  border-top: 1px solid var(--border);
 }
 
 #main {
@@ -308,17 +310,6 @@ html, body {
 
 /* ── HUD ────────────────────────────────────────────────── */
 
-#hud .hud-title {
-  font-family: var(--font-display);
-  font-size: 1rem;
-  font-weight: bold;
-  white-space: nowrap;
-  color: var(--cyan);
-  letter-spacing: 0.15em;
-  text-shadow: var(--glow-md) var(--cyan);
-  margin-right: auto;
-}
-
 #hud .hud-label {
   color: var(--text-dim);
   font-size: 0.75rem;
@@ -423,10 +414,11 @@ html, body {
 .hud-menu-wrap {
   position: relative;
   display: inline-flex;
+  margin-left: auto;   /* push the ☰ menu to the far right; status items stay left */
 }
 #hud-menu {
   position: absolute;
-  top: calc(100% + 0.4rem);
+  bottom: calc(100% + 0.4rem);   /* opens upward — the bar sits at the bottom of the screen */
   right: 0;
   z-index: 20;            /* above the header chrome + graph */
   display: flex;

--- a/docs/dev-sessions/2026-06-13-1220-header-to-status-bar/notes.md
+++ b/docs/dev-sessions/2026-06-13-1220-header-to-status-bar/notes.md
@@ -1,0 +1,51 @@
+# Notes: Eliminate top header → bottom status bar
+
+## Summary
+
+Removed the top HUD header entirely and relocated the status elements into a
+full-width status bar that sits directly above the terminal + hand strip
+(brainstorm layout "Option A"). The game title (`★ STARNET`) is gone; the graph
+now reclaims the whole top band.
+
+Kept `<starnet-hud>` as a single component — only its position, title, and the
+menu-dropdown direction changed. Because the component's public property API was
+untouched, `syncHud()` and the `main.js` `hud-action` wiring needed **no
+changes**, keeping the blast radius to render markup + CSS.
+
+## What changed
+
+- **`index.html`** — moved `<starnet-hud id="hud">` from the top of `#app` to
+  inside `#graph-column`, below the `.splitter` and above `#bottom-row`.
+- **`js/ui/components/starnet-hud.js`** — dropped the `★ STARNET` title;
+  re-added `${this._renderCheatLabel()}` (the `// CHEAT` label was preserved in
+  code specifically for this "status bar under the terminal"); refreshed the
+  stale comments and the component header comment ("Status bar", not "Header bar").
+- **`css/style.css`** — `#hud` restyled from top header (`border-bottom`,
+  `z-index:10`) to a bottom strip (`border-top`, normal flow); removed the
+  obsolete `.hud-title` rule; added `margin-left:auto` to `.hud-menu-wrap` so the
+  `☰` floats to the far right while status items stay left; flipped `#hud-menu`
+  to open upward (`bottom: calc(100% + 0.4rem)`).
+- **`MANUAL.md`** — updated the interface ASCII diagram (status bar now sits
+  below the graph, above the log), the HUD → "Status bar" description, and the
+  "header bar / HUD top bar / header controls panel" wording.
+
+## Hamburger decision
+
+Original ask floated putting `☰` inside the terminal input field. On reflection
+(and confirmed by Les) it went to the **right end of the status bar** instead —
+keeps `starnet-hud` a single component with no wiring split, and the bar sits one
+row above the input anyway so it's visually almost identical. Dropdown opens
+upward since the bar is at the bottom of the screen.
+
+## Verification
+
+- `make check` (tsc + tests): pass — 1150 tests, 0 fail.
+- Visual (Playwright against `make serve`): header band gone / graph reclaims it;
+  status bar reads `PASSIVE SCAN · ALERT: GREEN · WALLET · MISSION ▶ ACTIVE` with
+  `[ ☰ ]` far right; menu dropdown opens upward over the graph (verified menu
+  bottom 483px sits above button top 492px) and renders cleanly.
+
+## Follow-ups / notes
+
+- Hand strip layout is still a work in progress (Les) — left untouched.
+- No `preview.html` change: this relocates existing chrome, not a new effect.

--- a/docs/dev-sessions/2026-06-13-1220-header-to-status-bar/plan.md
+++ b/docs/dev-sessions/2026-06-13-1220-header-to-status-bar/plan.md
@@ -1,0 +1,50 @@
+# Plan: Eliminate top header → bottom status bar
+
+Small, contained change: one component `render()`, one DOM move, one CSS block.
+
+## Steps
+
+### 1. `index.html` — move the element
+- Remove the `<!-- HUD -->` block (`<starnet-hud id="hud">`) from the top of
+  `#app` (between the opening `#app` and `<main id="main">`).
+- Re-insert `<starnet-hud id="hud">` inside `#graph-column`, *after* the
+  `.splitter` and *before* `<div id="bottom-row">`, so it spans the full width
+  of the bottom section.
+
+### 2. `js/ui/components/starnet-hud.js` — render changes
+- Drop the `<span class="hud-title">★ STARNET</span>` line.
+- Re-add `${this._renderCheatLabel()}` to `render()` (update the stale comment
+  block above it).
+- Order within the bar: connection · alert · wallet · trace · mission · cheat ·
+  (spacer) · `☰` menu-wrap.
+
+### 3. `css/style.css` — restyle `#hud`
+- `#hud`: change `border-bottom` → `border-top`; drop `z-index:10` (it's now in
+  normal flow within `#graph-column`, not floating over the graph). Keep
+  `flex:0 0 auto`, `display:flex`, `align-items:center`, compact padding.
+- Replace the title's right-push: remove `.hud-title { margin-right:auto }`
+  (rule can go, title is gone) and add `margin-left:auto` to `.hud-menu-wrap` so
+  status items stay left-aligned and `☰` floats to the far right.
+- `#hud-menu`: flip `top: calc(100% + 0.4rem)` → `bottom: calc(100% + 0.4rem)`
+  so the dropdown opens upward. Keep its `z-index` so it layers above the graph.
+- Verify `.hud-cheat-label` styling still reads in the bar (it already has a rule).
+
+### 4. Verify
+- `make check` (tsc/JSDoc) — must pass.
+- `make test` — must pass.
+- `make serve` + browser: confirm header band is gone, status bar sits above the
+  terminal, dropdown opens upward and is clickable over the graph, all menu
+  actions work.
+
+### 5. Docs
+- Update `MANUAL.md` if it describes the old top header / title placement.
+- Write `notes.md` summary.
+
+### 6. PR
+- Commit, push branch, open PR into `main`.
+
+## Risk / rollback
+- Public property API of `starnet-hud` is unchanged → `syncHud()` and `main.js`
+  wiring untouched, so blast radius is render markup + CSS only.
+- If the dropdown clips or the bar misaligns, it's isolated to the `#hud` CSS
+  block. Clean restore point: the spec+plan commit before execution.

--- a/docs/dev-sessions/2026-06-13-1220-header-to-status-bar/spec.md
+++ b/docs/dev-sessions/2026-06-13-1220-header-to-status-bar/spec.md
@@ -1,0 +1,63 @@
+# Spec: Eliminate top header → bottom status bar
+
+## Goal
+
+Maximize the graph view by removing the top HUD header entirely. Drop the game
+title. Relocate the remaining status elements into a full-width status bar that
+sits directly above the terminal (and hand strip), with the hamburger menu at
+the bar's right end.
+
+This continues the ongoing UI-compaction arc (recent: #208 sidebar dissolved).
+
+## Background
+
+The top header is a single `<starnet-hud>` custom element pinned at the top of
+`#app`. It renders: `★ STARNET` title, connection status, alert lamp + level,
+wallet, trace countdown, mission block, and the hamburger `☰` button + dropdown
+(NEW RUN / PAUSE / SAVE / LOAD).
+
+Data flows in via `syncHud()` in `js/ui/visual-renderer.js` (sets properties on
+`#hud`). Menu actions flow out as `hud-action` CustomEvents handled in
+`js/ui/main.js`. A `// CHEAT` label already exists in the component, currently
+not rendered, with a code comment noting it was preserved for "a planned status
+bar under the terminal" — this is that status bar.
+
+## Decisions (from brainstorming)
+
+- **Layout: Option A** — the status bar spans the full width of the bottom
+  section, above both the terminal (`#log-pane`) and the hand strip.
+- **Hamburger: right end of the status bar** (not inside the input field). Keeps
+  `starnet-hud` a single component with no wiring split. The dropdown opens
+  *upward* since the bar is now at the bottom of the screen.
+- Keep `starnet-hud` as one component; its public property API is unchanged, so
+  `syncHud()` and the `main.js` `hud-action` wiring require **no changes**.
+
+## Scope
+
+### In scope
+- Remove `<starnet-hud>` from the top of `#app`; re-insert it inside
+  `#graph-column`, below the splitter and above `#bottom-row`.
+- Remove the `★ STARNET` title from the component render.
+- Restore the `// CHEAT` label into the bar.
+- Flip the menu dropdown to open upward.
+- Restyle `#hud` from a top header (`border-bottom`, `z-index:10`) into a bottom
+  status strip (`border-top`), and push the hamburger to the far right
+  (`margin-left:auto` on `.hud-menu-wrap`, replacing the title's `margin-right:auto`).
+- Update `MANUAL.md` if it describes the old top header.
+
+### Out of scope
+- No change to the floated graph `#vital-stack` (HEALTH/DECK waveforms + uplink).
+- No change to `syncHud()`, `main.js` action wiring, or the menu's actions.
+- No hand-strip redesign (still a work in progress, per Les).
+- No new `preview.html` entry — this relocates existing chrome, not a new effect.
+
+## Success criteria
+
+- Top header band is gone; the graph occupies that space.
+- Status elements (connection, alert, wallet, trace, mission, cheat) render in a
+  full-width bar directly above the terminal + hand strip.
+- Hamburger `☰` sits at the bar's right end; its dropdown opens upward and
+  remains clickable above the graph.
+- `make check` and `make test` pass.
+- GUI/console parity and all menu actions (new run, pause, save, load) behave
+  identically to before.

--- a/index.html
+++ b/index.html
@@ -18,9 +18,6 @@
 <body>
   <div id="app">
 
-    <!-- HUD -->
-    <starnet-hud id="hud"></starnet-hud>
-
     <!-- Main area: graph column (full width) -->
     <main id="main">
       <div id="graph-column">
@@ -54,6 +51,9 @@
           </div>
         </div>
         <div class="splitter splitter--row" data-resize="logH" title="Drag to resize — double-click to reset"></div>
+        <!-- Status bar: full-width strip above the terminal + hand strip.
+             Driven by visual-renderer.syncHud (alert, wallet, trace, connection, mission). -->
+        <starnet-hud id="hud"></starnet-hud>
         <div id="bottom-row">
           <div id="log-pane">
             <starnet-log id="log-entries"></starnet-log>

--- a/js/ui/components/starnet-hud.js
+++ b/js/ui/components/starnet-hud.js
@@ -1,4 +1,4 @@
-// <starnet-hud> — Header bar component.
+// <starnet-hud> — Status bar component (sits above the terminal).
 // Shows alert level, wallet, trace countdown, connection status, mission, and action buttons.
 
 import { html, nothing } from "lit";
@@ -76,8 +76,6 @@ class StarnetHud extends StarnetElement {
                                  "var(--red)";
 
     return html`
-      <span class="hud-title">★ STARNET</span>
-
       <div id="hud-connection">
         <img class="hud-lamp" id="conn-dot" alt="link ${this.connectionStatus}" src=${connStatusDataUri(this.connectionStatus)}>
         <span class="hud-value ${this.connectionStatus}" id="conn-status">${this.connectionLabel}</span>
@@ -97,6 +95,8 @@ class StarnetHud extends StarnetElement {
       ` : nothing}
 
       ${this._renderMission()}
+
+      ${this._renderCheatLabel()}
 
       <div class="hud-menu-wrap">
         <button id="hud-menu-btn" class=${this.menuOpen ? "active" : ""} title="Toggle controls"
@@ -118,9 +118,8 @@ class StarnetHud extends StarnetElement {
     `;
   }
 
-  // // CHEAT indicator — hidden for now (not rendered). Preserved intact for a
-  // planned status bar under the terminal; `isCheating` is still fed by the
-  // renderer. Re-add `${this._renderCheatLabel()}` to render() to restore it.
+  // // CHEAT indicator — shown in the status bar when cheats are active.
+  // `isCheating` is fed by the renderer.
   _renderCheatLabel() {
     return this.isCheating
       ? html`<span id="cheat-label" class="hud-cheat-label">// CHEAT</span>`


### PR DESCRIPTION
Continues the UI-compaction arc (after #208 dissolving the sidebar): removes the top HUD header entirely so the network graph reclaims that whole band.

## What changed
- **Title gone.** Dropped `★ STARNET`.
- **Status relocated.** Connection · alert · wallet · trace · mission (+ restored `// CHEAT` label) now live in a full-width **status bar directly above the terminal + hand strip** (brainstorm layout "Option A").
- **Hamburger** `☰` sits at the right end of the status bar; its dropdown (NEW RUN / PAUSE / SAVE / LOAD) opens **upward**.
- `starnet-hud` stays a **single component with an unchanged property API**, so `syncHud()` and the `main.js` `hud-action` wiring are untouched — blast radius is render markup + CSS only.
- `MANUAL.md` updated (interface diagram + HUD → status-bar wording).

## Verification
- `make check` (tsc + tests): **1150 pass, 0 fail**.
- Visual (Playwright vs `make serve`): header band gone; status bar reads correctly above the terminal; `☰` dropdown opens upward over the graph and renders cleanly.

Session docs: `docs/dev-sessions/2026-06-13-1220-header-to-status-bar/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)