### PR TITLE
Audio engine v1: reactive procedural music

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -478,6 +478,8 @@ needs a fill, a circle, or a dither, it's the wrong primitive.
 - Alert + trace system and ICE (multiple instances, grade-scaled behavior, detection/dwell)
 - Darknet store, exploit card decay (use/disclosure), health/deck loss-clock pressure
 - Headless playtest harness + automated bot + census for balance testing
+- Reactive procedural music (Tone.js): two-axis (progress/threat) layered scores, 8 selectable
+  Corporate variants, section-breakdown automation; see `docs/audio-direction.md`
 
 ## Out of Scope (Future)
 
@@ -485,7 +487,8 @@ needs a fill, a circle, or a dither, it's the wrong primitive.
 - Sprites, daemons, machine elves
 - Full player progression / persistent meta-loop between runs (overworld is early)
 - Wider world (galaxy, planets, cities)
-- Audio
+- Audio: sound effects + vocal-texture one-shots (music has shipped; SFX deferred — see
+  the fast-follows in `docs/audio-direction.md`)
 
 ## Backlog
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -796,6 +796,29 @@ help                   Command listing
 
 ---
 
+## AUDIO
+
+The soundtrack is **reactive** — it reads your run and scores it in real time, built up
+from layers rather than a fixed loop.
+
+- **Progress = reward.** As you penetrate deeper and own more of the LAN, the music
+  *unfolds* — percussion, bass, lead, and a celebratory arp layer in as you go.
+- **Threat = warning.** As the alert level climbs, ICE locks on, or your health/deck takes
+  damage, urgency layers and a filter sweep cut in — fast to rise, slow to ease back down.
+- **Variety.** Each run picks one of several scores (different moods/keys/tempos), and the
+  arrangement periodically shifts into breakdowns so a long run never sits still.
+- **The hub has its own calm ambient theme**, separate from the LAN scores. The run's music
+  **fades out** when you jack out, and the hub ambience drifts back in.
+
+**Music commands** (console): `music` shows what's playing, `music list` lists the scores,
+`music next` switches randomly, `music <name>` picks one (e.g. `music neon`), `music on|off`.
+
+**Music: On / Off** lives in the hamburger menu (`[ ☰ ]`). The choice is remembered between
+sessions. (Audio starts on your first click or keypress — browsers require a gesture before
+playing sound.)
+
+---
+
 ## TIPS
 
 **Probe before you exploit.** Without probing, you're attacking blind. A matched

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all serve dev lint test check bundle-vendor census bot-run generate gen-bot gen-json
 
 # Install dependencies and build vendor bundles
-all: node_modules dist/vendor.js dist/lit.js
+all: node_modules dist/vendor.js dist/lit.js dist/tone.js
 
 node_modules: package.json
 	npm install
@@ -11,6 +11,9 @@ dist/vendor.js: js/vendor.js node_modules
 
 dist/lit.js: js/lit-vendor.js node_modules
 	npx esbuild js/lit-vendor.js --bundle --outfile=dist/lit.js --format=esm --platform=browser --minify
+
+dist/tone.js: js/tone-vendor.js node_modules
+	npx esbuild js/tone-vendor.js --bundle --outfile=dist/tone.js --format=esm --platform=browser --minify
 
 # Start local dev server (open http://localhost:3000)
 serve:
@@ -26,7 +29,7 @@ dev: bundle-vendor serve
 #   fixtures/             (test fixture data)
 lint:
 	npx tsc --noEmit --allowJs --checkJs --target ES2020 --moduleResolution bundler --module ES2020 \
-		$(shell find js -name '*.js' ! -name '*.test.js' ! -path '*/fixtures/*' ! -name 'graph.js' ! -name 'vendor.js' ! -name 'lit-vendor.js')
+		$(shell find js -name '*.js' ! -name '*.test.js' ! -path '*/fixtures/*' ! -name 'graph.js' ! -name 'vendor.js' ! -name 'lit-vendor.js' ! -name 'tone-vendor.js')
 
 # Run unit + integration tests
 test:
@@ -35,10 +38,11 @@ test:
 # Full check: lint + test
 check: lint test
 
-# Bundle vendor dependencies (Cytoscape + layout extensions, Lit)
+# Bundle vendor dependencies (Cytoscape + layout extensions, Lit, Tone)
 bundle-vendor:
 	npx esbuild js/vendor.js --bundle --outfile=dist/vendor.js --format=iife --platform=browser --minify
 	npx esbuild js/lit-vendor.js --bundle --outfile=dist/lit.js --format=esm --platform=browser --minify
+	npx esbuild js/tone-vendor.js --bundle --outfile=dist/tone.js --format=esm --platform=browser --minify
 
 # Shared grade defaults for bot/census/generate targets
 THREAT ?= C

