### PR TITLE
Split game-types.js into node-factories + action-templates

### DIFF
--- a/data/networks/corporate-exchange.js
+++ b/data/networks/corporate-exchange.js
@@ -12,7 +12,7 @@ import { SET_PIECES } from "../biomes/corporate-pieces.js";
 import {
   createGateway, createRouter, createFirewall, createCryptovault,
   createWAN,
-} from "../../js/core/node-graph/game-types.js";
+} from "../../js/core/node-graph/node-factories.js";
 import { disguiseTrapNodes } from "../../js/core/network/disguise.js";
 import { makeSeededRng } from "../../js/core/rng.js";
 

--- a/data/networks/corporate-foothold.js
+++ b/data/networks/corporate-foothold.js
@@ -11,7 +11,7 @@ import { instantiate } from "../../js/core/network/set-pieces.js";
 import { SET_PIECES } from "../biomes/corporate-pieces.js";
 import {
   createGateway, createRouter, createWAN,
-} from "../../js/core/node-graph/game-types.js";
+} from "../../js/core/node-graph/node-factories.js";
 
 /**
  * @returns {{ graphDef: import('../../js/core/node-graph/runtime.js').NodeGraphDef, meta: object }}

--- a/data/networks/research-station.js
+++ b/data/networks/research-station.js
@@ -11,7 +11,7 @@ import { instantiate } from "../../js/core/network/set-pieces.js";
 import { SET_PIECES } from "../biomes/corporate-pieces.js";
 import {
   createGateway, createRouter, createFileserver, createWAN,
-} from "../../js/core/node-graph/game-types.js";
+} from "../../js/core/node-graph/node-factories.js";
 
 /**
  * @returns {{ graphDef: import('../../js/core/node-graph/runtime.js').NodeGraphDef, meta: object }}

--- a/js/core/node-graph/action-templates.js
+++ b/js/core/node-graph/action-templates.js
@@ -1,15 +1,18 @@
 // @ts-check
 /**
- * Game node type factories — produce trait-based NodeDef objects for each game
- * node type. Factories are optional sugar; the canonical authoring surface is
- * raw NodeDefs with traits lists.
+ * Action templates — the declarative ActionDef objects for the game's verbs
+ * (probe, xploit, dump, fetch, mine, reboot, corrupt, …) plus the shared
+ * timed-action wiring (NOT_BUSY) and the lie-low operator/attrs bundle.
  *
- * Traits provide operators, actions, and default attributes. Factories just
- * select the right trait list and apply config overrides.
+ * These are the *action half* of each mechanic; the matching timed-action
+ * *operators* live on the traits in `traits.js`, which is the sole consumer of
+ * this module (it pairs each operator with its template). Node-type factories
+ * select traits and never touch templates directly — see `node-factories.js`.
  */
 
 /** @typedef {import('./types.js').ActionDef} ActionDef */
-/** @typedef {import('./types.js').NodeDef} NodeDef */
+/** @typedef {import('./types.js').Condition} Condition */
+/** @typedef {import('./types.js').OperatorConfig} OperatorConfig */
 
 import { A } from "../action-ids.js";
 import { getExploitChoices, getExploitEmptyReason } from "../exploits.js";
@@ -281,9 +284,10 @@ const LIE_LOW_ACTION = {
   ],
 };
 
