### PR TITLE
Prefix quality-from-attr nodeId in instantiate rewriteCondition

### DIFF
--- a/js/core/network/set-pieces.js
+++ b/js/core/network/set-pieces.js
@@ -149,6 +149,12 @@ function rewriteCondition(cond, prefix) {
   switch (cond.type) {
     case "node-attr":
       return cond.nodeId ? { ...cond, nodeId: pfx(cond.nodeId, prefix) } : cond;
+    case "quality-from-attr":
+      // Prefix an explicit nodeId (mirrors node-attr). The quality NAME is read
+      // at runtime from the named attribute's value — it can't be prefixed here,
+      // and shouldn't be: those are dynamic/global key qualities (see the
+      // `encrypted` trait), not per-instance set-piece qualities.
+      return cond.nodeId ? { ...cond, nodeId: pfx(cond.nodeId, prefix) } : cond;
     case "quality-gte":
     case "quality-eq":
       return { ...cond, name: pfx(cond.name, prefix) };

--- a/js/core/network/set-pieces.test.js
+++ b/js/core/network/set-pieces.test.js
@@ -47,6 +47,34 @@ describe("instantiate: compound conditions are prefixed recursively", () => {
   });
 });
 
+describe("instantiate: quality-from-attr nodeId is prefixed", () => {
+  it("prefixes an explicit nodeId, leaving the dynamic quality name alone", () => {
+    // quality-from-attr reads its quality NAME at runtime from an attribute, so
+    // only an explicit nodeId can be rewritten at instantiate time (mirrors
+    // node-attr). Without this it would point at an unprefixed node.
+    const def = {
+      nodes: [{
+        id: "vault",
+        type: "test",
+        traits: [],
+        attributes: {},
+        operators: [],
+        actions: [{
+          id: "open",
+          requires: [{ type: "quality-from-attr", nodeId: "keyholder", attr: "keyName", gte: 1 }],
+          effects: [],
+        }],
+      }],
+      externalPorts: ["vault"],
+    };
+    const inst = instantiate(/** @type {any} */ (def), "t1");
+    const cond = /** @type {any} */ (inst.nodes[0].actions[0].requires[0]);
+    assert.equal(cond.type, "quality-from-attr");
+    assert.equal(cond.nodeId, "t1/keyholder");
+    assert.equal(cond.attr, "keyName"); // attribute name unchanged
+  });
+});
+
 describe("instantiate: trigger IDs and nodeIds are prefixed", () => {
   it("prefixes trigger IDs", () => {
     // combinationLock still has graph-level triggers (vault-reveal)


### PR DESCRIPTION
Follow-up to #215 — this change was pushed to that branch just after it was squash-merged, so it never landed on `main`. Re-submitting on its own.

## What

`instantiate()`s `rewriteCondition` had a `default` case that silently passed `quality-from-attr` conditions through unprefixed. #215 closed the same gap for `not`; this closes it for the last remaining type, so `rewriteCondition` now handles all 7 `Condition` types with no silent passthrough.

- Prefixes an explicit `nodeId` (mirrors `node-attr`) so a `quality-from-attr` pointing at another set-piece node resolves to the instance-prefixed id.
- The quality **name** is read at runtime from the named attributes value, so it is intentionally left unprefixed — those are dynamic/global key qualities (the `encrypted` traits decryption-key check), not per-instance set-piece qualities. No-op for that one existing usage (it has no explicit `nodeId`), so zero behavioral risk.

## Verification

- New test: `quality-from-attr` nodeId is prefixed, attribute name left unchanged.
- `make check` — lint clean, 1155/1155 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)