--- a/audio-elementary.html
+++ b/audio-elementary.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Starnet audio — Elementary</title>
+<style>
+  :root { --bg:#0a0a0f; --cyan:#22d3ee; --green:#39ff88; --mag:#ff00aa; --violet:#a78bfa; --dim:#1b2330; }
+  * { box-sizing:border-box; }
+  body { background:var(--bg); color:var(--green); font-family:ui-monospace,Menlo,Consolas,monospace;
+         margin:0; padding:2rem; line-height:1.5; }
+  h1 { color:var(--violet); font-weight:600; letter-spacing:.05em; font-size:1.2rem;
+       text-shadow:0 0 8px rgba(167,139,250,.5); margin:0 0 .25rem; }
+  .sub { color:#6b7a8d; font-size:.8rem; margin-bottom:1.5rem; }
+  .panel { border:1px solid var(--dim); border-radius:6px; padding:1.25rem; max-width:560px;
+           box-shadow:0 0 24px rgba(167,139,250,.07) inset; }
+  .row { display:flex; gap:.6rem; align-items:center; flex-wrap:wrap; margin:.6rem 0; }
+  button { background:transparent; color:var(--violet); border:1px solid var(--violet); border-radius:4px;
+           padding:.5rem 1rem; font:inherit; cursor:pointer; text-shadow:0 0 6px rgba(167,139,250,.6); }
+  button:hover { background:rgba(167,139,250,.08); }
+  button.stop { color:var(--mag); border-color:var(--mag); text-shadow:0 0 6px rgba(255,0,170,.6); }
+  .track { display:inline-flex; align-items:center; gap:.4rem; border:1px solid var(--dim);
+           border-radius:4px; padding:.4rem .7rem; cursor:pointer; user-select:none; color:#8aa; }
+  .track.on { color:var(--green); border-color:var(--green); text-shadow:0 0 6px rgba(57,255,136,.5); }
+  .track .dot { width:8px; height:8px; border:1px solid currentColor; transform:rotate(45deg); }
+  .track.on .dot { background:var(--green); box-shadow:0 0 6px var(--green); }
+  label.slider { display:flex; flex-direction:column; gap:.2rem; font-size:.75rem; color:#8aa; flex:1; min-width:160px; }
+  input[type=range]{ width:100%; accent-color:var(--mag); }
+  .val { color:var(--violet); }
+  .note { color:#5a6b7d; font-size:.72rem; margin-top:1.25rem; border-top:1px solid var(--dim); padding-top:.9rem; }
+  code { color:var(--cyan); }
+  #status.err { color:var(--mag); }
+</style>
+</head>
+<body>
+  <h1>STARNET // AUDIO ENGINE TEST — Elementary</h1>
+  <div class="sub">4-part synth song · per-track mute · tension preview · same composition as the Tone.js demo</div>
+
+  <div class="panel">
+    <div class="row">
+      <button id="play">▶ PLAY</button>
+      <button id="stop" class="stop">■ STOP</button>
+      <span id="status" style="color:#6b7a8d;font-size:.8rem">idle</span>
+    </div>
+
+    <div class="row" id="tracks"></div>
+
+    <div class="row">
+      <label class="slider">TEMPO <span class="val" id="bpmVal">104</span> bpm
+        <input type="range" id="bpm" min="70" max="150" value="104" />
+      </label>
+    </div>
+    <div class="row">
+      <label class="slider">ICE TENSION <span class="val" id="tenVal">0.00</span>
+        <input type="range" id="tension" min="0" max="100" value="0" />
+      </label>
+    </div>
+
+    <div class="note">
+      <b style="color:#8aa">What to listen for:</b> tension opens a master filter + fades in a detuned drone.<br>
+      <b style="color:#8aa">Engine:</b> Elementary (pure DSP, AudioWorklet). The whole song is one signal
+      function; every mute / slider move calls <code>core.render(...)</code> again and the engine diffs the
+      graph. Note there is no "trigger a note" — sequencing is a <code>metro</code> → <code>seq2</code> chain.
+    </div>
+  </div>
+
+<script type="module">
+import { el } from 'https://esm.sh/@elemaudio/core@3';
+import WebRenderer from 'https://esm.sh/@elemaudio/web-renderer@3';
+
+// ---- Composition (shared with Tone.js demo) ----------------------------------
+const LEAD = [
+  'A4',null,'C5',null,'E5',null,'D5',null,
+  'C5',null,'A4',null,'F4',null,'A4',null,
+  'E5',null,'G5',null,'E5',null,'C5',null,
+  'D5',null,'B4',null,'G4',null,'B4',null,
+];
+const BASS = [
+  'A2',null,'E2',null,'A2',null,'E2',null,
+  'F2',null,'C2',null,'F2',null,'C2',null,
+  'C2',null,'G2',null,'C2',null,'G2',null,
+  'G2',null,'D2',null,'G2',null,'D2',null,
+];
+const CHORDS = [ ['A3','C4','E4'], ['F3','A3','C4'], ['C4','E4','G4'], ['G3','B3','D4'] ];
+const STEPS = 32;
+
+const NI = { C:0,'C#':1,D:2,'D#':3,E:4,'F':5,'F#':6,G:7,'G#':8,A:9,'A#':10,B:11 };
+const freq = n => { if (!n) return 0; const m = n.match(/^([A-G]#?)(\d)$/);
+  const midi = (+m[2] + 1) * 12 + NI[m[1]]; return 440 * Math.pow(2, (midi - 69) / 12); };
+const gateOf = arr => arr.map(n => (n ? 1 : 0));
+
+// Build the three chord-tone lanes: triad freq at steps 0 & 4 of each bar, else 0.
+const chordLane = idx => Array.from({ length: STEPS }, (_, i) => {
+  const p = i % 8, bar = (i / 8) | 0;
+  return (p === 0 || p === 4) ? freq(CHORDS[bar][idx]) : 0;
+});
+const CH0 = chordLane(0), CH1 = chordLane(1), CH2 = chordLane(2);
+const chordGate = CH0.map(v => (v ? 1 : 0));
+// percussion gate lanes
+const kickGate  = Array.from({ length: STEPS }, (_, i) => (i % 2 === 0 ? 1 : 0));
+const snareGate = Array.from({ length: STEPS }, (_, i) => { const p = i % 8; return (p === 2 || p === 6) ? 1 : 0; });
+const hatGate   = Array.from({ length: STEPS }, (_, i) => (i % 2 === 1 ? 1 : 0));
+
+const LEADF = LEAD.map(freq), BASSF = BASS.map(freq);
+const LEADG = gateOf(LEAD), BASSG = gateOf(BASS);
+
+// ---- Engine ------------------------------------------------------------------
+let core, started = false;
+const state = { lead:true, bass:true, rhythm:true, perc:true, bpm:104, tension:0 };
+const status = document.getElementById('status');
+
+const reset = el.const({ key:'reset', value:0 });
+const gain  = (key, on) => el.sm(el.const({ key, value: on ? 1 : 0 }));
+
+function pitched(key, freqs, gates, osc) {
+  const tick = el.metro({ key:key+'-m', interval: 60000 / state.bpm / 2 });
+  const pitch = el.seq2({ key:key+'-p', seq:freqs, hold:true, loop:true }, tick, reset);
+  const g     = el.seq2({ key:key+'-g', seq:gates, hold:true, loop:true }, tick, reset);
+  const env   = el.adsr(0.005, 0.12, 0.3, 0.15, g);
+  return el.mul(osc(pitch), env);
+}
+
+function buildSignal() {
+  // melodic voices
+  const lead   = el.mul(pitched('lead', LEADF, LEADG, el.blepsaw), gain('g-lead', state.lead), 0.5);
+  const bass   = el.mul(pitched('bass', BASSF, BASSG, el.blepsquare), gain('g-bass', state.bass), 0.7);
+
+  // rhythm = three chord lanes sharing one gate/clock
+  const tick = el.metro({ key:'rhy-m', interval: 60000 / state.bpm / 2 });
+  const cg = el.adsr(0.005, 0.16, 0.0, 0.12, el.seq2({ key:'rhy-g', seq:chordGate, hold:true, loop:true }, tick, reset));
+  const lane = (k, seq) => el.mul(el.blepsaw(el.seq2({ key:k, seq, hold:true, loop:true }, tick, reset)), cg);
+  const rhythm = el.mul(el.add(lane('c0', CH0), lane('c1', CH1), lane('c2', CH2)), gain('g-rhy', state.rhythm), 0.18);
+
+  // percussion
+  const ptick = el.metro({ key:'perc-m', interval: 60000 / state.bpm / 2 });
+  const kg = el.seq2({ key:'kg', seq:kickGate, hold:true, loop:true }, ptick, reset);
+  const kPitch = el.add(45, el.mul(90, el.adsr(0.001, 0.07, 0, 0.07, kg)));
+  const kick = el.mul(el.cycle(kPitch), el.adsr(0.001, 0.22, 0, 0.22, kg), 0.9);
+  const sg = el.seq2({ key:'sg', seq:snareGate, hold:true, loop:true }, ptick, reset);
+  const snare = el.mul(el.noise(), el.adsr(0.001, 0.13, 0, 0.13, sg), 0.35);
+  const hg = el.seq2({ key:'hg', seq:hatGate, hold:true, loop:true }, ptick, reset);
+  const hat = el.mul(el.highpass(7000, 1, el.noise()), el.adsr(0.001, 0.03, 0, 0.03, hg), 0.25);
+  const perc = el.mul(el.add(kick, snare, hat), gain('g-perc', state.perc));
+
+  // ICE drone, fades in with tension
+  const ten = el.sm(el.const({ key:'tension', value: state.tension }));
+  const drone = el.mul(el.add(el.blepsaw(el.const({ key:'d1', value:freq('A2') })),
+                              el.blepsaw(el.const({ key:'d2', value:freq('E3') * 1.003 }))),
+                       el.mul(ten, 0.18));
+
+  const mix = el.add(lead, bass, rhythm, perc, drone);
+  // master filter opens with tension
+  const cutoff = el.add(500, el.mul(7000, ten));
+  return el.mul(el.lowpass(cutoff, 0.8, mix), 0.7);
+}
+
+function render() {
+  if (!core) return;
+  const out = buildSignal();
+  core.render(out, out);
+}
+
+async function start() {
+  if (started) return;
+  status.className = ''; status.textContent = 'initializing…';
+  const ctx = new AudioContext();
+  core = new WebRenderer();
+  const node = await core.initialize(ctx, { numberOfInputs:0, numberOfOutputs:1, outputChannelCount:[2] });
+  node.connect(ctx.destination);
+  await ctx.resume();
+  started = true;
+  render();
+  status.textContent = 'playing';
+}
+
+// ---- Controls ----------------------------------------------------------------
+const tracksEl = document.getElementById('tracks');
+for (const name of ['lead','bass','rhythm','perc']) {
+  const el2 = document.createElement('span');
+  el2.className = 'track on';
+  el2.innerHTML = `<span class="dot"></span>${name.toUpperCase()}`;
+  el2.onclick = () => { state[name] = !state[name]; el2.classList.toggle('on', state[name]); render(); };
+  tracksEl.appendChild(el2);
+}
+document.getElementById('play').onclick = async () => {
+  try { await start(); }
+  catch (e) { status.className = 'err'; status.textContent = 'ERROR: ' + e.message; console.error(e); }
+};
+document.getElementById('stop').onclick = () => { if (core) core.render(el.const({ value:0 }), el.const({ value:0 })); status.textContent = 'stopped'; };
+
+const bpm = document.getElementById('bpm'), bpmVal = document.getElementById('bpmVal');
+bpm.oninput = () => { state.bpm = +bpm.value; bpmVal.textContent = bpm.value; render(); };
+const tension = document.getElementById('tension'), tenVal = document.getElementById('tenVal');
+tension.oninput = () => { state.tension = +tension.value / 100; tenVal.textContent = state.tension.toFixed(2); render(); };
+</script>
+</body>
+</html>

--- a/audio-tone.html
+++ b/audio-tone.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Starnet audio — Tone.js</title>
+<style>
+  :root { --bg:#0a0a0f; --cyan:#22d3ee; --green:#39ff88; --mag:#ff00aa; --violet:#a78bfa; --dim:#1b2330; }
+  * { box-sizing:border-box; }
+  body { background:var(--bg); color:var(--green); font-family:ui-monospace,Menlo,Consolas,monospace;
+         margin:0; padding:2rem; line-height:1.5; }
+  h1 { color:var(--cyan); font-weight:600; letter-spacing:.05em; font-size:1.2rem;
+       text-shadow:0 0 8px rgba(34,211,238,.5); margin:0 0 .25rem; }
+  .sub { color:#6b7a8d; font-size:.8rem; margin-bottom:1.5rem; }
+  .panel { border:1px solid var(--dim); border-radius:6px; padding:1.25rem; max-width:560px;
+           box-shadow:0 0 24px rgba(34,211,238,.07) inset; }
+  .row { display:flex; gap:.6rem; align-items:center; flex-wrap:wrap; margin:.6rem 0; }
+  button { background:transparent; color:var(--cyan); border:1px solid var(--cyan); border-radius:4px;
+           padding:.5rem 1rem; font:inherit; cursor:pointer; text-shadow:0 0 6px rgba(34,211,238,.6); }
+  button:hover { background:rgba(34,211,238,.08); }
+  button.stop { color:var(--mag); border-color:var(--mag); text-shadow:0 0 6px rgba(255,0,170,.6); }
+  .track { display:inline-flex; align-items:center; gap:.4rem; border:1px solid var(--dim);
+           border-radius:4px; padding:.4rem .7rem; cursor:pointer; user-select:none; color:#8aa; }
+  .track.on { color:var(--green); border-color:var(--green); text-shadow:0 0 6px rgba(57,255,136,.5); }
+  .track .dot { width:8px; height:8px; border:1px solid currentColor; transform:rotate(45deg); }
+  .track.on .dot { background:var(--green); box-shadow:0 0 6px var(--green); }
+  label.slider { display:flex; flex-direction:column; gap:.2rem; font-size:.75rem; color:#8aa; flex:1; min-width:160px; }
+  input[type=range]{ width:100%; accent-color:var(--mag); }
+  .val { color:var(--violet); }
+  .note { color:#5a6b7d; font-size:.72rem; margin-top:1.25rem; border-top:1px solid var(--dim); padding-top:.9rem; }
+  code { color:var(--cyan); }
+</style>
+</head>
+<body>
+  <h1>STARNET // AUDIO ENGINE TEST — Tone.js</h1>
+  <div class="sub">4-part synth song · per-track mute · tension preview · same composition as the Elementary demo</div>
+
+  <div class="panel">
+    <div class="row">
+      <button id="play">▶ PLAY</button>
+      <button id="stop" class="stop">■ STOP</button>
+      <span id="status" style="color:#6b7a8d;font-size:.8rem">idle</span>
+    </div>
+
+    <div class="row" id="tracks"></div>
+
+    <div class="row">
+      <label class="slider">TEMPO <span class="val" id="bpmVal">104</span> bpm
+        <input type="range" id="bpm" min="70" max="150" value="104" />
+      </label>
+    </div>
+    <div class="row">
+      <label class="slider">ICE TENSION <span class="val" id="tenVal">0.00</span>
+        <input type="range" id="tension" min="0" max="100" value="0" />
+      </label>
+    </div>
+
+    <div class="note">
+      <b style="color:#8aa">What to listen for:</b> tension opens a filter + fades in a detuned drone —
+      this is the reactive hook the game would drive from the alert ladder / ICE attention.<br>
+      <b style="color:#8aa">Engine:</b> Tone.js (CDN). Synths are imperative objects; the song is plain
+      data + a per-step <code>callback</code>. Mutes flip a gain on a live object — no graph rebuild.
+    </div>
+  </div>
+
+<script src="https://cdn.jsdelivr.net/npm/tone@15/build/Tone.js"></script>
+<script>
+// ---- Composition (shared with Elementary demo) -------------------------------
+// 8th-note grid, 8 steps/bar, 4 bars = 32 steps. i–VI–III–VII in A minor.
+const LEAD = [ // melody, note or null
+  'A4',null,'C5',null,'E5',null,'D5',null,   // Am
+  'C5',null,'A4',null,'F4',null,'A4',null,   // F
+  'E5',null,'G5',null,'E5',null,'C5',null,   // C
+  'D5',null,'B4',null,'G4',null,'B4',null,   // G
+];
+const BASS = [ // root / fifth alternation
+  'A2',null,'E2',null,'A2',null,'E2',null,
+  'F2',null,'C2',null,'F2',null,'C2',null,
+  'C2',null,'G2',null,'C2',null,'G2',null,
+  'G2',null,'D2',null,'G2',null,'D2',null,
+];
+const CHORDS = [ // triad stab on beats 1 & 3 (steps 0 and 4 of each bar)
+  ['A3','C4','E4'], ['F3','A3','C4'], ['C4','E4','G4'], ['G3','B3','D4'],
+];
+const STEPS = 32;
+const step8 = i => i % 8;          // position within bar
+const barOf = i => (i / 8) | 0;    // 0..3
+
+// ---- Synths ------------------------------------------------------------------
+let parts, built = false;
+const enabled = { lead:true, bass:true, rhythm:true, perc:true };
+
+function build() {
+  if (built) return;
+  // MASTER BUS: every voice routes through this filter, so the tension sweep is
+  // truly global (drums + drone included) — the thing you liked in the Elementary demo.
+  const master = new Tone.Filter({ frequency: 8000, type: 'lowpass', Q: 0.7 }).toDestination();
+  const reverb = new Tone.Reverb({ decay: 2.2, wet: 0.18 }).connect(master);
+  const delay  = new Tone.FeedbackDelay('8n.', 0.25).connect(reverb);
+  delay.wet.value = 0.2;
+
+  // melodic voices share a static shaping filter, then feed the master bus
+  const toneFilter = new Tone.Filter(1200, 'lowpass').connect(delay);
+
+  const lead = new Tone.MonoSynth({
+    oscillator:{ type:'sawtooth' }, filter:{ Q:2 },
+    envelope:{ attack:0.01, decay:0.2, sustain:0.2, release:0.2 },
+    filterEnvelope:{ attack:0.02, decay:0.2, baseFrequency:600, octaves:3 },
+  }).connect(toneFilter);
+  lead.volume.value = -8;
+
+  const bass = new Tone.MonoSynth({
+    oscillator:{ type:'square' },
+    envelope:{ attack:0.01, decay:0.25, sustain:0.3, release:0.2 },
+    filterEnvelope:{ attack:0.01, decay:0.15, baseFrequency:200, octaves:2 },
+  }).connect(toneFilter);
+  bass.volume.value = -6;
+
+  const rhythm = new Tone.PolySynth(Tone.Synth, {
+    oscillator:{ type:'triangle' },
+    envelope:{ attack:0.01, decay:0.18, sustain:0, release:0.1 },
+  }).connect(toneFilter);
+  rhythm.volume.value = -16;
+
+  const kick = new Tone.MembraneSynth({ octaves:6, envelope:{ attack:0.001, decay:0.25, sustain:0 } }).connect(reverb);
+  const snare = new Tone.NoiseSynth({ noise:{ type:'white' }, envelope:{ attack:0.001, decay:0.15, sustain:0 } }).connect(reverb);
+  snare.volume.value = -10;
+  const hat = new Tone.NoiseSynth({ noise:{ type:'white' }, envelope:{ attack:0.001, decay:0.03, sustain:0 } }).connect(reverb);
+  hat.volume.value = -22;
+
+  // ICE drone: detuned saw pair that fades in with tension
+  const drone = new Tone.PolySynth(Tone.Synth, { oscillator:{ type:'sawtooth' },
+    envelope:{ attack:1.5, decay:0.5, sustain:1, release:2 } }).connect(reverb);
+  drone.volume.value = -60; // silent until tension
+  drone.triggerAttack(['A2','E3']);
+
+  const seq = new Tone.Sequence((time, i) => {
+    const b = barOf(i), p = step8(i);
+    if (enabled.lead && LEAD[i]) lead.triggerAttackRelease(LEAD[i], '8n', time);
+    if (enabled.bass && BASS[i]) bass.triggerAttackRelease(BASS[i], '8n', time);
+    if (enabled.rhythm && p % 4 === 0) rhythm.triggerAttackRelease(CHORDS[b], '8n', time);
+    if (enabled.perc) {
+      if (p % 2 === 0) kick.triggerAttackRelease('C1', '8n', time);   // four-on-floor
+      if (p === 2 || p === 6) snare.triggerAttackRelease('16n', time); // beats 2 & 4
+      if (p % 2 === 1) hat.triggerAttackRelease('32n', time);          // offbeats
+    }
+  }, [...Array(STEPS).keys()], '8n');
+  seq.start(0);
+
+  parts = { toneFilter, drone, master };
+  built = true;
+}
+
+// ---- Controls ----------------------------------------------------------------
+const tracksEl = document.getElementById('tracks');
+for (const name of ['lead','bass','rhythm','perc']) {
+  const el = document.createElement('span');
+  el.className = 'track on';
+  el.innerHTML = `<span class="dot"></span>${name.toUpperCase()}`;
+  el.onclick = () => { enabled[name] = !enabled[name]; el.classList.toggle('on', enabled[name]); };
+  tracksEl.appendChild(el);
+}
+
+const status = document.getElementById('status');
+document.getElementById('play').onclick = async () => {
+  await Tone.start();
+  build();
+  Tone.Transport.start();
+  status.textContent = 'playing';
+};
+document.getElementById('stop').onclick = () => { Tone.Transport.stop(); status.textContent = 'stopped'; };
+
+const bpm = document.getElementById('bpm'), bpmVal = document.getElementById('bpmVal');
+bpm.oninput = () => { Tone.Transport.bpm.value = +bpm.value; bpmVal.textContent = bpm.value; };
+
+const tension = document.getElementById('tension'), tenVal = document.getElementById('tenVal');
+tension.oninput = () => {
+  const t = +tension.value / 100;
+  tenVal.textContent = t.toFixed(2);
+  if (!built) return;
+  // GLOBAL sweep on the master bus: brighten + resonate the whole mix, fade in the drone
+  parts.master.frequency.rampTo(600 + t * 8000, 0.3);  // 600 Hz (dark) → ~8.6 kHz (open)
+  parts.master.Q.rampTo(0.7 + t * 4, 0.3);             // resonance climbs with pressure
+  parts.drone.volume.rampTo(-60 + t * 48, 0.4);        // -60 → -12 dB
+};
+</script>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -362,7 +362,7 @@ html, body {
   50%       { opacity: 0.4; }
 }
 
-#new-run-btn, #pause-btn, #save-btn, #load-btn {
+#new-run-btn, #pause-btn, #music-btn, #save-btn, #load-btn {
   background: transparent;
   border: 1px solid var(--cyan);
   color: var(--cyan);
@@ -377,7 +377,7 @@ html, body {
   transition: background 0.15s, box-shadow 0.15s;
 }
 
-#new-run-btn:hover, #pause-btn:hover, #save-btn:hover, #load-btn:hover {
+#new-run-btn:hover, #pause-btn:hover, #music-btn:hover, #save-btn:hover, #load-btn:hover {
   background: rgba(0, 255, 255, 0.1);
   box-shadow: var(--glow-lg) rgba(0, 255, 255, 0.5);
 }

--- a/docs/audio-direction.md
+++ b/docs/audio-direction.md
@@ -1,0 +1,281 @@
+# Starnet — Audio Direction
+
+> **Status: v1 shipped — wired into the game.** Reactive two-axis music with 8 selectable
+> Corporate scores + section-breakdown automation, driven by live game state. Tuning harness
+> at `preview/audio.html`. Deferred / fast-follow items are tracked at the bottom.
+
+## Why this doc exists
+
+Two reasons:
+
+1. **Persist the design** so a future session doesn't re-litigate engine choice, references, or architecture.
+2. **Bridge a hard constraint:** the AI assistant (Claude) building this *cannot hear the
+   output*. Collaboration on sound therefore depends on a **shared technical + referential
+   vocabulary** — precise enough that Les's ears plus Claude's parameter control converge
+   without Claude ever hearing a note. That vocabulary is part of this doc on purpose.
+
+## Decisions so far
+
+### Engine: Tone.js (synthesis, not samples)
+
+Chosen over Elementary, SunVox, and Strudel. Rationale:
+
+- **Aesthetic:** Starnet is a retro-vector / phosphene game; the sonic analog is **synthesis**,
+  not sample stems. (Rules out sample-loop workflows.)
+- **AI-tractability** (the thing this project is exploring):
+  - Large training corpus → Claude generates reliable Tone.js, hallucinates little.
+  - Imperative, stateful objects with normal JS exceptions → **debuggable**, vs Elementary's
+    declarative AudioWorklet graph that fails as *silence/noise* with no stack trace.
+  - Permits the only architecture that's testable-without-hearing: push **musical decision
+    logic into pure, testable JS** (like `js/ui/node-glyphs.js`) and let the engine be a dumb
+    output device.
+- **One library covers music *and* SFX:** Tone's one-shot `triggerAttackRelease` maps directly
+  onto game events; Elementary's persistent graph makes fire-and-forget SFX awkward.
+- **License:** MIT (Strudel is AGPL — avoided).
+
+SunVox stays a possible *later* hybrid (author set-piece tracks, drive reactive layers from JS)
+if the JS-synth timbre ceiling ever frustrates. Not for v1 — one engine, learn the loop first.
+
+### Intensity model: TWO AXES (progress + threat)
+
+The music's state is driven by two **independent** axes that combine:
+
+- **PROGRESS axis** — how deep / how much of the LAN is owned. Controls **fullness**:
+  adds layers as the player penetrates (drone + sparse perc → double-time perc → lead + backup).
+  This is the "reward" feel.
+- **THREAT axis** — alert level, ICE detection, injury. Controls **aggression**:
+  dissonance, master-filter sweep, urgent drone, the darksynth color.
+
+They're separable on purpose: a **deep-but-safe** LAN sounds rich & calm; a **shallow-but-hot**
+LAN sounds sparse & menacing. (Not one combined "heat" ladder — that couldn't tell those apart.)
+
+**Guiding principle:** *progression = reward via unfolding; threat = warning via urgency.* This
+dictates how each axis sounds — progress layers **blossom** (satisfying, melodic, additive);
+threat layers **alarm** (urgent, dissonant, intrusive).
+
+### The layering vision (Les's words)
+
+- Start **sparse and spare** — just percussion + a subtle wandering synth drone.
+- Layer in **double-time percussion** as the player progresses deeper into the LAN.
+- Reward progress by layering in **lead + backup** (progress is "also a kind of tension").
+- On **injury / detection / ICE discovery**, throw in more **audio urgency**.
+- Music **changes setting by biome** (see palette); alien/ancient biomes get *much weirder*.
+- **Texture: triggered vocal samples.** Occasional short vocal/voice fragments as atmosphere
+  (Boards of Canada style) — garbled comms, numbers-station counts, corrupted system voices,
+  detuned whispers. Very on-theme for a hacking game. See the texture note below.
+
+### Generation: authored patterns-as-data
+
+Each layer is a fixed note/pattern array (like the prototype), hand-authored per biome **score**.
+The two axes fade layers in/out. Variety comes from **seeded selection among authored pattern
+variants** (using the game's existing `js/rng.js` named streams), not full generativity — keeps
+runs deterministic and the vibe intentional. A *hybrid* pass (light generative fills/variation
+on top) is a possible later enhancement, not v1.
+
+### Texture: triggered vocal/sample one-shots
+
+A deliberate, **bounded** reintroduction of samples — one-shots, **not** music stems (the
+synthesis-over-stems rule still holds for the music itself). Tone handles these natively
+(`Tone.Player` / `Tone.Players` / `Tone.Sampler`), and they're the fire-and-forget shape Tone
+excels at.
+
+- **Content (cyberpunk-appropriate):** corrupted comms, numbers-station counting, distorted
+  system voices ("access… denied"), hazy whispers. Pairs with the BoC alien-biome flavor *and*
+  can flavor Corporate (system-voice fragments).
+- **Processed through the master-bus FX** (pitch/detune, filter, reverb) for the *wrong/hazy*
+  feel — they shouldn't sound clean.
+- **Assets:** small files, lazy-loaded, **browser-only** (headless-safe like everything else).
+  Source = record/synthesize **originals** (avoid sampling others' copyrighted tracks).
+
+### Texture: aged-media / lo-fi processing
+
+A *processing* flavor — the "70s filmstrip" feel in some Boards of Canada: **vinyl crackle,
+tape hiss/saturation, wow-and-flutter** pitch wobble, band-limited EQ. In Tone: a low-level
+noise/crackle bed + chorus/vibrato for the wobble + filtering/bitcrush. It's an **FX flavor
+applied to a score**, not a score itself — pairs naturally with the trip-hop/spy and alien
+palettes, and with the vocal-texture one-shots.
+
+### Flavor within a biome
+
+Scores are keyed by **biome**, but a biome can host **multiple flavors** so different LANs feel
+distinct — e.g. a swanky spy-jazz infiltration vs a sterile corporate grid, both "corporate."
+A score = base palette + layer set + optional processing flavor (e.g. aged-media).
+**Decision (v1):** a LAN picks its flavor by **seeded random selection within its biome**
+(via `js/rng.js` — e.g. the `world` stream), trivial today with a single biome and a small
+flavor set.
+
+## Reference palette
+
+These are a **palette**, not a single choice — assign per biome and per flavor *within* a biome.
+Retain all of them.
+
+| Anchor | Character | Use for |
+|---|---|---|
+| **Mr. Robot** (Mac Quayle) | minimal, static, pulsing, glitchy, "hacking" | Corporate **base** layer (low threat) |
+| **Perturbator / Carpenter Brut** (darksynth) | aggressive, driving, neon menace | Corporate **high-threat** layer |
+| **Deus Ex** (Alexander Brandon) | dark ambient + trip-hop/industrial, brooding | Corporate mid-layer / alt flavor |
+| **Blade Runner / Vangelis** | lush noir saw pads, reverb-drenched | atmosphere/ambience, any biome |
+| **Trip-hop / spy-jazz** (Portishead, Massive Attack; *Sneakers*, John Barry, Lalo Schifrin) | downtempo noir, swanky "infiltration cool" — vibraphone, muted trumpet, upright bass, wah, vinyl crackle | "heist/infiltration" **LAN flavor**; a swanky Corporate sub-flavor |
+| **Boards of Canada** | warm, hazy, **detuned**, unsettling, *off* | **alien/ancient biomes** (future) |
+| **EVE Online** (RealX, Jon Hallur & co.) | vast, cold, slow-evolving deep-space ambience; melancholic wonder | the **sparse base "wandering drone"** layer; interplanetary atmosphere / overworld |
+| **Ladytron** (early — *604* / *Light & Magic*) | cold, deadpan, motorik analog synthpop; minimal | a **colder, more detached** Corporate flavor (vs Mr. Robot's brooding) |
+| **Ladyhawke** ("Magic") | relentless driving bass, periodic **choral voice** stabs, occasional **handclaps** | propulsive Corporate flavor; concrete layer ideas — a choral-stab layer + handclap perc accent |
+| *(room for weirder)* | glitch/IDM (Aphex, Autechre) | truly alien LANs, if BoC isn't strange enough |
+
+**Corporate biome (the only one built today):** Mr. Robot static dread at the base, sliding
+toward Perturbator aggression as threat rises.
+
+## Shared sound vocabulary
+
+The grid we use to talk about sound precisely. Each maps to a Tone.js lever Claude controls,
+a plain-language effect, and an anchor.
+
+| Dimension | Tone.js lever | Sonic effect | Anchor |
+|---|---|---|---|
+| **Timbre** | `oscillator.type`: saw/square/triangle/sine/FM/noise | saw=bright/buzzy; square=hollow/chip; triangle=soft; sine=pure/sub; FM=metallic; noise=wind/perc | saw→Vangelis; FM→DX7 |
+| **Brightness** | filter `frequency` (cutoff), `Q` (resonance) | low=dark/muffled; high=open; high Q=whistling/acid | the tension sweep |
+| **Envelope** | ADSR `attack/decay/sustain/release` | slow attack=pad; fast+low sustain=pluck/stab; long release=washy | pad vs stab |
+| **Register/density** | octave choice, notes per bar | sub-bass↔lead; sparse↔wall-of-sound | Carpenter vs Perturbator |
+| **Harmony/mode** | note arrays, chord progression | major=bright; natural minor=melancholy; **Phrygian ♭2=menace**; static drone=dread | the mood engine |
+| **Groove** | tempo, grid, syncopation | propulsive↔floating; mechanical↔human | techno vs ambient |
+| **Space/grit** | reverb, delay, chorus/detune, distortion, bitcrush | room size; echo; width; aggression/digital decay | BR reverb; bitcrush="ICE hit" |
+
+**Calibration protocol:** Claude predicts a sound *from its parameters*; Les reports what his
+ears actually hear; we tune Claude's mental model from the divergence. (Already found one purely
+from theory: a plain Am–F–C–G progression reads "anthemic indie," not "cyberpunk intrusion" —
+fixes are harmonic: go static/modal or add the Phrygian ♭2.)
+
+## Integration surface (from a code scan — verify file:line at implementation time)
+
+The audio system is a **new event-bus subscriber**, `js/audio/audio-renderer.js`, mirroring
+`js/ui/visual-renderer.js` / `js/ui/log-renderer.js` (but living in its own `js/audio/` subsystem).
+
+- **Event bus:** `import { on, E } from "../core/events.js";`
+- **Wiring:** call `initAudioRenderer()` in `js/ui/main.js` (after `initVisualRenderer()`).
+- **Headless-safe:** main.js is the *only* browser entry. The headless paths
+  (`scripts/playtest.js`, `scripts/bot/cli.js`, `scripts/lib/headless-engine.js`) do **not**
+  import the renderers — audio must stay out of them too, or it breaks the bot/census.
+- **AudioContext** must be created behind a **user gesture** (first click/keypress).
+
+### Signals → axes
+
+**PROGRESS axis** — compute from `state.nodes` on `E.STATE_CHANGED`:
+- `ownedCount / total` where `node.accessLevel === "owned"` (best single "penetration" metric).
+- Finer grain available via `node.visibility` (`hidden`/`revealed`/`accessible`) and
+  `accessLevel` (`locked`/`open`/`owned`).
+- Per-event nudges: `E.NODE_ACCESSED` (went deeper), `E.NODE_REVEALED`.
+
+**THREAT axis** — from state + events:
+- `state.globalAlert`: `"green" | "yellow" | "red" | "trace"`; `state.traceSecondsRemaining`.
+- Events: `E.ALERT_GLOBAL_RAISED {prev,next}`, `E.ALERT_COOLED`, `E.ALERT_TRACE_STARTED {seconds}`,
+  `E.ALERT_TRACE_CANCELLED`.
+- ICE: `E.ICE_DETECT_PENDING {label,dwellMs}` (rising), `E.ICE_DETECTED {label}` (lock!),
+  `E.ICE_MOVED {toVisible,...}`; `state.ice.instances[*].detectionCount` / `attentionNodeId`.
+- Injury: `state.player.health.current`, `state.player.deckIntegrity.current` — **no dedicated
+  event**; diff on `E.STATE_CHANGED`.
+
+### Biome selection
+
+- `state` carries a biome via network `meta.biome` (currently only `"corporate"`, set in
+  `js/core/network/assemble.js`). Also `state.spec.threat/wealth/complexity/depth` (Grades S–F)
+  for difficulty-aware flavor.
+- Audio picks a **score** (layer set + synth configs + reference palette) keyed on biome,
+  defaulting to `"corporate"`.
+
+### Discrete event SFX (Tone one-shots)
+
+`E.ACTION_FEEDBACK {action,phase,progress}` and `E.ACTION_RESOLVED {action,success,detail}`
+cover probe/xploit/dump/fetch/mine — natural hooks for fire-and-forget SFX. `E.RUN_STARTED` /
+`E.RUN_ENDED {outcome}` for stingers.
+
+## v1 Design (approved)
+
+**Guiding principle:** progression = **reward via unfolding**; threat = **warning via urgency**.
+
+### Scope
+
+- **Shipped:** music only — a two-axis layered engine wired to live game state; **8 selectable
+  Corporate scores** (Dread / Cold / Noir / Vast / Neon / Industrial / Pulse / Haze) chosen per
+  run by an independent seeded RNG; **section-breakdown automation** (seeded-random, no-repeat,
+  bar-quantized, subtractive over progress layers); a biome-independent **hub ambient** track
+  (all sustained pads) with **faded transitions** (hub ↔ run, fade-out on jack-out); a **Music
+  on/off** menu toggle (persisted); **`music` console commands** (status/list/next/set/on/off);
+  and the `preview/audio.html` tuning harness.
+- **Perf:** per-note AudioParam automation is pruned by recycling sequenced synths when they
+  fall silent (Web Audio never prunes past automation; unbounded growth caused over-time
+  stutter — see the `engine.js` recycle logic).
+- **Deferred (fast-follows, not precluded):** event SFX; vocal-texture one-shots (content-blocked
+  on original recordings); bar-quantized layer entrances; the aged-media processing flavor; other
+  biomes; the hybrid generative pass. **Constraint:** the engine MUST expose its master bus + FX
+  chain so the deferred SFX / vocal one-shots can be added later as a pure addition — no rework.
+
+### Module layout (`js/audio/` subsystem)
+
+- **`js/audio/mixer.js`** — *pure; no Tone, no DOM.* `(progress, threat) → { perLayerGain,
+  masterCutoff, masterQ }`. **Unit-tested without sound** — the only layer either collaborator
+  can verify.
+- **`js/audio/scores/corporate.js`** — *pure data.* Layer definitions: pattern note-arrays,
+  synth configs, per-layer axis mapping, flavor variants.
+- **`js/audio/engine.js`** — Tone wrapper. Owns AudioContext, Transport/sequencer, per-layer
+  synths + gain nodes, master bus + master filter, `rampTo` automation. Imports Tone from
+  `/dist/tone.js`. API: `start() / stop() / setProgress(x) / setThreat(x) / setScore(s)`.
+- **`js/audio/audio-renderer.js`** — event-bus subscriber (browser-only). Derives the two axis
+  scalars from state/events, calls engine methods. Gates AudioContext on first user gesture.
+  Wired in `js/ui/main.js` after `initVisualRenderer()`; kept out of all headless entry points.
+- **Vendor:** bundle Tone → `dist/tone.js` (esbuild ESM, like `dist/lit.js`) + a `make` target.
+- **Tuning harness:** new **`preview/audio.html`** + **`js/audio/playground.js`** — per-layer
+  mutes + progress/threat sliders + play/stop. (Leaves the existing root `preview.html` in place;
+  a `preview/` reorg of the old harness is an optional separate tidy-up.)
+
+### Corporate score — layers & axis mapping
+
+All layers run on the Transport in sync from the start; only their **gains** move, so everything
+stays rhythmically aligned as layers fade in. Progress layers *blossom*; threat layers *alarm*.
+
+| Layer | Role / character | Driven by | Anchor |
+|---|---|---|---|
+| **Drone** | wandering detuned pad, always present | baseline + slight ↑ progress | EVE / BoC |
+| **Base perc** | sparse kick + hat, minimal pulse | progress > 0 (early) | Mr. Robot |
+| **Double-time perc** | busier hats/snare | progress ~0.3→0.7 | Mr. Robot |
+| **Bass** | square/sub bassline | progress ~0.2→0.5 | — |
+| **Lead** | melodic lead — the reward | progress ~0.55→0.85 | — |
+| **Backup** | chord stabs / harmony pad | progress ~0.6→0.9 | — |
+| **Tension drone** | detuned aggressive swell | **threat** 0→1 | Perturbator |
+| **Urgency arp** | driving darksynth arp / double-kick | **threat** ~0.6→1 | Perturbator |
+| *master filter* | cutoff + Q sweep over whole mix | **threat** | (the tension sweep) |
+
+**Progress scalar** = `ownedCount / totalNodes` (smoothed), nudged earlier by revealed/accessed
+counts so the music starts unfolding before nodes are fully owned.
+**Threat scalar** = `globalAlert` (green/yellow/red/trace → 0/.33/.66/1) blended with a transient
+bump from recent `ICE_DETECTED` and a term for low health/deck. Smoothed, **fast attack (~0.3s)
+/ slow release (~1.5s)** — adrenaline spike, gradual calm-down.
+
+### Transitions
+
+- **One continuous piece per run** — starts at `RUN_STARTED` (post-gesture), evolves the whole
+  run, resolves with an outcome-appropriate tail at `RUN_ENDED`.
+- **Smooth `rampTo` crossfades** for layer entrances (~0.5–2s). All patterns are Transport-synced,
+  so a fade-in still lands on the grid — smoothness without bar-queue complexity (bar-quantized
+  entrances deferred).
+
+## Prototypes
+
+- `audio-tone.html` — Tone.js, 4-part song, per-track mutes, tempo, global tension sweep
+  (master lowpass + Q + drone). **The chosen direction.**
+- `audio-elementary.html` — Elementary equivalent (same song), kept for reference/comparison.
+
+## Deferred / fast-follows (not blocking v1)
+
+1. **More instrument variety across scores** — teach the engine more synth voices (FM/bell,
+   metal, pluck, AM) so scores can vary timbre *while keeping the cohesive "voice font"* (Les:
+   the current shared palette fits together well — widen it, don't fragment it).
+2. **Event SFX** — one-shots on probe/xploit/dump/fetch and run start/end. Hooks exist
+   (`E.ACTION_FEEDBACK`, `E.ACTION_RESOLVED`); engine exposes `getMasterInput()` for routing.
+3. **Vocal/texture one-shots** — BoC-style fragments; triggering model + original samples.
+4. **Aged-media / lo-fi processing flavor** — vinyl crackle, tape wobble, band-limited EQ.
+5. **Other biomes** — alien/ancient (BoC/weirder); the per-biome score pool already supports it.
+6. **Hand-authored section arcs** — ordered section sequences (intro → build → drop) shuffled
+   among, for more intentional arrangement than pure seeded-random (Les's idea).
+7. **Hybrid generative pass** — light generative fills/variation atop the authored patterns.
+8. **`setScore` mid-run rebuilds the whole graph** (brief gap) — fine for per-run selection;
+   revisit if seamless live score transitions are ever wanted.

--- a/docs/audio-engine-plan.md
+++ b/docs/audio-engine-plan.md
@@ -1,0 +1,975 @@
+# Audio Engine v1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the v1 reactive music engine for Starnet — a two-axis (progress + threat) layered Corporate score driven by live game state, with a standalone tuning harness.
+
+**Architecture:** A new `js/audio/` subsystem. Pure, unit-tested logic (`signals.js` derives the two axis scalars from game state; `mixer.js` maps `(progress, threat)` + score data → per-layer gains and master-filter values). A Tone.js wrapper (`engine.js`) owns all Web Audio objects. An event-bus subscriber (`audio-renderer.js`, browser-only) wires game events → axis scalars → engine. Tone is vendored to `dist/tone.js`. A `preview/audio.html` harness drives the engine directly for tuning.
+
+**Tech Stack:** Vanilla ES modules, Tone.js (vendored via esbuild), `node:test` for unit tests, JSDoc `@ts-check`.
+
+**Reference:** `docs/audio-direction.md` (the approved design + guiding principle: *progression = reward via unfolding; threat = warning via urgency*).
+
+---
+
+## File Structure
+
+| File | Responsibility | Type-checked? |
+|---|---|---|
+| `js/tone-vendor.js` | esbuild entry: re-export Tone | no (excluded, like `lit-vendor.js`) |
+| `js/audio/signals.js` | pure: game state → `{progress, threat}` scalars | yes (`@ts-check`) |
+| `js/audio/mixer.js` | pure: `(score, progress, threat)` → `{gains, masterCutoff, masterQ}` | yes |
+| `js/audio/scores/corporate.js` | pure data: layer defs, patterns, synth configs, flavors | yes |
+| `js/audio/engine.js` | Tone wrapper: synths, Transport, gains, master filter | no (`@ts-nocheck`, imports untyped Tone) |
+| `js/audio/audio-renderer.js` | event-bus subscriber; gesture gating; drives engine | yes |
+| `js/audio/playground.js` | tuning harness logic | no (`@ts-nocheck`) |
+| `preview/audio.html` | tuning harness page | n/a |
+| `tests/audio-signals.test.js` | unit tests for `signals.js` | n/a |
+| `tests/audio-mixer.test.js` | unit tests for `mixer.js` | n/a |
+| `tests/audio-score.test.js` | structural validation of `corporate.js` | n/a |
+
+Canonical layer keys (used identically across score, mixer, engine):
+`"drone"`, `"basePerc"`, `"doublePerc"`, `"bass"`, `"lead"`, `"backup"`, `"progArp"`, `"tensionDrone"`, `"urgencyArp"`.
+(`progArp` — a celebratory progress-driven arp — was added during the by-ear tuning pass, as
+were the section-breakdown automation and the hub ambient; this plan captures the original v1
+scope. See `docs/audio-direction.md` for the shipped system.)
+
+---
+
+## Task 1: Vendor Tone.js → `dist/tone.js`
+
+**Files:**
+- Modify: `package.json` (add `tone` dependency)
+- Create: `js/tone-vendor.js`
+- Modify: `Makefile` (bundle target + lint exclude)
+
+- [ ] **Step 1: Install Tone**
+
+Run: `npm install --save tone@^15`
+Expected: `tone` appears under `dependencies` in `package.json`, present in `node_modules/tone`.
+
+- [ ] **Step 2: Create the vendor entry**
+
+Create `js/tone-vendor.js`:
+
+```js
+// Tone.js vendor bundle entry point.
+// Bundled with esbuild into dist/tone.js (ESM).
+// Audio modules import from "/dist/tone.js" as: import * as Tone from "/dist/tone.js";
+export * from "tone";
+```
+
+- [ ] **Step 3: Add the esbuild bundle to the Makefile**
+
+In `Makefile`, find the `bundle-vendor:` target and add a third esbuild line:
+
+```make
+bundle-vendor:
+	npx esbuild js/vendor.js --bundle --outfile=dist/vendor.js --format=iife --platform=browser --minify
+	npx esbuild js/lit-vendor.js --bundle --outfile=dist/lit.js --format=esm --platform=browser --minify
+	npx esbuild js/tone-vendor.js --bundle --outfile=dist/tone.js --format=esm --platform=browser --minify
+```
+
+Also add the same `dist/tone.js` line to the `all:` target's `dist/lit.js` rule block by adding a new rule after the `dist/lit.js` rule:
+
+```make
+dist/tone.js: js/tone-vendor.js node_modules
+	npx esbuild js/tone-vendor.js --bundle --outfile=dist/tone.js --format=esm --platform=browser --minify
+```
+
+And add `dist/tone.js` to the `all:` prerequisites:
+
+```make
+all: node_modules dist/vendor.js dist/lit.js dist/tone.js
+```
+
+- [ ] **Step 4: Exclude the vendor entry from lint**
+
+In `Makefile`, in the `lint:` target's `find` command, add `! -name 'tone-vendor.js'` alongside the existing `! -name 'lit-vendor.js'`:
+
+```make
+		$(shell find js -name '*.js' ! -name '*.test.js' ! -path '*/fixtures/*' ! -name 'graph.js' ! -name 'vendor.js' ! -name 'lit-vendor.js' ! -name 'tone-vendor.js')
+```
+
+- [ ] **Step 5: Build and verify the bundle exists**
+
+Run: `make bundle-vendor && ls -la dist/tone.js`
+Expected: `dist/tone.js` exists, non-trivial size (hundreds of KB).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json package-lock.json js/tone-vendor.js Makefile
+git commit -m 'Vendor Tone.js to dist/tone.js'
+```
+
+---
+
+## Task 2: Pure axis-signal derivation (`signals.js`)
+
+Derives the two scalars from game state. No Tone, no DOM, no smoothing (smoothing lives in the engine).
+
+**Files:**
+- Create: `js/audio/signals.js`
+- Test: `tests/audio-signals.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/audio-signals.test.js`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { deriveProgress, deriveThreat } from "../js/audio/signals.js";
+
+function nodes(spec) {
+  // spec: array of accessLevel strings
+  const out = {};
+  spec.forEach((accessLevel, i) => { out["n" + i] = { accessLevel, visibility: "revealed" }; });
+  return out;
+}
+
+test("deriveProgress is 0 when nothing is owned", () => {
+  const state = { nodes: nodes(["locked", "locked", "open"]) };
+  assert.equal(deriveProgress(state), 0);
+});
+
+test("deriveProgress is ownedCount/total", () => {
+  const state = { nodes: nodes(["owned", "owned", "locked", "locked"]) };
+  assert.equal(deriveProgress(state), 0.5);
+});
+
+test("deriveProgress returns 0 for empty/missing nodes", () => {
+  assert.equal(deriveProgress({ nodes: {} }), 0);
+  assert.equal(deriveProgress({}), 0);
+});
+
+test("deriveThreat maps alert levels to the ladder", () => {
+  assert.equal(deriveThreat({ globalAlert: "green" }), 0);
+  assert.equal(deriveThreat({ globalAlert: "yellow" }), 1 / 3);
+  assert.equal(deriveThreat({ globalAlert: "red" }), 2 / 3);
+  assert.equal(deriveThreat({ globalAlert: "trace" }), 1);
+});
+
+test("deriveThreat adds an injury term as health drops", () => {
+  const hurt = { globalAlert: "green", player: { health: { current: 0, max: 100 }, deckIntegrity: { current: 100, max: 100 } } };
+  // green=0 base, full injury on health contributes up to 0.25
+  assert.ok(deriveThreat(hurt) > 0);
+  assert.ok(deriveThreat(hurt) <= 1);
+});
+
+test("deriveThreat never exceeds 1", () => {
+  const maxed = { globalAlert: "trace", player: { health: { current: 0, max: 100 }, deckIntegrity: { current: 0, max: 100 } } };
+  assert.equal(deriveThreat(maxed), 1);
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `node --test tests/audio-signals.test.js`
+Expected: FAIL — `Cannot find module '../js/audio/signals.js'`.
+
+- [ ] **Step 3: Implement `signals.js`**
+
+Create `js/audio/signals.js`:
+
+```js
+// @ts-check
+// Pure derivation of the two music axes from game state. No Tone, no DOM, no smoothing.
+
+/** Clamp x into [0,1]. @param {number} x @returns {number} */
+const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+/** Alert ladder → 0..1. */
+const ALERT_LEVEL = { green: 0, yellow: 1 / 3, red: 2 / 3, trace: 1 };
+
+/**
+ * PROGRESS axis: how much of the LAN the player owns, 0..1.
+ * @param {any} state
+ * @returns {number}
+ */
+export function deriveProgress(state) {
+  const nodes = state?.nodes;
+  if (!nodes) return 0;
+  const all = Object.values(nodes);
+  if (all.length === 0) return 0;
+  const owned = all.filter((n) => /** @type {any} */ (n).accessLevel === "owned").length;
+  return clamp01(owned / all.length);
+}
+
+/**
+ * THREAT axis: alert ladder blended with an injury term, 0..1.
+ * @param {any} state
+ * @returns {number}
+ */
+export function deriveThreat(state) {
+  const alert = ALERT_LEVEL[state?.globalAlert] ?? 0;
+  const p = state?.player;
+  let injury = 0;
+  if (p?.health?.max) injury += 0.25 * (1 - clamp01(p.health.current / p.health.max));
+  if (p?.deckIntegrity?.max) injury += 0.25 * (1 - clamp01(p.deckIntegrity.current / p.deckIntegrity.max));
+  return clamp01(alert + injury);
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `node --test tests/audio-signals.test.js`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/audio/signals.js tests/audio-signals.test.js
+git commit -m 'Add pure audio axis-signal derivation (signals.js)'
+```
+
+---
+
+## Task 3: Pure mixer (`mixer.js`)
+
+Maps a score's layer axis-specs + the two scalars → per-layer gains + master-filter values.
+
+**Files:**
+- Create: `js/audio/mixer.js`
+- Test: `tests/audio-mixer.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/audio-mixer.test.js`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computeMix, smoothstep } from "../js/audio/mixer.js";
+
+const SCORE = {
+  layers: [
+    { key: "drone", axis: "base", baseGain: 0.6, progressBoost: 0.2 },
+    { key: "bass", axis: "progress", lo: 0.2, hi: 0.5 },
+    { key: "tensionDrone", axis: "threat", lo: 0.0, hi: 1.0 },
+  ],
+  masterFilter: { cutoffLo: 600, cutoffHi: 8600, qLo: 0.7, qHi: 4.7 },
+};
+
+test("smoothstep clamps and is monotone", () => {
+  assert.equal(smoothstep(0.2, 0.5, 0.1), 0);
+  assert.equal(smoothstep(0.2, 0.5, 0.6), 1);
+  assert.ok(smoothstep(0.2, 0.5, 0.35) > 0 && smoothstep(0.2, 0.5, 0.35) < 1);
+});
+
+test("base layer gain = baseGain + progressBoost*progress", () => {
+  assert.equal(computeMix(SCORE, 0, 0).gains.drone, 0.6);
+  assert.ok(Math.abs(computeMix(SCORE, 1, 0).gains.drone - 0.8) < 1e-9);
+});
+
+test("progress layer fades across its lo..hi range", () => {
+  assert.equal(computeMix(SCORE, 0.1, 0).gains.bass, 0);
+  assert.equal(computeMix(SCORE, 0.6, 0).gains.bass, 1);
+});
+
+test("threat layer is driven by threat only", () => {
+  assert.equal(computeMix(SCORE, 1, 0).gains.tensionDrone, 0);
+  assert.equal(computeMix(SCORE, 0, 1).gains.tensionDrone, 1);
+});
+
+test("master filter lerps cutoff and Q with threat", () => {
+  const m0 = computeMix(SCORE, 0, 0);
+  assert.equal(m0.masterCutoff, 600);
+  assert.equal(m0.masterQ, 0.7);
+  const m1 = computeMix(SCORE, 0, 1);
+  assert.equal(m1.masterCutoff, 8600);
+  assert.ok(Math.abs(m1.masterQ - 4.7) < 1e-9);
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `node --test tests/audio-mixer.test.js`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `mixer.js`**
+
+Create `js/audio/mixer.js`:
+
+```js
+// @ts-check
+// Pure mixing logic: score + (progress, threat) → per-layer gains + master filter.
+
+/** Clamp x into [0,1]. @param {number} x */
+const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+/** Linear interpolate. @param {number} a @param {number} b @param {number} t */
+const lerp = (a, b, t) => a + (b - a) * clamp01(t);
+
+/**
+ * Smooth Hermite ramp from 0 at `lo` to 1 at `hi`.
+ * @param {number} lo @param {number} hi @param {number} x @returns {number}
+ */
+export function smoothstep(lo, hi, x) {
+  if (hi <= lo) return x >= hi ? 1 : 0;
+  const t = clamp01((x - lo) / (hi - lo));
+  return t * t * (3 - 2 * t);
+}
+
+/**
+ * @typedef {Object} LayerSpec
+ * @property {string} key
+ * @property {"base"|"progress"|"threat"} axis
+ * @property {number} [baseGain]
+ * @property {number} [progressBoost]
+ * @property {number} [lo]
+ * @property {number} [hi]
+ */
+
+/**
+ * @param {{layers: LayerSpec[], masterFilter: {cutoffLo:number,cutoffHi:number,qLo:number,qHi:number}}} score
+ * @param {number} progress 0..1
+ * @param {number} threat 0..1
+ * @returns {{gains: Record<string, number>, masterCutoff: number, masterQ: number}}
+ */
+export function computeMix(score, progress, threat) {
+  /** @type {Record<string, number>} */
+  const gains = {};
+  for (const layer of score.layers) {
+    if (layer.axis === "base") {
+      gains[layer.key] = clamp01((layer.baseGain ?? 0) + (layer.progressBoost ?? 0) * progress);
+    } else {
+      const axisVal = layer.axis === "threat" ? threat : progress;
+      gains[layer.key] = smoothstep(layer.lo ?? 0, layer.hi ?? 1, axisVal);
+    }
+  }
+  const mf = score.masterFilter;
+  return {
+    gains,
+    masterCutoff: lerp(mf.cutoffLo, mf.cutoffHi, threat),
+    masterQ: lerp(mf.qLo, mf.qHi, threat),
+  };
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `node --test tests/audio-mixer.test.js`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/audio/mixer.js tests/audio-mixer.test.js
+git commit -m 'Add pure audio mixer (mixer.js)'
+```
+
+---
+
+## Task 4: Corporate score data (`scores/corporate.js`)
+
+Pure data: tempo, the 8 layers (axis-spec + pattern + synth config), master-filter range, and flavors. Patterns lean static/modal A-minor with a Phrygian ♭2 turn (per the calibration note — avoids the "anthemic pop" trap). `null` = rest. Pitched patterns are 8th-note grids of 32 steps (4 bars); `urgencyArp` is a 16th grid of 64 steps. Sustained layers (`drone`, `tensionDrone`) carry `sustain: [...]` chords instead of a step pattern.
+
+**Files:**
+- Create: `js/audio/scores/corporate.js`
+- Test: `tests/audio-score.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/audio-score.test.js`:
+
+```js
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CORPORATE_SCORE, LAYER_KEYS } from "../js/audio/scores/corporate.js";
+import { computeMix } from "../js/audio/mixer.js";
+
+test("score defines exactly the canonical layer keys", () => {
+  const keys = CORPORATE_SCORE.layers.map((l) => l.key).sort();
+  assert.deepEqual(keys, [...LAYER_KEYS].sort());
+});
+
+test("every layer has a valid axis and a sound source", () => {
+  for (const l of CORPORATE_SCORE.layers) {
+    assert.ok(["base", "progress", "threat"].includes(l.axis), `bad axis for ${l.key}`);
+    assert.ok(l.synth, `missing synth config for ${l.key}`);
+    assert.ok(Array.isArray(l.pattern) || Array.isArray(l.sustain), `${l.key} needs pattern or sustain`);
+  }
+});
+
+test("8th-grid patterns are 32 steps; urgencyArp is 64", () => {
+  const byKey = Object.fromEntries(CORPORATE_SCORE.layers.map((l) => [l.key, l]));
+  for (const k of ["basePerc", "doublePerc", "bass", "lead", "backup"]) {
+    assert.equal(byKey[k].pattern.length, 32, `${k} wrong length`);
+  }
+  assert.equal(byKey.urgencyArp.pattern.length, 64);
+});
+
+test("computeMix accepts the real score and covers every layer", () => {
+  const mix = computeMix(CORPORATE_SCORE, 0.5, 0.5);
+  for (const k of LAYER_KEYS) assert.ok(k in mix.gains, `missing gain for ${k}`);
+});
+
+test("at least one flavor exists", () => {
+  assert.ok(CORPORATE_SCORE.flavors.length >= 1);
+});
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `node --test tests/audio-score.test.js`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `scores/corporate.js`**
+
+Create `js/audio/scores/corporate.js`:
+
+```js
+// @ts-check
+// Corporate biome score — authored patterns-as-data. null = rest.
+// Static/modal A-minor with a Phrygian ♭2 (Bb) turn for menace. See docs/audio-direction.md.
+
+export const LAYER_KEYS = Object.freeze([
+  "drone", "basePerc", "doublePerc", "bass", "lead", "backup", "tensionDrone", "urgencyArp",
+]);
+
+// 8th-note grid, 8 steps/bar, 4 bars = 32 steps.
+const K = null; // rest alias for readability
+const KICK = "C1", HAT = "hat", SNARE = "snare"; // perc tokens (engine maps to drum voices)
+
+const basePerc = [
+  KICK, K, K, K, HAT, K, K, K,   // bar 1
+  KICK, K, K, K, HAT, K, K, K,   // bar 2
+  KICK, K, K, K, HAT, K, K, K,   // bar 3
+  KICK, K, K, K, HAT, K, K, K,   // bar 4
+];
+const doublePerc = [
+  K, HAT, SNARE, HAT, K, HAT, SNARE, HAT,
+  K, HAT, SNARE, HAT, K, HAT, SNARE, HAT,
+  K, HAT, SNARE, HAT, K, HAT, SNARE, HAT,
+  K, HAT, SNARE, HAT, K, HAT, SNARE, HAT,
+];
+// Mostly an A pedal (static dread); bar 4 leans to Bb (Phrygian ♭2).
+const bass = [
+  "A1", K, K, "A1", K, "A1", K, K,
+  "A1", K, K, "A1", K, "A1", K, K,
+  "A1", K, K, "A1", K, "A1", K, K,
+  "Bb1", K, K, "Bb1", K, "A1", K, K,
+];
+// Sparse modal lead (A Aeolian / pentatonic), leaving space.
+const lead = [
+  "E4", K, K, "A4", K, K, "C5", K,
+  K, "B4", K, "A4", K, K, K, K,
+  "E4", K, "G4", K, "A4", K, K, K,
+  "Bb4", K, "A4", K, "E4", K, K, K,
+];
+// Triad stabs: Am held three bars, Bb (♭2) on bar 4. Chords as arrays.
+const backup = [
+  ["A3","C4","E4"], K, K, K, ["A3","C4","E4"], K, K, K,
+  ["A3","C4","E4"], K, K, K, ["A3","C4","E4"], K, K, K,
+  ["A3","C4","E4"], K, K, K, ["A3","C4","E4"], K, K, K,
+  ["Bb3","D4","F4"], K, K, K, ["Bb3","D4","F4"], K, K, K,
+];
+// 16th-note grid, 16 steps/bar, 4 bars = 64. Driving Am arp with ♭2 menace.
+const urgencyArp = [
+  "A4","C5","E5","A5","E5","C5","A4","C5","E5","A5","E5","C5","A4","C5","E5","Bb5",
+  "A4","C5","E5","A5","E5","C5","A4","C5","E5","A5","E5","C5","A4","C5","E5","Bb5",
+  "A4","C5","E5","A5","E5","C5","A4","C5","E5","A5","E5","C5","A4","C5","E5","Bb5",
+  "A4","C5","E5","A5","E5","C5","A4","C5","E5","A5","E5","C5","Bb4","Bb5","A5","E5",
+];
+
+export const CORPORATE_SCORE = Object.freeze({
+  biome: "corporate",
+  bpm: 96,
+  masterFilter: { cutoffLo: 600, cutoffHi: 8600, qLo: 0.7, qHi: 4.7 },
+  layers: [
+    // base
+    { key: "drone", axis: "base", baseGain: 0.55, progressBoost: 0.2,
+      sustain: ["A2", "E3"], synth: { type: "fatsawtooth", count: 3, spread: 18, attack: 2, release: 3, volume: -16 } },
+    // progress (blossom)
+    { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,
+      synth: { kind: "drums", volume: -6 } },
+    { key: "doublePerc", axis: "progress", lo: 0.3, hi: 0.7, pattern: doublePerc,
+      synth: { kind: "drums", volume: -10 } },
+    { key: "bass", axis: "progress", lo: 0.2, hi: 0.5, pattern: bass,
+      synth: { type: "square", attack: 0.01, decay: 0.25, sustain: 0.3, release: 0.2, volume: -8 } },
+    { key: "lead", axis: "progress", lo: 0.55, hi: 0.85, pattern: lead,
+      synth: { type: "sawtooth", attack: 0.01, decay: 0.2, sustain: 0.2, release: 0.2, volume: -12 } },
+    { key: "backup", axis: "progress", lo: 0.6, hi: 0.9, pattern: backup,
+      synth: { kind: "poly", type: "triangle", attack: 0.02, decay: 0.4, sustain: 0.0, release: 0.3, volume: -18 } },
+    // threat (alarm)
+    { key: "tensionDrone", axis: "threat", lo: 0.0, hi: 1.0,
+      sustain: ["A2", "Bb2"], synth: { type: "fatsawtooth", count: 3, spread: 30, attack: 0.8, release: 1.5, volume: -14 } },
+    { key: "urgencyArp", axis: "threat", lo: 0.55, hi: 1.0, grid: "16n", pattern: urgencyArp,
+      synth: { type: "sawtooth", attack: 0.005, decay: 0.12, sustain: 0.0, release: 0.08, volume: -16 } },
+  ],
+  flavors: [
+    { id: "default", processing: null },
+    // aged-media flavor deferred; placeholder id kept minimal for v1 (single flavor).
+  ],
+});
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `node --test tests/audio-score.test.js`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add js/audio/scores/corporate.js tests/audio-score.test.js
+git commit -m 'Add Corporate score data (8 layers, static modal A-minor)'
+```
+
+---
+
+## Task 5: Tone engine wrapper (`engine.js`)
+
+Owns all Web Audio. Builds synths from a score, runs all patterns on the Transport in sync, and on `setProgress/setThreat` recomputes the mix and `rampTo`s each layer gain + master filter. Threat ramps are asymmetric (fast up, slow down). Verified via the playground (Task 7), not unit tests — it needs a real AudioContext.
+
+**Files:**
+- Create: `js/audio/engine.js`
+
+- [ ] **Step 1: Implement `engine.js`**
+
+Create `js/audio/engine.js`:
+
+```js
+// @ts-nocheck
+// Tone.js wrapper. The only module that touches Web Audio. Imports the vendored bundle.
+import * as Tone from "/dist/tone.js";
+import { computeMix } from "./mixer.js";
+
+const GRID = "8n";          // default step grid
+const RAMP_UP = 0.3;        // threat fast attack (s)
+const RAMP_DOWN = 1.5;      // threat slow release (s)
+const RAMP_PROGRESS = 1.0;  // progress crossfade (s)
+
+export function createAudioEngine() {
+  let started = false;
+  let score = null;
+  let progress = 0, threat = 0;
+  let master, masterFilter, reverb;
+  const layers = {};        // key → { gain, voice, seq, sustainSynth }
+  const muted = {};         // key → bool (playground only)
+
+  function buildMasterBus() {
+    master = new Tone.Gain(0.9).toDestination();
+    reverb = new Tone.Reverb({ decay: 2.4, wet: 0.16 }).connect(master);
+    masterFilter = new Tone.Filter({ frequency: 8000, type: "lowpass", Q: 0.7 }).connect(reverb);
+  }
+
+  function drumVoices() {
+    const kick = new Tone.MembraneSynth({ octaves: 6, envelope: { attack: 0.001, decay: 0.25, sustain: 0 } });
+    const snare = new Tone.NoiseSynth({ noise: { type: "white" }, envelope: { attack: 0.001, decay: 0.15, sustain: 0 } });
+    const hat = new Tone.NoiseSynth({ noise: { type: "white" }, envelope: { attack: 0.001, decay: 0.03, sustain: 0 } });
+    snare.volume.value = -8; hat.volume.value = -20;
+    return { kick, snare, hat };
+  }
+
+  function buildLayer(spec) {
+    const gain = new Tone.Gain(0).connect(masterFilter);
+    const grid = spec.grid || GRID;
+
+    if (spec.sustain) {
+      // continuously sustained chord, gain-controlled
+      const s = new Tone.PolySynth(Tone.Synth, {
+        oscillator: { type: spec.synth.type || "fatsawtooth", count: spec.synth.count, spread: spec.synth.spread },
+        envelope: { attack: spec.synth.attack ?? 1, decay: 0.3, sustain: 1, release: spec.synth.release ?? 2 },
+      }).connect(gain);
+      if (spec.synth.volume != null) s.volume.value = spec.synth.volume;
+      layers[spec.key] = { gain, sustainSynth: s, sustain: spec.sustain };
+      return;
+    }
+
+    if (spec.synth.kind === "drums") {
+      const voices = drumVoices();
+      Object.values(voices).forEach((v) => v.connect(gain));
+      if (spec.synth.volume != null) gain.gain.value = 0; // gain set by mix
+      const seq = new Tone.Sequence((time, tok) => {
+        if (!tok) return;
+        if (tok === "snare") voices.snare.triggerAttackRelease("16n", time);
+        else if (tok === "hat") voices.hat.triggerAttackRelease("32n", time);
+        else voices.kick.triggerAttackRelease("C1", "8n", time);
+      }, spec.pattern, grid);
+      seq.start(0);
+      layers[spec.key] = { gain, voices, seq };
+      return;
+    }
+
+    if (spec.synth.kind === "poly") {
+      const s = new Tone.PolySynth(Tone.Synth, {
+        oscillator: { type: spec.synth.type || "triangle" },
+        envelope: { attack: spec.synth.attack, decay: spec.synth.decay, sustain: spec.synth.sustain, release: spec.synth.release },
+      }).connect(gain);
+      if (spec.synth.volume != null) s.volume.value = spec.synth.volume;
+      const seq = new Tone.Sequence((time, note) => {
+        if (note) s.triggerAttackRelease(note, grid, time);
+      }, spec.pattern, grid);
+      seq.start(0);
+      layers[spec.key] = { gain, voice: s, seq };
+      return;
+    }
+
+    // mono-ish synth (poly under the hood for safety on fast arps)
+    const s = new Tone.PolySynth(Tone.Synth, {
+      oscillator: { type: spec.synth.type || "sawtooth" },
+      envelope: { attack: spec.synth.attack, decay: spec.synth.decay, sustain: spec.synth.sustain, release: spec.synth.release },
+    }).connect(gain);
+    if (spec.synth.volume != null) s.volume.value = spec.synth.volume;
+    const seq = new Tone.Sequence((time, note) => {
+      if (note) s.triggerAttackRelease(note, grid, time);
+    }, spec.pattern, grid);
+    seq.start(0);
+    layers[spec.key] = { gain, voice: s, seq };
+  }
+
+  function applyMix(immediate) {
+    if (!score) return;
+    const mix = computeMix(score, progress, threat);
+    for (const [key, layer] of Object.entries(layers)) {
+      const target = muted[key] ? 0 : (mix.gains[key] ?? 0);
+      const ramp = immediate ? 0.01 : RAMP_PROGRESS;
+      layer.gain.gain.rampTo(target, ramp);
+    }
+    const tRamp = immediate ? 0.01 : (threat >= (applyMix._lastThreat ?? 0) ? RAMP_UP : RAMP_DOWN);
+    masterFilter.frequency.rampTo(mix.masterCutoff, tRamp);
+    masterFilter.Q.rampTo(mix.masterQ, tRamp);
+    applyMix._lastThreat = threat;
+  }
+
+  return {
+    /** @param {object} s score object */
+    setScore(s) { score = s; },
+
+    async start() {
+      if (started) return;
+      await Tone.start();
+      buildMasterBus();
+      Tone.Transport.bpm.value = score?.bpm ?? 100;
+      for (const spec of score.layers) buildLayer(spec);
+      // kick off sustained layers
+      for (const layer of Object.values(layers)) {
+        if (layer.sustainSynth) layer.sustainSynth.triggerAttack(layer.sustain);
+      }
+      applyMix(true);
+      Tone.Transport.start();
+      started = true;
+    },
+
+    stop() {
+      if (!started) return;
+      Tone.Transport.stop();
+      for (const layer of Object.values(layers)) {
+        if (layer.sustainSynth) layer.sustainSynth.releaseAll?.();
+        layer.seq?.dispose?.();
+      }
+      started = false;
+    },
+
+    setProgress(x) { progress = Math.max(0, Math.min(1, x)); if (started) applyMix(false); },
+    setThreat(x) { threat = Math.max(0, Math.min(1, x)); if (started) applyMix(false); },
+
+    // playground-only
+    setMuted(key, isMuted) { muted[key] = isMuted; if (started) applyMix(false); },
+    isStarted() { return started; },
+
+    // exposed for deferred SFX / vocal one-shots (constraint from the spec)
+    getMasterInput() { return masterFilter; },
+  };
+}
+```
+
+- [ ] **Step 2: Lint (the @ts-nocheck file is skipped; ensure nothing else broke)**
+
+Run: `make lint`
+Expected: PASS (no new type errors; `engine.js` skipped via `@ts-nocheck`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add js/audio/engine.js
+git commit -m 'Add Tone engine wrapper (engine.js)'
+```
+
+---
+
+## Task 6: Event-bus subscriber (`audio-renderer.js`)
+
+Browser-only. Lazily starts the engine on first user gesture, then maps `STATE_CHANGED` (+ run lifecycle) to the two axis scalars via `signals.js`.
+
+**Files:**
+- Create: `js/audio/audio-renderer.js`
+
+- [ ] **Step 1: Implement `audio-renderer.js`**
+
+Create `js/audio/audio-renderer.js`:
+
+```js
+// @ts-check
+import { on, E } from "../core/events.js";
+import { deriveProgress, deriveThreat } from "./signals.js";
+import { computeFlavor } from "./scores/index.js";
+import { createAudioEngine } from "./engine.js";
+
+/**
+ * Wire the audio engine to the event bus. Browser-only — do NOT import from
+ * headless entry points (scripts/playtest.js, scripts/bot/cli.js).
+ */
+export function initAudioRenderer() {
+  const engine = createAudioEngine();
+  let armed = false;
+
+  // AudioContext needs a user gesture. Arm on the first pointer/key event.
+  function arm() {
+    if (armed) return;
+    armed = true;
+    window.removeEventListener("pointerdown", arm);
+    window.removeEventListener("keydown", arm);
+    // engine.start() resolves the AudioContext; safe to call before a run exists.
+    engine.setScore(computeFlavor("corporate"));
+    engine.start();
+  }
+  window.addEventListener("pointerdown", arm);
+  window.addEventListener("keydown", arm);
+
+  on(E.STATE_CHANGED, (state) => {
+    if (!state) return;
+    engine.setProgress(deriveProgress(state));
+    engine.setThreat(deriveThreat(state));
+  });
+
+  on(E.RUN_STARTED, ({ state }) => {
+    // (re)select the score for this run's biome; corporate is the only one today.
+    const biome = state?.spec?.biome ?? state?.meta?.biome ?? "corporate";
+    engine.setScore(computeFlavor(biome));
+  });
+
+  // expose for the playground / debugging
+  return engine;
+}
+```
+
+- [ ] **Step 2: Create the score selector `scores/index.js`**
+
+Create `js/audio/scores/index.js`:
+
+```js
+// @ts-check
+// Score registry + seeded flavor selection within a biome.
+import { random, RNG } from "../../core/rng.js";
+import { CORPORATE_SCORE } from "./corporate.js";
+
+const SCORES = { corporate: CORPORATE_SCORE };
+
+/**
+ * Pick a score for a biome, choosing a flavor by seeded RNG (WORLD stream).
+ * Falls back to corporate for unknown biomes.
+ * @param {string} biome
+ * @returns {object}
+ */
+export function computeFlavor(biome) {
+  const score = SCORES[biome] ?? CORPORATE_SCORE;
+  const flavors = score.flavors ?? [{ id: "default", processing: null }];
+  const idx = Math.floor(random(RNG.WORLD) * flavors.length);
+  return { ...score, activeFlavor: flavors[idx] ?? flavors[0] };
+}
+```
+
+- [ ] **Step 3: Lint**
+
+Run: `make lint`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add js/audio/audio-renderer.js js/audio/scores/index.js
+git commit -m 'Add audio-renderer event subscriber + score selector'
+```
+
+---
+
+## Task 7: Tuning harness (`preview/audio.html` + `playground.js`)
+
+Standalone page that drives the engine directly: per-layer mutes + the two axis sliders. Leaves the root `preview.html` untouched.
+
+**Files:**
+- Create: `preview/audio.html`
+- Create: `js/audio/playground.js`
+
+- [ ] **Step 1: Implement `playground.js`**
+
+Create `js/audio/playground.js`:
+
+```js
+// @ts-nocheck
+import { createAudioEngine } from "./engine.js";
+import { CORPORATE_SCORE, LAYER_KEYS } from "./scores/corporate.js";
+
+const engine = createAudioEngine();
+engine.setScore(CORPORATE_SCORE);
+
+const status = document.getElementById("status");
+document.getElementById("play").onclick = async () => {
+  try { await engine.start(); status.textContent = "playing"; }
+  catch (e) { status.textContent = "ERROR: " + e.message; console.error(e); }
+};
+document.getElementById("stop").onclick = () => { engine.stop(); status.textContent = "stopped"; };
+
+const tracks = document.getElementById("tracks");
+for (const key of LAYER_KEYS) {
+  const el = document.createElement("span");
+  el.className = "track on";
+  el.innerHTML = `<span class="dot"></span>${key}`;
+  el.onclick = () => { const on = el.classList.toggle("on"); engine.setMuted(key, !on); };
+  tracks.appendChild(el);
+}
+
+const prog = document.getElementById("progress"), progVal = document.getElementById("progressVal");
+prog.oninput = () => { const v = +prog.value / 100; progVal.textContent = v.toFixed(2); engine.setProgress(v); };
+const threat = document.getElementById("threat"), threatVal = document.getElementById("threatVal");
+threat.oninput = () => { const v = +threat.value / 100; threatVal.textContent = v.toFixed(2); engine.setThreat(v); };
+```
+
+- [ ] **Step 2: Implement `preview/audio.html`**
+
+Create `preview/audio.html`:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Starnet audio — tuning harness</title>
+<style>
+  :root { --bg:#0a0a0f; --cyan:#22d3ee; --green:#39ff88; --mag:#ff00aa; --dim:#1b2330; }
+  body { background:var(--bg); color:var(--green); font-family:ui-monospace,monospace; margin:0; padding:2rem; }
+  h1 { color:var(--cyan); font-size:1.1rem; text-shadow:0 0 8px rgba(34,211,238,.5); }
+  .panel { border:1px solid var(--dim); border-radius:6px; padding:1.25rem; max-width:600px; }
+  .row { display:flex; gap:.6rem; align-items:center; flex-wrap:wrap; margin:.6rem 0; }
+  button { background:transparent; color:var(--cyan); border:1px solid var(--cyan); border-radius:4px; padding:.5rem 1rem; font:inherit; cursor:pointer; }
+  button.stop { color:var(--mag); border-color:var(--mag); }
+  .track { display:inline-flex; align-items:center; gap:.4rem; border:1px solid var(--dim); border-radius:4px; padding:.35rem .6rem; cursor:pointer; user-select:none; color:#8aa; font-size:.8rem; }
+  .track.on { color:var(--green); border-color:var(--green); }
+  .track .dot { width:8px; height:8px; border:1px solid currentColor; transform:rotate(45deg); }
+  .track.on .dot { background:var(--green); }
+  label.slider { display:flex; flex-direction:column; gap:.2rem; font-size:.75rem; color:#8aa; flex:1; min-width:200px; }
+  input[type=range]{ width:100%; accent-color:var(--mag); }
+  .val { color:#a78bfa; }
+</style>
+</head>
+<body>
+  <h1>STARNET // AUDIO TUNING HARNESS</h1>
+  <div class="panel">
+    <div class="row">
+      <button id="play">▶ PLAY</button>
+      <button id="stop" class="stop">■ STOP</button>
+      <span id="status" style="color:#6b7a8d;font-size:.8rem">idle</span>
+    </div>
+    <div class="row" id="tracks"></div>
+    <div class="row"><label class="slider">PROGRESS <span class="val" id="progressVal">0.00</span>
+      <input type="range" id="progress" min="0" max="100" value="0" /></label></div>
+    <div class="row"><label class="slider">THREAT <span class="val" id="threatVal">0.00</span>
+      <input type="range" id="threat" min="0" max="100" value="0" /></label></div>
+  </div>
+  <script type="module" src="/js/audio/playground.js"></script>
+</body>
+</html>
+```
+
+- [ ] **Step 3: Build the bundle and smoke-test in a headless browser**
+
+Run: `make bundle-vendor`
+Then start a server and run a Playwright load check (confirms the bundle imports, the engine builds its graph, and no JS errors — cannot verify *sound*):
+
+Create `/tmp/audio_pg_check.mjs`:
+
+```js
+import pkg from '/home/lmorchard/.npm/_npx/e41f203b7505f1fb/node_modules/playwright/index.js';
+const { chromium } = pkg;
+const b = await chromium.launch({ headless: true, args: ['--autoplay-policy=no-user-gesture-required'] });
+const page = await b.newPage();
+const errs = [];
+page.on('pageerror', e => errs.push(String(e)));
+await page.goto('http://localhost:3000/preview/audio.html');
+await page.waitForLoadState('networkidle');
+await page.click('#play');
+await page.waitForTimeout(2500);
+await page.$eval('#progress', el => { el.value = 70; el.dispatchEvent(new Event('input')); });
+await page.$eval('#threat', el => { el.value = 80; el.dispatchEvent(new Event('input')); });
+await page.click('text=lead');
+await page.waitForTimeout(800);
+console.log('status:', JSON.stringify(await page.textContent('#status')));
+console.log('pageerrors:', errs.length ? errs : 'none');
+await b.close();
+```
+
+Run (server already running via `make serve` in the worktree):
+`node /tmp/audio_pg_check.mjs`
+Expected: `status: "playing"`, `pageerrors: none`.
+
+- [ ] **Step 4: Manual listen checkpoint (Les)**
+
+Open `http://localhost:3000/preview/audio.html`, press PLAY, sweep PROGRESS (layers should *blossom* in) and THREAT (filter sweep + tension/arp should *alarm*). Mute/unmute layers. This is the real verification the headless test can't give.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add preview/audio.html js/audio/playground.js
+git commit -m 'Add audio tuning harness (preview/audio.html)'
+```
+
+---
+
+## Task 8: Wire into the game + final checks
+
+**Files:**
+- Modify: `js/ui/main.js`
+
+- [ ] **Step 1: Import and call the renderer in main.js**
+
+In `js/ui/main.js`, add the import near the other renderer imports (after line 10, `import { initLogRenderer } from "./log-renderer.js";`):
+
+```js
+import { initAudioRenderer } from "../audio/audio-renderer.js";
+```
+
+Then in `init()`, add the call immediately after `initVisualRenderer();` (line 69):
+
+```js
+  initVisualRenderer();  // must subscribe before initGame fires STATE_CHANGED
+  initAudioRenderer();   // browser-only audio; arms on first user gesture
+```
+
+- [ ] **Step 2: Confirm headless paths stay audio-free**
+
+Run: `grep -rn "audio-renderer\|audio/engine\|/dist/tone" scripts/`
+Expected: NO matches (audio must never load in playtest/bot/census).
+
+- [ ] **Step 3: Full check**
+
+Run: `make check`
+Expected: lint PASS, all tests PASS (including the three new audio test files).
+
+- [ ] **Step 4: In-game listen checkpoint (Les)**
+
+Run `make serve`, open the game, start a run, click to arm audio. Confirm: music starts sparse; owning nodes layers it up; raising the alert / ICE detection brings urgency + filter sweep; calming eases it back.
+
+- [ ] **Step 5: Update docs status**
+
+In `docs/audio-direction.md`, change the status line to:
+`> **Status: v1 shipped.** ...`
+and note the playground at `preview/audio.html`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add js/ui/main.js docs/audio-direction.md
+git commit -m 'Wire audio-renderer into the game (main.js)'
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** engine + two axes (Tasks 2,3,5), Corporate score with all 8 layers (Task 4), `js/audio/` module layout incl. `audio-renderer.js` in `js/audio/` (Tasks 5,6), Tone vendored (Task 1), browser-only + gesture gating + headless-safety (Tasks 6,8), continuous-piece transitions + smooth ramps + asymmetric threat (Task 5), seeded flavor selection (Task 6), tuning harness at `preview/audio.html` (Task 7), master bus exposed for deferred SFX/vocal (`getMasterInput`, Task 5). Deferred items (SFX, vocal one-shots, aged-media, bar-quantize, other biomes, hybrid) are intentionally out of scope.
+- **Type consistency:** layer keys are the same `LAYER_KEYS` list across `corporate.js`, `mixer.js` consumers, `engine.js`, and `playground.js`. `computeMix(score, progress, threat)` signature is identical in mixer tests, score test, and engine. `createAudioEngine()` API (`setScore/start/stop/setProgress/setThreat/setMuted/isStarted/getMasterInput`) is used consistently by `audio-renderer.js` and `playground.js`.
+- **Placeholders:** none — all code is complete. The single-flavor `flavors` array is intentional for v1 (aged-media deferred).

--- a/js/audio/audio-renderer.js
+++ b/js/audio/audio-renderer.js
@@ -1,0 +1,180 @@
+// @ts-check
+import { on, emitEvent, E } from "../core/events.js";
+import { deriveProgress, deriveThreat } from "./signals.js";
+import { selectScore, ALL_SCORES } from "./scores/index.js";
+import { HUB_AMBIENT } from "./scores/hub.js";
+import { createAudioEngine } from "./engine.js";
+
+// Music on/off is a client preference (NOT game state — audio is never serialized).
+const MUSIC_PREF_KEY = "starnet:music-enabled";
+function loadMusicPref() {
+  try {
+    const v = localStorage.getItem(MUSIC_PREF_KEY);
+    return v === null ? true : v === "true";
+  } catch {
+    return true;
+  }
+}
+function saveMusicPref(on) {
+  try { localStorage.setItem(MUSIC_PREF_KEY, String(!!on)); } catch { /* ignore */ }
+}
+
+// Fade timings (seconds).
+const HUB_FADE_IN = 3;     // hub ambient swells in gently
+const RUN_FADE_IN = 1.2;   // run music comes up fairly quick
+const RUN_END_FADE = 2;    // run music fades out on jack-out (requested)
+const SWITCH_FADE = 0.8;   // brief dip between tracks / live score switches
+
+let _engine = null;
+let _enabled = true;
+let _armed = false;        // AudioContext unlocked (first gesture)
+let _runActive = false;
+let _biome = "corporate";
+let _currentScore = null;  // the selected RUN score (per-run pick or manual override)
+let _playing = null;       // score object currently started, or null (set optimistically)
+let _gen = 0;              // transition generation — cancels stale crossfades
+
+/** What should be sounding right now: nothing in the hub if disabled/unarmed, else hub ambient or the run score. */
+function desiredScore() {
+  if (!_enabled || !_armed) return null;
+  return _runActive ? (_currentScore || HUB_AMBIENT) : HUB_AMBIENT;
+}
+
+/**
+ * Reconcile playback toward desiredScore() with fades. Crossfades by fading the current
+ * track out, then starting the next after the fade. A generation counter cancels a
+ * superseded transition (e.g. jack out then immediately start a new run).
+ */
+function refresh(fadeIn = HUB_FADE_IN, fadeOut = SWITCH_FADE) {
+  if (!_engine) return;
+  const want = desiredScore();
+  if (want === _playing) return;          // already playing / already decided
+  const gen = ++_gen;
+  const prev = _playing;
+  _playing = want;                        // optimistic: re-entrant calls with same want no-op
+
+  if (want === null) { _engine.stop(fadeOut); return; }
+
+  if (prev === null && !_engine.isStarted()) {
+    _engine.setScore(want);
+    _engine.start(fadeIn);
+    return;
+  }
+  // something is playing (or still tearing down) → fade out, then start the new track
+  _engine.stop(fadeOut);
+  setTimeout(() => {
+    if (gen !== _gen || !_engine) return; // a newer transition superseded this one
+    _engine.setScore(want);
+    _engine.start(fadeIn);
+  }, fadeOut * 1000 + 90);
+}
+
+/**
+ * Wire the audio engine to the event bus. Browser-only — do NOT import from headless
+ * entry points (scripts/playtest.js, scripts/bot/cli.js).
+ *
+ * Playback: a calm hub ambient plays in the overworld; a fresh biome score plays during a
+ * run; transitions and jack-out are faded. All gated on the music on/off preference.
+ */
+export function initAudioRenderer() {
+  const engine = createAudioEngine();
+  _engine = engine;
+  _enabled = loadMusicPref();
+
+  // AudioContext needs a user gesture to start. On the first gesture, unlock it and bring
+  // up the hub ambient (the player boots into the hub).
+  function arm() {
+    if (_armed) return;
+    _armed = true;
+    window.removeEventListener("pointerdown", arm);
+    window.removeEventListener("keydown", arm);
+    engine.unlock();
+    refresh(HUB_FADE_IN);
+  }
+  window.addEventListener("pointerdown", arm);
+  window.addEventListener("keydown", arm);
+
+  on(E.STATE_CHANGED, (state) => {
+    if (!state) return;
+    engine.setProgress(deriveProgress(state));
+    engine.setThreat(deriveThreat(state));
+  });
+
+  on(E.RUN_STARTED, ({ state }) => {
+    _runActive = true;
+    _biome = state?.spec?.biome ?? state?.meta?.biome ?? "corporate";
+    _currentScore = selectScore(_biome);   // fresh pick each run
+    refresh(RUN_FADE_IN, SWITCH_FADE);
+  });
+
+  on(E.RUN_ENDED, () => {
+    _runActive = false;
+    refresh(HUB_FADE_IN, RUN_END_FADE);    // fade the run music out, ambient back in
+  });
+
+  return engine;
+}
+
+/** @returns {boolean} whether music is enabled (the on/off preference). */
+export function isMusicEnabled() { return _enabled; }
+
+/** @returns {string|null} name of the track currently sounding (hub ambient or run score). */
+export function getNowPlayingName() { return _playing?.name ?? null; }
+
+/** @returns {string|null} name of the selected RUN score (the per-run pick / manual override). */
+export function getCurrentScoreName() { return _currentScore?.name ?? null; }
+
+/** @returns {boolean} whether a run's music is the live track (so a switch takes effect now). */
+export function isRunMusicLive() { return _enabled && _runActive; }
+
+/** @returns {string[]} display names of all selectable run scores. */
+export function listScoreNames() { return ALL_SCORES.map((s) => s.name); }
+
+/**
+ * Enable or disable music, persisting the choice. Reconciles playback with a fade.
+ * @param {boolean} on
+ * @returns {boolean} the new enabled state
+ */
+export function setMusicEnabled(on) {
+  _enabled = !!on;
+  saveMusicPref(_enabled);
+  refresh(_runActive ? RUN_FADE_IN : HUB_FADE_IN, SWITCH_FADE);
+  emitEvent(E.MUSIC_CHANGED, { enabled: _enabled });  // keep HUD button + console in sync
+  return _enabled;
+}
+
+/** Flip music on↔off. @returns {boolean} the new enabled state */
+export function toggleMusic() { return setMusicEnabled(!_enabled); }
+
+/**
+ * Switch the selected RUN score by name (exact, else case-insensitive substring — so
+ * "neon" matches "Corporate — Neon"). Live-switches (faded) if a run is playing; otherwise
+ * applies to the next run.
+ * @param {string} name
+ * @returns {string|null} the matched score's name, or null
+ */
+export function setScoreByName(name) {
+  const q = String(name ?? "").toLowerCase();
+  if (!q) return null;
+  const target = ALL_SCORES.find((s) => s.name.toLowerCase() === q)
+    || ALL_SCORES.find((s) => s.name.toLowerCase().includes(q));
+  if (!target) return null;
+  _currentScore = target;
+  if (_runActive) refresh(RUN_FADE_IN, SWITCH_FADE);
+  return target.name;
+}
+
+/**
+ * Switch the selected RUN score to a random different one. Genuinely random (manual action,
+ * not seeded run state).
+ * @returns {string|null} the new score's name, or null
+ */
+export function randomScore() {
+  if (ALL_SCORES.length === 0) return null;
+  const others = ALL_SCORES.filter((s) => s !== _currentScore);
+  const pool = others.length ? others : ALL_SCORES;
+  const pick = pool[Math.floor(Math.random() * pool.length)];
+  _currentScore = pick;
+  if (_runActive) refresh(RUN_FADE_IN, SWITCH_FADE);
+  return pick.name;
+}

--- a/js/audio/engine.js
+++ b/js/audio/engine.js
@@ -1,0 +1,333 @@
+// @ts-nocheck
+// Tone.js wrapper. The only module that touches Web Audio. Imports the vendored bundle.
+import * as Tone from "/dist/tone.js";
+import { computeMix } from "./mixer.js";
+import { makeSeededRng, getSeed } from "../core/rng.js";
+
+const GRID = "8n";          // default step grid
+const RAMP_UP = 0.3;        // threat fast attack (s)
+const RAMP_DOWN = 1.5;      // threat slow release (s)
+const RAMP_PROGRESS = 1.0;  // progress crossfade (s)
+
+export function createAudioEngine() {
+  let started = false;
+  let score = null;
+  let progress = 0, threat = 0;
+  let lastThreat = 0;
+  let master, masterFilter, reverb;
+  const layers = {};        // key → { gain, voice, seq, sustainSynth }
+  const muted = {};         // key → bool (playground only)
+
+  // Section automation — periodically masks a subset of progress layers for arrangement variety.
+  let sectionsEnabled = true;   // master toggle (playground A/B; on in-game)
+  let sectionActive = null;     // Set of progress keys audible this section (null = no sections)
+  let sectionIdx = 0;
+  let sectionRng = null;
+  let sectionTimerId = null;
+  let maskable = new Set();     // progress-axis layer keys eligible for masking
+
+  // Param-event recycling. Web Audio never prunes past automation events, so a sequenced
+  // synth's frequency timeline grows unbounded as it plays (worst on the fast arps) →
+  // audio-thread stutter that compounds over a run. The cure is recreating the synth.
+  // We do it once a layer falls silent (gain ~0) for a click-free swap; a long-audible
+  // layer is force-recycled as a backstop.
+  const dirty = {};          // key → has been audible since last recycle
+  const lastGain = {};       // key → last computed target gain
+  const applied = {};        // key → last gain actually ramped (skip redundant ramps)
+  const audibleSince = {};   // key → ms timestamp it last became audible
+  let appliedCutoff = -1, appliedQ = -1;
+  let recycleTimer = null;
+  let fadeTimer = null;      // pending teardown after a fade-out
+  const RECYCLE_CHECK_MS = 4000;
+  const FORCE_RECYCLE_MS = 120000;
+  const nowMs = () => (typeof performance !== "undefined" ? performance.now() : 0);
+
+  function buildMasterBus() {
+    master = new Tone.Gain(0.9).toDestination();
+    reverb = new Tone.Reverb({ decay: 2.4, wet: 0.16 }).connect(master);
+    masterFilter = new Tone.Filter({ frequency: 8000, type: "lowpass", Q: 0.7 }).connect(reverb);
+  }
+
+  function drumVoices() {
+    const kick = new Tone.MembraneSynth({ octaves: 6, envelope: { attack: 0.001, decay: 0.25, sustain: 0 } });
+    const snare = new Tone.NoiseSynth({ noise: { type: "white" }, envelope: { attack: 0.001, decay: 0.15, sustain: 0 } });
+    const hat = new Tone.NoiseSynth({ noise: { type: "white" }, envelope: { attack: 0.001, decay: 0.03, sustain: 0 } });
+    snare.volume.value = -8; hat.volume.value = -20;
+    return { kick, snare, hat };
+  }
+
+  function buildLayer(spec) {
+    const gain = new Tone.Gain(0).connect(masterFilter);
+    const grid = spec.grid || GRID;
+
+    if (spec.sustain) {
+      // continuously sustained chord, gain-controlled
+      const s = new Tone.PolySynth(Tone.Synth, {
+        oscillator: { type: spec.synth.type || "fatsawtooth", count: spec.synth.count, spread: spec.synth.spread },
+        envelope: { attack: spec.synth.attack ?? 1, decay: 0.3, sustain: 1, release: spec.synth.release ?? 2 },
+      }).connect(gain);
+      if (spec.synth.volume != null) s.volume.value = spec.synth.volume;
+      layers[spec.key] = { gain, sustainSynth: s, sustain: spec.sustain };
+      return;
+    }
+
+    if (spec.synth.kind === "drums") {
+      const voices = drumVoices();
+      const trim = spec.synth.volume ?? 0;
+      Object.values(voices).forEach((v) => { v.connect(gain); if (trim) v.volume.value += trim; });
+      const seq = new Tone.Sequence((time, tok) => {
+        if (!tok) return;
+        if (tok === "snare") voices.snare.triggerAttackRelease("16n", time);
+        else if (tok === "hat") voices.hat.triggerAttackRelease("32n", time);
+        else voices.kick.triggerAttackRelease("C1", "8n", time);
+      }, spec.pattern, grid);
+      seq.start(0);
+      layers[spec.key] = { gain, voices, seq };
+      return;
+    }
+
+    if (spec.synth.kind === "poly") {
+      const s = new Tone.PolySynth(Tone.Synth, {
+        oscillator: { type: spec.synth.type || "triangle" },
+        envelope: { attack: spec.synth.attack, decay: spec.synth.decay, sustain: spec.synth.sustain, release: spec.synth.release },
+      }).connect(gain);
+      if (spec.synth.volume != null) s.volume.value = spec.synth.volume;
+      const seq = new Tone.Sequence((time, note) => {
+        if (note) s.triggerAttackRelease(note, grid, time);
+      }, spec.pattern, grid);
+      seq.start(0);
+      layers[spec.key] = { gain, voice: s, seq };
+      return;
+    }
+
+    // Monophonic line (bass / lead / arps). A single Synth is far cheaper than a
+    // PolySynth — no per-note voice allocation/GC — which matters on the fast 16th arps.
+    const s = new Tone.Synth({
+      oscillator: { type: spec.synth.type || "sawtooth" },
+      envelope: { attack: spec.synth.attack, decay: spec.synth.decay, sustain: spec.synth.sustain, release: spec.synth.release },
+    }).connect(gain);
+    if (spec.synth.volume != null) s.volume.value = spec.synth.volume;
+    const seq = new Tone.Sequence((time, note) => {
+      if (note) s.triggerAttackRelease(note, grid, time);
+    }, spec.pattern, grid);
+    seq.start(0);
+    layers[spec.key] = { gain, voice: s, seq };
+  }
+
+  function applyMix(immediate) {
+    if (!score) return;
+    const mix = computeMix(score, progress, threat);
+    for (const [key, layer] of Object.entries(layers)) {
+      let target = muted[key] ? 0 : (mix.gains[key] ?? 0);
+      // Section mask is subtractive: it can only silence an already-earned progress
+      // layer, never force one in. Drone (base) and threat layers are exempt.
+      if (sectionsEnabled && sectionActive && maskable.has(key) && !sectionActive.has(key)) target = 0;
+      if (target > 0.01 && !dirty[key]) { dirty[key] = true; audibleSince[key] = nowMs(); }
+      lastGain[key] = target;
+      // Only schedule a ramp when this layer's target actually moved — avoids piling
+      // automation events on params that didn't change (most layers, most updates).
+      if (immediate || Math.abs(target - (applied[key] ?? -1)) > 1e-4) {
+        layer.gain.gain.rampTo(target, immediate ? 0.01 : RAMP_PROGRESS);
+        applied[key] = target;
+      }
+    }
+    const tRamp = immediate ? 0.01 : (threat >= lastThreat ? RAMP_UP : RAMP_DOWN);
+    if (immediate || Math.abs(mix.masterCutoff - appliedCutoff) > 0.5) {
+      masterFilter.frequency.rampTo(mix.masterCutoff, tRamp); appliedCutoff = mix.masterCutoff;
+    }
+    if (immediate || Math.abs(mix.masterQ - appliedQ) > 1e-3) {
+      masterFilter.Q.rampTo(mix.masterQ, tRamp); appliedQ = mix.masterQ;
+    }
+    lastThreat = threat;
+  }
+
+  // Advance to the next section on a bar boundary: seeded-random, no immediate repeat.
+  function advanceSection() {
+    const secs = score?.sections;
+    if (!secs || secs.length === 0) return;
+    if (secs.length === 1) {
+      sectionIdx = 0;
+    } else {
+      let idx;
+      do { idx = Math.floor(sectionRng() * secs.length); } while (idx === sectionIdx);
+      sectionIdx = idx;
+    }
+    sectionActive = new Set(secs[sectionIdx]);
+    applyMix(false);
+  }
+
+  // Recreate a sequenced layer's synth + sequence, clearing its accumulated param
+  // automation. The new gain is set instantly to the layer's current target (≈0 for a
+  // silent recycle → no click; no rampTo event added). Sustained layers don't accumulate
+  // (one trigger) and the master bus is left intact (no reverb regen).
+  function recycleLayer(key) {
+    const l = layers[key];
+    if (!l || !l.seq) return;
+    const spec = score.layers.find((s) => s.key === key);
+    if (!spec) return;
+    l.seq.dispose();
+    l.voice?.dispose?.();
+    if (l.voices) Object.values(l.voices).forEach((v) => v.dispose?.());
+    l.gain.dispose();
+    buildLayer(spec);                                  // fresh synth + seq + gain(0) → masterFilter
+    layers[key].gain.gain.value = lastGain[key] ?? 0;  // restore level instantly
+    applied[key] = lastGain[key] ?? 0;
+  }
+
+  function recycleTick() {
+    const now = nowMs();
+    for (const [key, l] of Object.entries(layers)) {
+      if (!l?.seq || !dirty[key]) continue;            // only sequenced layers that have played
+      const silent = (lastGain[key] ?? 0) <= 0.011;
+      const longAudible = now - (audibleSince[key] ?? now) > FORCE_RECYCLE_MS;
+      if (silent || longAudible) {
+        recycleLayer(key);
+        dirty[key] = false;
+        audibleSince[key] = now;
+      }
+    }
+  }
+
+  // Full synchronous teardown — disposes every node and resets all transient state.
+  function teardown() {
+    Tone.Transport.stop();
+    if (recycleTimer != null) { clearInterval(recycleTimer); recycleTimer = null; }
+    if (fadeTimer != null) { clearTimeout(fadeTimer); fadeTimer = null; }
+    for (const k of Object.keys(dirty)) delete dirty[k];
+    for (const k of Object.keys(lastGain)) delete lastGain[k];
+    for (const k of Object.keys(applied)) delete applied[k];
+    for (const k of Object.keys(audibleSince)) delete audibleSince[k];
+    appliedCutoff = -1; appliedQ = -1;
+    if (sectionTimerId != null) { Tone.Transport.clear(sectionTimerId); sectionTimerId = null; }
+    sectionActive = null; sectionIdx = 0; sectionRng = null; maskable = new Set();
+    for (const key of Object.keys(layers)) {
+      const layer = layers[key];
+      layer.seq?.dispose?.();
+      layer.voice?.dispose?.();
+      if (layer.sustainSynth) { layer.sustainSynth.releaseAll?.(); layer.sustainSynth.dispose?.(); }
+      if (layer.voices) Object.values(layer.voices).forEach((v) => v.dispose?.());
+      layer.gain?.dispose?.();
+      delete layers[key];
+    }
+    masterFilter?.dispose?.();
+    reverb?.dispose?.();
+    master?.dispose?.();
+    masterFilter = reverb = master = undefined;
+    started = false;
+  }
+
+  return {
+    /**
+     * Set the active score. If the engine is already running and the score
+     * actually changes, rebuild the live graph so the synths + section state match
+     * the new score. (Relies on method-call invocation: `engine.setScore(...)`.)
+     * @param {object} s score object
+     */
+    setScore(s) {
+      if (s === score) return undefined;
+      const wasStarted = started;
+      if (wasStarted) this.stop();
+      score = s;
+      return wasStarted ? this.start() : undefined; // resolves when the rebuilt graph is running
+    },
+
+    /** @param {number} [fadeInSec] ramp master gain up from 0 over this many seconds */
+    async start(fadeInSec = 0) {
+      if (started || !score) return;
+      if (fadeTimer != null) { clearTimeout(fadeTimer); fadeTimer = null; }  // cancel a pending teardown
+      await Tone.start();
+      // Buffer the scheduler against main-thread jank (the game's visuals get busier as a
+      // run grows). Music doesn't need low latency, so a larger lookahead trades latency
+      // for glitch-resistance.
+      Tone.getContext().lookAhead = 0.2;
+      buildMasterBus();
+      if (fadeInSec > 0) { master.gain.value = 0; master.gain.rampTo(0.9, fadeInSec); }
+      Tone.Transport.bpm.value = score?.bpm ?? 100;
+      for (const spec of score.layers) buildLayer(spec);
+      // kick off sustained layers
+      for (const layer of Object.values(layers)) {
+        if (layer.sustainSynth) layer.sustainSynth.triggerAttack(layer.sustain);
+      }
+      // section automation: mask a rotating subset of progress layers over time
+      maskable = new Set(score.layers.filter((l) => l.axis === "progress").map((l) => l.key));
+      if (score.sections && score.sections.length) {
+        sectionRng = makeSeededRng((getSeed() || "audio") + ":sections");
+        sectionIdx = 0;
+        sectionActive = new Set(score.sections[0]);
+        const bars = score.sectionBars || 8;
+        sectionTimerId = Tone.Transport.scheduleRepeat(() => advanceSection(), `${bars}m`, `${bars}m`);
+      } else {
+        sectionActive = null;
+      }
+      applyMix(true);
+      Tone.Transport.start();
+      recycleTimer = setInterval(recycleTick, RECYCLE_CHECK_MS);  // prune accumulated synth params
+      started = true;
+    },
+
+    /** @param {number} [fadeSec] ramp master gain to 0 over this many seconds, then tear down */
+    stop(fadeSec = 0) {
+      if (!started) return;
+      if (fadeSec > 0 && master) {
+        master.gain.rampTo(0, fadeSec);
+        if (fadeTimer != null) clearTimeout(fadeTimer);
+        fadeTimer = setTimeout(() => { fadeTimer = null; teardown(); }, fadeSec * 1000 + 60);
+      } else {
+        teardown();
+      }
+    },
+
+    setProgress(x) {
+      const v = Math.max(0, Math.min(1, x));
+      if (Math.abs(v - progress) < 1e-3) return;  // STATE_CHANGED fires often; skip no-op rampTo storms
+      progress = v;
+      if (started) applyMix(false);
+    },
+    setThreat(x) {
+      const v = Math.max(0, Math.min(1, x));
+      if (Math.abs(v - threat) < 1e-3) return;
+      threat = v;
+      if (started) applyMix(false);
+    },
+
+    // playground-only
+    setMuted(key, isMuted) { muted[key] = isMuted; if (started) applyMix(false); },
+    setSectionsEnabled(on) { sectionsEnabled = !!on; if (started) applyMix(false); },
+    isStarted() { return started; },
+
+    /** Resume the AudioContext (needs a user gesture) WITHOUT starting playback. */
+    async unlock() { await Tone.start(); },
+
+    /** Diagnostic snapshot of structures that could accumulate over a long run. */
+    _debugStats() {
+      const T = Tone.getTransport();
+      const safe = (fn) => { try { const v = fn(); return v == null ? -1 : v; } catch { return -1; } };
+      // Probe several known Tone-internal event-timeline paths for a Param/Signal.
+      const evLen = (node) => {
+        if (!node) return null;
+        const tries = {
+          _events: () => node._events?.length,
+          param: () => node._param?._events?.length,
+          input: () => node.input?._events?.length,
+        };
+        const out = {};
+        for (const [k, fn] of Object.entries(tries)) { const v = safe(fn); if (v !== -1) out[k] = v; }
+        return Object.keys(out).length ? out : null;
+      };
+      const pick = (o) => (o ? (o._events ?? o.param ?? o.input) : -1);
+      const per = {};
+      for (const [k, l] of Object.entries(layers)) {
+        per[k] = `g${pick(evLen(l.gain?.gain))}/f${pick(evLen(l.voice?.frequency))}`;
+      }
+      return {
+        transportScheduled: safe(() => Object.keys(T._scheduledEvents || {}).length),
+        mFiltFreq: pick(evLen(masterFilter?.frequency)),
+        mFiltQ: pick(evLen(masterFilter?.Q)),
+        layers: per,
+      };
+    },
+
+    // exposed for deferred SFX / vocal one-shots (constraint from the spec)
+    getMasterInput() { return masterFilter; },
+  };
+}

--- a/js/audio/mixer.js
+++ b/js/audio/mixer.js
@@ -1,0 +1,72 @@
+// @ts-check
+// Pure mixing logic: score + (progress, threat) → per-layer gains + master filter.
+
+/** Clamp x into [0,1]. @param {number} x */
+const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+/** Linear interpolate. @param {number} a @param {number} b @param {number} t */
+const lerp = (a, b, t) => a + (b - a) * clamp01(t);
+
+/**
+ * Smooth Hermite ramp from 0 at `lo` to 1 at `hi`.
+ * @param {number} lo @param {number} hi @param {number} x @returns {number}
+ */
+export function smoothstep(lo, hi, x) {
+  if (hi <= lo) return x >= hi ? 1 : 0;
+  const t = clamp01((x - lo) / (hi - lo));
+  return t * t * (3 - 2 * t);
+}
+
+/**
+ * @typedef {Object} MasterFilterSpec
+ * @property {number} cutoffLo
+ * @property {number} cutoffHi
+ * @property {number} qLo
+ * @property {number} qHi
+ */
+
+/**
+ * The subset of a score the mixer reads. Real scores carry more fields
+ * (bpm, patterns, synth configs) which the mixer ignores.
+ * @typedef {Object} AudioScore
+ * @property {LayerSpec[]} layers
+ * @property {MasterFilterSpec} masterFilter
+ */
+
+/**
+ * @typedef {Object} LayerSpec
+ * @property {string} key
+ * @property {"base"|"progress"|"threat"} axis
+ * @property {number} [baseGain]
+ * @property {number} [progressBoost]
+ * @property {number} [lo]
+ * @property {number} [hi]
+ */
+
+/**
+ * @param {AudioScore} score
+ * @param {number} progress 0..1
+ * @param {number} threat 0..1
+ * @returns {{gains: Record<string, number>, masterCutoff: number, masterQ: number}}
+ */
+export function computeMix(score, progress, threat) {
+  /** @type {Record<string, number>} */
+  const gains = {};
+  for (const layer of score.layers) {
+    if (layer.axis === "base") {
+      gains[layer.key] = clamp01((layer.baseGain ?? 0) + (layer.progressBoost ?? 0) * progress);
+    } else {
+      const axisVal = layer.axis === "threat" ? threat : progress;
+      gains[layer.key] = smoothstep(layer.lo ?? 0, layer.hi ?? 1, axisVal);
+    }
+  }
+  const mf = score.masterFilter;
+  // Both axes brighten the mix (open the cutoff); resonance stays threat-driven, so
+  // progress reads as celebratory brightness while threat adds menacing resonance.
+  const openness = Math.max(progress, threat);
+  return {
+    gains,
+    masterCutoff: lerp(mf.cutoffLo, mf.cutoffHi, openness),
+    masterQ: lerp(mf.qLo, mf.qHi, threat),
+  };
+}

--- a/js/audio/music-commands.js
+++ b/js/audio/music-commands.js
@@ -1,0 +1,58 @@
+// @ts-check
+// Console commands for music control. Registered from the audio (browser) layer so
+// core/headless never imports audio. Mirrors the hamburger-menu music controls for
+// GUI/console symmetry. Imported once from js/ui/main.js.
+import { registerCommand } from "../core/console-commands/index.js";
+import { emitEvent, E } from "../core/events.js";
+import {
+  isMusicEnabled, getNowPlayingName, isRunMusicLive, setMusicEnabled,
+  listScoreNames, setScoreByName, randomScore,
+} from "./audio-renderer.js";
+
+function log(text, type = "meta") { emitEvent(E.LOG_ENTRY, { text, type }); }
+
+const SUBCOMMANDS = ["status", "on", "off", "list", "next", "random", "set"];
+/** Short single-word alias per score (its last word), e.g. "Corporate — Neon" → "neon". */
+const aliases = () => listScoreNames().map((n) => (n.split(/\s+/).pop() || "").toLowerCase());
+
+function showStatus() {
+  if (!isMusicEnabled()) { log("[MUSIC] off"); return; }
+  const now = getNowPlayingName();
+  log(now ? `[MUSIC] playing: ${now}` : "[MUSIC] on (idle — click in to start)");
+}
+
+registerCommand({
+  verb: "music",
+  complete(args, partial) {
+    const p = partial.toLowerCase();
+    // first token: subcommands + score aliases; after `set`: score aliases only
+    const pool = args.length === 0 ? [...SUBCOMMANDS, ...aliases()]
+      : (args[0] === "set" ? aliases() : []);
+    const matches = pool.filter((s) => s.startsWith(p));
+    return matches.length ? { insertTexts: matches, displayTexts: matches } : null;
+  },
+  execute(args) {
+    const sub = (args[0] || "").toLowerCase();
+    if (!sub || sub === "status") { showStatus(); return; }
+    if (sub === "on")  { setMusicEnabled(true);  showStatus(); return; }
+    if (sub === "off") { setMusicEnabled(false); log("[MUSIC] off"); return; }
+    if (sub === "list") {
+      log("[MUSIC] scores:");
+      listScoreNames().forEach((n, i) => log(`  [${i + 1}] ${n}`));
+      return;
+    }
+    const pending = isRunMusicLive() ? "" : " (applies to your next run)";
+    if (sub === "next" || sub === "random") {
+      const name = randomScore();
+      if (name) log(`[MUSIC] switched to: ${name}${pending}`);
+      else log("[MUSIC] no scores available", "error");
+      return;
+    }
+    // `music set <name>` or the shorthand `music <name>`
+    const query = (sub === "set" ? args.slice(1) : args).join(" ");
+    if (!query) { log("Usage: music [status | on | off | list | next | set <name> | <name>]", "error"); return; }
+    const name = setScoreByName(query);
+    if (name) log(`[MUSIC] score: ${name}${pending}`);
+    else log(`[MUSIC] no score matching "${query}" — try: music list`, "error");
+  },
+});

--- a/js/audio/playground.js
+++ b/js/audio/playground.js
@@ -1,0 +1,49 @@
+// @ts-nocheck
+import { createAudioEngine } from "./engine.js";
+import { LAYER_KEYS } from "./scores/corporate.js";
+import { ALL_SCORES } from "./scores/index.js";
+
+const engine = createAudioEngine();
+engine.setScore(ALL_SCORES[0]);
+/** @type {any} */ (window)._audio = engine;  // diagnostics handle
+
+const status = document.getElementById("status");
+
+// Score selector — switch among all scores; restart if currently playing.
+const scoreSel = document.getElementById("score");
+ALL_SCORES.forEach((s, i) => {
+  const opt = document.createElement("option");
+  opt.value = String(i);
+  opt.textContent = s.name ?? s.biome ?? `score ${i}`;
+  scoreSel.appendChild(opt);
+});
+scoreSel.onchange = async () => {
+  // setScore rebuilds the live graph if already playing; await the rebuilt start.
+  await engine.setScore(ALL_SCORES[+scoreSel.value]);
+  status.textContent = engine.isStarted() ? "playing" : "stopped";
+};
+
+// Section-breakdown toggle — A/B the arrangement masking with vs without.
+const secToggle = document.getElementById("sections");
+secToggle.onchange = () => engine.setSectionsEnabled(secToggle.checked);
+engine.setSectionsEnabled(secToggle.checked);
+
+document.getElementById("play").onclick = async () => {
+  try { await engine.start(); status.textContent = "playing"; }
+  catch (e) { status.textContent = "ERROR: " + e.message; console.error(e); }
+};
+document.getElementById("stop").onclick = () => { engine.stop(); status.textContent = "stopped"; };
+
+const tracks = document.getElementById("tracks");
+for (const key of LAYER_KEYS) {
+  const el = document.createElement("span");
+  el.className = "track on";
+  el.innerHTML = `<span class="dot"></span>${key}`;
+  el.onclick = () => { const on = el.classList.toggle("on"); engine.setMuted(key, !on); };
+  tracks.appendChild(el);
+}
+
+const prog = document.getElementById("progress"), progVal = document.getElementById("progressVal");
+prog.oninput = () => { const v = +prog.value / 100; progVal.textContent = v.toFixed(2); engine.setProgress(v); };
+const threat = document.getElementById("threat"), threatVal = document.getElementById("threatVal");
+threat.oninput = () => { const v = +threat.value / 100; threatVal.textContent = v.toFixed(2); engine.setThreat(v); };

--- a/js/audio/scores/corporate-cold.js
+++ b/js/audio/scores/corporate-cold.js
@@ -1,0 +1,106 @@
+// @ts-check
+// Corporate biome score — COLD variant. Cold, deadpan, motorik analog synthpop.
+// Key: C minor (C D Eb F G Ab Bb); Phrygian ♭2 = Db for menace. BPM 138, mechanical.
+
+// 8th-note grid, 8 steps/bar, 4 bars = 32 steps.
+const K = null; // rest alias for readability
+const KICK = "C1", HAT = "hat", SNARE = "snare"; // perc tokens (engine maps to drum voices)
+
+// Motorik four-on-the-floor: kick on each quarter note (steps 0,2,4,6 of each 8-step bar).
+// Minimal snare — only a cold bar-4 accent on beat 4.
+const basePerc = [
+  KICK, K, KICK, K, KICK, K, KICK, K,             // bar 1 — pure motorik, no snare
+  KICK, K, KICK, K, KICK, K, KICK, K,             // bar 2
+  KICK, K, KICK, K, KICK, K, KICK, K,             // bar 3
+  KICK, K, KICK, K, KICK, K, SNARE, K,            // bar 4 — cold single snare accent
+];
+
+// Relentless straight hats with a cold offbeat snare on 2-and-4.
+const doublePerc = [
+  K, HAT, SNARE, HAT, K, HAT, SNARE, HAT,         // bar 1
+  K, HAT, SNARE, HAT, K, HAT, SNARE, HAT,         // bar 2
+  K, HAT, SNARE, HAT, K, HAT, SNARE, HAT,         // bar 3
+  K, HAT, SNARE, HAT, K, HAT, SNARE, HAT,         // bar 4 — deadpan, no variation
+];
+
+// Insistent C pedal (eighth notes mostly); cold move to Ab/Bb in bar 4.
+const bass = [
+  "C2", K, "C2", K, "C2", K, "C2", K,
+  "C2", K, "C2", K, "C2", K, "C2", K,
+  "C2", K, "C2", K, "C2", K, "C2", K,
+  "Ab1", K, "Ab1", K, "Bb1", K, "C2", K,
+];
+
+// Detached, repetitive two-/three-note square motif in C minor (C Eb G Bb).
+const lead = [
+  "C5", K, "Eb5", K, K, K, K, K,
+  "G4", K, "Eb5", K, "C5", K, K, K,
+  "C5", K, "Bb4", K, K, K, "Eb5", K,
+  "G4", K, K, K, "C5", K, "Bb4", K,
+];
+
+// Cm [C Eb G] stabs moving to Ab major [Ab C Eb] (VI); deadpan, mechanical.
+const backup = [
+  ["C3","Eb3","G3"], K, K, K, ["C3","Eb3","G3"], K, K, K,
+  ["C3","Eb3","G3"], K, K, K, ["C3","Eb3","G3"], K, K, K,
+  ["C3","Eb3","G3"], K, K, K, ["Ab2","C3","Eb3"], K, K, K,
+  ["Ab2","C3","Eb3"], K, K, K, ["C3","Eb3","G3"], K, K, K,
+];
+
+// 16th-note grid, 16 steps/bar, 4 bars = 64 steps.
+// Eb major (relative major: Eb G Bb) ascending arp — the celebratory progress lift.
+const progArp = [
+  "Eb5",K,"G5",K,"Bb5",K,"Eb6",K,"Bb5",K,"G5",K,"Bb5",K,"Eb6",K,
+  "Eb5",K,"G5",K,"Bb5",K,"Eb6",K,"Bb5",K,"G5",K,"Bb5",K,"Eb6",K,
+  "Eb5",K,"G5",K,"Bb5",K,"Eb6",K,"Bb5",K,"G5",K,"Bb5",K,"Eb6",K,
+  "G5",K,"Bb5",K,"Eb6",K,"Bb5",K,"G5",K,"Eb5",K,"G5",K,"Bb5",K,
+];
+
+// 16th grid, 64 steps. Driving C-minor 16th arp (C Eb G C) with Db for menace.
+const urgencyArp = [
+  "C5","Eb5","G5","C6","G5","Eb5","C5","Eb5","G5","C6","G5","Eb5","C5","Eb5","G5","Db6",
+  "C5","Eb5","G5","C6","G5","Eb5","C5","Eb5","G5","C6","G5","Eb5","C5","Eb5","G5","Db6",
+  "C5","Eb5","G5","C6","G5","Eb5","C5","Eb5","G5","C6","G5","Eb5","C5","Eb5","G5","Db6",
+  "C5","Eb5","G5","C6","G5","Eb5","C5","Eb5","G5","C6","Eb5","C5","Db5","Db6","C6","G5",
+];
+
+export const CORPORATE_COLD = Object.freeze({
+  biome: "corporate",
+  name: "Corporate — Cold",
+  bpm: 138,
+  masterFilter: { cutoffLo: 600, cutoffHi: 8600, qLo: 0.7, qHi: 4.0 },
+  layers: [
+    // base
+    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.2,
+      sustain: ["C3", "G3"], synth: { type: "fatsawtooth", count: 3, spread: 16, attack: 2, release: 3, volume: -16 } },
+    // progress (blossom — mechanical, cold)
+    { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,
+      synth: { kind: "drums", volume: -6 } },
+    { key: "bass", axis: "progress", lo: 0.1, hi: 0.35, pattern: bass,
+      synth: { type: "square", attack: 0.01, decay: 0.22, sustain: 0.3, release: 0.2, volume: -7 } },
+    { key: "doublePerc", axis: "progress", lo: 0.25, hi: 0.55, pattern: doublePerc,
+      synth: { kind: "drums", volume: -8 } },
+    { key: "lead", axis: "progress", lo: 0.35, hi: 0.65, pattern: lead,
+      synth: { type: "square", attack: 0.01, decay: 0.18, sustain: 0.15, release: 0.15, volume: -8 } },
+    { key: "backup", axis: "progress", lo: 0.5, hi: 0.78, pattern: backup,
+      synth: { kind: "poly", type: "triangle", attack: 0.02, decay: 0.35, sustain: 0.0, release: 0.25, volume: -14 } },
+    { key: "progArp", axis: "progress", lo: 0.62, hi: 0.95, grid: "16n", pattern: progArp,
+      synth: { type: "square", attack: 0.005, decay: 0.14, sustain: 0.0, release: 0.1, volume: -13 } },
+    // threat (alarm)
+    { key: "tensionDrone", axis: "threat", lo: 0.0, hi: 1.0,
+      sustain: ["C3", "Db3"], synth: { type: "fatsawtooth", count: 3, spread: 30, attack: 0.8, release: 1.5, volume: -15 } },
+    { key: "urgencyArp", axis: "threat", lo: 0.55, hi: 1.0, grid: "16n", pattern: urgencyArp,
+      synth: { type: "sawtooth", attack: 0.005, decay: 0.12, sustain: 0.0, release: 0.08, volume: -14 } },
+  ],
+  // Arrangement sections (progress layers audible per section); seeded-random, no repeat.
+  sections: [
+    ["basePerc", "doublePerc", "bass", "lead", "backup", "progArp"], // full
+    ["basePerc", "bass", "progArp"],                                 // motorik core
+    ["basePerc", "doublePerc", "lead"],                              // perc + lead
+    ["bass", "lead", "backup"],                                      // synth breakdown (no drums)
+  ],
+  sectionBars: 8,
+  flavors: [
+    { id: "default", processing: null },
+  ],
+});

--- a/js/audio/scores/corporate-haze.js
+++ b/js/audio/scores/corporate-haze.js
@@ -1,0 +1,110 @@
+// @ts-check
+// Corporate biome score — HAZE variant. Warm, hazy, detuned, nostalgic. Boards of Canada feel.
+// Key: G major (G A B C D E F#) with E minor lean. BPM 84, slow and woozy.
+
+// 8th-note grid, 8 steps/bar, 4 bars = 32 steps.
+const K = null; // rest alias for readability
+const KICK = "C1", HAT = "hat", SNARE = "snare"; // perc tokens (engine maps to drum voices)
+
+// Soft, unhurried boom-bap: gentle kick on 1, light syncopation, sparse snare on 3.
+// Human-feel irregularity — not punchy or mechanical.
+const basePerc = [
+  KICK, K, K, K, K, K, KICK, K,                     // bar 1 — soft kick on 1, syncopated late kick
+  K, K, SNARE, K, K, K, K, K,                        // bar 2 — soft snare on 3, spacious
+  KICK, K, K, K, KICK, K, K, K,                      // bar 3 — gentle kick feel
+  K, K, SNARE, K, K, KICK, K, K,                     // bar 4 — snare on 3, late kick for woozy feel
+];
+
+// Lazy, relaxed hats with occasional soft snare — lots of rests, spacious.
+const doublePerc = [
+  K, HAT, K, K, K, HAT, K, K,                        // bar 1 — sparse, sleepy
+  K, K, K, HAT, SNARE, K, K, HAT,                    // bar 2 — lazy snare placement
+  K, HAT, K, K, K, K, HAT, K,                        // bar 3 — wide open space
+  K, K, HAT, K, SNARE, K, K, HAT,                    // bar 4 — gentle close
+];
+
+// Warm, rounded G bassline — slow-moving, mostly held with lots of space.
+// G root, then wandering to E and C for warmth.
+const bass = [
+  "G2", K, K, K, "G2", K, K, K,
+  "G2", K, K, K, "E2", K, K, K,
+  "C2", K, K, K, "C2", K, "D2", K,
+  "G2", K, K, K, "G2", K, K, K,
+];
+
+// Wistful, nostalgic melody in G major / E minor — long notes, child-like and simple.
+// G B D E with C and F# color notes; sparse and dreamy.
+const lead = [
+  "G4", K, K, K, "B4", K, K, K,
+  "D5", K, K, K, K, K, "E5", K,
+  "D5", K, "B4", K, K, K, "C5", K,
+  "G4", K, K, K, K, K, "F#4", K,
+];
+
+// Warm sustained pads — G major [G3 B3 D4], E minor [E3 G3 B3], C major [C3 E3 G3].
+// Long and washy, slow chord shifts.
+const backup = [
+  ["G3","B3","D4"], K, K, K, ["G3","B3","D4"], K, K, K,
+  ["E3","G3","B3"], K, K, K, ["E3","G3","B3"], K, K, K,
+  ["C3","E3","G3"], K, K, K, ["C3","E3","G3"], K, K, K,
+  ["G3","B3","D4"], K, K, K, ["G3","B3","D4"], K, K, K,
+];
+
+// 16th-note grid, 16 steps/bar, 4 bars = 64 steps.
+// Gentle shimmering G-major arp (G B D G) — dreamy, not bright or aggressive.
+const progArp = [
+  "G5",K,"B5",K,"D6",K,"G6",K,"D6",K,"B5",K,"G5",K,"B5",K,
+  "G5",K,"B5",K,"D6",K,"G6",K,"D6",K,"B5",K,"D6",K,"G6",K,
+  "B5",K,"D6",K,"G6",K,"D6",K,"B5",K,"G5",K,"B5",K,"D6",K,
+  "G5",K,"D6",K,"B5",K,"G5",K,"B5",K,"D6",K,"G6",K,"D6",K,
+];
+
+// 16th grid, 64 steps. E-minor-ish arp (E G B E) with Ab/F for unease under threat.
+const urgencyArp = [
+  "E5","G5","B5","E6","B5","G5","E5","G5","B5","E6","G5","E5","Ab5","E6","B5","G5",
+  "E5","G5","B5","E6","B5","G5","E5","G5","B5","E6","G5","E5","Ab5","E6","B5","G5",
+  "E5","G5","B5","E6","B5","G5","F5","G5","B5","E6","G5","E5","Ab5","E6","B5","G5",
+  "E5","G5","B5","E6","B5","Ab5","E5","G5","B5","E6","G5","F5","Ab5","E6","B5","E5",
+];
+
+export const CORPORATE_HAZE = Object.freeze({
+  biome: "corporate",
+  name: "Corporate — Haze",
+  bpm: 84,
+  masterFilter: { cutoffLo: 500, cutoffHi: 8000, qLo: 0.7, qHi: 3.0 },
+  layers: [
+    // base
+    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.15,
+      sustain: ["G2", "D3"], synth: { type: "fatsawtooth", count: 3, spread: 20, attack: 3, release: 4, volume: -17 } },
+    // progress (blossom — warm, hazy, nostalgic)
+    { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,
+      synth: { kind: "drums", volume: -9 } },
+    { key: "bass", axis: "progress", lo: 0.1, hi: 0.35, pattern: bass,
+      synth: { type: "triangle", attack: 0.08, decay: 0.4, sustain: 0.5, release: 0.6, volume: -9 } },
+    { key: "doublePerc", axis: "progress", lo: 0.25, hi: 0.55, pattern: doublePerc,
+      synth: { kind: "drums", volume: -11 } },
+    { key: "lead", axis: "progress", lo: 0.35, hi: 0.65, pattern: lead,
+      synth: { type: "fatsawtooth", count: 2, spread: 10, attack: 0.12, decay: 0.5, sustain: 0.4, release: 0.8, volume: -11 } },
+    { key: "backup", axis: "progress", lo: 0.5, hi: 0.78, pattern: backup,
+      synth: { kind: "poly", type: "triangle", attack: 0.3, decay: 1.2, sustain: 0.6, release: 1.5, volume: -15 } },
+    { key: "progArp", axis: "progress", lo: 0.62, hi: 0.95, grid: "16n", pattern: progArp,
+      synth: { type: "triangle", attack: 0.04, decay: 0.3, sustain: 0.2, release: 0.4, volume: -14 } },
+    // threat (alarm)
+    { key: "tensionDrone", axis: "threat", lo: 0.0, hi: 1.0,
+      sustain: ["G2", "Ab2"], synth: { type: "fatsawtooth", count: 3, spread: 25, attack: 1.2, release: 2.0, volume: -16 } },
+    { key: "urgencyArp", axis: "threat", lo: 0.55, hi: 1.0, grid: "16n", pattern: urgencyArp,
+      synth: { type: "fatsawtooth", count: 2, spread: 12, attack: 0.02, decay: 0.18, sustain: 0.1, release: 0.2, volume: -14 } },
+  ],
+  // Arrangement sections (progress layers audible per section); seeded-random, no repeat.
+  sections: [
+    ["basePerc", "doublePerc", "bass", "lead", "backup", "progArp"], // full
+    ["basePerc", "bass", "backup"],                                   // warm foundation
+    ["basePerc", "doublePerc", "lead"],                               // perc + melody
+    ["bass", "lead", "backup"],                                       // pad breakdown (no drums)
+    ["basePerc", "doublePerc", "bass", "lead"],                       // drums + core melody
+  ],
+  sectionBars: 16,
+  flavors: [
+    { id: "default", processing: null },
+  ],
+});

--- a/js/audio/scores/corporate-industrial.js
+++ b/js/audio/scores/corporate-industrial.js
@@ -1,0 +1,107 @@
+// @ts-check
+// Corporate biome score — INDUSTRIAL variant. Dark, gritty, brooding industrial + trip-hop.
+// Key: E minor (E F# G A B C D); Phrygian ♭2 = F for menace. BPM 100, mid-tempo and heavy.
+
+// 8th-note grid, 8 steps/bar, 4 bars = 32 steps.
+const K = null; // rest alias for readability
+const KICK = "C1", HAT = "hat", SNARE = "snare"; // perc tokens (engine maps to drum voices)
+
+// Heavy, deliberate beat: strong kick on 1 & 3 (steps 0,4 per bar), hard snare on 2 & 4
+// (steps 2,6), with mechanical syncopated accents — gritty industrial feel.
+const basePerc = [
+  KICK, K, SNARE, K, KICK, KICK, SNARE, K,          // bar 1 — kick 1&3, snare 2&4, syncopated kick accent
+  KICK, K, SNARE, K, KICK, K, SNARE, K,             // bar 2 — clean heavy pulse
+  KICK, K, SNARE, KICK, KICK, K, SNARE, K,          // bar 3 — syncopated accent on 2-and
+  KICK, K, SNARE, K, KICK, KICK, SNARE, KICK,       // bar 4 — heavy drive into turnaround
+];
+
+// Industrial hats + extra metallic snare hits, machine-like relentless texture.
+const doublePerc = [
+  HAT, HAT, SNARE, HAT, HAT, HAT, SNARE, HAT,      // bar 1 — machine hats, metallic snares
+  HAT, SNARE, HAT, HAT, HAT, SNARE, HAT, HAT,      // bar 2 — shifted snare accents
+  HAT, HAT, SNARE, HAT, HAT, HAT, SNARE, HAT,      // bar 3
+  HAT, SNARE, HAT, SNARE, HAT, HAT, SNARE, HAT,    // bar 4 — dense metallic clatter
+];
+
+// Heavy distorted-feel E pedal with menacing movement (E, then C and D), syncopated.
+const bass = [
+  "E2", K, "E2", K, "E2", K, "E2", K,
+  "E2", K, "E2", "G2", "E2", K, "D2", K,
+  "E2", K, "C2", K, "E2", K, "C2", K,
+  "D2", K, "D2", K, "E2", K, "E2", K,
+];
+
+// Sparse, brooding, ominous E-minor motif (E G B D, with F♮ for unease); leaves space.
+const lead = [
+  "E5", K, K, K, "G4", K, K, K,
+  "B4", K, "D5", K, K, K, K, K,
+  "E5", K, K, K, "F4", K, "G4", K,
+  "B4", K, K, K, "E5", K, "D5", K,
+];
+
+// Em [E3 G3 B3] / C [C3 E3 G3] dark sustained stabs.
+const backup = [
+  ["E3","G3","B3"], K, K, K, ["E3","G3","B3"], K, K, K,
+  ["E3","G3","B3"], K, K, K, ["C3","E3","G3"], K, K, K,
+  ["C3","E3","G3"], K, K, K, ["E3","G3","B3"], K, K, K,
+  ["D3","F3","A3"], K, K, K, ["E3","G3","B3"], K, K, K,
+];
+
+// 16th-note grid, 16 steps/bar, 4 bars = 64 steps.
+// G major (relative major: G B D) arp — colder, less bright "lift" than other scores.
+const progArp = [
+  "G5",K,"B5",K,"D6",K,"G6",K,"D6",K,"B5",K,"G5",K,"B5",K,
+  "G5",K,"B5",K,"D6",K,"G6",K,"D6",K,"B5",K,"G5",K,"D6",K,
+  "G5",K,"B5",K,"D6",K,"G6",K,"D6",K,"B5",K,"G5",K,"B5",K,
+  "B5",K,"D6",K,"G6",K,"D6",K,"B5",K,"G5",K,"B5",K,"D6",K,
+];
+
+// 16th grid, 64 steps. Pounding E-minor 16th arp (E G B E) with F for menace.
+const urgencyArp = [
+  "E5","G5","B5","E6","B5","G5","E5","G5","B5","E6","B5","G5","E5","G5","B5","F6",
+  "E5","G5","B5","E6","B5","G5","E5","G5","B5","E6","B5","G5","E5","G5","B5","F6",
+  "E5","G5","B5","E6","B5","G5","E5","G5","B5","E6","B5","G5","E5","G5","B5","F6",
+  "E5","G5","B5","E6","B5","G5","E5","G5","B5","E6","G5","E5","F5","F6","E6","B5",
+];
+
+export const CORPORATE_INDUSTRIAL = Object.freeze({
+  biome: "corporate",
+  name: "Corporate — Industrial",
+  bpm: 100,
+  masterFilter: { cutoffLo: 450, cutoffHi: 6500, qLo: 0.8, qHi: 4.0 },
+  layers: [
+    // base
+    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.2,
+      sustain: ["E2", "B2"], synth: { type: "fatsawtooth", count: 3, spread: 18, attack: 2, release: 3, volume: -14 } },
+    // progress (blossom — industrial, heavy)
+    { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,
+      synth: { kind: "drums", volume: -5 } },
+    { key: "bass", axis: "progress", lo: 0.1, hi: 0.35, pattern: bass,
+      synth: { type: "sawtooth", attack: 0.01, decay: 0.28, sustain: 0.35, release: 0.2, volume: -7 } },
+    { key: "doublePerc", axis: "progress", lo: 0.25, hi: 0.55, pattern: doublePerc,
+      synth: { kind: "drums", volume: -9 } },
+    { key: "lead", axis: "progress", lo: 0.35, hi: 0.65, pattern: lead,
+      synth: { type: "sawtooth", attack: 0.02, decay: 0.22, sustain: 0.18, release: 0.18, volume: -10 } },
+    { key: "backup", axis: "progress", lo: 0.5, hi: 0.78, pattern: backup,
+      synth: { kind: "poly", type: "sawtooth", attack: 0.04, decay: 0.4, sustain: 0.0, release: 0.3, volume: -15 } },
+    { key: "progArp", axis: "progress", lo: 0.62, hi: 0.95, grid: "16n", pattern: progArp,
+      synth: { type: "sawtooth", attack: 0.005, decay: 0.16, sustain: 0.0, release: 0.1, volume: -14 } },
+    // threat (alarm)
+    { key: "tensionDrone", axis: "threat", lo: 0.0, hi: 1.0,
+      sustain: ["E2", "F2"], synth: { type: "fatsawtooth", count: 3, spread: 30, attack: 0.8, release: 1.5, volume: -13 } },
+    { key: "urgencyArp", axis: "threat", lo: 0.55, hi: 1.0, grid: "16n", pattern: urgencyArp,
+      synth: { type: "sawtooth", attack: 0.005, decay: 0.12, sustain: 0.0, release: 0.08, volume: -15 } },
+  ],
+  // Arrangement sections (progress layers audible per section); seeded-random, no repeat.
+  sections: [
+    ["basePerc", "doublePerc", "bass", "lead", "backup", "progArp"], // full
+    ["basePerc", "bass", "lead"],                                     // gritty core
+    ["basePerc", "doublePerc", "bass"],                               // industrial drive (no lead)
+    ["bass", "lead", "backup"],                                       // synth breakdown (no drums)
+    ["basePerc", "doublePerc", "lead", "progArp"],                   // perc + lead + arp lift
+  ],
+  sectionBars: 8,
+  flavors: [
+    { id: "default", processing: null },
+  ],
+});

--- a/js/audio/scores/corporate-neon.js
+++ b/js/audio/scores/corporate-neon.js
@@ -1,0 +1,106 @@
+// @ts-check
+// Corporate biome score — NEON variant. Aggressive, driving darksynth menace.
+// Key: F# minor (F# G# A B C# D E); Phrygian ♭2 = G for menace. BPM 128, propulsive.
+
+// 8th-note grid, 8 steps/bar, 4 bars = 32 steps.
+const K = null; // rest alias for readability
+const KICK = "C1", HAT = "hat", SNARE = "snare"; // perc tokens (engine maps to drum voices)
+
+// Four-on-the-floor kick with hard backbeat snare on beats 2 & 4 (steps 2 & 6 per bar).
+const basePerc = [
+  KICK, K, SNARE, K, KICK, K, SNARE, K,            // bar 1 — four-on-floor + hard backbeat
+  KICK, K, SNARE, K, KICK, K, SNARE, K,            // bar 2
+  KICK, K, SNARE, K, KICK, K, SNARE, K,            // bar 3
+  KICK, K, SNARE, K, KICK, K, SNARE, KICK,         // bar 4 — extra kick at tail for drive
+];
+
+// Driving hats on every 8th with snare accents — energetic 16th-feel pattern.
+const doublePerc = [
+  HAT, HAT, SNARE, HAT, HAT, HAT, SNARE, HAT,      // bar 1
+  HAT, HAT, SNARE, HAT, HAT, HAT, SNARE, HAT,      // bar 2
+  HAT, HAT, SNARE, HAT, HAT, HAT, SNARE, HAT,      // bar 3
+  HAT, HAT, SNARE, HAT, HAT, SNARE, HAT, HAT,      // bar 4 — double snare fill
+];
+
+// Relentless gated-style F# pulse with octave jumps (F#1/F#2), driving.
+const bass = [
+  "F#1", K, "F#2", K, "F#1", K, "F#2", K,
+  "F#1", K, "F#2", K, "F#1", K, "F#2", K,
+  "F#1", K, "F#2", K, "B1",  K, "C#2", K,
+  "A1",  K, "F#1", K, "F#2", K, "F#1", K,
+];
+
+// Soaring anthemic saw lead in F# minor (F# A C# E), bold and memorable.
+const lead = [
+  "F#5", K, "A5",  K, "C#5", K, K,     K,
+  "E5",  K, "C#5", K, "A4",  K, "F#5", K,
+  "F#5", K, "A5",  K, "C#6", K, K,     K,
+  "E5",  K, "C#5", K, "A5",  K, "F#5", K,
+];
+
+// F#m [F#3 A3 C#4] / D [D3 F#3 A3] big saw stabs.
+const backup = [
+  ["F#3","A3","C#4"], K, K, K, ["F#3","A3","C#4"], K, K, K,
+  ["F#3","A3","C#4"], K, K, K, ["D3","F#3","A3"],  K, K, K,
+  ["F#3","A3","C#4"], K, K, K, ["F#3","A3","C#4"], K, K, K,
+  ["D3","F#3","A3"],  K, K, K, ["F#3","A3","C#4"], K, K, K,
+];
+
+// 16th-note grid, 16 steps/bar, 4 bars = 64 steps.
+// A major (relative major: A C# E) ascending arp — celebratory lift.
+const progArp = [
+  "A5",K,"C#6",K,"E6",K,"A6",K,"E6",K,"C#6",K,"E6",K,"A6",K,
+  "A5",K,"C#6",K,"E6",K,"A6",K,"E6",K,"C#6",K,"E6",K,"A6",K,
+  "A5",K,"C#6",K,"E6",K,"A6",K,"E6",K,"C#6",K,"E6",K,"A6",K,
+  "C#6",K,"E6",K,"A6",K,"E6",K,"C#6",K,"A5",K,"C#6",K,"E6",K,
+];
+
+// 16th grid, 64 steps. Driving F#-minor 16th arp (F# A C# F#) with G for menace.
+const urgencyArp = [
+  "F#5","A5","C#6","F#6","C#6","A5","F#5","A5","C#6","F#6","C#6","A5","F#5","A5","C#6","G6",
+  "F#5","A5","C#6","F#6","C#6","A5","F#5","A5","C#6","F#6","C#6","A5","F#5","A5","C#6","G6",
+  "F#5","A5","C#6","F#6","C#6","A5","F#5","A5","C#6","F#6","C#6","A5","F#5","A5","C#6","G6",
+  "F#5","A5","C#6","F#6","C#6","A5","F#5","A5","C#6","G6","A5","F#5","G5","G6","F#6","C#6",
+];
+
+export const CORPORATE_NEON = Object.freeze({
+  biome: "corporate",
+  name: "Corporate — Neon",
+  bpm: 128,
+  masterFilter: { cutoffLo: 700, cutoffHi: 9000, qLo: 0.7, qHi: 4.5 },
+  layers: [
+    // base
+    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.2,
+      sustain: ["F#2", "C#3"], synth: { type: "fatsawtooth", count: 3, spread: 18, attack: 2, release: 3, volume: -15 } },
+    // progress (blossom — aggressive, neon)
+    { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,
+      synth: { kind: "drums", volume: -5 } },
+    { key: "bass", axis: "progress", lo: 0.1, hi: 0.35, pattern: bass,
+      synth: { type: "fatsawtooth", count: 2, spread: 10, attack: 0.005, decay: 0.18, sustain: 0.4, release: 0.15, volume: -7 } },
+    { key: "doublePerc", axis: "progress", lo: 0.25, hi: 0.55, pattern: doublePerc,
+      synth: { kind: "drums", volume: -7 } },
+    { key: "lead", axis: "progress", lo: 0.35, hi: 0.65, pattern: lead,
+      synth: { type: "sawtooth", attack: 0.01, decay: 0.2, sustain: 0.3, release: 0.2, volume: -9 } },
+    { key: "backup", axis: "progress", lo: 0.5, hi: 0.78, pattern: backup,
+      synth: { kind: "poly", type: "sawtooth", attack: 0.02, decay: 0.3, sustain: 0.0, release: 0.2, volume: -14 } },
+    { key: "progArp", axis: "progress", lo: 0.62, hi: 0.95, grid: "16n", pattern: progArp,
+      synth: { type: "sawtooth", attack: 0.005, decay: 0.12, sustain: 0.0, release: 0.08, volume: -13 } },
+    // threat (alarm)
+    { key: "tensionDrone", axis: "threat", lo: 0.0, hi: 1.0,
+      sustain: ["F#2", "G2"], synth: { type: "fatsawtooth", count: 3, spread: 30, attack: 0.8, release: 1.5, volume: -16 } },
+    { key: "urgencyArp", axis: "threat", lo: 0.55, hi: 1.0, grid: "16n", pattern: urgencyArp,
+      synth: { type: "sawtooth", attack: 0.005, decay: 0.10, sustain: 0.0, release: 0.07, volume: -14 } },
+  ],
+  // Arrangement sections (progress layers audible per section); seeded-random, no repeat.
+  sections: [
+    ["basePerc", "doublePerc", "bass", "lead", "backup", "progArp"], // full
+    ["basePerc", "bass", "progArp"],                                 // driving core
+    ["basePerc", "doublePerc", "lead"],                              // perc + lead
+    ["bass", "lead", "backup"],                                      // synth breakdown (no drums)
+    ["basePerc", "doublePerc", "bass", "lead"],                      // propulsive verse
+  ],
+  sectionBars: 8,
+  flavors: [
+    { id: "default", processing: null },
+  ],
+});

--- a/js/audio/scores/corporate-noir.js
+++ b/js/audio/scores/corporate-noir.js
@@ -1,0 +1,94 @@
+// @ts-check
+// Corporate Noir biome score — authored patterns-as-data. null = rest.
+// Trip-hop / spy-jazz: Portishead, Sneakers, John Barry. Key: D minor, 84 bpm, laid-back.
+
+const K = null; // rest alias for readability
+const KICK = "C1", HAT = "hat", SNARE = "snare"; // perc tokens (engine maps to drum voices)
+
+// Laid-back boom-bap: kick on beat 1 and syncopated pickup, snare backbeat on step 4 (beat 3).
+// Sparse with swing-feel syncopation; bar 4 adds a small fill.
+const basePerc = [
+  KICK, K,    K,    K,    SNARE, K,    KICK,  K,         // bar 1
+  KICK, K,    K,    K,    SNARE, K,    K,     KICK,       // bar 2 (pickup into bar 3)
+  KICK, K,    K,    K,    SNARE, K,    KICK,  K,          // bar 3
+  KICK, K,    KICK, SNARE, K,   SNARE, KICK,  SNARE,     // bar 4 (fill)
+];
+// Trip-hop hats with syncopated ghost snares off the straight grid.
+const doublePerc = [
+  K,    HAT,  K,    HAT,  SNARE, HAT,  K,    HAT,        // bar 1
+  SNARE, HAT, K,    HAT,  K,    HAT,  SNARE, HAT,        // bar 2
+  K,    HAT,  K,    HAT,  SNARE, HAT,  K,    HAT,        // bar 3
+  SNARE, HAT, SNARE, HAT, SNARE, HAT,  SNARE, SNARE,     // bar 4 (fill)
+];
+// Smoky upright-style walking bass in D minor (D F A C), syncopated with chromatic passing notes.
+const bass = [
+  "D2", K,    "F2", K,    "A2", K,    K,    "C2",        // bar 1
+  "D2", K,    K,    "F2", K,    "A2", K,    K,           // bar 2
+  "C2", K,    "D2", K,    "F2", K,    "Ab2", K,          // bar 3 (chromatic color)
+  "A2", K,    "G2", K,    "F2", K,    "E2", "D2",        // bar 4 (walking home)
+];
+// Jazzy muted-trumpet-style melody, D minor pentatonic with blue notes (F, Ab). Sparse.
+const lead = [
+  "D4", K,    K,    "F4", K,    K,    "A4", K,           // bar 1
+  K,    "C5", K,    "A4", K,    K,    K,    K,           // bar 2
+  "F4", K,    K,    "Ab4", K,   "F4", K,    K,           // bar 3 (blue note Ab)
+  "A4", K,    "G4", K,    "F4", K,    K,    K,           // bar 4
+];
+// Lush jazz chords held long and smoky: Dm7, Gm7, A7.
+const backup = [
+  ["D3","F3","A3","C4"], K, K, K, ["D3","F3","A3","C4"], K, K, K,   // bar 1: Dm7
+  ["G3","Bb3","D4","F4"], K, K, K, ["G3","Bb3","D4","F4"], K, K, K, // bar 2: Gm7
+  ["D3","F3","A3","C4"], K, K, K, ["D3","F3","A3","C4"], K, K, K,   // bar 3: Dm7
+  ["A3","C#4","E4","G4"], K, K, K, ["A3","C#4","E4","G4"], K, K, K, // bar 4: A7 (turnaround)
+];
+// Warm vibraphone-style (triangle) F-major / Dm-relative ascending arp — the celebratory lift.
+// 16th-note grid, 4 bars = 64 steps. Rests interspersed for vibraphone breathiness.
+const progArp = [
+  "F4",K,"A4",K,"C5",K,"F5",K,"C5",K,"A4",K,"C5",K,"F5",K,
+  "F4",K,"A4",K,"C5",K,"F5",K,"C5",K,"A4",K,"C5",K,"F5",K,
+  "D4",K,"F4",K,"A4",K,"D5",K,"A4",K,"F4",K,"A4",K,"D5",K,
+  "D4",K,"F4",K,"A4",K,"C5",K,"F5",K,"A4",K,"F4",K,"D4",K,
+];
+// Driving D-minor 16th arp (D F A D) with an Eb for menace, 64 steps.
+const urgencyArp = [
+  "D4","F4","A4","D5","A4","F4","D4","F4","A4","D5","A4","F4","D4","F4","A4","Eb5",
+  "D4","F4","A4","D5","A4","F4","D4","F4","A4","D5","A4","F4","D4","F4","A4","Eb5",
+  "D4","F4","A4","D5","A4","F4","D4","F4","A4","D5","A4","F4","D4","F4","A4","Eb5",
+  "D4","F4","A4","D5","A4","F4","D4","F4","A4","D5","Eb4","Eb5","D5","A4","F4","D4",
+];
+
+export const CORPORATE_NOIR = Object.freeze({
+  biome: "corporate",
+  name: "Corporate — Noir",
+  bpm: 84,
+  masterFilter: { cutoffLo: 500, cutoffHi: 7000, qLo: 0.7, qHi: 3.5 },
+  layers: [
+    { key: "drone",        axis: "base",     baseGain: 0.5, progressBoost: 0.2,
+      sustain: ["D3","A3"], synth: { type: "fatsawtooth", count: 3, spread: 14, attack: 2.5, release: 4, volume: -17 } },
+    { key: "basePerc",     axis: "progress", lo: 0.0,  hi: 0.05, pattern: basePerc,
+      synth: { kind: "drums", volume: -7 } },
+    { key: "bass",         axis: "progress", lo: 0.1,  hi: 0.35, pattern: bass,
+      synth: { type: "triangle", attack: 0.01, decay: 0.3, sustain: 0.2, release: 0.2, volume: -8 } },
+    { key: "doublePerc",   axis: "progress", lo: 0.25, hi: 0.55, pattern: doublePerc,
+      synth: { kind: "drums", volume: -9 } },
+    { key: "lead",         axis: "progress", lo: 0.35, hi: 0.65, pattern: lead,
+      synth: { type: "triangle", attack: 0.02, decay: 0.25, sustain: 0.2, release: 0.3, volume: -9 } },
+    { key: "backup",       axis: "progress", lo: 0.5,  hi: 0.78, pattern: backup,
+      synth: { kind: "poly", type: "triangle", attack: 0.03, decay: 0.5, sustain: 0.1, release: 0.5, volume: -14 } },
+    { key: "progArp",      axis: "progress", lo: 0.62, hi: 0.95, grid: "16n", pattern: progArp,
+      synth: { type: "triangle", attack: 0.005, decay: 0.3, sustain: 0.0, release: 0.2, volume: -13 } },
+    { key: "tensionDrone", axis: "threat",   lo: 0.0,  hi: 1.0,
+      sustain: ["D3","Eb3"], synth: { type: "fatsawtooth", count: 3, spread: 30, attack: 0.8, release: 1.5, volume: -15 } },
+    { key: "urgencyArp",   axis: "threat",   lo: 0.55, hi: 1.0, grid: "16n", pattern: urgencyArp,
+      synth: { type: "sawtooth", attack: 0.005, decay: 0.12, sustain: 0.0, release: 0.08, volume: -14 } },
+  ],
+  // Arrangement sections (progress layers audible per section); seeded-random, no repeat.
+  sections: [
+    ["basePerc", "doublePerc", "bass", "lead", "backup", "progArp"], // full
+    ["bass", "basePerc", "backup"],                                  // smoky groove + chords
+    ["lead", "backup", "progArp"],                                   // melodic, no drums
+    ["basePerc", "doublePerc", "bass"],                              // rhythm section
+  ],
+  sectionBars: 8,
+  flavors: [ { id: "default", processing: null } ],
+});

--- a/js/audio/scores/corporate-pulse.js
+++ b/js/audio/scores/corporate-pulse.js
@@ -1,0 +1,108 @@
+// @ts-check
+// Corporate biome score — PULSE variant. Relentless, propulsive, bright synthpop.
+// Key: A major (A B C# D E F# G#); ♭2 = Bb for menace in threat layers. BPM 120, energetic.
+
+// 8th-note grid, 8 steps/bar, 4 bars = 32 steps.
+const K = null; // rest alias for readability
+const KICK = "C1", HAT = "hat", SNARE = "snare"; // perc tokens (engine maps to drum voices)
+
+// Four-on-the-floor kick with handclap backbeat — SNARE on beats 2 & 4 (steps 2 & 6).
+// Punchy and steady, reading as claps against the constant kick.
+const basePerc = [
+  KICK, K, SNARE, K, KICK, K, SNARE, K,             // bar 1 — four-on-the-floor + clap backbeat
+  KICK, K, SNARE, K, KICK, K, SNARE, K,             // bar 2
+  KICK, K, SNARE, K, KICK, K, SNARE, K,             // bar 3
+  KICK, K, SNARE, K, KICK, K, SNARE, K,             // bar 4 — consistent, relentless
+];
+
+// Relentless straight hats with extra SNARE clap accents on the upbeats.
+const doublePerc = [
+  HAT, HAT, SNARE, HAT, HAT, HAT, SNARE, HAT,       // bar 1
+  HAT, HAT, SNARE, HAT, HAT, HAT, SNARE, HAT,       // bar 2
+  HAT, HAT, SNARE, HAT, HAT, HAT, SNARE, HAT,       // bar 3
+  HAT, HAT, SNARE, HAT, HAT, HAT, SNARE, HAT,       // bar 4 — driving and relentless
+];
+
+// Relentless driving A pulse — straight eighth notes, root-and-fifth (A1/E2), very steady.
+const bass = [
+  "A1", K, "A1", K, "E2", K, "A1", K,
+  "A1", K, "A1", K, "E2", K, "A1", K,
+  "A1", K, "A1", K, "E2", K, "A1", K,
+  "A1", K, "E2", K, "A1", K, "E2", K,
+];
+
+// Bright, hooky A-major lead (A C# E F#) — catchy and memorable.
+const lead = [
+  "A4", K, "C#5", K, K, K, "E5", K,
+  "F#5", K, "E5", K, "C#5", K, K, K,
+  "A4", K, "C#5", K, "E5", K, K, K,
+  "F#5", K, K, K, "E5", K, "C#5", K,
+];
+
+// Choral-stab style — big sustained chord stabs A [A3 C#4 E4] / D [D3 F#3 A3] / E [E3 G#3 B3].
+// Longer attack/release for a choir-like swell.
+const backup = [
+  ["A3","C#4","E4"], K, K, K, ["A3","C#4","E4"], K, K, K,
+  ["D3","F#3","A3"], K, K, K, ["D3","F#3","A3"], K, K, K,
+  ["A3","C#4","E4"], K, K, K, ["E3","G#3","B3"], K, K, K,
+  ["E3","G#3","B3"], K, K, K, ["A3","C#4","E4"], K, K, K,
+];
+
+// 16th-note grid, 16 steps/bar, 4 bars = 64 steps.
+// Sparkling A-major ascending arp (A C# E A) — celebratory.
+const progArp = [
+  "A4",K,"C#5",K,"E5",K,"A5",K,"E5",K,"C#5",K,"E5",K,"A5",K,
+  "A4",K,"C#5",K,"E5",K,"A5",K,"E5",K,"C#5",K,"E5",K,"A5",K,
+  "A4",K,"C#5",K,"E5",K,"A5",K,"E5",K,"C#5",K,"E5",K,"A5",K,
+  "C#5",K,"E5",K,"A5",K,"E5",K,"C#5",K,"A4",K,"C#5",K,"E5",K,
+];
+
+// 16th grid, 64 steps. Driving A-minor-ish 16th arp with Bb menace (A C E A ... Bb) to darken.
+const urgencyArp = [
+  "A4","C5","E5","A5","E5","C5","A4","C5","E5","A5","E5","C5","A4","C5","E5","Bb5",
+  "A4","C5","E5","A5","E5","C5","A4","C5","E5","A5","E5","C5","A4","C5","E5","Bb5",
+  "A4","C5","E5","A5","E5","C5","A4","C5","E5","A5","E5","C5","A4","C5","E5","Bb5",
+  "A4","C5","E5","A5","E5","C5","A4","C5","E5","A5","C5","A4","Bb4","Bb5","A5","E5",
+];
+
+export const CORPORATE_PULSE = Object.freeze({
+  biome: "corporate",
+  name: "Corporate — Pulse",
+  bpm: 120,
+  masterFilter: { cutoffLo: 700, cutoffHi: 9500, qLo: 0.7, qHi: 4.0 },
+  layers: [
+    // base
+    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.2,
+      sustain: ["A2", "E3"], synth: { type: "fatsawtooth", count: 3, spread: 16, attack: 2, release: 3, volume: -16 } },
+    // progress (blossom — propulsive, bright)
+    { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,
+      synth: { kind: "drums", volume: -6 } },
+    { key: "bass", axis: "progress", lo: 0.1, hi: 0.35, pattern: bass,
+      synth: { type: "sawtooth", attack: 0.005, decay: 0.18, sustain: 0.4, release: 0.15, volume: -7 } },
+    { key: "doublePerc", axis: "progress", lo: 0.25, hi: 0.55, pattern: doublePerc,
+      synth: { kind: "drums", volume: -7 } },
+    { key: "lead", axis: "progress", lo: 0.35, hi: 0.65, pattern: lead,
+      synth: { type: "sawtooth", attack: 0.01, decay: 0.18, sustain: 0.2, release: 0.15, volume: -9 } },
+    { key: "backup", axis: "progress", lo: 0.5, hi: 0.78, pattern: backup,
+      synth: { kind: "poly", type: "fatsawtooth", attack: 0.12, decay: 0.5, sustain: 0.3, release: 0.6, volume: -13 } },
+    { key: "progArp", axis: "progress", lo: 0.62, hi: 0.95, grid: "16n", pattern: progArp,
+      synth: { type: "square", attack: 0.005, decay: 0.12, sustain: 0.0, release: 0.08, volume: -13 } },
+    // threat (alarm)
+    { key: "tensionDrone", axis: "threat", lo: 0.0, hi: 1.0,
+      sustain: ["A2", "Bb2"], synth: { type: "fatsawtooth", count: 3, spread: 30, attack: 0.8, release: 1.5, volume: -15 } },
+    { key: "urgencyArp", axis: "threat", lo: 0.55, hi: 1.0, grid: "16n", pattern: urgencyArp,
+      synth: { type: "sawtooth", attack: 0.005, decay: 0.12, sustain: 0.0, release: 0.08, volume: -14 } },
+  ],
+  // Arrangement sections (progress layers audible per section); seeded-random, no repeat.
+  sections: [
+    ["basePerc", "doublePerc", "bass", "lead", "backup", "progArp"], // full
+    ["basePerc", "bass", "progArp"],                                  // pulse core
+    ["basePerc", "doublePerc", "lead"],                               // perc + lead
+    ["bass", "lead", "backup"],                                       // synth breakdown (no drums)
+    ["basePerc", "doublePerc", "bass", "lead"],                       // drive without pads/arp
+  ],
+  sectionBars: 8,
+  flavors: [
+    { id: "default", processing: null },
+  ],
+});

--- a/js/audio/scores/corporate-vast.js
+++ b/js/audio/scores/corporate-vast.js
@@ -1,0 +1,99 @@
+// @ts-check
+// Corporate biome score — Vast variant. Slow, cold, deep-space ambience; melancholic wonder.
+// Key: A minor (Aeolian). bpm 72. Sparse, lush, wide. See docs/audio-direction.md.
+
+// 8th-note grid, 8 steps/bar, 4 bars = 32 steps.
+const K = null; // rest alias for readability
+const KICK = "C1", HAT = "hat", SNARE = "snare"; // perc tokens (engine maps to drum voices)
+
+// Very sparse: kick only on bar downbeats (step 0 of each bar). One soft snare in bar 4. Space.
+const basePerc = [
+  KICK, K, K, K, K, K, K, K,   // bar 1 — downbeat only
+  KICK, K, K, K, K, K, K, K,   // bar 2 — downbeat only
+  KICK, K, K, K, K, K, K, K,   // bar 3 — downbeat only
+  KICK, K, K, K, K, K, SNARE, K, // bar 4 — downbeat + single late snare
+];
+// Still sparse when present: occasional hats, soft snare. Leave most steps as rests.
+const doublePerc = [
+  K, K, HAT, K, K, K, K, K,      // bar 1 — single hat
+  K, K, HAT, K, SNARE, K, K, K,  // bar 2 — hat + snare
+  K, K, HAT, K, K, K, HAT, K,    // bar 3 — two hats
+  K, K, HAT, K, SNARE, K, HAT, K, // bar 4 — hat + snare + hat
+];
+// Slow, sustained roots. A pedal with a breath toward F and C. Mostly rests.
+const bass = [
+  "A1", K, K, K, K, K, K, K,
+  "A1", K, K, K, "F1", K, K, K,
+  "A1", K, K, K, K, K, K, K,
+  "C2", K, K, K, "A1", K, K, K,
+];
+// Wide, melancholic melody. A Aeolian (A B C D E F G). Long held notes, big rests.
+const lead = [
+  "A4", K, K, K, K, K, "E4", K,
+  K, K, K, "C5", K, K, K, K,
+  "E4", K, K, K, "A4", K, K, K,
+  K, K, "G4", K, K, K, "A4", K,
+];
+// Lush sustained pad chords: Am, F, C, Am. Long, washy, few hits.
+const backup = [
+  ["A3","C4","E4"], K, K, K, K, K, K, K,
+  ["F3","A3","C4"], K, K, K, K, K, K, K,
+  ["C4","E4","G4"], K, K, K, K, K, K, K,
+  ["A3","C4","E4"], K, K, K, K, K, K, K,
+];
+// 16th-note grid, 16 steps/bar, 4 bars = 64. Shimmering consonant C major arp; gentle, spacious.
+const progArp = [
+  "C5",K,K,K,"E5",K,K,K,"G5",K,K,K,"C6",K,K,K,
+  "C5",K,K,K,"E5",K,K,K,"G5",K,K,K,"C6",K,K,K,
+  "G5",K,K,K,"E5",K,K,K,"C5",K,K,K,"E5",K,K,K,
+  "A5",K,K,K,"C6",K,K,K,"E6",K,K,K,"C6",K,K,K,
+];
+// 16th grid, 64 steps. A-minor arp (A C E A) with Bb menace; the one driving element at high threat.
+const urgencyArp = [
+  "A4",K,"C5",K,"E5",K,"A5",K,"E5",K,"C5",K,"A4",K,"Bb4",K,
+  "A4",K,"C5",K,"E5",K,"A5",K,"E5",K,"C5",K,"A4",K,"Bb4",K,
+  "A4",K,"C5",K,"E5",K,"A5",K,"E5",K,"C5",K,"A4",K,"Bb4",K,
+  "A4",K,"C5",K,"E5",K,"A5",K,"E5",K,"C5",K,"Bb4",K,"A4",K,
+];
+
+export const CORPORATE_VAST = Object.freeze({
+  biome: "corporate",
+  name: "Corporate — Vast",
+  bpm: 72,
+  masterFilter: { cutoffLo: 500, cutoffHi: 9000, qLo: 0.7, qHi: 3.5 },
+  layers: [
+    // base — always-on low pad
+    { key: "drone", axis: "base", baseGain: 0.6, progressBoost: 0.2,
+      sustain: ["A2","E3","A3"], synth: { type: "fatsawtooth", count: 3, spread: 20, attack: 4.0, release: 5.0, volume: -16 } },
+    // progress (blossom — sparse percussion first, then melody and pads layer in)
+    { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,
+      synth: { kind: "drums", volume: -9 } },
+    { key: "bass", axis: "progress", lo: 0.1, hi: 0.35, pattern: bass,
+      synth: { type: "sine", attack: 0.05, decay: 0.4, sustain: 0.5, release: 0.6, volume: -10 } },
+    { key: "doublePerc", axis: "progress", lo: 0.25, hi: 0.55, pattern: doublePerc,
+      synth: { kind: "drums", volume: -11 } },
+    { key: "lead", axis: "progress", lo: 0.35, hi: 0.65, pattern: lead,
+      synth: { type: "triangle", attack: 0.08, decay: 0.4, sustain: 0.4, release: 0.8, volume: -12 } },
+    { key: "backup", axis: "progress", lo: 0.5, hi: 0.78, pattern: backup,
+      synth: { kind: "poly", type: "fatsawtooth", attack: 0.3, decay: 0.6, sustain: 0.4, release: 1.2, volume: -15 } },
+    { key: "progArp", axis: "progress", lo: 0.62, hi: 0.95, grid: "16n", pattern: progArp,
+      synth: { type: "triangle", attack: 0.01, decay: 0.4, sustain: 0.0, release: 0.4, volume: -15 } },
+    // threat (swell)
+    { key: "tensionDrone", axis: "threat", lo: 0.0, hi: 1.0,
+      sustain: ["A2","Bb2"], synth: { type: "fatsawtooth", count: 3, spread: 30, attack: 1.2, release: 2.0, volume: -17 } },
+    { key: "urgencyArp", axis: "threat", lo: 0.55, hi: 1.0, grid: "16n", pattern: urgencyArp,
+      synth: { type: "sawtooth", attack: 0.005, decay: 0.12, sustain: 0.0, release: 0.08, volume: -14 } },
+  ],
+  // Arrangement sections (progress layers audible per section); seeded-random, no repeat.
+  // Long sections (16 bars) to let the ambience breathe.
+  sections: [
+    ["basePerc", "doublePerc", "bass", "lead", "backup", "progArp"], // full
+    ["backup", "progArp"],                                           // pads + shimmer (no drums)
+    ["lead", "backup"],                                              // melodic wash
+    ["basePerc", "bass", "backup"],                                  // sparse pulse
+  ],
+  sectionBars: 16,
+  flavors: [
+    { id: "default", processing: null },
+  ],
+});

--- a/js/audio/scores/corporate.js
+++ b/js/audio/scores/corporate.js
@@ -1,0 +1,105 @@
+// @ts-check
+// Corporate biome score — authored patterns-as-data. null = rest.
+// Static/modal A-minor with a Phrygian ♭2 (Bb) turn for menace. See docs/audio-direction.md.
+
+export const LAYER_KEYS = Object.freeze([
+  "drone", "basePerc", "doublePerc", "bass", "lead", "backup", "progArp", "tensionDrone", "urgencyArp",
+]);
+
+// 8th-note grid, 8 steps/bar, 4 bars = 32 steps.
+const K = null; // rest alias for readability
+const KICK = "C1", HAT = "hat", SNARE = "snare"; // perc tokens (engine maps to drum voices)
+
+// Sparse kick pulse with a counterpoint snare answering on beat 4; bar 4 adds a small fill.
+const basePerc = [
+  KICK, K, K, KICK, HAT, K, SNARE, KICK,         // bar 1
+  KICK, K, K, K, HAT, K, SNARE, K,         // bar 2
+  KICK, K, K, KICK, HAT, K, SNARE, KICK,         // bar 3
+  KICK, K, K, SNARE, HAT, K, SNARE, SNARE, // bar 4 (fill)
+];
+// Busier layer: snare pushed off the straight 2-&-4 onto syncopated off-eighths; bar 4 fills.
+const doublePerc = [
+  K, HAT, SNARE, HAT, K, SNARE, HAT, SNARE,      // bar 1
+  K, HAT, SNARE, HAT, SNARE, HAT, K, SNARE,      // bar 2
+  K, HAT, SNARE, HAT, K, SNARE, HAT, SNARE,      // bar 3
+  SNARE, HAT, SNARE, HAT, SNARE, SNARE, HAT, SNARE, // bar 4 (fill)
+];
+// Mostly an A pedal (static dread); bar 4 leans to Bb (Phrygian ♭2).
+const bass = [
+  "A1", K, K, "A1", K, "A1", K, K,
+  "A1", K, K, "A1", K, "A1", K, K,
+  "A1", K, K, "A1", K, "A1", K, K,
+  "Bb1", K, K, "Bb1", K, "A1", K, K,
+];
+// Sparse modal lead (A Aeolian / pentatonic), leaving space.
+const lead = [
+  "E4", K, K, "A4", K, K, "C5", K,
+  K, "B4", K, "A4", K, K, K, K,
+  "E4", K, "G4", K, "A4", K, K, K,
+  "Bb4", K, "A4", K, "E4", K, K, K,
+];
+// Triad stabs: Am held three bars, Bb (♭2) on bar 4. Chords as arrays.
+const backup = [
+  ["A3","C4","E4"], K, K, K, ["A3","C4","E4"], K, K, K,
+  ["A3","C4","E4"], K, K, K, ["A3","C4","E4"], K, K, K,
+  ["A3","C4","E4"], K, K, K, ["A3","C4","E4"], K, K, K,
+  ["Bb3","D4","F4"], K, K, K, ["Bb3","D4","F4"], K, K, K,
+];
+// 16th-note grid, 16 steps/bar, 4 bars = 64. Driving Am arp with ♭2 menace.
+const urgencyArp = [
+  "A4","C5","E5","A5","E5","C5","A4","C5","E5","A5","E5","C5","A4","C5","E5","Bb5",
+  "A4","C5","E5","A5","E5","C5","A4","C5","E5","A5","E5","C5","A4","C5","E5","Bb5",
+  "A4","C5","E5","A5","E5","C5","A4","C5","E5","A5","E5","C5","A4","C5","E5","Bb5",
+  "A4","C5","E5","A5","E5","C5","A4","C5","E5","A5","E5","C5","Bb4","Bb5","A5","E5",
+];
+// 16th grid, 64 steps. Celebratory consonant lift (C major / Am-relative) — the progress
+// counterpart to the menacing urgencyArp; syncopated with rests so the two interlock at the top.
+const progArp = [
+  "C5",K,"E5",K,"G5",K,"C6",K,"G5",K,"E5",K,"G5",K,"C6",K,
+  "C5",K,"E5",K,"G5",K,"C6",K,"G5",K,"E5",K,"G5",K,"C6",K,
+  "C5",K,"E5",K,"G5",K,"C6",K,"G5",K,"E5",K,"G5",K,"C6",K,
+  "A5",K,"C6",K,"E6",K,"C6",K,"G5",K,"E5",K,"C5",K,"E5",K,
+];
+
+export const CORPORATE_SCORE = Object.freeze({
+  biome: "corporate",
+  name: "Corporate — Dread",
+  bpm: 120,
+  masterFilter: { cutoffLo: 600, cutoffHi: 8600, qLo: 0.7, qHi: 4.7 },
+  layers: [
+    // base
+    { key: "drone", axis: "base", baseGain: 0.55, progressBoost: 0.2,
+      sustain: ["A2", "E3"], synth: { type: "fatsawtooth", count: 3, spread: 18, attack: 2, release: 3, volume: -16 } },
+    // progress (blossom — bolder, earlier, opens up celebratory toward the top)
+    { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,
+      synth: { kind: "drums", volume: -5 } },
+    { key: "bass", axis: "progress", lo: 0.1, hi: 0.35, pattern: bass,
+      synth: { type: "square", attack: 0.01, decay: 0.25, sustain: 0.3, release: 0.2, volume: -6 } },
+    { key: "doublePerc", axis: "progress", lo: 0.25, hi: 0.55, pattern: doublePerc,
+      synth: { kind: "drums", volume: -8 } },
+    { key: "lead", axis: "progress", lo: 0.35, hi: 0.65, pattern: lead,
+      synth: { type: "sawtooth", attack: 0.01, decay: 0.2, sustain: 0.2, release: 0.2, volume: -9 } },
+    { key: "backup", axis: "progress", lo: 0.5, hi: 0.78, pattern: backup,
+      synth: { kind: "poly", type: "triangle", attack: 0.02, decay: 0.4, sustain: 0.0, release: 0.3, volume: -13 } },
+    { key: "progArp", axis: "progress", lo: 0.62, hi: 0.95, grid: "16n", pattern: progArp,
+      synth: { type: "sawtooth", attack: 0.005, decay: 0.16, sustain: 0.0, release: 0.12, volume: -12 } },
+    // threat (alarm)
+    { key: "tensionDrone", axis: "threat", lo: 0.0, hi: 1.0,
+      sustain: ["A2", "Bb2"], synth: { type: "fatsawtooth", count: 3, spread: 30, attack: 0.8, release: 1.5, volume: -14 } },
+    { key: "urgencyArp", axis: "threat", lo: 0.55, hi: 1.0, grid: "16n", pattern: urgencyArp,
+      synth: { type: "sawtooth", attack: 0.005, decay: 0.12, sustain: 0.0, release: 0.08, volume: -16 } },
+  ],
+  // Arrangement sections — each lists the progress layers audible; chosen seeded-random,
+  // no immediate repeat, switching every `sectionBars`. Drone + threat layers are exempt.
+  sections: [
+    ["basePerc", "doublePerc", "bass", "lead", "backup", "progArp"], // full
+    ["basePerc", "doublePerc", "progArp"],                            // perc + arp breakdown
+    ["lead", "progArp", "bass"],                                      // lead + arp over bass
+    ["basePerc", "bass"],                                             // stripped groove
+    ["backup", "progArp"],                                            // pads + shimmer breath
+  ],
+  sectionBars: 8,
+  flavors: [
+    { id: "default", processing: null },
+  ],
+});

--- a/js/audio/scores/hub.js
+++ b/js/audio/scores/hub.js
@@ -1,0 +1,22 @@
+// @ts-check
+// Hub ambient — a calm, biome-independent background for the overworld hub. Intentionally
+// ALL sustained pads (no sequenced notes), so it adds no per-note param accumulation while
+// the player lingers between runs. A warm, slightly-hopeful drift (Am over a Cmaj shimmer).
+export const HUB_AMBIENT = Object.freeze({
+  biome: "hub",
+  name: "Hub Ambient",
+  bpm: 70,
+  masterFilter: { cutoffLo: 2200, cutoffHi: 7000, qLo: 0.7, qHi: 1.5 },
+  layers: [
+    { key: "drone", axis: "base", baseGain: 0.6,
+      sustain: ["A2", "E3"],
+      synth: { type: "fatsawtooth", count: 3, spread: 22, attack: 3, release: 4, volume: -15 } },
+    { key: "pad", axis: "base", baseGain: 0.5,
+      sustain: ["C4", "E4", "G4"],
+      synth: { type: "fatsawtooth", count: 3, spread: 26, attack: 4, release: 5, volume: -19 } },
+    { key: "shimmer", axis: "base", baseGain: 0.32,
+      sustain: ["E5", "B5"],
+      synth: { type: "triangle", attack: 5, release: 6, volume: -24 } },
+  ],
+  flavors: [{ id: "default", processing: null }],
+});

--- a/js/audio/scores/index.js
+++ b/js/audio/scores/index.js
@@ -1,0 +1,39 @@
+// @ts-check
+// Score registry + seeded selection within a biome. A biome owns a pool of full
+// scores (variety); one is chosen per run by an INDEPENDENT seeded RNG (derived from the
+// run seed, never a gameplay RNG stream — audio must not perturb game determinism).
+import { makeSeededRng, getSeed } from "../../core/rng.js";
+import { CORPORATE_SCORE } from "./corporate.js";
+import { CORPORATE_COLD } from "./corporate-cold.js";
+import { CORPORATE_NOIR } from "./corporate-noir.js";
+import { CORPORATE_VAST } from "./corporate-vast.js";
+import { CORPORATE_NEON } from "./corporate-neon.js";
+import { CORPORATE_INDUSTRIAL } from "./corporate-industrial.js";
+import { CORPORATE_PULSE } from "./corporate-pulse.js";
+import { CORPORATE_HAZE } from "./corporate-haze.js";
+
+/** Scores available per biome (index 0 is the default fallback). */
+const BIOME_SCORES = {
+  corporate: [
+    CORPORATE_SCORE, CORPORATE_COLD, CORPORATE_NOIR, CORPORATE_VAST,
+    CORPORATE_NEON, CORPORATE_INDUSTRIAL, CORPORATE_PULSE, CORPORATE_HAZE,
+  ],
+};
+
+/** Flat list of every score, for the tuning harness. */
+export const ALL_SCORES = Object.values(BIOME_SCORES).flat();
+
+/**
+ * Pick a score for a biome using an independent seeded RNG (deterministic per run seed,
+ * consumes no gameplay RNG stream). Unknown biome → corporate.
+ * @param {string} biome
+ * @returns {object}
+ */
+export function selectScore(biome) {
+  const pool = BIOME_SCORES[biome] ?? BIOME_SCORES.corporate;
+  // Independent seeded RNG: deterministic per run seed WITHOUT consuming any gameplay
+  // RNG stream — audio must never perturb game determinism.
+  const rng = makeSeededRng((getSeed() || "audio") + ":score");
+  const idx = Math.floor(rng() * pool.length);
+  return pool[idx] ?? pool[0];
+}

--- a/js/audio/signals.js
+++ b/js/audio/signals.js
@@ -1,0 +1,41 @@
+// @ts-check
+// Pure derivation of the two music axes from game state. No Tone, no DOM, no smoothing.
+
+/** @typedef {import('../core/types.js').GameState} GameState */
+
+/** Clamp x into [0,1]. @param {number} x @returns {number} */
+const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+/** Alert ladder → 0..1. */
+const ALERT_LEVEL = { green: 0, yellow: 1 / 3, red: 2 / 3, trace: 1 };
+
+/** Each resource pool (health, deck) contributes at most this much to the threat signal. */
+const INJURY_WEIGHT = 0.25;
+
+/**
+ * PROGRESS axis: how much of the LAN the player owns, 0..1.
+ * @param {GameState} state
+ * @returns {number}
+ */
+export function deriveProgress(state) {
+  const nodes = state?.nodes;
+  if (!nodes) return 0;
+  const all = Object.values(nodes);
+  if (all.length === 0) return 0;
+  const owned = all.filter((n) => /** @type {any} */ (n).accessLevel === "owned").length;
+  return clamp01(owned / all.length);
+}
+
+/**
+ * THREAT axis: alert ladder blended with an injury term, 0..1.
+ * @param {GameState} state
+ * @returns {number}
+ */
+export function deriveThreat(state) {
+  const alert = ALERT_LEVEL[state?.globalAlert] ?? 0;
+  const p = state?.player;
+  let injury = 0;
+  if (p?.health?.max) injury += INJURY_WEIGHT * (1 - clamp01(p.health.current / p.health.max));
+  if (p?.deckIntegrity?.max) injury += INJURY_WEIGHT * (1 - clamp01(p.deckIntegrity.current / p.deckIntegrity.max));
+  return clamp01(alert + injury);
+}

--- a/js/core/events.js
+++ b/js/core/events.js
@@ -75,4 +75,7 @@ export const E = Object.freeze({
   NODE_STATE_CHANGED:   "graph:node-state-changed",
   MESSAGE_PROPAGATED:   "graph:message-propagated",
   QUALITY_CHANGED:      "graph:quality-changed",
+
+  // Audio (music on/off changed — keeps HUD + console in sync)
+  MUSIC_CHANGED:        "audio:music-changed",
 });

--- a/js/tone-vendor.js
+++ b/js/tone-vendor.js
@@ -1,0 +1,4 @@
+// Tone.js vendor bundle entry point.
+// Bundled with esbuild into dist/tone.js (ESM).
+// Audio modules import from "/dist/tone.js" as: import * as Tone from "/dist/tone.js";
+export * from "tone";

--- a/js/ui/components/starnet-hud.js
+++ b/js/ui/components/starnet-hud.js
@@ -17,6 +17,7 @@ class StarnetHud extends StarnetElement {
     paused: { type: Boolean },
     mission: { type: Object },
     menuOpen: { type: Boolean },
+    musicEnabled: { type: Boolean },
   };
 
   constructor() {
@@ -31,6 +32,7 @@ class StarnetHud extends StarnetElement {
     this.paused = false;
     this.mission = null;
     this.menuOpen = false;
+    this.musicEnabled = true;
   }
 
   _emit(action, detail = {}) {
@@ -107,6 +109,8 @@ class StarnetHud extends StarnetElement {
                   @click=${() => this._emit("new-run")}>[ NEW RUN ]</button>
           <button id="pause-btn" class="${this.paused ? "active" : ""}"
                   @click=${() => this._emit("pause")}>${this.paused ? "[ RESUME ]" : "[ PAUSE ]"}</button>
+          <button id="music-btn" title="Toggle music"
+                  @click=${() => this._emit("toggle-music")}>${this.musicEnabled ? "[ MUSIC: ON ]" : "[ MUSIC: OFF ]"}</button>
           <button id="save-btn" title="Save game state to file"
                   @click=${() => this._emit("save")}>[ SAVE ]</button>
           <label id="load-btn" title="Load game state from file">[ LOAD ]

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -8,6 +8,7 @@ import { tick, TICK_MS, TIMER, getVisibleTimers, pauseTimers, resumeTimers } fro
 import { handleTraceTick } from "../core/alert.js";
 import { initVisualRenderer } from "./visual-renderer.js";
 import { initLogRenderer } from "./log-renderer.js";
+import { initAudioRenderer, toggleMusic, isMusicEnabled } from "../audio/audio-renderer.js";
 import { buildActionContext, initActionDispatcher, buildNodeClickHandler } from "../core/actions/action-context.js";
 import { openDarknetsStore } from "./store.js";
 import { initGraphBridge } from "../core/graph-bridge.js";
@@ -18,6 +19,7 @@ import { openHub, initHub, quickStartRun } from "./hub.js";
 import { initProfileRunCommit } from "./profile-store.js";
 import { initResizers } from "./resizers.js";
 import "./hub-commands.js";
+import "../audio/music-commands.js";
 
 import { NAMED_NETWORKS, DEFAULT_NETWORK, buildGenerated } from "../../data/networks/index.js";
 
@@ -67,6 +69,7 @@ function init() {
   initConsole();
   initResizers();  // apply saved layout + wire the resize splitters
   initVisualRenderer();  // must subscribe before initGame fires STATE_CHANGED
+  const audioEngine = initAudioRenderer();   // browser-only reactive audio; silent until a run starts
   initGraphBridge();
   initDynamicActions();
   initProfileRunCommit();  // wire RUN_ENDED → commit results back to the profile
@@ -86,7 +89,7 @@ function init() {
   }, TICK_MS);
 
   // LLM playtesting API — accessible via browser console or Playwright evaluate
-  /** @type {any} */ (window).starnet = { cmd: runCommand, state: getState };
+  /** @type {any} */ (window).starnet = { cmd: runCommand, state: getState, audio: audioEngine };
 
   // Pause timers when tab is hidden; resume when visible again
   document.addEventListener("visibilitychange", () => {
@@ -112,6 +115,9 @@ function init() {
   // typed `any` so its component props (.paused) and CustomEvent details don't need casts.
   let _userPaused = false;
   const hudEl = /** @type {any} */ (document.getElementById("hud"));
+  hudEl.musicEnabled = isMusicEnabled();  // reflect the persisted music preference
+  // Keep the menu button in sync however music is toggled (button OR `music` console command).
+  on(E.MUSIC_CHANGED, ({ enabled }) => { hudEl.musicEnabled = enabled; });
   hudEl.addEventListener("hud-action", (e) => {
     const { action, file } = e.detail;
     switch (action) {
@@ -134,6 +140,9 @@ function init() {
         hudEl.menuOpen = open;
         break;
       }
+      case "toggle-music":
+        toggleMusic();  // emits MUSIC_CHANGED → the handler above updates the button
+        break;
     }
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,21 @@
         "cytoscape-fcose": "^2.2.0",
         "cytoscape-klay": "^3.1.4",
         "cytoscape-spread": "^3.0.0",
-        "lit": "^3.3.2"
+        "lit": "^3.3.2",
+        "tone": "^15.1.22"
       },
       "devDependencies": {
         "esbuild": "^0.27.3",
         "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -484,6 +494,19 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
+    "node_modules/automation-events": {
+      "version": "7.1.19",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.19.tgz",
+      "integrity": "sha512-cD+TLhJTI0q4AI3ktd353lrGZiVa9AchowSDzQzzGjSoYe22js4vlS32VUtWuaulghi1Yq0KYNWKk9wWuGymPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
+    },
     "node_modules/cose-base": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
@@ -750,6 +773,33 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
+    },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.77",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
+      "integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "automation-events": "^7.0.9",
+        "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/tone": {
+      "version": "15.1.22",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-15.1.22.tgz",
+      "integrity": "sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "standardized-audio-context": "^25.3.70",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cytoscape-fcose": "^2.2.0",
     "cytoscape-klay": "^3.1.4",
     "cytoscape-spread": "^3.0.0",
-    "lit": "^3.3.2"
+    "lit": "^3.3.2",
+    "tone": "^15.1.22"
   }
 }

--- a/preview/audio.html
+++ b/preview/audio.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Starnet audio — tuning harness</title>
+<style>
+  :root { --bg:#0a0a0f; --cyan:#22d3ee; --green:#39ff88; --mag:#ff00aa; --dim:#1b2330; }
+  body { background:var(--bg); color:var(--green); font-family:ui-monospace,monospace; margin:0; padding:2rem; }
+  h1 { color:var(--cyan); font-size:1.1rem; text-shadow:0 0 8px rgba(34,211,238,.5); }
+  .panel { border:1px solid var(--dim); border-radius:6px; padding:1.25rem; max-width:600px; }
+  .row { display:flex; gap:.6rem; align-items:center; flex-wrap:wrap; margin:.6rem 0; }
+  button { background:transparent; color:var(--cyan); border:1px solid var(--cyan); border-radius:4px; padding:.5rem 1rem; font:inherit; cursor:pointer; }
+  button.stop { color:var(--mag); border-color:var(--mag); }
+  .track { display:inline-flex; align-items:center; gap:.4rem; border:1px solid var(--dim); border-radius:4px; padding:.35rem .6rem; cursor:pointer; user-select:none; color:#8aa; font-size:.8rem; }
+  .track.on { color:var(--green); border-color:var(--green); }
+  .track .dot { width:8px; height:8px; border:1px solid currentColor; transform:rotate(45deg); }
+  .track.on .dot { background:var(--green); }
+  label.slider { display:flex; flex-direction:column; gap:.2rem; font-size:.75rem; color:#8aa; flex:1; min-width:200px; }
+  input[type=range]{ width:100%; accent-color:var(--mag); }
+  .val { color:#a78bfa; }
+  select { background:var(--bg); color:var(--green); border:1px solid var(--dim); border-radius:4px; font:inherit; padding:.35rem .5rem; }
+</style>
+</head>
+<body>
+  <h1>STARNET // AUDIO TUNING HARNESS</h1>
+  <div class="panel">
+    <div class="row">
+      <button id="play">▶ PLAY</button>
+      <button id="stop" class="stop">■ STOP</button>
+      <span id="status" style="color:#6b7a8d;font-size:.8rem">idle</span>
+    </div>
+    <div class="row"><label class="slider" style="max-width:280px;flex-direction:row;align-items:center;gap:.5rem">SCORE
+      <select id="score"></select></label></div>
+    <div class="row"><label style="font-size:.8rem;color:#8aa;display:flex;align-items:center;gap:.4rem">
+      <input type="checkbox" id="sections" checked /> SECTION BREAKDOWNS</label></div>
+    <div class="row" id="tracks"></div>
+    <div class="row"><label class="slider">PROGRESS <span class="val" id="progressVal">0.00</span>
+      <input type="range" id="progress" min="0" max="100" value="0" /></label></div>
+    <div class="row"><label class="slider">THREAT <span class="val" id="threatVal">0.00</span>
+      <input type="range" id="threat" min="0" max="100" value="0" /></label></div>
+  </div>
+  <script type="module" src="/js/audio/playground.js"></script>
+</body>
+</html>

--- a/tests/audio-mixer.test.js
+++ b/tests/audio-mixer.test.js
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { computeMix, smoothstep } from "../js/audio/mixer.js";
+
+const SCORE = {
+  layers: [
+    { key: "drone", axis: "base", baseGain: 0.6, progressBoost: 0.2 },
+    { key: "bass", axis: "progress", lo: 0.2, hi: 0.5 },
+    { key: "tensionDrone", axis: "threat", lo: 0.0, hi: 1.0 },
+  ],
+  masterFilter: { cutoffLo: 600, cutoffHi: 8600, qLo: 0.7, qHi: 4.7 },
+};
+
+test("smoothstep clamps and is monotone", () => {
+  assert.equal(smoothstep(0.2, 0.5, 0.1), 0);
+  assert.equal(smoothstep(0.2, 0.5, 0.6), 1);
+  assert.ok(smoothstep(0.2, 0.5, 0.35) > 0 && smoothstep(0.2, 0.5, 0.35) < 1);
+});
+
+test("base layer gain = baseGain + progressBoost*progress", () => {
+  assert.equal(computeMix(SCORE, 0, 0).gains.drone, 0.6);
+  assert.ok(Math.abs(computeMix(SCORE, 1, 0).gains.drone - 0.8) < 1e-9);
+});
+
+test("progress layer fades across its lo..hi range", () => {
+  assert.equal(computeMix(SCORE, 0.1, 0).gains.bass, 0);
+  assert.equal(computeMix(SCORE, 0.6, 0).gains.bass, 1);
+  // progress layer must ignore the threat axis
+  assert.equal(computeMix(SCORE, 0.1, 1).gains.bass, 0);
+  assert.equal(computeMix(SCORE, 0.6, 1).gains.bass, 1);
+});
+
+test("threat layer is driven by threat only", () => {
+  assert.equal(computeMix(SCORE, 1, 0).gains.tensionDrone, 0);
+  assert.equal(computeMix(SCORE, 0, 1).gains.tensionDrone, 1);
+});
+
+test("master cutoff opens with EITHER axis; Q is threat-only", () => {
+  // both axes at 0 → closed, low resonance
+  const m0 = computeMix(SCORE, 0, 0);
+  assert.equal(m0.masterCutoff, 600);
+  assert.equal(m0.masterQ, 0.7);
+  // progress alone opens the cutoff (celebratory brightness) but not Q
+  const mProg = computeMix(SCORE, 1, 0);
+  assert.equal(mProg.masterCutoff, 8600);
+  assert.equal(mProg.masterQ, 0.7);
+  // threat alone opens the cutoff AND raises Q (menacing resonance)
+  const mThreat = computeMix(SCORE, 0, 1);
+  assert.equal(mThreat.masterCutoff, 8600);
+  assert.ok(Math.abs(mThreat.masterQ - 4.7) < 1e-9);
+  // cutoff follows max(progress, threat)
+  assert.equal(computeMix(SCORE, 0.5, 0).masterCutoff, computeMix(SCORE, 0, 0.5).masterCutoff);
+});

--- a/tests/audio-score.test.js
+++ b/tests/audio-score.test.js
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CORPORATE_SCORE, LAYER_KEYS } from "../js/audio/scores/corporate.js";
+import { computeMix } from "../js/audio/mixer.js";
+
+test("score defines exactly the canonical layer keys", () => {
+  const keys = CORPORATE_SCORE.layers.map((l) => l.key).sort();
+  assert.deepEqual(keys, [...LAYER_KEYS].sort());
+});
+
+test("every layer has a valid axis and a sound source", () => {
+  for (const l of CORPORATE_SCORE.layers) {
+    assert.ok(["base", "progress", "threat"].includes(l.axis), `bad axis for ${l.key}`);
+    assert.ok(l.synth, `missing synth config for ${l.key}`);
+    assert.ok(Array.isArray(l.pattern) || Array.isArray(l.sustain), `${l.key} needs pattern or sustain`);
+  }
+});
+
+test("8th-grid patterns are 32 steps; 16th arps (progArp, urgencyArp) are 64", () => {
+  const byKey = Object.fromEntries(CORPORATE_SCORE.layers.map((l) => [l.key, l]));
+  for (const k of ["basePerc", "doublePerc", "bass", "lead", "backup"]) {
+    assert.equal(byKey[k].pattern.length, 32, `${k} wrong length`);
+  }
+  for (const k of ["progArp", "urgencyArp"]) {
+    assert.equal(byKey[k].pattern.length, 64, `${k} wrong length`);
+  }
+});
+
+test("computeMix accepts the real score and covers every layer", () => {
+  const mix = computeMix(CORPORATE_SCORE, 0.5, 0.5);
+  for (const k of LAYER_KEYS) assert.ok(k in mix.gains, `missing gain for ${k}`);
+});
+
+test("at least one flavor exists", () => {
+  assert.ok(CORPORATE_SCORE.flavors.length >= 1);
+});

--- a/tests/audio-scores-all.test.js
+++ b/tests/audio-scores-all.test.js
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ALL_SCORES } from "../js/audio/scores/index.js";
+import { LAYER_KEYS } from "../js/audio/scores/corporate.js";
+import { computeMix } from "../js/audio/mixer.js";
+
+// Structural validation across EVERY score — the safety net for authored data
+// (note-name typos, wrong pattern lengths, bad perc tokens) that can't be heard.
+
+const NOTE_RE = /^[A-G][#b]?\d$/;
+const PERC = new Set(["C1", "hat", "snare"]);
+const validNote = (n) => typeof n === "string" && NOTE_RE.test(n);
+
+test("there are 8 selectable scores", () => {
+  assert.equal(ALL_SCORES.length, 8);
+});
+
+test("every score has a unique display name", () => {
+  const names = ALL_SCORES.map((s) => s.name);
+  assert.ok(names.every((n) => typeof n === "string" && n.length > 0), "all named");
+  assert.equal(new Set(names).size, names.length, "names unique");
+});
+
+for (const score of ALL_SCORES) {
+  const label = score.name ?? score.biome;
+
+  test(`[${label}] defines exactly the canonical layer keys`, () => {
+    assert.deepEqual(score.layers.map((l) => l.key).sort(), [...LAYER_KEYS].sort());
+  });
+
+  test(`[${label}] has a positive bpm and a complete masterFilter`, () => {
+    assert.ok(typeof score.bpm === "number" && score.bpm > 0, "bpm");
+    for (const k of ["cutoffLo", "cutoffHi", "qLo", "qHi"]) {
+      assert.ok(typeof score.masterFilter[k] === "number", `masterFilter.${k}`);
+    }
+  });
+
+  test(`[${label}] layers are well-formed (axis, source, lengths, tokens, notes)`, () => {
+    const byKey = Object.fromEntries(score.layers.map((l) => [l.key, l]));
+    for (const l of score.layers) {
+      assert.ok(["base", "progress", "threat"].includes(l.axis), `${l.key} axis`);
+      assert.ok(l.synth, `${l.key} synth`);
+      assert.ok(Array.isArray(l.pattern) || Array.isArray(l.sustain), `${l.key} source`);
+    }
+    // grid lengths
+    for (const k of ["basePerc", "doublePerc", "bass", "lead", "backup"]) {
+      assert.equal(byKey[k].pattern.length, 32, `${k} length`);
+    }
+    for (const k of ["progArp", "urgencyArp"]) {
+      assert.equal(byKey[k].pattern.length, 64, `${k} length`);
+    }
+    // perc tokens
+    for (const k of ["basePerc", "doublePerc"]) {
+      for (const t of byKey[k].pattern) assert.ok(t === null || PERC.has(t), `${k} bad token: ${t}`);
+    }
+    // pitched single-note patterns
+    for (const k of ["bass", "lead", "progArp", "urgencyArp"]) {
+      for (const n of byKey[k].pattern) assert.ok(n === null || validNote(n), `${k} bad note: ${n}`);
+    }
+    // backup: notes or chord arrays
+    for (const c of byKey.backup.pattern) {
+      if (c === null) continue;
+      if (Array.isArray(c)) c.forEach((n) => assert.ok(validNote(n), `backup chord note: ${n}`));
+      else assert.ok(validNote(c), `backup note: ${c}`);
+    }
+    // sustained layers
+    for (const k of ["drone", "tensionDrone"]) {
+      assert.ok(byKey[k].sustain.length >= 1, `${k} sustain`);
+      for (const n of byKey[k].sustain) assert.ok(validNote(n), `${k} sustain note: ${n}`);
+    }
+  });
+
+  test(`[${label}] computeMix produces a gain for every layer`, () => {
+    const mix = computeMix(score, 0.5, 0.5);
+    for (const k of LAYER_KEYS) assert.ok(k in mix.gains, `missing gain for ${k}`);
+  });
+
+  test(`[${label}] sections (if any) reference only maskable progress layers`, () => {
+    if (!score.sections) return;
+    assert.ok(Array.isArray(score.sections) && score.sections.length >= 1, "sections array");
+    assert.ok(typeof score.sectionBars === "number" && score.sectionBars > 0, "sectionBars > 0");
+    const maskable = new Set(score.layers.filter((l) => l.axis === "progress").map((l) => l.key));
+    for (const sec of score.sections) {
+      assert.ok(Array.isArray(sec) && sec.length >= 1, "each section is a non-empty array");
+      for (const k of sec) assert.ok(maskable.has(k), `section references non-maskable layer: ${k}`);
+    }
+  });
+}

--- a/tests/audio-signals.test.js
+++ b/tests/audio-signals.test.js
@@ -1,0 +1,42 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { deriveProgress, deriveThreat } from "../js/audio/signals.js";
+
+function nodes(spec) {
+  // spec: array of accessLevel strings
+  const out = {};
+  spec.forEach((accessLevel, i) => { out["n" + i] = { accessLevel, visibility: "revealed" }; });
+  return out;
+}
+
+test("deriveProgress is 0 when nothing is owned", () => {
+  const state = { nodes: nodes(["locked", "locked", "open"]) };
+  assert.equal(deriveProgress(state), 0);
+});
+
+test("deriveProgress is ownedCount/total", () => {
+  const state = { nodes: nodes(["owned", "owned", "locked", "locked"]) };
+  assert.equal(deriveProgress(state), 0.5);
+});
+
+test("deriveProgress returns 0 for empty/missing nodes", () => {
+  assert.equal(deriveProgress({ nodes: {} }), 0);
+  assert.equal(deriveProgress({}), 0);
+});
+
+test("deriveThreat maps alert levels to the ladder", () => {
+  assert.equal(deriveThreat({ globalAlert: "green" }), 0);
+  assert.equal(deriveThreat({ globalAlert: "yellow" }), 1 / 3);
+  assert.equal(deriveThreat({ globalAlert: "red" }), 2 / 3);
+  assert.equal(deriveThreat({ globalAlert: "trace" }), 1);
+});
+
+test("deriveThreat adds an injury term as health drops", () => {
+  const hurt = { globalAlert: "green", player: { health: { current: 0, max: 100 }, deckIntegrity: { current: 100, max: 100 } } };
+  assert.equal(deriveThreat(hurt), 0.25);
+});
+
+test("deriveThreat never exceeds 1", () => {
+  const maxed = { globalAlert: "trace", player: { health: { current: 0, max: 100 }, deckIntegrity: { current: 0, max: 100 } } };
+  assert.equal(deriveThreat(maxed), 1);
+});


### PR DESCRIPTION
Adds a reactive procedural music system to Starnet, built with Tone.js. Music is driven by live game state along two independent axes:

- **Progress = reward via unfolding.** As you own more of the LAN, layers blossom in (drone → percussion → bass → lead → backup → a celebratory arp).
- **Threat = warning via urgency.** Rising alert / ICE detection / injury bring dissonant urgency layers and a resonant master-filter sweep — fast to rise, slow to ease.

Full design rationale, references, and the shared "sound vocabulary" are in `docs/audio-direction.md`.

## What's included

- **Engine** (`js/audio/`): a Tone.js wrapper (`engine.js`, the only Web Audio boundary) driven by pure, unit-tested logic — `signals.js` (state → axis scalars) and `mixer.js` (axes → per-layer gains + filter). Browser-only subscriber `audio-renderer.js` mirrors the existing renderer pattern; **kept out of all headless entry points** (bot/playtest/census stay audio-free).
- **8 selectable Corporate scores** — Dread, Cold, Noir, Vast, Neon, Industrial, Pulse, Haze — each a distinct mood/key/tempo sharing one cohesive voice font. One is chosen per run by an **independent** seeded RNG (never consumes a gameplay RNG stream → no determinism impact).
- **Section-breakdown automation** — every few bars the arrangement masks a rotating subset of progress layers (seeded-random, no immediate repeat, bar-quantized). Subtractive only: never silences the drone or the threat/danger layers.
- **Music On/Off toggle** in the hamburger menu, persisted to localStorage.
- **Vendored Tone.js** → `dist/tone.js` (esbuild, like `dist/lit.js`) + Makefile target.
- **Tuning harness** at `preview/audio.html` (per-layer mutes, progress/threat sliders, score selector, breakdowns toggle) for tuning by ear without playing through the game.

## Testing

- `make check` green: 1208 tests pass, lint clean. New pure-logic suites cover signals, mixer, and structural validation across all 8 scores (note-name/length/section integrity — the safety net for authored data that can't be heard).
- Browser-verified via Playwright: harness builds/plays all 8 scores + breakdowns with no errors; the wired game boots and runs clean; the music toggle flips and persists across reload.

## Deferred fast-follows (tracked in `docs/audio-direction.md`)

More instrument variety (FM/metal/pluck voices) while keeping the cohesive font; event SFX; BoC-style vocal-texture one-shots; aged-media processing; other biomes; hand-authored section arcs.

## Notes

- The early A/B prototypes (`audio-tone.html`, `audio-elementary.html`) are kept at repo root as reference for the engine-choice rationale (Tone.js vs Elementary).
- Aside (pre-existing, not addressed here): opening the hamburger menu in the Overworld Hub with no active run throws `mutate requires an active run` from `toggleMenuOpen()` — unrelated to audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)