-// Lie-low wiring shared by every WAN node — the createWAN factory and the `darknet` trait.
-// Attributes track the per-run uses; the timed-action operator is the "time cost" wait that
-// fires ctx.lieLow on completion. (Tunable: LIE_LOW_USES, LIE_LOW_TICKS.)
+// Lie-low wiring shared by every WAN node — the `darknet` trait (and, through it,
+// the createWAN factory). Attributes track the per-run uses; the timed-action
+// operator is the "time cost" wait that fires ctx.lieLow on completion.
+// (Tunable: LIE_LOW_USES, LIE_LOW_TICKS.)
 const LIE_LOW_USES = 2;
 const LIE_LOW_TICKS = 50; // ~5s wait; flat across grades (the wait isn't grade-scaled)
 export const LIE_LOW_ATTRS = {
@@ -291,7 +295,7 @@ export const LIE_LOW_ATTRS = {
   lieLowUsesRemaining: LIE_LOW_USES,
   lieLowExhausted: false,
 };
-/** @type {import('./types.js').OperatorConfig} */
+/** @type {OperatorConfig} */
 export const LIE_LOW_OPERATOR = {
   name: "timed-action",
   action: "lie-low", // matches A.LIE_LOW so ACTION_FEEDBACK.action correlates across start/cancel
@@ -300,181 +304,7 @@ export const LIE_LOW_OPERATOR = {
   onComplete: [{ effect: "ctx-call", method: "lieLow", args: ["$nodeId"] }],
 };
 
-
-// ── Node type factories (optional sugar) ─────────────────────
-
-/**
- * @typedef {Object} NodeConfig
- * @property {string} [label]
- * @property {string} [grade]
- * @property {Record<string, any>} [attributes]
- */
-
-/**
- * Gateway — entry point.
- * @param {string} id
- * @param {NodeConfig} [config]
- * @returns {NodeDef}
- */
-export function createGateway(id, config = {}) {
-  return {
-    id,
-    type: "gateway",
-    traits: ["graded", "hackable", "rebootable", "gate"],
-    attributes: {
-      label: config.label || id,
-      grade: config.grade || "D",
-      gateAccess: "probed",
-      ...config.attributes,
-    },
-  };
-}
-
-/**
- * Router — relay operator (broadcasts non-tick messages).
- * @param {string} id
- * @param {NodeConfig} [config]
- * @returns {NodeDef}
- */
-export function createRouter(id, config = {}) {
-  return {
-    id,
-    type: "router",
-    traits: ["graded", "hackable", "rebootable", "relay", "gate"],
-    attributes: {
-      label: config.label || id,
-      grade: config.grade || "D",
-      gateAccess: "open",
-      ...config.attributes,
-    },
-  };
-}
-
-/**
- * IDS — alert relay + reconfigure action.
- * @param {string} id
- * @param {NodeConfig} [config]
- * @returns {NodeDef}
- */
-export function createIDS(id, config = {}) {
-  return {
-    id,
-    type: "ids",
-    traits: ["graded", "hackable", "rebootable", "detectable", "gate"],
-    attributes: {
-      label: config.label || id,
-      grade: config.grade || "C",
-      gateAccess: "owned",
-      ...config.attributes,
-    },
-  };
-}
-
-/**
- * Security Monitor — aggregates alerts, cancel-trace action.
- * @param {string} id
- * @param {NodeConfig} [config]
- * @returns {NodeDef}
- */
-export function createSecurityMonitor(id, config = {}) {
-  return {
-    id,
-    type: "security-monitor",
-    traits: ["graded", "hackable", "rebootable", "security", "gate"],
-    attributes: {
-      label: config.label || id,
-      grade: config.grade || "B",
-      gateAccess: "owned",
-      ...config.attributes,
-    },
-  };
-}
-
-/**
- * Fileserver — lootable node with macguffins.
- * @param {string} id
- * @param {NodeConfig & { lootCount?: [number, number] }} [config]
- * @returns {NodeDef}
- */
-export function createFileserver(id, config = {}) {
-  return {
-    id,
-    type: "fileserver",
-    traits: ["graded", "hackable", "rebootable", "lootable", "gate"],
-    attributes: {
-      label: config.label || id,
-      grade: config.grade || "D",
-      lootCount: config.lootCount || [1, 2],
-      ...config.attributes,
-    },
-  };
-}
-
-/**
- * Cryptovault — hardened lootable, quality-gated access possible.
- * @param {string} id
- * @param {NodeConfig & { lootCount?: [number, number] }} [config]
- * @returns {NodeDef}
- */
-export function createCryptovault(id, config = {}) {
-  return {
-    id,
-    type: "cryptovault",
-    traits: ["graded", "hackable", "rebootable", "lootable", "gate"],
-    attributes: {
-      label: config.label || id,
-      grade: config.grade || "B",
-      lootCount: config.lootCount || [1, 3],
-      ...config.attributes,
-    },
-  };
-}
-
-/**
- * Firewall — high-grade barrier, no relay behavior.
- * @param {string} id
- * @param {NodeConfig} [config]
- * @returns {NodeDef}
- */
-export function createFirewall(id, config = {}) {
-  return {
-    id,
-    type: "firewall",
-    traits: ["graded", "hackable", "rebootable", "gate"],
-    attributes: {
-      label: config.label || id,
-      grade: config.grade || "A",
-      gateAccess: "owned",
-      ...config.attributes,
-    },
-  };
-}
-
-/**
- * WAN — darknet store access. Starts accessible, no hack required.
- * @param {string} id
- * @param {NodeConfig} [config]
- * @returns {NodeDef}
- */
-export function createWAN(id, config = {}) {
-  return {
-    id,
-    type: "wan",
-    attributes: {
-      label: config.label || id,
-      grade: "F",
-      visibility: "accessible",
-      accessLevel: "owned",
-      ...LIE_LOW_ATTRS,
-      ...config.attributes,
-    },
-    operators: [LIE_LOW_OPERATOR],
-    actions: [ACCESS_DARKNET_ACTION, LIE_LOW_ACTION, DISCONNECT_ACTION],
-  };
-}
-
-
-// ── Export action templates for testing ───────────────────────
+// ── Template registry ─────────────────────────────────────────
 
 export const ACTION_TEMPLATES = {
   PROBE: PROBE_ACTION,
@@ -492,4 +322,3 @@ export const ACTION_TEMPLATES = {
   LIE_LOW: LIE_LOW_ACTION,
   DISCONNECT: DISCONNECT_ACTION,
 };
-

--- a/js/core/node-graph/action-templates.test.js
+++ b/js/core/node-graph/action-templates.test.js
@@ -1,0 +1,22 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ACTION_TEMPLATES } from "./action-templates.js";
+
+// ── Action templates ─────────────────────────────────────────
+
+describe("action templates", () => {
+  it("all templates have id, label, requires, and effects", () => {
+    for (const [name, template] of Object.entries(ACTION_TEMPLATES)) {
+      assert.ok(template.id, `${name} missing id`);
+      assert.ok(template.label, `${name} missing label`);
+      assert.ok(Array.isArray(template.requires), `${name} requires not an array`);
+      assert.ok(Array.isArray(template.effects), `${name} effects not an array`);
+    }
+  });
+
+  it("all templates have desc field", () => {
+    for (const [name, template] of Object.entries(ACTION_TEMPLATES)) {
+      assert.ok(template.desc, `${name} missing desc`);
+    }
+  });
+});

--- a/js/core/node-graph/mini-network.js
+++ b/js/core/node-graph/mini-network.js
@@ -7,7 +7,7 @@
 
 import { instantiate } from "../network/set-pieces.js";
 import { SET_PIECES } from "../../../data/biomes/corporate-pieces.js";
-import { createGateway, createWAN } from "./game-types.js";
+import { createGateway, createWAN } from "./node-factories.js";
 
 /**
  * Wrap a raw NodeGraphDef in a mini-network with gateway + WAN.

--- a/js/core/node-graph/node-factories.js
+++ b/js/core/node-graph/node-factories.js
@@ -1,0 +1,186 @@
+// @ts-check
+/**
+ * Node-type factories — produce trait-based NodeDef objects for each game node
+ * type. Factories are optional sugar; the canonical authoring surface is raw
+ * NodeDefs with traits lists (see `traits.js`, and `data/biomes/` for the
+ * procedural set-piece content). The hand-crafted named levels in
+ * `data/networks/` are the live consumers of these factories.
+ *
+ * A factory just selects the right trait list and applies config overrides.
+ * The verbs the traits grant (probe, xploit, dump, …) are defined as action
+ * templates in `action-templates.js`.
+ */
+
+/** @typedef {import('./types.js').NodeDef} NodeDef */
+
+// ── Node type factories (optional sugar) ─────────────────────
+
+/**
+ * @typedef {Object} NodeConfig
+ * @property {string} [label]
+ * @property {string} [grade]
+ * @property {Record<string, any>} [attributes]
+ */
+
+/**
+ * Gateway — entry point.
+ * @param {string} id
+ * @param {NodeConfig} [config]
+ * @returns {NodeDef}
+ */
+export function createGateway(id, config = {}) {
+  return {
+    id,
+    type: "gateway",
+    traits: ["graded", "hackable", "rebootable", "gate"],
+    attributes: {
+      label: config.label || id,
+      grade: config.grade || "D",
+      gateAccess: "probed",
+      ...config.attributes,
+    },
+  };
+}
+
+/**
+ * Router — relay operator (broadcasts non-tick messages).
+ * @param {string} id
+ * @param {NodeConfig} [config]
+ * @returns {NodeDef}
+ */
+export function createRouter(id, config = {}) {
+  return {
+    id,
+    type: "router",
+    traits: ["graded", "hackable", "rebootable", "relay", "gate"],
+    attributes: {
+      label: config.label || id,
+      grade: config.grade || "D",
+      gateAccess: "open",
+      ...config.attributes,
+    },
+  };
+}
+
+/**
+ * IDS — alert relay + reconfigure action.
+ * @param {string} id
+ * @param {NodeConfig} [config]
+ * @returns {NodeDef}
+ */
+export function createIDS(id, config = {}) {
+  return {
+    id,
+    type: "ids",
+    traits: ["graded", "hackable", "rebootable", "detectable", "gate"],
+    attributes: {
+      label: config.label || id,
+      grade: config.grade || "C",
+      gateAccess: "owned",
+      ...config.attributes,
+    },
+  };
+}
+
+/**
+ * Security Monitor — aggregates alerts, cancel-trace action.
+ * @param {string} id
+ * @param {NodeConfig} [config]
+ * @returns {NodeDef}
+ */
+export function createSecurityMonitor(id, config = {}) {
+  return {
+    id,
+    type: "security-monitor",
+    traits: ["graded", "hackable", "rebootable", "security", "gate"],
+    attributes: {
+      label: config.label || id,
+      grade: config.grade || "B",
+      gateAccess: "owned",
+      ...config.attributes,
+    },
+  };
+}
+
+/**
+ * Fileserver — lootable node with macguffins.
+ * @param {string} id
+ * @param {NodeConfig & { lootCount?: [number, number] }} [config]
+ * @returns {NodeDef}
+ */
+export function createFileserver(id, config = {}) {
+  return {
+    id,
+    type: "fileserver",
+    traits: ["graded", "hackable", "rebootable", "lootable", "gate"],
+    attributes: {
+      label: config.label || id,
+      grade: config.grade || "D",
+      lootCount: config.lootCount || [1, 2],
+      ...config.attributes,
+    },
+  };
+}
+
+/**
+ * Cryptovault — hardened lootable, quality-gated access possible.
+ * @param {string} id
+ * @param {NodeConfig & { lootCount?: [number, number] }} [config]
+ * @returns {NodeDef}
+ */
+export function createCryptovault(id, config = {}) {
+  return {
+    id,
+    type: "cryptovault",
+    traits: ["graded", "hackable", "rebootable", "lootable", "gate"],
+    attributes: {
+      label: config.label || id,
+      grade: config.grade || "B",
+      lootCount: config.lootCount || [1, 3],
+      ...config.attributes,
+    },
+  };
+}
+
+/**
+ * Firewall — high-grade barrier, no relay behavior.
+ * @param {string} id
+ * @param {NodeConfig} [config]
+ * @returns {NodeDef}
+ */
+export function createFirewall(id, config = {}) {
+  return {
+    id,
+    type: "firewall",
+    traits: ["graded", "hackable", "rebootable", "gate"],
+    attributes: {
+      label: config.label || id,
+      grade: config.grade || "A",
+      gateAccess: "owned",
+      ...config.attributes,
+    },
+  };
+}
+
+/**
+ * WAN — darknet store access. Starts accessible, no hack required. The `darknet`
+ * trait supplies the access-darknet / lie-low / disconnect actions, the lie-low
+ * timed-action operator, and the lie-low attributes.
+ * @param {string} id
+ * @param {NodeConfig} [config]
+ * @returns {NodeDef}
+ */
+export function createWAN(id, config = {}) {
+  return {
+    id,
+    type: "wan",
+    traits: ["darknet"],
+    attributes: {
+      label: config.label || id,
+      grade: "F",
+      visibility: "accessible",
+      accessLevel: "owned",
+      ...config.attributes,
+    },
+  };
+}

--- a/js/core/node-graph/node-factories.test.js
+++ b/js/core/node-graph/node-factories.test.js
@@ -6,8 +6,7 @@ import { resolveTraits } from "./traits.js";
 import {
   createGateway, createRouter, createIDS, createSecurityMonitor,
   createFileserver, createCryptovault, createFirewall, createWAN,
-  ACTION_TEMPLATES,
-} from "./game-types.js";
+} from "./node-factories.js";
 
 // Helper: resolve factory output to get full attributes/operators/actions
 function resolve(def) { return resolveTraits(def); }
@@ -68,9 +67,9 @@ describe("traits assignment", () => {
     }
   });
 
