### PR TITLE
Fast-start: always deal a fresh ephemeral starter hand

### DIFF
--- a/js/ui/hub.js
+++ b/js/ui/hub.js
@@ -5,7 +5,7 @@
 // same log output (the GUI/console symmetry principle). The pure profile model is
 // in js/core/profile; the run-start path is run-control.js.
 
-import { loadProfile, saveProfile, prepareLaunch } from "./profile-store.js";
+import { loadProfile, saveProfile, prepareLaunch, prepareFastStartLaunch } from "./profile-store.js";
 import { generateTargets, removeDisclosedCards } from "../core/profile/index.js";
 import { buyFromStoreToProfile } from "../core/store-logic.js";
 import { getStoreCatalog } from "../core/exploits.js";
@@ -63,26 +63,17 @@ function showHub() {
 }
 
 /**
- * Canned "hub start" for fast-start scenarios (e.g. a `?network=` deep-link): bootstrap/load
- * the profile, auto-equip a default starter loadout (the profile's inventory, up to
- * MAX_LOADOUT), and launch directly into the given prebuilt network — skipping the overworld
- * hub UI entirely. Carries no cash. Reuses the same prepareLaunch → startRun path the hub uses,
- * so the run is committed back to the profile on RUN_ENDED like any other.
+ * Canned "hub start" for fast-start scenarios (e.g. a `?network=` deep-link): deal a fresh
+ * generated starter hand and launch directly into the given prebuilt network, skipping the
+ * overworld hub entirely. Fast-start is a throwaway test session — the hand is ephemeral
+ * (not drawn from the profile) and the run does NOT commit back (no cash, no kept/burned
+ * cards), so it always lands in a playable LAN regardless of profile state.
  * @param {{ graphDef: any, meta: any }} networkResult
- * @returns {boolean} true if a run was launched; false if launch prep failed (caller should
- *   fall back to the hub rather than leave the player in an unplayable/empty run).
+ * @returns {boolean} always true (a run is always launched); the boolean preserves the
+ *   caller's `quickStartRun(...) || openHub()` contract.
  */
 export function quickStartRun(networkResult) {
-  const p = loadProfile(); // bootstraps a fresh profile (starter inventory) if absent
-  const loadoutIds = p.inventory.slice(0, MAX_LOADOUT).map((c) => c.instanceId);
-  // prepareLaunch returns null only if the launch can't be prepared (e.g. a corrupt profile
-  // with a negative bank). Don't launch a loadout-less, unplayable run — bail and let the
-  // caller open the hub. (mirrors launchTarget's null handling.)
-  const launchMeta = prepareLaunch({ loadoutInstanceIds: loadoutIds, withdrawAmount: 0 });
-  if (!launchMeta) {
-    log("[HUB] Fast-start could not prepare a loadout — opening the hub instead.", "error");
-    return false;
-  }
+  const launchMeta = prepareFastStartLaunch(MAX_LOADOUT);
   log(`[HUB] Fast-start (overworld hub skipped) — ${networkResult.meta?.name ?? "network"}.`, "success");
   startRun({ graphDef: networkResult.graphDef, meta: { ...networkResult.meta, ...launchMeta } });
   return true;

--- a/js/ui/hub.test.js
+++ b/js/ui/hub.test.js
@@ -15,9 +15,11 @@ globalThis.localStorage = globalThis.localStorage ?? {
 };
 
 const { quickStartRun } = await import("./hub.js");
+const { initProfileRunCommit } = await import("./profile-store.js");
 const { getState } = await import("../core/state.js");
 const { buildNetwork } = await import("../../data/networks/generated.js");
 const { initRng } = await import("../core/rng.js");
+const { emitEvent, E } = await import("../core/events.js");
 
 const PROFILE_KEY = "starnet:profile"; // mirror profile-store.js
 
@@ -33,16 +35,37 @@ describe("quickStartRun — canned hub start (fast-start / deep-link)", () => {
     assert.ok(Object.keys(getState().nodes).length > 0, "the run's network should be loaded");
   });
 
-  test("equips a default starter loadout so the run is playable (non-empty hand)", () => {
+  test("always deals a fresh, playable starter hand (no profile needed)", () => {
     quickStartRun(buildNetwork({ seed: "qs-2" }));
     assert.ok(getState().player.hand.length > 0,
-      "fast-start must deal a starter hand, not launch with an empty loadout");
+      "fast-start must always deal a fresh starter hand, never launch empty-handed");
   });
 
-  test("returns false (caller falls back to the hub) when the loadout can't be prepared", () => {
-    // Corrupt profile: negative bank makes withdraw(_, 0) fail → prepareLaunch returns null.
-    localStorage.setItem(PROFILE_KEY, JSON.stringify({ version: 1, bank: -1, inventory: [], _instanceSeq: 0 }));
-    assert.equal(quickStartRun(buildNetwork({ seed: "qs-3" })), false,
-      "a failed launch prep must report false rather than start an unplayable run");
+  test("ignores the profile inventory and does not mutate it", () => {
+    // Give the profile a single distinctive card. Fast-start should deal a FRESH full
+    // starter hand (not the 1-card inventory) and must not draw from or write to the
+    // profile — the inventory is unchanged afterward.
+    const oneCard = { version: 1, bank: 1000, _instanceSeq: 1,
+      inventory: [{ instanceId: "inv-0", name: "Solo Relic", rarity: "common", targetVulnTypes: [] }] };
+    localStorage.setItem(PROFILE_KEY, JSON.stringify(oneCard));
+    quickStartRun(buildNetwork({ seed: "qs-3" }));
+    assert.ok(getState().player.hand.length > 1,
+      "the dealt hand must be a fresh starter set, not the single inventory card");
+    const after = JSON.parse(localStorage.getItem(PROFILE_KEY));
+    assert.equal(after.inventory.length, 1, "fast-start must not mutate the profile inventory");
+    assert.equal(after.inventory[0].instanceId, "inv-0");
+  });
+
+  test("a fast-start run does not commit back to the profile on RUN_ENDED", () => {
+    // Throwaway test session: ending a fast-start run must not deposit cash or keep/burn
+    // cards. prepareFastStartLaunch clears activeRun, so the commit subscriber no-ops.
+    initProfileRunCommit();
+    const before = { version: 1, bank: 1000, _instanceSeq: 1,
+      inventory: [{ instanceId: "inv-0", name: "Solo Relic", rarity: "common", targetVulnTypes: [] }] };
+    localStorage.setItem(PROFILE_KEY, JSON.stringify(before));
+    quickStartRun(buildNetwork({ seed: "qs-4" }));
+    emitEvent(E.RUN_ENDED, { outcome: "success" });
+    const after = JSON.parse(localStorage.getItem(PROFILE_KEY));
+    assert.deepEqual(after, before, "a fast-start run must leave the profile untouched");
   });
 });

--- a/js/ui/profile-store.js
+++ b/js/ui/profile-store.js
@@ -87,6 +87,21 @@ function bootstrapProfile() {
 let activeRun = null;
 
 /**
+ * Prepare an ephemeral fast-start launch: a freshly generated starter hand that is
+ * neither drawn from nor committed back to the profile. Clears any active run so the
+ * RUN_ENDED commit subscriber no-ops — fast-start sessions are throwaway tests and must
+ * not deposit cash, keep cards, or burn a loadout. Always succeeds (no bank/inventory
+ * dependency), so the player lands in a playable LAN regardless of profile state.
+ * @param {number} maxCards - cap the dealt hand to the normal loadout size
+ * @returns {{ startHandCards: import('../core/types.js').ExploitCard[], startCash: number }}
+ */
+export function prepareFastStartLaunch(maxCards) {
+  activeRun = null; // a fast-start run does not commit back to the profile
+  const hand = generateStartingHand().slice(0, maxCards);
+  return { startHandCards: buildRunHand(hand), startCash: 0 };
+}
+
+/**
  * Prepare a run launch from the profile: withdraw the carried cash, clone the
  * chosen loadout, and record the carried set so the run can be committed when it
  * ends. Returns the meta additions (startHandCards + startCash) for the caller to


### PR DESCRIPTION
Using fast-start (`?network=` deep-link), the starting hand was unreliable — an existing profile with a drained inventory jacked into an empty-handed, unplayable run, and even a populated profile dealt whatever happened to be in inventory.

## Decision

Fast-start is a **throwaway test session**. It now:

- **Always deals a freshly generated starter hand** (capped at the normal loadout size), regardless of profile state — empty, drained, or populated.
- **Does not touch the profile**: it neither reads the inventory for the loadout nor commits results back on `RUN_ENDED` (no cash deposited, no cards kept or burned, no inventory growth).

This makes fast-start reproducible and side-effect-free — exactly what you want for quickly jumping into a LAN to test, without it depending on or mutating your accumulated profile.

(Supersedes an earlier "re-stock the inventory when empty" approach on this branch — fast-start no longer involves the profile at all, which is simpler and avoids polluting it.)

## Changes

- `prepareFastStartLaunch(maxCards)` (`profile-store.js`): generates a starter hand, caps it to the loadout size, and clears `activeRun` so the `RUN_ENDED` commit subscriber no-ops.
- `quickStartRun` (`hub.js`): drops the profile/`prepareLaunch` path entirely; always launches.

## Verification

- Tests: always deals a fresh non-empty hand (no profile needed); ignores and does not mutate the profile inventory; does not commit on `RUN_ENDED`.
- Verified live in-browser with a populated profile: fresh 5-card hand (none of the profile cards), profile inventory + bank untouched.
- `make check` — lint clean, 1155/1155 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)