### PR TITLE
Make trace cancellation explicit (player must run cancel-trace); fix log spam

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -120,7 +120,7 @@ Each node in the LAN has a **type** that determines what it does and why you wan
 | **File Server**   | Rack stack        | Probe        | Where documents live. Usually where your mission target is. |
 | **Cryptovault**   | Safe + dial       | Probe        | High-value encrypted storage. Hardest targets.    |
 | **IDS**           | Camera eye        | Owned        | Intrusion Detection System. Must own to see connections. Can be subverted. |
-| **Security Mon.** | Scope + crosshair | Owned        | Aggregates IDS alerts. Must own to see connections. Can cancel trace. |
+| **Security Mon.** | Scope + crosshair | Owned        | Aggregates IDS alerts. Must own to see connections. Own it, then run `cancel-trace` to abort a trace. |
 
 Every node is drawn as a 12-sided container holding a small glyph of the device
 it represents, rendered as a glowing vector outline. The glyph (and its color)
@@ -520,7 +520,7 @@ exploit failure  →  IDS  →  (relay, unless corrupted)  →  Security Monitor
 trace after a grade-scaled number of detections (see ICE, below).
 
 A LAN with no ICE is more static and forgiving — the grid is the only clock, and you control
-it: hack carefully, corrupt the IDS to go dark, or own the monitor to cancel a trace.
+it: hack carefully, corrupt the IDS to go dark, or own the monitor and run `cancel-trace`.
 
 **Global alert levels** (lamp shape: hexagon → point-up triangle → inverted triangle → inverted triangle):
 
@@ -819,7 +819,8 @@ ready.
 the high-grade nodes. A disclosed card is deadweight.
 
 **The security monitor is the kill switch.** If you can own the security monitor,
