### PR TITLE
Compact node inspector: drop the "GRADE" label

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -670,7 +670,6 @@ html, body {
   font-size: 0.62rem;
   letter-spacing: 0.06em;
 }
-#node-context-menu .insp-meta .im-key { color: var(--text-dim); }
 #node-context-menu .insp-meta .im-sep { color: var(--border); }
 #node-context-menu .insp-meta .im-val { color: var(--green); }
 #node-context-menu .nd-section-label { margin-bottom: 0.3rem; }

--- a/js/ui/components/starnet-context-menu.js
+++ b/js/ui/components/starnet-context-menu.js
@@ -118,7 +118,6 @@ class StarnetContextMenu extends StarnetElement {
         <div class="insp-typerow">
           <span class="nd-type">[${type}]</span>
           <div class="insp-meta">
-            <span class="im-key">GRADE</span>
             <span class="im-val grade-${obscured ? "" : (node.grade || "")}">${grade}</span>
             <span class="im-sep">·</span>
             <span class="im-val"><img class="access-glyph" alt="" src=${accessGlyphDataUri(node.accessLevel)}> ${(node.accessLevel || "—").toUpperCase()}</span>


### PR DESCRIPTION
Small compaction tweak. The node inspector header meta row showed `GRADE F · OWNED · GREEN`; the literal word **GRADE** was redundant beside the grade letter, so it is removed — the row now reads `F · OWNED · GREEN`. Also drops the now-orphaned `.im-key` CSS rule.

Follow-up Les flagged: the grade indicator itself could be compacted/restyled further — left for a separate pass.

## Verification
- `make check` (tsc + tests): **1150 pass, 0 fail**.
- Visual (Playwright vs `make serve`): inspector header reads `[WAN]  F · ⌂ OWNED · ◌ GREEN`, no "GRADE" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)