-  it("WAN has no traits (special case)", () => {
+  it("WAN uses the darknet trait", () => {
     const wan = createWAN("wan-1");
-    assert.ok(!wan.traits || wan.traits.length === 0);
+    assert.deepStrictEqual(wan.traits, ["darknet"]);
   });
 
 
@@ -154,7 +153,8 @@ describe("operators", () => {
   });
 
   it("wan has the lie-low timed-action operator (#174) and the darknet + lie-low actions", () => {
-    const def = createWAN("test");
+    // Supplied by the darknet trait, so resolve before inspecting operators/actions/attrs.
+    const def = resolve(createWAN("test"));
     assert.ok(def.operators.some(o => o.name === "timed-action" && o.action === "lie-low"),
       "WAN carries the lie-low timed-action");
     assert.ok(def.actions.some(a => a.id === "access-darknet"));
@@ -331,25 +331,6 @@ describe("action execution", () => {
     const graph = new NodeGraph({ nodes: [wan], edges: [] }, ctx);
     graph.executeAction("wan-1", "access-darknet");
     assert.equal(ctx.calls.openDarknetsStore?.length, 1);
-  });
-});
-
-// ── Action templates ─────────────────────────────────────────
-
-describe("action templates", () => {
-  it("all templates have id, label, requires, and effects", () => {
-    for (const [name, template] of Object.entries(ACTION_TEMPLATES)) {
-      assert.ok(template.id, `${name} missing id`);
-      assert.ok(template.label, `${name} missing label`);
-      assert.ok(Array.isArray(template.requires), `${name} requires not an array`);
-      assert.ok(Array.isArray(template.effects), `${name} effects not an array`);
-    }
-  });
-
-  it("all templates have desc field", () => {
-    for (const [name, template] of Object.entries(ACTION_TEMPLATES)) {
-      assert.ok(template.desc, `${name} missing desc`);
-    }
   });
 });
 

--- a/js/core/node-graph/timed-actions.js
+++ b/js/core/node-graph/timed-actions.js
@@ -5,9 +5,9 @@
 // (operators.js): it sets an `activeAttr` true, ticks a `_ta_<action>_progress`
 // attribute toward `_ta_<action>_duration`, then fires its onComplete. The action
 // id, the (irregular) activeAttr flag, and whether ABORT can cancel it were
-// previously enumerated independently across traits.js, game-types.js, and
+// previously enumerated independently across traits.js, action-templates.js, and
 // game-ctx.js — adding one meant touching all three by hand. They derive from this
-// registry now: game-types builds ABORT/NOT_BUSY from ABORTABLE_FLAGS, game-ctx and
+// registry now: action-templates builds ABORT/NOT_BUSY from ABORTABLE_FLAGS, game-ctx and
 // runtime build attribute names via getTimedActionAttrNames, and a test
 // (timed-actions.test.js) asserts the traits.js operator configs still match.
 
@@ -31,7 +31,7 @@ export const TIMED_ACTIONS = [
 
 /**
  * activeAttr flags for the ABORTABLE timed actions. ABORT shows when any is true;
- * NOT_BUSY (game-types.js) requires all of them — plus `rebooting` — false.
+ * NOT_BUSY (action-templates.js) requires all of them — plus `rebooting` — false.
  * @type {string[]}
  */
 export const ABORTABLE_FLAGS = TIMED_ACTIONS.filter((t) => t.abortable).map((t) => t.activeAttr);

--- a/js/core/node-graph/timed-actions.test.js
+++ b/js/core/node-graph/timed-actions.test.js
@@ -8,14 +8,14 @@ import assert from "node:assert/strict";
 
 import { TIMED_ACTIONS, ABORTABLE_FLAGS, getTimedActionAttrNames } from "./timed-actions.js";
 import { getTrait } from "./traits.js";
-import { LIE_LOW_OPERATOR } from "./game-types.js";
+import { LIE_LOW_OPERATOR } from "./action-templates.js";
 
 // Importing traits.js registers the built-in traits at module load.
 const TRAITS_WITH_TIMED_ACTIONS = ["hackable", "lootable", "rebootable"];
 
 /**
  * Every (action, activeAttr) from a timed-action operator the game defines —
- * across the built-in traits plus the standalone LIE_LOW_OPERATOR in game-types.js
+ * across the built-in traits plus the standalone LIE_LOW_OPERATOR in action-templates.js
  * (lie-low is a WAN action, not a trait). This is the set the registry must mirror.
  */
 function definedTimedActions() {

--- a/js/core/node-graph/traits.js
+++ b/js/core/node-graph/traits.js
@@ -143,7 +143,7 @@ export function clearTraits() {
 
 // ── Built-in trait definitions ──────────────────────────────────
 
-import { ACTION_TEMPLATES, LIE_LOW_ATTRS, LIE_LOW_OPERATOR } from "./game-types.js";
+import { ACTION_TEMPLATES, LIE_LOW_ATTRS, LIE_LOW_OPERATOR } from "./action-templates.js";
 
 registerTrait("graded", {
   attributes: { grade: "D" },
@@ -305,7 +305,7 @@ registerTrait("gate", {
 });
 
 // WAN-boundary darknet broker: access-darknet opens the in-run store; lie-low is the
-// time-costly, per-run-limited grid cooldown (same wiring as the createWAN factory).
+// time-costly, per-run-limited grid cooldown. The createWAN factory applies this trait.
 registerTrait("darknet", {
   attributes: { ...LIE_LOW_ATTRS },
   operators: [LIE_LOW_OPERATOR],

--- a/js/core/store-logic.test.js
+++ b/js/core/store-logic.test.js
@@ -6,7 +6,7 @@ import { getStoreCatalog } from "./exploits.js";
 import { initGame, getState } from "./state.js";
 import { initRng } from "./rng.js";
 import { createProfile } from "./profile/index.js";
-import { createGateway, createRouter } from "./node-graph/game-types.js";
+import { createGateway, createRouter } from "./node-graph/node-factories.js";
 
 function buildStoreLAN() {
   return {

--- a/tests/ice-multi-detection.test.js
+++ b/tests/ice-multi-detection.test.js
@@ -11,7 +11,7 @@ import assert from "node:assert/strict";
 
 import {
   createGateway, createRouter,
-} from "../js/core/node-graph/game-types.js";
+} from "../js/core/node-graph/node-factories.js";
 import { initGame, getState } from "../js/core/state.js";
 import { startIce, handleIceTick, handleIceDetect, ejectIce } from "../js/core/ice.js";
 import { handleTraceTick } from "../js/core/alert.js";

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -8,7 +8,7 @@
 //   - Direct state mutation is used sparingly to set up conditions
 //     (same pattern as cheats.js: mutate field + emit NODE_ACCESSED).
 //
-// Each test group constructs a minimal LAN fixture using game-types.js factories.
+// Each test group constructs a minimal LAN fixture using node-factories.js factories.
 // This avoids coupling tests to the full network topology.
 //
 // SEED CONVENTION: every initGame() call passes an explicit seed string ("itest-N").
@@ -24,7 +24,7 @@ import assert from "node:assert/strict";
 import {
   createGateway, createRouter, createIDS, createSecurityMonitor,
   createFileserver, createFirewall, createWAN,
-} from "../js/core/node-graph/game-types.js";
+} from "../js/core/node-graph/node-factories.js";
 import { buildSetPieceMiniNetwork } from "../js/core/node-graph/mini-network.js";
 import { initGame, getState, isIceVisible, buyExploit } from "../js/core/state.js";
 import { navigateTo, navigateAway } from "../js/core/navigation.js";

--- a/tests/ui-state.test.js
+++ b/tests/ui-state.test.js
@@ -4,7 +4,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { createGateway, createRouter } from "../js/core/node-graph/game-types.js";
+import { createGateway, createRouter } from "../js/core/node-graph/node-factories.js";
 import { initGame, getState, serializeState, deserializeState } from "../js/core/state.js";
 import { toggleMenuOpen, toggleHandCollapsed } from "../js/core/state/game.js";
 


### PR DESCRIPTION
Follow-up to the question: "is `game-types.js` mostly dead code?" It is not — but the *module home* was the real problem. The file held two unrelated concerns under a misleading name (it sat next to `types.js` yet contained zero typedefs).

## What changed

- **`game-types.js` → `node-factories.js`** — now holds only the `create*` node-type factories. The hand-crafted named levels in `data/networks/*` (live, player-selectable) and `mini-network.js` are the consumers.
- **New `action-templates.js`** — the `*_ACTION` defs, `ACTION_TEMPLATES`, `NOT_BUSY`, and the `LIE_LOW_OPERATOR`/`LIE_LOW_ATTRS` bundle. `traits.js` is the sole consumer; it already holds the matching timed-action *operators*, so the two halves of each mechanic now live next to each other instead of importing across a misnamed seam.
- **`createWAN` simplified** — it previously inlined the lie-low operator + access-darknet/lie-low/disconnect actions, duplicating exactly what the `darknet` trait provides. It now declares `traits: ["darknet"]` like every other factory.
- Test file split to match: `node-factories.test.js` (factories) + `action-templates.test.js` (template shape). The two WAN tests that asserted the old *inlined* shape now `resolve()` traits first and assert the same observable resolved shape (lie-low operator present, darknet actions present, `lieLowUsesRemaining === 2`).

Dependency flow is clean and acyclic: `node-factories → (nothing)`, `traits → action-templates`.

## What did NOT change

Pure reorganization — **no behavior change**. No factory was deleted (incl. the test-only `createIDS`/`createSecurityMonitor` — they keep the set symmetric and are the obvious reach for a future hand-authored alert circuit).

## Verification

`make check` green — 1156 tests pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)