-you can cancel the trace and work at your own pace. It's usually the hardest node
+you can run `cancel-trace` to abort the countdown and work at your own pace (owning
+alone doesn't stop it — you have to issue the command). It's usually the hardest node
 on the board — but worth it if you're going for a deep run.
 
 **If your hand doesn't match, resupply.** Two options: detour to the WAN node and

--- a/js/core/alert.js
+++ b/js/core/alert.js
@@ -55,6 +55,13 @@ export function handleTraceTick() {
 
 export function cancelTraceCountdown() {
   const s = getState();
+  // Event-idempotent: bail when there is no trace to cancel. The security trait's
+  // owned-cancel-trace trigger is repeating and calls this every evaluation cycle
+  // while the monitor stays owned; without this guard each cycle re-emits
+  // ALERT_TRACE_CANCELLED (spamming the log) and re-forces the alert to green.
+  if (s.traceTimerId === null && s.traceSecondsRemaining === null && s.globalAlert !== "trace") {
+    return;
+  }
   if (s.traceTimerId !== null) {
     cancelEvent(s.traceTimerId);
     setTraceTimerId(null);

--- a/js/core/node-graph/node-factories.test.js
+++ b/js/core/node-graph/node-factories.test.js
@@ -319,10 +319,10 @@ describe("action execution", () => {
       attributes: { visibility: "accessible", accessLevel: "owned" },
     });
     const graph = new NodeGraph({ nodes: [mon], edges: [] }, ctx);
-    // executeAction fires the action's ctx-call effect (cancelTrace #1) AND
-    // evaluates triggers — security trait's owned-cancel-trace trigger fires (#2)
+    // executeAction fires the action's ctx-call effect exactly once. There is no
+    // owned-cancel-trace trigger — cancelling a trace is explicit, player-driven only.
     graph.executeAction("mon-1", "cancel-trace");
-    assert.ok(ctx.calls.cancelTrace?.length >= 1, "cancelTrace should be called at least once");
+    assert.equal(ctx.calls.cancelTrace?.length, 1, "cancelTrace should be called exactly once");
   });
 
   it("access-darknet action calls ctx.openDarknetsStore", () => {

--- a/js/core/node-graph/traits.js
+++ b/js/core/node-graph/traits.js
@@ -281,21 +281,13 @@ registerTrait("security", {
     { name: "report", on: "alert", call: "recordMonitorAlert" },
   ],
   actions: [ACTION_TEMPLATES.CANCEL_TRACE, ACTION_TEMPLATES.SCRUB_LOGS],
-  triggers: [
-    // (alert-escalate removed: escalation now flows per-alert through the report operator
-    //  → recordMonitorAlert, which climbs green→yellow→red→trace by accumulated count.)
-    {
-      // Repeating, not one-shot: owning the monitor must cancel a trace even if the
-      // node was owned BEFORE the trace started (a one-shot would fire once into a
-      // no-op and never re-fire). cancelTrace is idempotent, so re-firing is safe.
-      id: "owned-cancel-trace",
-      repeating: true,
-      when: { type: "node-attr", attr: "accessLevel", eq: "owned" },
-      then: [
-        { effect: "ctx-call", method: "cancelTrace", args: [] },
-      ],
-    },
-  ],
+  // No triggers: cancelling a trace is explicit and player-driven via the CANCEL_TRACE
+  // action. There is deliberately no owned-cancel-trace trigger — owning the monitor
+  // reveals connections and aggregates alerts, but the player must run cancel-trace to
+  // abort the countdown. (A prior repeating trigger auto-cancelled on own and re-emitted
+  // ALERT_TRACE_CANCELLED every evaluation cycle, spamming the log.)
+  // (alert-escalate also removed: escalation flows per-alert through the report operator
+  //  → recordMonitorAlert, which climbs green→yellow→red→trace by accumulated count.)
 });
 
 registerTrait("gate", {

--- a/js/core/node-graph/traits.test.js
+++ b/js/core/node-graph/traits.test.js
@@ -358,12 +358,13 @@ describe("Built-in traits", () => {
   });
 });
 
-describe("security trait: owned-cancel-trace behavior", () => {
+describe("security trait: cancelling a trace is explicit (no auto-cancel trigger)", () => {
   beforeEach(() => { restoreBuiltIns(); });
 
-  it("re-fires cancelTrace while the monitor stays owned (not one-shot)", () => {
-    // Reproduces the bug where owning the security monitor BEFORE a trace starts
-    // spends the one-shot trigger, so a later trace is never auto-cancelled.
+  it("never calls cancelTrace from a trigger while the monitor is owned", () => {
+    // Cancelling a trace is player-driven only — via the cancel-trace action. Owning
+    // the monitor must NOT auto-cancel (an earlier repeating trigger did, which spammed
+    // the log every evaluation cycle while owned). Ticking while owned calls nothing.
     const ctx = mockCtx();
     const graph = new NodeGraph({
       nodes: [{
@@ -373,16 +374,16 @@ describe("security trait: owned-cancel-trace behavior", () => {
       edges: [],
     }, ctx);
 
-    // First evaluation: trigger fires once (no trace active yet — cancelTrace is idempotent).
     graph.tick(0);
-    const afterFirst = ctx.calls.cancelTrace?.length ?? 0;
-
-    // A trace starts later while the monitor is still owned. The trigger must fire
-    // AGAIN to cancel it. A one-shot trigger would already be spent and stay silent.
     graph.tick(0);
-    const afterSecond = ctx.calls.cancelTrace?.length ?? 0;
+    assert.equal(ctx.calls.cancelTrace?.length ?? 0, 0,
+      "owning the monitor must not auto-cancel the trace");
+  });
 
-    assert.ok(afterSecond > afterFirst,
-      `owned-cancel-trace must re-fire while owned (got ${afterFirst} then ${afterSecond})`);
+  it("the security trait exposes the cancel-trace action", () => {
+    const t = getTrait("security");
+    const actionIds = t.actions.map((a) => a.id);
+    assert.ok(actionIds.includes("cancel-trace"),
+      "cancel-trace must remain the explicit, player-driven cancel path");
   });
 });

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -275,6 +275,20 @@ describe("Lifecycle: monitor — owning security-monitor cancels active trace", 
     s.nodeGraph.setNodeAttr("sec-mon", "accessLevel", "owned");
     assert.equal(getState().traceSecondsRemaining, null);
   });
+
+  it("does not re-emit ALERT_TRACE_CANCELLED while the monitor stays owned", () => {
+    // Regression: the security trait's owned-cancel-trace trigger is repeating and
+    // calls ctx.cancelTrace() every evaluation cycle while the monitor is owned.
+    // cancelTraceCountdown must be event-idempotent — once the trace is cancelled,
+    // subsequent ticks must not re-emit and spam the log.
+    const s = getState();
+    s.nodeGraph.setNodeAttr("sec-mon", "accessLevel", "owned"); // cancels the trace (emits once)
+    const fired = withEvents(E.ALERT_TRACE_CANCELLED, () => {
+      s.nodeGraph.tick(5);
+      s.nodeGraph.tick(5);
+    });
+    assert.equal(fired.length, 0, "no re-emit once the trace is already cancelled");
+  });
 });
 
 // ── Trace ↔ global alert consistency (#114 WS3) ───────────────────────────────

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -250,7 +250,7 @@ describe("Lifecycle: iceResident — owning security-monitor stops ICE", () => {
 
 // ── Lifecycle: monitor — trace cancellation ───────────────────────────────────
 
-describe("Lifecycle: monitor — owning security-monitor cancels active trace", () => {
+describe("Lifecycle: monitor — cancelling an active trace is explicit", () => {
   beforeEach(() => {
     clearAll();
     initGame(() => buildIceWithMonitorLAN(), "itest-5");
@@ -261,33 +261,28 @@ describe("Lifecycle: monitor — owning security-monitor cancels active trace", 
     assert.notEqual(getState().traceSecondsRemaining, null);
   });
 
-  it("owning security-monitor emits ALERT_TRACE_CANCELLED", () => {
+  it("owning the monitor does NOT auto-cancel the trace", () => {
+    // The player must explicitly run cancel-trace; merely owning the monitor (which
+    // reveals connections / aggregates alerts) leaves the trace running. Ticking while
+    // owned must not cancel it either — there is no owned-cancel-trace trigger.
     const s = getState();
     const fired = withEvents(E.ALERT_TRACE_CANCELLED, () => {
-      // Set via graph so the trigger fires
       s.nodeGraph.setNodeAttr("sec-mon", "accessLevel", "owned");
+      s.nodeGraph.tick(5);
+      s.nodeGraph.tick(5);
     });
-    assert.equal(fired.length, 1);
+    assert.equal(fired.length, 0, "owning the monitor must not emit ALERT_TRACE_CANCELLED");
+    assert.notEqual(getState().traceSecondsRemaining, null, "trace must still be running");
   });
 
-  it("traceSecondsRemaining is null after owning security-monitor", () => {
+  it("executing cancel-trace on the owned monitor cancels the trace (emits once)", () => {
     const s = getState();
     s.nodeGraph.setNodeAttr("sec-mon", "accessLevel", "owned");
-    assert.equal(getState().traceSecondsRemaining, null);
-  });
-
-  it("does not re-emit ALERT_TRACE_CANCELLED while the monitor stays owned", () => {
-    // Regression: the security trait's owned-cancel-trace trigger is repeating and
-    // calls ctx.cancelTrace() every evaluation cycle while the monitor is owned.
-    // cancelTraceCountdown must be event-idempotent — once the trace is cancelled,
-    // subsequent ticks must not re-emit and spam the log.
-    const s = getState();
-    s.nodeGraph.setNodeAttr("sec-mon", "accessLevel", "owned"); // cancels the trace (emits once)
     const fired = withEvents(E.ALERT_TRACE_CANCELLED, () => {
-      s.nodeGraph.tick(5);
-      s.nodeGraph.tick(5);
+      s.nodeGraph.executeAction("sec-mon", "cancel-trace");
     });
-    assert.equal(fired.length, 0, "no re-emit once the trace is already cancelled");
+    assert.equal(fired.length, 1);
+    assert.equal(getState().traceSecondsRemaining, null);
   });
 });
 
@@ -1366,14 +1361,18 @@ describe("security grid: IDS->monitor escalation (#173)", () => {
     assert.equal(getState().traceSecondsRemaining, null, "a corrupted IDS must not start a trace");
   });
 
-  it("owning the monitor cancels an in-flight grid trace", () => {
+  it("cancel-trace on the owned monitor cancels an in-flight grid trace", () => {
     initGame(() => buildSetPieceMiniNetwork("idsRelayChain"), "grid-seed-3");
     const graph = getState().nodeGraph;
     alertUntilTrace(graph);
     assert.notEqual(getState().traceSecondsRemaining, null, "trace should be running first");
 
-    graph.setNodeAttr("sp/monitor", "accessLevel", "owned"); // owned-cancel-trace (repeating)
-    assert.equal(getState().traceSecondsRemaining, null, "owning the monitor cancels the trace");
+    graph.setNodeAttr("sp/monitor", "accessLevel", "owned");
+    assert.notEqual(getState().traceSecondsRemaining, null,
+      "owning alone must NOT cancel — cancelling is explicit");
+    graph.executeAction("sp/monitor", "cancel-trace");
+    assert.equal(getState().traceSecondsRemaining, null,
+      "running cancel-trace on the owned monitor cancels the trace");
   });
 });
 


### PR DESCRIPTION
During a playtest, owning a security-monitor node during an active trace produced an infinite loop of `[ALERT] Trace cancelled. Network alert cleared.` log entries.

## What changed

Cancelling a trace is now **explicit and player-driven**. Owning the security monitor no longer auto-cancels the trace — the player must run the `cancel-trace` action (which already existed, and is what `MANUAL.md` already documented). Owning the monitor still reveals connections and aggregates IDS alerts; only the automatic countdown abort goes away.

## Root cause of the spam

The `security` trait had a **repeating** `owned-cancel-trace` trigger that called `ctx.cancelTrace()` on every evaluation cycle while the monitor was owned. `cancelTraceCountdown()` unconditionally emitted `ALERT_TRACE_CANCELLED` and re-forced `globalAlert` to green on every call, so each tick re-fired the event and spammed the log forever.

## Fix (two commits)

1. **Event-idempotency guard** in `cancelTraceCountdown()` — bails when there is no trace to cancel. Kept as defensive hardening for the action/cheat paths.
2. **Removed the `owned-cancel-trace` trigger** entirely — this was the actual spam source and the behavior change Les asked for. Cancelling is now solely via the explicit `cancel-trace` action.

## Tests & docs

- Integration + trait tests updated: owning the monitor must **not** cancel an active trace; executing `cancel-trace` does (emits exactly once).
- `MANUAL.md` lines that implied owning alone cancels are corrected to "own it **and run `cancel-trace`**".
- `make check`: 1252 tests pass, lint clean.
- Census (`SEEDS=15`) matches `main`: `successRate 0.4`, `traceFiredRate 0.667`, identical alert distribution — the bot already issues `cancel-trace` explicitly when it owns the monitor during a trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)