### PR TITLE
Throttle graph container resizes to stop drag flicker

### DIFF
--- a/js/ui/graph.js
+++ b/js/ui/graph.js
@@ -158,6 +158,13 @@ let bloomIntensity = 1;
 // _suspendBloomDuringViewport / _rampBloomIn.
 const BLOOM_RESTORE_DELAY_MS = 150;
 const BLOOM_RAMP_MS = 180;
+
+// Throttle interval for container resizes (e.g. dragging a layout splitter).
+// cy.resize() clears and repaints every canvas layer, so firing it on every
+// ResizeObserver frame strobes the graph. Throttling to a few times a second
+// turns that into the occasional single redraw while keeping the canvas roughly
+// tracking the container. A trailing call guarantees the final size is correct.
+const RESIZE_THROTTLE_MS = 250;
 let _bloomRestoreTimer = null;
 let _bloomRampRaf = null;
 
@@ -346,7 +353,29 @@ export function initGraph(networkData, onNodeClick, onBackgroundTap) {
   // (nodes/edges added on reveal, layout settles) or the container resizes.
   cy.on("add remove layoutstop", updateZoomFloor);
   if (typeof ResizeObserver !== "undefined") {
-    const ro = new ResizeObserver(() => { cy.resize(); updateZoomFloor(); });
+    // cy.resize() clears and repaints every canvas layer, so firing it on every
+    // ResizeObserver frame while a splitter is dragged strobes the graph. Throttle
+    // to RESIZE_THROTTLE_MS: resize on the leading edge so the canvas starts
+    // tracking immediately, then at most once per interval, with a trailing call
+    // so the final container size is always matched once the drag settles.
+    let lastResize = 0;
+    let trailingTimer = null;
+    const doResize = () => { cy.resize(); updateZoomFloor(); };
+    const ro = new ResizeObserver(() => {
+      const now = performance.now();
+      const sinceLast = now - lastResize;
+      if (sinceLast >= RESIZE_THROTTLE_MS) {
+        lastResize = now;
+        if (trailingTimer !== null) { clearTimeout(trailingTimer); trailingTimer = null; }
+        doResize();
+      } else if (trailingTimer === null) {
+        trailingTimer = setTimeout(() => {
+          trailingTimer = null;
+          lastResize = performance.now();
+          doResize();
+        }, RESIZE_THROTTLE_MS - sinceLast);
+      }
+    });
     ro.observe(graphContainer);
   }
   updateZoomFloor();


### PR DESCRIPTION
When dragging a layout splitter (e.g. the terminal/graph divider), `#graph-container` resized every frame and the `ResizeObserver` fired `cy.resize()` on each one. `cy.resize()` clears and repaints all three Cytoscape canvas layers, so the graph visibly strobed — blanking and redrawing dozens of times a second — for the duration of the drag.

## Fix

Throttle the resize handler to `RESIZE_THROTTLE_MS` (250ms):

- **Leading edge** — resize immediately on the first event so the canvas starts tracking right away.
- **Throttled** — at most one resize per interval during a continuous drag.
- **Trailing call** — a guaranteed final resize so the container size is always matched exactly once the drag settles.

This cuts the redraw rate from ~60/s to a few/s while keeping the canvas roughly tracking the pane, so there are no large blank strips when enlarging the graph.

## Investigation notes

Ruled out two red herrings along the way (verified live in-browser):

- **Bloom filter** — suspending the full-canvas `#starnet-bloom` filter during the drag (the pan/zoom mitigation) did *not* fix it; the flicker is the raw canvas clear, not the filter re-raster.
- **Zoom-floor snapping** — `updateZoomFloor()` runs per frame too, but `zoom`/`minZoom`/`pan` measured rock-steady during a drag, so it was not contributing.

The throttle interval was tuned by feel to 250ms.

## Verification

- Live before/after measurement: canvas repaints during an 18-frame continuous drag dropped from 18 (one per frame) to ~4, with the trailing call landing the exact final size.
- `make check` — lint clean, 1150/1150 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)