### PR TITLE
Add synthesized event SFX layer (#229)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,16 @@ why. Derive the branch name from the session slug where possible.
 The only commits that may land directly on `main` are pure documentation changes (like
 this one) that don't touch game logic.
 
+### Squash before merge
+
+**Prefer squashing a PR's commits into one clean commit once review comments are
+addressed, before merging.** The incremental "fix review comment" / "address feedback"
+commits are useful while iterating, but they're noise in `main`'s history. After the
+review is settled and the branch is green, collapse the branch into a single commit
+(`git reset --soft $(git merge-base origin/main HEAD)` then recommit, or GitHub's
+"Squash and merge") with a message that describes the change as shipped, not the path
+it took to get there.
+
 ### Git commit messages
 
 **Use single-quoted `-m` strings for commit messages**, not `$(cat <<EOF ...)`
@@ -480,6 +490,8 @@ needs a fill, a circle, or a dither, it's the wrong primitive.
 - Headless playtest harness + automated bot + census for balance testing
 - Reactive procedural music (Tone.js): two-axis (progress/threat) layered scores, 8 selectable
   Corporate variants, section-breakdown automation; see `docs/audio-direction.md`
+- Synthesized event SFX (Tone.js): one-shot cues on game events, own always-available bus +
+  on/off toggle, independent of music; see `docs/audio-direction.md`
 
 ## Out of Scope (Future)
 
@@ -487,8 +499,8 @@ needs a fill, a circle, or a dither, it's the wrong primitive.
 - Sprites, daemons, machine elves
 - Full player progression / persistent meta-loop between runs (overworld is early)
 - Wider world (galaxy, planets, cities)
-- Audio: sound effects + vocal-texture one-shots (music has shipped; SFX deferred — see
-  the fast-follows in `docs/audio-direction.md`)
+- Audio: vocal-texture / sample one-shots (music + event SFX have shipped; sample-based one-shots
+  deferred — see the fast-follows in `docs/audio-direction.md`)
 
 ## Backlog
 

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -817,6 +817,39 @@ from layers rather than a fixed loop.
 sessions. (Audio starts on your first click or keypress — browsers require a gesture before
 playing sound.)
 
+### Sound effects
+
+Separate from the music, a layer of **synthesized sound effects** punctuates what's happening —
+short cyberpunk-terminal cues organized into families you can read by ear:
+
+- **info** — soft blips for probing, navigating, and revealing nodes.
+- **success** — bright rising tones when an exploit lands or a node opens up.
+- **reward** — chimes and quick arpeggios for fetching loot, mining a card, and completing a run.
+- **failure** — dark buzzes and thuds for failed exploits, traps, and damage taken.
+- **danger** — harsh rising alarms as the alert climbs, ICE locks on, or a trace begins.
+- **relief** — settled descending tones when the alert cools or a trace is cancelled.
+
+Many cues are **state-reflective** — they encode what happened, not just that something did:
+gaining access plays a rising 2-hit chord for **open** and a fuller 3-hit for **owned**; mined
+cards escalate by rarity (common → uncommon → rare); a big-value loot haul gets a richer cue than
+a small one; and **revealing nodes is a "discovery rush"** — a single reveal is a bright blip, but
+unlocking a cluster of neighbors cascades into a quick rising run.
+
+Every **timed action** (probe, xploit, dump, fetch, mine, lie-low, reboot) also gets its own
+**sustained drone** that plays while the action is in progress and evolves as it advances —
+echoing the action's on-graph animation (a scanning pulse for probe, a grinding tighten for xploit,
+a lock-on beat that settles for mine, and so on). The drone stops when the action completes or is
+cancelled, and the usual one-shot fires at the end.
+
+SFX are **independent of the music** — they have their own on/off and run on their own audio bus,
+so you can have effects with the music off, and they play in the hub as well as in a run.
+
+**SFX commands** (console): `sfx` shows on/off status, `sfx list` lists every cue,
+`sfx test <cue>` auditions one, `sfx on|off` toggles them.
+
+**SFX: On / Off** lives in the hamburger menu (`[ ☰ ]`) next to the music toggle. The choice is
+remembered between sessions.
+
 ---
 
 ## TIPS

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ dist/tone.js: js/tone-vendor.js node_modules
 serve:
 	npx serve .
 
-# Build vendor bundles, then start the dev server
-dev: bundle-vendor serve
+# Install deps, build vendor bundles (if stale), then start the dev server
+dev: all serve
 
 # Run JSDoc/TypeScript type checker (no build step, annotations only)
 # Discovers all js/**/*.js automatically; excludes:

--- a/css/style.css
+++ b/css/style.css
@@ -362,7 +362,7 @@ html, body {
   50%       { opacity: 0.4; }
 }
 
-#new-run-btn, #pause-btn, #music-btn, #save-btn, #load-btn {
+#new-run-btn, #pause-btn, #music-btn, #sfx-btn, #save-btn, #load-btn {
   background: transparent;
   border: 1px solid var(--cyan);
   color: var(--cyan);
@@ -377,7 +377,7 @@ html, body {
   transition: background 0.15s, box-shadow 0.15s;
 }
 
-#new-run-btn:hover, #pause-btn:hover, #music-btn:hover, #save-btn:hover, #load-btn:hover {
+#new-run-btn:hover, #pause-btn:hover, #music-btn:hover, #sfx-btn:hover, #save-btn:hover, #load-btn:hover {
   background: rgba(0, 255, 255, 0.1);
   box-shadow: var(--glow-lg) rgba(0, 255, 255, 0.5);
 }

--- a/docs/audio-direction.md
+++ b/docs/audio-direction.md
@@ -258,6 +258,127 @@ bump from recent `ICE_DETECTED` and a term for low health/deck. Smoothed, **fast
   so a fade-in still lands on the grid — smoothness without bar-queue complexity (bar-quantized
   entrances deferred).
 
+## Event SFX subsystem (shipped, #229)
+
+A synthesized **sound-effects layer**, independent of the music: discrete one-shot cues fired on
+game events **plus a sustained drone per timed action in progress**, in a **"cold machine
+telemetry"** palette (dry, low-register, technical — detuned/minor intervals over major triads,
+danger in low FM growl; reverb is opt-in per cue, default dry). It mirrors the music subsystem's
+split (pure data + pure mapping + a thin Tone boundary + a browser-only subscriber) and runs on its
+**own always-available bus** — SFX work with music off, and in the hub.
+
+**Modules (`js/audio/`):**
+
+- **`sfx/defs.js`** — *pure data, `@ts-check`.* `CUES` map (`cueId → { kind, ...params, volume }`)
+  grouped by family + `CUE_IDS`. Unit-tested (`tests/sfx-defs.test.js`): every cue's `kind` is a
+  known primitive with its required params.
+- **`sfx/cues.js`** — *pure, `@ts-check`.* `resolveCue(type, payload) → cueId | null` — the
+  event→cue mapping. Unit-tested (`tests/sfx-cues.test.js`): key cases + exhaustiveness (every
+  resolvable cue exists in `CUES`). **State-reflective cues** read fields off the payload: access
+  by `next` level (`access.open`/`access.owned`), mine by `detail.rarity`, fetch by `detail.total`
+  tier (`fetch`/`fetch.big`), `EXPLOIT_PARTIAL_BURN`→`burn`, `NODE_ALERT_RAISED`→`node.alert`.
+  Cues that need state beyond the payload — `NODE_REVEALED` (node grade + burst cascade), and the
+  per-event pitch tweaks (`alert.up`/`node.alert`/`burn` detune) — are applied renderer-side.
+  Encoding vocabulary: more hits/notes + ascending pitch = more control/value/rarity; lower +
+  dissonant = loss/wear. The `chord` primitive's `hits`/`hitGap` give the "double/triple hit".
+- **`sfx/drones.js`** — *pure data, `@ts-check`.* `DRONES` (one sustained-voice spec per timed
+  action — probe/xploit/dump/fetch/mine/lie-low/reboot) + `DRONE_IDS` + `resolveDrone(action)`.
+  Each drone echoes its action's on-graph animation (scanning pulse, grinding tighten, draining
+  noise, lock-on beat, etc.). Spec values sweep with progress via `{from,to}` ranges on
+  cutoff/detune/gain. Unit-tested (`tests/sfx-drones.test.js`).
+- **`sfx/engine.js`** — *`@ts-nocheck`, the only Web Audio boundary for SFX.* `createSfx()` →
+  `{ unlock, setEnabled, isEnabled, play, startDrone, getMasterInput }`. Owns its own master `Gain`
+  → opt-in reverb → destination. `play(spec)` synthesizes a one-shot from five **primitives** —
+  `blip` / `sweep` / `chord` / `noise` / `fm` — scheduled at `ctx.currentTime + 0.02` (not
+  `Tone.now()`, to dodge the music's lookahead) and **disposed after it finishes**.
+  `startDrone(spec) → { setProgress(p), stop() }` builds a **held** voice
+  (osc/noise/fm/dual source → filter → amp gain → fade gain), fades in, re-shapes on progress
+  0→1, and fades out + disposes on stop. Both paths dispose after use, so SFX add no long-lived
+  AudioParam accumulation (the bug that caused the music engine's over-time stutter). One-shot
+  voice cap drops cues over the limit; drones are bounded by concurrent timed actions.
+- **`sfx/renderer.js`** — *browser-only, `@ts-check`.* `initSfxRenderer()` subscribes to the routed
+  events, resolves each to a cue, and plays it; pitches `alert.up` up at red; diffs
+  `player.health` / `deckIntegrity` on `STATE_CHANGED` for `hurt.*` (no damage event exists);
+  dedupes identical cues within 50ms; arms the AudioContext on first gesture. Drives the drones from
+  `ACTION_FEEDBACK` (`start` → `startDrone` keyed by `nodeId:action`; `progress` → `setProgress`;
+  `complete`/`cancel` → `stop`); stops all drones on `RUN_STARTED`/`RUN_ENDED` and when SFX is
+  disabled. Owns the persisted `starnet:sfx-enabled` pref and emits `SFX_CHANGED`.
+- **`sfx/commands.js`** — *browser-only.* `sfx` console command (`status | on | off | list |
+  test <cue>`), mirroring `music-commands.js`.
+- **HUD:** an `SFX: ON/OFF` menu button beside the music toggle; `SFX_CHANGED` keeps button +
+  console in sync (GUI/console symmetry).
+- **Wiring:** `initSfxRenderer()` + `sfx-commands` import live in `js/ui/main.js` only. Headless
+  entry points (`scripts/`) never import any of it.
+- **Harness:** `preview/sfx.html` + `js/audio/sfx/playground.js` — a button per one-shot cue, and a
+  toggle + progress slider per drone to audition/tune the sustained voices.
+
+**Not in v1:** music ducking under SFX; sample/vocal one-shots (item 3 above); positional audio;
+per-cue volume UI beyond the master SFX toggle. Starter cue specs are ear-tunable (rough drafts).
+
+## Testing, verifying & debugging the audio code
+
+Hard-won notes from building the music + SFX engines. Audio bugs are easy to misdiagnose because
+the obvious analysis tool (offline render) does not reproduce a whole class of them.
+
+### What you can test without a browser
+
+The audio subsystem deliberately splits **pure logic** (no Tone, no DOM) from the **Tone boundary**.
+Everything pure is unit-tested with `node --test`, no browser:
+
+- `mixer.js` (`computeMix`), `signals.js` (progress/threat derivation) — music.
+- `sfx/defs.js` (cue catalog well-formed), `sfx/cues.js` (`resolveCue` mapping + exhaustiveness),
+  `sfx/drones.js` (drone specs + `resolveDrone`).
+- Any future `harmony.js` (scale/chord math) — same pattern.
+
+If you can express the thing as data → data, put it in a pure module and unit-test it there. The
+Tone files (`engine.js`, `sfx/engine.js`) are `@ts-nocheck` glue that should hold as little logic as possible.
+
+### The offline-vs-realtime trap (read this before debugging an onset/envelope bug)
+
+`Tone.Offline()` renders deterministically and is great for **synthesis content** — relative
+levels, strike counts, cue mapping, "does this cue make sound." **BUT it pre-resolves signals
+before rendering, so it CANNOT reproduce realtime startup transients.**
+
+The canonical example (the drone/one-shot "onset volume spike" bug): setting level via Tone's
+`source.volume` (a *dB-mapped signal*) blasts at 0 dB for ~100–200 ms in **realtime** before the
+signal settles — a hard attack→decay→sustain on every voice. Offline showed perfectly clean
+fade-ins and sent me down a wrong root cause (LFO timing) for a whole fix cycle. **Lesson: for any
+onset / envelope / transient / "it sounds different live" bug, measure REALTIME, not offline.**
+
+Corollary rule already baked into `sfx/engine.js`: **never use `.volume` for levels — use a linear `Gain`
+(`dbToGain`)**, which has no startup transient.
+
+### How to measure realtime audio (headless)
+
+There is no Web Audio in Node, and the repo has no standing browser-test harness — these were
+throwaway Playwright scripts against `make serve` (port 3000). Pattern that works:
+
+1. Launch headless Chromium with `--autoplay-policy=no-user-gesture-required` (and `--mute-audio`)
+   so the AudioContext actually runs without a real gesture/device. The in-app gesture-arm will NOT
+   fire on a synthetic click, so also `await Tone.start()` then `await ctx.resume()` in the page.
+2. Tap the output: `analyser = ctx.createAnalyser(); Tone.getDestination().output.connect(analyser)`.
+3. Sample `getFloatTimeDomainData` each rAF; reduce to **RMS per ~20 ms window**, not peak.
+   Per-window *peak* aliases against the oscillator period and fakes a ~1.2–1.7× overshoot on steady
+   tones — use RMS for loudness/envelope shape. (Peak at fine 5 ms resolution is fine for *counting
+   discrete strikes*, e.g. verifying a 3-hit chord.)
+4. To compare a fix: render the same cue/drone before vs after and compare onset-window RMS vs
+   steady-state RMS. ~1.0 = no spike.
+
+`import { createSfx } from "/js/audio/sfx/engine.js"` and drive it directly, or `initSfxRenderer()` +
+`emitEvent(E.*)` to exercise the event→cue path end to end.
+
+### Ear-tuning
+
+Synth params are rough drafts tuned by ear in the **preview harnesses** (`preview/audio.html` for
+music layers, `preview/sfx.html` for cues + drones). Numbers in the score/cue/drone data are feel,
+not spec — change them freely and listen.
+
+### Don't regress the headless paths
+
+The SFX renderer/engine are browser-only. Confirm headless game entry points never import them:
+`grep -rn "audio/sfx" scripts/` must be empty. (`engine.js`/`audio-renderer.js` likewise — music is
+wired only in `js/ui/main.js`.)
+
 ## Prototypes
 
 - `audio-tone.html` — Tone.js, 4-part song, per-track mutes, tempo, global tension sweep
@@ -269,8 +390,8 @@ bump from recent `ICE_DETECTED` and a term for low health/deck. Smoothed, **fast
 1. **More instrument variety across scores** — teach the engine more synth voices (FM/bell,
    metal, pluck, AM) so scores can vary timbre *while keeping the cohesive "voice font"* (Les:
    the current shared palette fits together well — widen it, don't fragment it).
-2. **Event SFX** — one-shots on probe/xploit/dump/fetch and run start/end. Hooks exist
-   (`E.ACTION_FEEDBACK`, `E.ACTION_RESOLVED`); engine exposes `getMasterInput()` for routing.
+2. ~~**Event SFX** — one-shots on probe/xploit/dump/fetch and run start/end.~~ **Shipped (#229).**
+   See "Event SFX subsystem" below.
 3. **Vocal/texture one-shots** — BoC-style fragments; triggering model + original samples.
 4. **Aged-media / lo-fi processing flavor** — vinyl crackle, tape wobble, band-limited EQ.
 5. **Other biomes** — alien/ancient (BoC/weirder); the per-biome score pool already supports it.

--- a/docs/dev-sessions/2026-06-14-1852-audio-event-sfx/notes.md
+++ b/docs/dev-sessions/2026-06-14-1852-audio-event-sfx/notes.md
@@ -1,0 +1,53 @@
+# SFX for Game Actions — Session Notes
+
+Issue **#229 — Audio: event SFX for game actions**. Branch/worktree: `audio-event-sfx`.
+
+## Recap
+
+Built a synthesized, event-driven SFX layer mirroring the music subsystem's split, independent of
+the music and on its own always-available bus. Executed the 8-task plan; this session resumed an
+interrupted run where Tasks 1–7 were already committed and finished Task 8 + verification.
+
+### What shipped (per task)
+
+1. `sfx-defs.js` — `CUES` (32 cues, 6 families) + `CUE_IDS`; structural test.
+2. `sfx-cues.js` — pure `resolveCue(type, payload) → cueId|null`; mapping test (key cases + exhaustiveness).
+3. `sfx.js` — Tone boundary: 5 primitives (`blip`/`sweep`/`chord`/`noise`/`fm`), own master Gain →
+   reverb → destination, schedule at `ctx.currentTime+0.02`, dispose-after-play, voice cap.
+4. `SFX_CHANGED` event + `sfx-renderer.js` — event subscriber, gesture-arm, `alert.up` pitch-by-level,
+   health/deck `STATE_CHANGED` diff for `hurt.*`, persisted `starnet:sfx-enabled` pref.
+5. `sfx-commands.js` — `sfx status|on|off|list|test <cue>` console command.
+6. HUD `SFX: ON/OFF` button + `main.js` wiring (`initSfxRenderer()`, `SFX_CHANGED`, `toggle-sfx`).
+7. `preview/sfx.html` + `sfx-playground.js` audition harness.
+8. Docs: MANUAL.md SFX section; audio-direction.md "Event SFX subsystem" (shipped) + deferred-list
+   update; CLAUDE.md moved SFX from Out of Scope → What's Shipped.
+
+## Verification
+
+- `make check` green: 1356 tests pass, lint clean.
+- All 6 new `js/audio/sfx*.js` modules `node --check` clean.
+- Headless SFX-free confirmed: `grep -rn "audio/sfx" scripts/` empty.
+- **Browser smoke (headless Chromium via Playwright):** SFX button present in HUD; all 32 cues
+  synthesize via `playCue` with zero console errors; `toggleSfx` flips; `sfx` console command
+  registered (`getCommand("sfx")` truthy). Only console output was Tone's banner + the expected
+  "AudioContext needs a gesture" warnings (headless synthetic clicks aren't trusted gestures).
+
+## Diverged from plan
+
+- **Plan said "Playwright smoke" as a test artifact; the repo has no Playwright/browser-test infra.**
+  Did the smoke as a throwaway script against `npx serve` rather than introducing a new test
+  dependency. Pure logic is covered by the two committed unit suites.
+- Couldn't drive the in-game console input in the smoke — the overworld hub overlay intercepts
+  pointer events at app start. Confirmed command registration + the underlying renderer API instead
+  (the command is a thin wrapper over those functions).
+
+## Still needs Les
+
+- **Listen / by-ear tuning checkpoint (Task 7).** Cue specs in `sfx-defs.js` are ear-tunable rough
+  drafts. Audition via `preview/sfx.html` (button per cue) or in-game `sfx test <cue>`; flag any
+  cues to retune. This is the one step that genuinely needs ears, not automation.
+
+## Open / deferred
+
+- Store-purchase `buy` cue dropped for v1 (no event exists; one-line emit in store-logic.js later).
+- No music ducking under SFX in v1.

--- a/docs/dev-sessions/2026-06-14-1852-audio-event-sfx/plan.md
+++ b/docs/dev-sessions/2026-06-14-1852-audio-event-sfx/plan.md
@@ -1,0 +1,175 @@
+# SFX for Game Actions — Implementation Plan
+
+**Goal:** A synthesized, event-driven SFX layer (issue #229) — one-shot cyberpunk-terminal cues
+on game events, independent of the music, with its own bus + on/off control.
+
+**Architecture:** Mirrors the music subsystem. Pure data (`sfx-defs.js` cues) + pure mapping
+(`sfx-cues.js` event→cueId) + a thin Tone boundary (`sfx.js`, the only Web Audio for SFX) + a
+browser-only event subscriber (`sfx-renderer.js`). Console command + HUD button mirror the music
+controls. Headless entry points never import any of it.
+
+**Tech:** Tone.js (vendored at `dist/tone.js`), `node:test`, JSDoc `@ts-check`.
+
+**Verified event reality (from log-renderer.js + events.js):**
+- `ACTION_RESOLVED {action, success?, detail}`: xploit success is top-level `success`; mine sub-case
+  is `detail.outcome` (`"card"|"miss"|"trap"`); fetch honey-pot is `detail.trap`.
+- `RUN_ENDED {outcome}` = `"success"|"caught"|"burned"|"bricked"`.
+- Health/deck have NO damage event → diff `state.player.health.current` / `.deckIntegrity.current`
+  on `STATE_CHANGED`.
+- `ALERT_PROPAGATED` never emitted — skip. Store-purchase has no event — `buy` cue dropped for v1.
+- Mirror: `js/audio/audio-renderer.js`, `engine.js`, `music-commands.js`, the HUD music button +
+  `css/style.css`, and `MUSIC_CHANGED` in `events.js`.
+
+---
+
+## File structure
+
+| File | Responsibility | Checked |
+|---|---|---|
+| `js/audio/sfx-defs.js` | pure: `CUES` map (cueId → sound spec) + `CUE_IDS` | `@ts-check` |
+| `js/audio/sfx-cues.js` | pure: `resolveCue(type, payload)` → cueId\|null | `@ts-check` |
+| `js/audio/sfx.js` | Tone boundary: primitives, `play(spec)`, `unlock`, `setEnabled` | `@ts-nocheck` |
+| `js/audio/sfx-renderer.js` | browser-only: events → resolveCue → play; gesture arm; health/deck diff; pref | `@ts-check` |
+| `js/audio/sfx-commands.js` | browser-only: `sfx` console command | `@ts-check` |
+| `preview/sfx.html` + `js/audio/sfx-playground.js` | audition harness (button per cue) | n/a / `@ts-nocheck` |
+| `tests/sfx-defs.test.js` | every cue has a valid spec; primitive kinds known | n/a |
+| `tests/sfx-cues.test.js` | resolveCue returns only defined cues; key cases correct | n/a |
+| modify `js/core/events.js` | add `SFX_CHANGED` | — |
+| modify `js/ui/components/starnet-hud.js` | `SFX: ON/OFF` button + `sfxEnabled` prop | — |
+| modify `css/style.css` | add `#sfx-btn` to shared menu-button rules | — |
+| modify `js/ui/main.js` | `initSfxRenderer()`, `import sfx-commands`, hud-action + `SFX_CHANGED` wiring | — |
+
+---
+
+## Sound primitives (the `play(spec)` interpreter in `sfx.js`)
+
+All specs: `{ kind, volume?, ...params }`. Engine connects each voice to the SFX master and
+**disposes it after it finishes** (no lingering param accumulation). Schedule at
+`ctx.currentTime + 0.02` (NOT `Tone.now()`) so SFX aren't delayed by the music's 200ms lookahead.
+
+- **`blip`** `{ note, osc="triangle", decay=0.12 }` → `Tone.Synth({oscillator:{type:osc}, envelope:{attack:0.001, decay, sustain:0, release:0.05}})`, `triggerAttackRelease(note, decay, t)`.
+- **`sweep`** `{ from, to, dur=0.18, osc="sawtooth" }` → `Tone.Synth`; set `frequency=from`, `triggerAttack(t)`, `frequency.rampTo(to, dur, t)`, `triggerRelease(t+dur)`. (rising=tension, falling=relief.)
+- **`chord`** `{ notes:[...], osc="triangle", decay=0.35, strum=0 }` → `Tone.PolySynth(Tone.Synth,{...})`; if strum, offset each note by `strum`s; reward/chime.
+- **`noise`** `{ dur=0.15, cutoff=4000, type="white", hp=false }` → `Tone.NoiseSynth` → `Tone.Filter`; zap/impact/static/power-down.
+- **`fm`** `{ note, harmonicity=3, modIndex=12, decay=0.2 }` → `Tone.FMSynth`; metallic/glitch.
+
+Master: `Tone.Gain(0.9)` → `Tone.Reverb({decay:1.2, wet:0.12})` → destination. Voice cap (~12);
+drop new cues over cap.
+
+---
+
+## Cue catalog (`sfx-defs.js`) — starter specs (ear-tunable)
+
+```
+export const CUES = {
+  // info / neutral
+  probe:        { kind:"blip",  note:"A5", osc:"sine",     decay:0.08, volume:-16 },
+  navigate:     { kind:"blip",  note:"E5", osc:"triangle", decay:0.05, volume:-22 },
+  reveal:       { kind:"blip",  note:"C6", osc:"sine",     decay:0.10, volume:-18 },
+  dump:         { kind:"sweep", from:300, to:1200, dur:0.22, osc:"sawtooth", volume:-18 },
+  "mine.miss":  { kind:"noise", dur:0.10, cutoff:2500, volume:-20 },
+  "ice.move":   { kind:"blip",  note:"F4", osc:"triangle", decay:0.05, volume:-24 },
+  decay:        { kind:"blip",  note:"D4", osc:"square",   decay:0.06, volume:-22 },
+  // success
+  "xploit.ok":  { kind:"sweep", from:440, to:1320, dur:0.16, osc:"square", volume:-12 },
+  access:       { kind:"chord", notes:["A4","E5"], decay:0.2, osc:"triangle", volume:-14 },
+  "ice.down":   { kind:"sweep", from:1400, to:200, dur:0.5, osc:"sawtooth", volume:-12 },
+  // reward
+  fetch:        { kind:"chord", notes:["C5","E5","G5","C6"], strum:0.04, decay:0.35, volume:-11 },
+  "mine.card":  { kind:"chord", notes:["E5","A5","C6"], strum:0.03, decay:0.3, volume:-12 },
+  mission:      { kind:"chord", notes:["C5","G5","C6","E6","G6"], strum:0.05, decay:0.5, volume:-9 },
+  // failure
+  "xploit.fail":{ kind:"noise", dur:0.18, cutoff:900, volume:-12 },
+  "mine.trap":  { kind:"fm",    note:"A2", harmonicity:1.5, modIndex:18, decay:0.3, volume:-11 },
+  "fetch.trap": { kind:"fm",    note:"C3", harmonicity:2, modIndex:14, decay:0.25, volume:-12 },
+  "hurt.health":{ kind:"noise", dur:0.2, cutoff:600, volume:-10 },
+  "ice.ejected":{ kind:"sweep", from:800, to:120, dur:0.3, osc:"sawtooth", volume:-12 },
+  // danger
+  "alert.up":   { kind:"sweep", from:330, to:660, dur:0.25, osc:"sawtooth", volume:-13 },
+  "trace.start":{ kind:"fm",    note:"A3", harmonicity:2, modIndex:20, decay:0.6, volume:-9 },
+  "ice.pending":{ kind:"sweep", from:500, to:900, dur:0.35, osc:"square", volume:-14 },
+  "ice.locked": { kind:"fm",    note:"E3", harmonicity:1.5, modIndex:22, decay:0.5, volume:-9 },
+  // glitch
+  corrupt:      { kind:"fm",    note:"G3", harmonicity:3.5, modIndex:16, decay:0.25, volume:-13 },
+  "hurt.deck":  { kind:"fm",    note:"D3", harmonicity:4, modIndex:20, decay:0.3, volume:-11 },
+  // relief / resolution
+  "alert.down": { kind:"sweep", from:520, to:300, dur:0.3, osc:"triangle", volume:-16 },
+  "trace.cancel":{ kind:"chord", notes:["E5","A5"], decay:0.4, osc:"triangle", volume:-13 },
+  "ice.reboot": { kind:"blip",  note:"G4", osc:"sine", decay:0.15, volume:-16 },
+  // run lifecycle
+  "run.start":  { kind:"sweep", from:120, to:600, dur:0.5, osc:"sawtooth", volume:-12 },
+  "run.success":{ kind:"chord", notes:["C5","E5","G5","C6"], strum:0.06, decay:0.6, volume:-9 },
+  "run.caught": { kind:"fm",    note:"A2", harmonicity:1, modIndex:24, decay:0.8, volume:-9 },
+  "run.burned": { kind:"noise", dur:0.6, cutoff:500, volume:-9 },
+  "run.bricked":{ kind:"fm",    note:"C2", harmonicity:5, modIndex:24, decay:0.8, volume:-9 },
+};
+export const CUE_IDS = Object.freeze(Object.keys(CUES));
+```
+
+## Event → cue mapping (`sfx-cues.js`, pure) — `resolveCue(type, payload)` → cueId|null
+
+- `ACTION_RESOLVED` switch on `payload.action`:
+  `probe`→`probe`; `dump`→`dump`; `corrupt`→`corrupt`;
+  `xploit`→ `success ? "xploit.ok" : "xploit.fail"`;
+  `fetch`→ `detail?.trap ? "fetch.trap" : "fetch"`;
+  `mine`→ `{card:"mine.card",trap:"mine.trap",miss:"mine.miss"}[detail?.outcome] ?? null`; else null.
+- `NODE_REVEALED`→`reveal`; `NODE_ACCESSED`→`access`; `PLAYER_NAVIGATED`→ `payload.nodeId ? "navigate" : null`.
+- `ALERT_GLOBAL_RAISED`→ `next==="trace" ? null : "alert.up"`; `ALERT_COOLED`→`alert.down`.
+- `ALERT_TRACE_STARTED`→`trace.start`; `ALERT_TRACE_CANCELLED`→`trace.cancel`.
+- `ICE_DETECT_PENDING`→`ice.pending`; `ICE_DETECTED`→`ice.locked`; `ICE_EJECTED`→`ice.ejected`;
+  `ICE_REBOOTED`→`ice.reboot`; `ICE_DISABLED`→`ice.down`; `ICE_MOVED`→ `payload.toVisible ? "ice.move" : null`.
+- `RUN_STARTED`→`run.start`; `RUN_ENDED`→ `"run."+payload.outcome`.
+- `MISSION_COMPLETE`→`mission`; `EXPLOIT_DISCLOSED`→`decay`.
+- Health/deck damage handled in the renderer (STATE_CHANGED diff), not resolveCue.
+- For `alert.up`, the renderer applies a pitch multiplier by level (yellow lower / red higher) at play time.
+
+---
+
+## Tasks
+
+### Task 1 — `sfx-defs.js` + test
+Create the `CUES`/`CUE_IDS` module above. Test (`tests/sfx-defs.test.js`): each cue `kind` ∈
+{blip,sweep,chord,noise,fm}; required params per kind present (blip/fm→`note`, chord→`notes[]`,
+sweep→`from`/`to`, noise→`dur`); `volume` is a number ≤ 0. `node --test` + `make lint` pass. Commit.
+
+### Task 2 — `sfx-cues.js` + test
+Implement `resolveCue` per the mapping (import `E`). Test: key cases (xploit ok/fail; mine
+card/miss/trap; fetch normal/trap; run.* per outcome; ICE_MOVED visible vs not; ALERT next=trace →
+null) + exhaustiveness (every cueId resolveCue can return exists in `CUES`). Pass + lint. Commit.
+
+### Task 3 — `sfx.js` engine
+`createSfx()` → `{ unlock, setEnabled, isEnabled, play, getMasterInput }`. Lazy master bus on first
+unlock/play; `play(spec)` builds the primitive, schedules at `ctx.currentTime+0.02`, disposes after
+the sound; voice cap; no-op if disabled. `node --check` + lint + test clean. Commit.
+
+### Task 4 — `SFX_CHANGED` event + `sfx-renderer.js`
+Add `E.SFX_CHANGED`. `initSfxRenderer()`: create engine; load `starnet:sfx-enabled` pref; gesture
+arm (unlock); subscribe mapped events → `resolveCue` → `play`; STATE_CHANGED health/deck diff →
+`hurt.*` (reset prev on RUN_STARTED); exports `isSfxEnabled/setSfxEnabled/toggleSfx/playCue/listCues`
+(set* persists + emits `SFX_CHANGED`). lint + test clean. Commit.
+
+### Task 5 — `sfx-commands.js`
+`sfx` command (`status|on|off|list|test <cue>`) mirroring `music-commands.js` (tab-complete cue ids
+for `test`). lint + test clean. Commit.
+
+### Task 6 — HUD button + main.js wiring
+`starnet-hud.js`: `sfxEnabled` prop + `SFX: ON/OFF` button → `toggle-sfx`. `css`: `#sfx-btn` in the
+shared button rules. `main.js`: import + `initSfxRenderer()` after `initAudioRenderer()`;
+`hudEl.sfxEnabled = isSfxEnabled()`; `on(E.SFX_CHANGED, …)`; `case "toggle-sfx": toggleSfx()`.
+`make check`; `grep -rn "audio/sfx" scripts/` empty. Commit.
+
+### Task 7 — preview harness + smoke + listen checkpoint
+`preview/sfx.html` + `js/audio/sfx-playground.js`: a button per `CUE_IDS` cue → `play(CUES[id])`;
+`window._sfx` handle. Playwright smoke (click cues, run game actions → no errors; `sfx test` works).
+**Listen checkpoint (Les)** to flag tuning. Commit.
+
+### Task 8 — docs + final checks
+Update `MANUAL.md` + `docs/audio-direction.md`. `make check` green; headless SFX-free; in-game smoke
+clean. Commit.
+
+---
+
+## Notes / deferred
+- Store-purchase cue dropped (no event); one-line emit in store-logic.js later if wanted.
+- No music ducking in v1. Sounds are rough drafts → by-ear tuning pass follows.
+- `alert.up` pitch-by-level is renderer-side parameterization, not separate cues.

--- a/docs/dev-sessions/2026-06-14-1852-audio-event-sfx/spec.md
+++ b/docs/dev-sessions/2026-06-14-1852-audio-event-sfx/spec.md
@@ -1,0 +1,222 @@
+# SFX for Game Actions — Spec
+
+Issue: **#229 — Audio: event SFX for game actions**
+Branch/worktree: `audio-event-sfx`
+
+## Goal
+
+A synthesized **sound-effects layer** that makes game happenings audible — short one-shot cues
+fired on discrete game events across the whole game, in the cyberpunk-terminal aesthetic,
+**independent of the music**. The aural landscape should become much richer and clearly
+indicative of what's happening (per the issue).
+
+This complements the reactive **music** (already shipped): music sets mood by axis; SFX are the
+discrete *punctuation* of events. (Aligns with the project rule that every visible game event
+should have audible/loggable feedback.)
+
+## Decisions (from brainstorm)
+
+- **Coverage: comprehensive** — core loop, alerts, ICE, run lifecycle, and misc events.
+- **Character: cyberpunk terminal UI** — clean synth bleeps / zaps / filtered sweeps / chimes,
+  no samples. Organized into **semantic sound families** so events read by ear:
+  - **info / neutral** — soft blip/tick (probe, navigate, reveal)
+  - **success** — bright, rising (xploit success, access)
+  - **reward** — chime / quick arpeggio (fetch loot, mine card, mission complete)
+  - **failure** — dark buzz / thud (xploit fail, mine trap)
+  - **danger** — harsh rising alarm (alert escalation, ICE detect/lock, trace)
+  - **relief / resolution** — settled descending tone (alert cooled, trace cancelled, clean jack-out)
+- **Synthesis only** (Tone.js), matching the music palette. Samples are out of scope (that's #230).
+- **Independent of music:** SFX have their **own persisted on/off** (menu button + `sfx` console
+  command) and run on a **separate, always-available audio bus** (not torn down between hub and
+  runs, unlike the music engine). You can have SFX with music off, or in the hub.
+
+## Architecture (`js/audio/`)
+
+Mirrors the music subsystem's split (pure data + pure logic + a thin Tone boundary + a
+browser-only event subscriber):
+
+- **`sfx-defs.js`** — *pure data.* `CUES`: a map of `cueId → sound spec` (a synth primitive +
+  params), grouped by family. `@ts-check`, unit-tested.
+- **`sfx.js`** — *`@ts-nocheck`, the only Web Audio boundary for SFX.* Owns its own master
+  `Gain` (+ a light shared reverb) → destination, persistent for the session. `play(spec)`
+  synthesizes a one-shot from a small set of **primitives**; `unlock()` (Tone.start on gesture);
+  `setEnabled()`. Voice cap + per-cue throttle to avoid spam.
+- **`sfx-renderer.js`** — *`@ts-check`, browser-only.* Subscribes to `E.*` events, maps each to a
+  `cueId`, and calls `sfx.play(CUES[cueId])`. Arms the AudioContext on first gesture. Tracks
+  prev `player.health`/`deckIntegrity` to fire damage cues (no dedicated event — diff on
+  `STATE_CHANGED`, like the music's injury term).
+- **`sfx-commands.js`** — *browser-only.* `sfx` console command: `status | on | off | list |
+  test <cue>` (mirrors the `music` command; `test` auditions a cue).
+- **Wiring:** `initSfxRenderer()` called from `js/ui/main.js` (browser entry only). Headless
+  entry points (`scripts/`) never import it.
+- **HUD:** a **`SFX: ON / OFF`** menu button mirroring the Music button; an `SFX_CHANGED` event
+  (like `MUSIC_CHANGED`) keeps the button in sync with the console command.
+- **Harness:** an SFX section in the preview harness with a button per cue to audition/tune
+  (per the project rule that new audio effects get a preview).
+
+## Sound primitives (in `sfx.js`)
+
+A small interpreter so cues are data, not bespoke code:
+
+- **`blip`** — single pitched osc (sine/triangle/square/sawtooth) with a fast pluck envelope.
+- **`tone`/`chord`** — one or more held notes (stab/chime), optional quick arpeggio.
+- **`sweep`** — pitch and/or filter glide over a short duration (rising = tension, falling = relief).
+- **`noise`** — filtered noise burst (zap / impact / static / power-down).
+- **`fm`** — FM blip for metallic/glitchy cues (corrupt, deck damage).
+
+Spec shape: `{ kind, ...params, volume, decay }`. The engine routes all through the SFX master
+(+ a touch of reverb) so cues sit in the same space as the music.
+
+## Cue catalog (event → cue → family)
+
+Comprehensive. Exact event names/payloads to be confirmed against `js/core/events.js` and
+`js/ui/log-renderer.js` (which already maps these events) during planning.
+
+| Event (condition) | cue | family |
+|---|---|---|
+| `ACTION_RESOLVED` probe | `probe` | info |
+| `ACTION_RESOLVED` xploit (success) / (fail) | `xploit.ok` / `xploit.fail` | success / failure |
+| `ACTION_RESOLVED` dump | `dump` | info (data sweep) |
+| `ACTION_RESOLVED` fetch | `fetch` | reward |
+| `ACTION_RESOLVED` mine (card) / (trap) | `mine.card` / `mine.trap` | reward / failure |
+| `ACTION_RESOLVED` corrupt | `corrupt` | glitch (fm/sweep) |
+| `PLAYER_NAVIGATED` | `navigate` | info (soft move tick) |
+| `NODE_REVEALED` / `NODE_ACCESSED` | `reveal` / `access` | info / success |
+| `ALERT_GLOBAL_RAISED` (→yellow/→red) | `alert.up` (pitch by level) | danger |
+| `ALERT_COOLED` | `alert.down` | relief |
+| `ALERT_TRACE_STARTED` / `ALERT_TRACE_CANCELLED` | `trace.start` / `trace.cancel` | danger / relief |
+| `ICE_DETECT_PENDING` / `ICE_DETECTED` | `ice.pending` / `ice.locked` | danger (rising / harsh) |
+| `ICE_MOVED` (visible) / `ICE_REBOOTED` / `ICE_DISABLED` | `ice.move` / `ice.reboot` / `ice.down` | info / info / success |
+| `RUN_STARTED` | `run.start` | info (jack-in) |
+| `RUN_ENDED` (success/caught/burned/bricked) | `run.<outcome>` | resolution / failure variants |
+| `MISSION_COMPLETE` | `mission` | reward (fanfare) |
+| health damage / deck damage (STATE diff) | `hurt.health` / `hurt.deck` | failure / glitch |
+| `EXPLOIT_DISCLOSED` | `decay` | info (subtle degrade) |
+| store purchase (hub) | `buy` | reward (if a suitable event/hook exists) |
+
+(Some low-value or noisy events may be dropped during tuning; the catalog is the upper bound.)
+
+## Behavior details
+
+- **Dispose-after-play:** each one-shot creates its synth, triggers, and is disposed shortly
+  after it finishes. SFX therefore add **no long-lived AudioParam accumulation** — the unbounded
+  per-note automation growth that caused the music engine's over-time stutter. (Cues are
+  infrequent, so create/dispose churn is negligible.)
+- **Throttle / dedupe:** collapse identical cues fired within ~50 ms; cap simultaneous SFX voices
+  so a burst of events can't overwhelm the mix.
+- **No music ducking** in v1 (SFX simply mixed to cut through) — ducking is a future tuning item.
+- **AudioContext** is shared (Tone global); SFX arm on first gesture independently of music, so
+  SFX work even if music is disabled.
+- **Persisted pref** `starnet:sfx-enabled` (default on).
+
+## Testing
+
+- **Pure tests:** `sfx-defs` structural validation (every `cueId` has a well-formed spec with a
+  known `kind`); and a test that the renderer's event→cue mapping references only defined cues.
+- **Engine/wiring:** Playwright smoke (events fire cues with no errors; `sfx test <cue>` works;
+  the SFX toggle + button stay in sync) and ear-tuning via the preview harness.
+- `make check` green; headless paths confirmed SFX-free.
+
+## Out of scope (future)
+
+- Music ducking under SFX.
+- Sample-based vocal/texture one-shots (#230).
+- Positional / per-node spatial audio.
+- Per-cue volume mixing UI beyond the master SFX toggle.
+
+---
+
+## v2 — Dark retone + per-action sustained drones (post-first-listen)
+
+First listen feedback (Les): the one-shots are "too blippy, bouncy, and happy" — want them
+**colder / more technical / darker**; and we want **extended drone-y sounds for every timed action
+in progress** (mirroring how each timed action has its own animation). Same branch / PR #237
+(within issue #229).
+
+### Part 1 — Retone one-shots → "cold machine telemetry"
+
+No structural change (same cue ids / families / event mapping). Re-spec `sfx-defs.js` values:
+
+- Kill cheerful arpeggios (`fetch`, `mission`, `run.success`, `mine.card`, `trace.cancel`) → terse
+  low data-bursts / single sober resolved tones.
+- Detune + darken pitched cues (`xploit.ok` → short detuned minor two-note; `probe`/`reveal`/
+  `navigate` → dry filtered ticks, minimal pitch bounce).
+- Push danger cues lower into FM growl / dissonant clusters (`alert.up`, `trace.start`, `ice.locked`).
+- **Reverb becomes per-cue (default dry)** instead of a global always-on bed — the wet tail was a
+  big part of the "bounce". Engine gains a `detune` param on `blip`/`sweep` and an optional per-cue
+  `reverb` flag. Still ear-tuned afterward.
+
+### Part 2 — Per-action sustained drones (new engine capability)
+
+- **`sfx.js` gains a sustained voice:** `startDrone(spec) → { setProgress(p), stop() }` — a held
+  synth graph (osc/noise/fm + filter + optional LFO + fade-in/out gain) tracked separately from the
+  one-shot voice cap. Fades in on start, re-shapes on progress 0→1, fades out on stop (click-free).
+- **New pure data `sfx-drones.js`:** `DRONES` (one spec per timed action) + `DRONE_IDS` +
+  `resolveDrone(action) → droneId|null`. Each drone echoes its action's animation:
+  - probe → thin scanning pulse, filter brightens as the sweep fills
+  - xploit → grinding low FM that tightens (pitch/filter close in) as brackets converge
+  - dump → chunky low data-churn
+  - fetch → flowing filtered-noise that thins as it drains (gain down with progress)
+  - mine → two detuned tones beating, converging to a stable pitch (lock-on) at p→1
+  - lie-low → hushed sub hum + soft rhythmic tick, very quiet
+  - reboot → adversarial slow pulsing low drone, loops (no progress sweep — system, not player)
+- **`sfx-renderer.js`** subscribes to `ACTION_FEEDBACK`: `phase:"start"` → `startDrone` keyed by
+  `${nodeId}:${action}`; `"progress"` → `setProgress(p)`; `"complete"`/`"cancel"` → `stop()`.
+  `RUN_ENDED` stops all live drones. The existing completion one-shot (`ACTION_RESOLVED`) still
+  fires — timed action = drone *during* + telemetry blip *at end*.
+- **Harness:** `preview/sfx.html` gets a play/stop + progress-slider row per drone.
+- **Tests:** `sfx-drones.test.js` (every drone is a well-formed spec) + drone-mapping cases.
+
+### v2 scope calls (confirmed)
+
+- **Reboot** gets a drone, but a distinctly *adversarial* looping one (involuntary system state).
+- **Trace countdown** is NOT a timed action → no sustained "trace bed" this pass (it keeps the
+  `trace.start` one-shot).
+
+---
+
+## v3 — One-shot enrichment: state-reflective motifs (post-listen)
+
+Feedback (Les): the one-shots are all "little ticks and boops" — want **variety and meaning**,
+e.g. an access-level change as a double/triple chord hit reflecting the level. Broad enrichment
+pass (his call), still on PR #237 / issue #229.
+
+### Sound vocabulary (encoding language)
+
+- **More control / value / rarity / progress** → more hits or notes, ascending pitch, a touch
+  brighter. **Loss / wear / danger** → lower, dissonant, FM/noise, descending.
+- All stays cold/technical (the v2 palette); "richer" = a short *motif*, never a cheerful chime.
+
+### Engine (`sfx.js`)
+
+- Add `hits` + `hitGap` to the `chord` primitive — strike the chord N times in succession (the
+  "double/triple hit"). Lifetime/track adjusted for the extra strikes.
+
+### Enriched cues
+
+| Event | State used | Cue |
+|---|---|---|
+| `NODE_ACCESSED` | `next` | `access.open` (chord ×2 hits, ascending) / `access.owned` (×3, fuller/higher) |
+| `ACTION_RESOLVED` mine | `detail.rarity` | `mine.common` / `mine.uncommon` (2-note) / `mine.rare` (3-note ascending); miss/trap unchanged |
+| `ACTION_RESOLVED` fetch | `detail.total` | `fetch` (small) / `fetch.big` (over a value threshold); trap unchanged |
+| `NODE_REVEALED` | node `grade`/`type` (renderer `getState()` lookup) | **"discovery rush"** — brighter rising motif; pitch by grade; **NO dedupe**; **burst cascade**: reveals within ~250 ms step pitch up (ascending run), reset after a gap. Single reveal brighter than the old tick; mass reveal brighter still. |
+| `EXPLOIT_PARTIAL_BURN` | `usesRemaining` | new `burn` wear-chirp; pitch drops as the card wears |
+| `NODE_ALERT_RAISED` | `next` | new subtle `node.alert` tick, pitch by tier; low vol, hard-deduped (tuning risk — may pull back) |
+| health/deck damage | (existing diff) | sharpen `hurt.health` (body thud) vs `hurt.deck` (glitch) |
+
+**Stays terse** (frequent telemetry): `probe`, `navigate`, `dump`, `ice.move`, `decay`, `mine.miss`.
+
+### Architecture
+
+- access/mine/fetch/burn/node-alert carry their state in the payload → `resolveCue` stays pure
+  (extends the `mine.*`/`run.*` pattern). `ROUTED` gains `EXPLOIT_PARTIAL_BURN` + `NODE_ALERT_RAISED`.
+- `NODE_REVEALED` grade/type + cascade + per-burn pitch are **renderer-side** (browser-only, uses
+  `getState()` and short-lived non-game cascade state, like the health/deck diff). Reveal is
+  exempted from the 50 ms dedupe so bursts cascade.
+
+### Testing
+
+- `sfx-defs` test: new cues well-formed; `chord.hits` numeric when present.
+- `sfx-cues` test: access-by-level, mine-by-rarity, fetch-by-tier, burn, node-alert branches.
+- Browser realtime smoke: enriched cues fire error-free; reveal cascade ascends; levels sane.
+- `make check` green.

--- a/js/audio/sfx/commands.js
+++ b/js/audio/sfx/commands.js
@@ -1,0 +1,39 @@
+// @ts-check
+// Console command for SFX control. Registered from the audio (browser) layer so core/headless
+// never imports audio. Mirrors `music-commands.js` and the SFX menu toggle (GUI/console symmetry).
+import { registerCommand } from "../../core/console-commands/index.js";
+import { emitEvent, E } from "../../core/events.js";
+import { isSfxEnabled, setSfxEnabled, listCues, playCue } from "./renderer.js";
+
+function log(text, type = "meta") { emitEvent(E.LOG_ENTRY, { text, type }); }
+
+registerCommand({
+  verb: "sfx",
+  complete(args, partial) {
+    const subs = ["status", "on", "off", "list", "test"];
+    const p = partial.toLowerCase();
+    const pool = args.length === 0 ? subs : (args[0] === "test" ? listCues() : []);
+    const matches = pool.filter((s) => s.toLowerCase().startsWith(p));
+    return matches.length ? { insertTexts: matches, displayTexts: matches } : null;
+  },
+  execute(args) {
+    const sub = (args[0] || "").toLowerCase();
+    if (!sub || sub === "status") { log(`[SFX] ${isSfxEnabled() ? "on" : "off"}`); return; }
+    if (sub === "on")  { setSfxEnabled(true);  log("[SFX] on"); return; }
+    if (sub === "off") { setSfxEnabled(false); log("[SFX] off"); return; }
+    if (sub === "list") {
+      log("[SFX] cues:");
+      listCues().forEach((id) => log(`  ${id}`));
+      return;
+    }
+    if (sub === "test") {
+      const id = args[1];
+      if (!id) { log("Usage: sfx test <cue> — see `sfx list`", "error"); return; }
+      if (!listCues().includes(id)) { log(`[SFX] no cue "${id}" — try: sfx list`, "error"); return; }
+      playCue(id);
+      log(`[SFX] ▶ ${id}`);
+      return;
+    }
+    log("Usage: sfx [status | on | off | list | test <cue>]", "error");
+  },
+});

--- a/js/audio/sfx/cues.js
+++ b/js/audio/sfx/cues.js
@@ -1,0 +1,60 @@
+// @ts-check
+// Pure event -> cue mapping. Returns a cue id (key in defs.js CUES) or null. No side effects.
+// Health/deck damage cues are NOT handled here (the renderer derives them from STATE_CHANGED diffs).
+// NODE_REVEALED grade/type + burst-cascade pitch are applied renderer-side (needs getState()).
+import { E } from "../../core/events.js";
+
+/** Mining card hit → cue id by rarity (escalating motif). */
+const MINE_RARITY = { common: "mine.common", uncommon: "mine.uncommon", rare: "mine.rare" };
+/** A fetch haul at or above this total cash value gets the richer "big haul" cue. */
+const FETCH_BIG_TOTAL = 3000;
+
+/**
+ * Map a game event to a sound-cue id.
+ * @param {string} type  the E.* event string
+ * @param {any} payload  the event payload
+ * @returns {string|null} cue id, or null for "no cue"
+ */
+export function resolveCue(type, payload) {
+  switch (type) {
+    case E.ACTION_RESOLVED: {
+      const a = payload?.action;
+      if (a === "probe") return "probe";
+      if (a === "dump") return "dump";
+      if (a === "corrupt") return "corrupt";
+      if (a === "xploit") return payload?.success ? "xploit.ok" : "xploit.fail";
+      if (a === "fetch") {
+        if (payload?.detail?.trap) return "fetch.trap";
+        return (payload?.detail?.total ?? 0) >= FETCH_BIG_TOTAL ? "fetch.big" : "fetch";
+      }
+      if (a === "mine") {
+        const d = payload?.detail;
+        if (d?.outcome === "trap") return "mine.trap";
+        if (d?.outcome === "miss") return "mine.miss";
+        if (d?.outcome === "card") return MINE_RARITY[/** @type {string} */ (d?.rarity)] ?? "mine.common";
+        return null;
+      }
+      return null;
+    }
+    case E.NODE_REVEALED:         return "reveal";
+    case E.NODE_ACCESSED:         return payload?.next === "owned" ? "access.owned" : "access.open";
+    case E.PLAYER_NAVIGATED:      return payload?.nodeId ? "navigate" : null;
+    case E.ALERT_GLOBAL_RAISED:   return payload?.next === "trace" ? null : "alert.up";
+    case E.ALERT_COOLED:          return "alert.down";
+    case E.ALERT_TRACE_STARTED:   return "trace.start";
+    case E.ALERT_TRACE_CANCELLED: return "trace.cancel";
+    case E.NODE_ALERT_RAISED:     return payload?.next === "green" ? null : "node.alert";
+    case E.ICE_DETECT_PENDING:    return "ice.pending";
+    case E.ICE_DETECTED:          return "ice.locked";
+    case E.ICE_EJECTED:           return "ice.ejected";
+    case E.ICE_REBOOTED:          return "ice.reboot";
+    case E.ICE_DISABLED:          return "ice.down";
+    case E.ICE_MOVED:             return payload?.toVisible ? "ice.move" : null;
+    case E.RUN_STARTED:           return "run.start";
+    case E.RUN_ENDED:             return payload?.outcome ? "run." + payload.outcome : null;
+    case E.MISSION_COMPLETE:      return "mission";
+    case E.EXPLOIT_DISCLOSED:     return "decay";
+    case E.EXPLOIT_PARTIAL_BURN:  return "burn";
+    default: return null;
+  }
+}

--- a/js/audio/sfx/defs.js
+++ b/js/audio/sfx/defs.js
@@ -1,0 +1,62 @@
+// @ts-check
+// Sound-effect cue catalog — pure data. Each cue is a spec interpreted by engine.js into a
+// synthesized one-shot. Families: info, success, reward, failure, danger, glitch, relief.
+//
+// Aesthetic: "cold machine telemetry" — dry, low-register, technical. No cheerful arpeggios;
+// detuned/minor intervals over major triads; danger leans into low FM growl. Reverb is opt-in
+// per cue (`reverb:true`), default dry. Starter values; tuned by ear later in the harness.
+
+export const CUES = {
+  // info / neutral — dry filtered ticks, minimal pitch bounce
+  probe:        { kind:"blip",  note:"A3", osc:"square",   decay:0.05, detune:-8, volume:-17 },
+  navigate:     { kind:"blip",  note:"E3", osc:"square",   decay:0.03, volume:-24 },
+  // reveal — a brighter "discovery rush" blip; renderer pitches it by node grade and steps it up
+  // per reveal in a burst (ascending cascade). Single = bright; mass reveal = a rising run.
+  reveal:       { kind:"blip",  note:"E5", osc:"triangle", decay:0.07, volume:-17 },
+  dump:         { kind:"sweep", from:380, to:160, dur:0.20, osc:"square", detune:-6, volume:-19 },
+  "mine.miss":  { kind:"noise", dur:0.08, cutoff:1400, volume:-21 },
+  "ice.move":   { kind:"blip",  note:"D3", osc:"square",   decay:0.04, volume:-25 },
+  decay:        { kind:"blip",  note:"A2", osc:"square",   decay:0.05, detune:-14, volume:-22 },
+  // node-alert — subtle per-node alert tick; renderer pitches up at red. Low + deduped.
+  "node.alert": { kind:"blip",  note:"D3", osc:"square",   decay:0.04, detune:-6, volume:-25 },
+  // exploit wear — dry chirp; renderer drops pitch as the card wears down
+  burn:         { kind:"blip",  note:"C4", osc:"square",   decay:0.05, volume:-21 },
+  // success — terse, detuned. access escalates by level: open = 2 hits, owned = 3 hits + fuller.
+  "xploit.ok":  { kind:"chord", notes:["A3","C4"], decay:0.14, osc:"square", detune:-6, volume:-14 },
+  "access.open":  { kind:"chord", notes:["A3","E4"], decay:0.15, osc:"square", detune:-4, hits:2, hitGap:0.09, volume:-14 },
+  "access.owned": { kind:"chord", notes:["A3","E4","A4"], decay:0.17, osc:"sawtooth", detune:-4, hits:3, hitGap:0.085, volume:-13 },
+  "ice.down":   { kind:"sweep", from:900, to:90, dur:0.45, osc:"sawtooth", volume:-13 },
+  // reward — low data-bursts / sober resolved tones, NOT chimes. mine escalates by rarity.
+  fetch:        { kind:"noise", dur:0.16, cutoff:2200, hp:true, volume:-15 },
+  "fetch.big":  { kind:"chord", notes:["A2","E3"], decay:0.26, osc:"sawtooth", detune:-5, hits:2, hitGap:0.1, volume:-12, reverb:true },
+  "mine.common":   { kind:"blip",  note:"E3", osc:"square", decay:0.07, detune:-4, volume:-15 },
+  "mine.uncommon": { kind:"chord", notes:["E3","B3"], decay:0.16, osc:"square", detune:-4, volume:-14 },
+  "mine.rare":     { kind:"chord", notes:["E3","B3","E4"], strum:0.05, decay:0.22, osc:"sawtooth", detune:-3, volume:-12 },
+  mission:      { kind:"chord", notes:["A2","E3","A3"], decay:0.4, osc:"sawtooth", detune:-6, volume:-12, reverb:true },
+  // failure — sub-thuds / low FM
+  "xploit.fail":{ kind:"noise", dur:0.20, cutoff:600, volume:-12 },
+  "mine.trap":  { kind:"fm",    note:"A1", harmonicity:1.5, modIndex:20, decay:0.32, volume:-11 },
+  "fetch.trap": { kind:"fm",    note:"C2", harmonicity:2, modIndex:16, decay:0.28, volume:-12 },
+  "hurt.health":{ kind:"noise", dur:0.24, cutoff:340, volume:-9 },
+  "ice.ejected":{ kind:"sweep", from:600, to:80, dur:0.3, osc:"sawtooth", volume:-12 },
+  // danger — low growl / dissonant clusters
+  "alert.up":   { kind:"fm",    note:"D2", harmonicity:1.5, modIndex:14, decay:0.3, volume:-13 },
+  "trace.start":{ kind:"fm",    note:"A1", harmonicity:1.25, modIndex:24, decay:0.7, volume:-9, reverb:true },
+  "ice.pending":{ kind:"sweep", from:300, to:520, dur:0.4, osc:"square", detune:-10, volume:-15 },
+  "ice.locked": { kind:"fm",    note:"D2", harmonicity:1.5, modIndex:26, decay:0.5, volume:-9 },
+  // glitch — metallic FM
+  corrupt:      { kind:"fm",    note:"G2", harmonicity:3.5, modIndex:18, decay:0.24, volume:-13 },
+  "hurt.deck":  { kind:"fm",    note:"D2", harmonicity:4.5, modIndex:22, decay:0.3, volume:-11 },
+  // relief / resolution — settled descending, no major chord
+  "alert.down": { kind:"sweep", from:420, to:200, dur:0.32, osc:"triangle", detune:-4, volume:-17 },
+  "trace.cancel":{ kind:"sweep", from:520, to:180, dur:0.4, osc:"sawtooth", detune:-6, volume:-14 },
+  "ice.reboot": { kind:"blip",  note:"E3", osc:"sine", decay:0.14, detune:-4, volume:-17 },
+  // run lifecycle
+  "run.start":  { kind:"sweep", from:70, to:340, dur:0.55, osc:"sawtooth", detune:-8, volume:-12 },
+  "run.success":{ kind:"chord", notes:["A2","E3","A3"], decay:0.6, osc:"sawtooth", detune:-5, volume:-11, reverb:true },
+  "run.caught": { kind:"fm",    note:"A1", harmonicity:1, modIndex:26, decay:0.9, volume:-9, reverb:true },
+  "run.burned": { kind:"noise", dur:0.7, cutoff:380, volume:-9 },
+  "run.bricked":{ kind:"fm",    note:"C1", harmonicity:5, modIndex:26, decay:0.9, volume:-9, reverb:true },
+};
+
+export const CUE_IDS = Object.freeze(Object.keys(CUES));

--- a/js/audio/sfx/drones.js
+++ b/js/audio/sfx/drones.js
@@ -1,0 +1,48 @@
+// @ts-check
+// Sustained "action in progress" drones — pure data. Each timed action gets one drone, played by
+// engine.js startDrone() for the action's duration and re-shaped by progress 0→1. Each echoes its
+// on-graph animation's character (see js/ui/overlays/*). Keyed by the ACTION_FEEDBACK `action`
+// string. `loop:true` ignores progress (reboot — an involuntary system state, not a player sweep).
+//
+// Spec shape (interpreted in engine.js): {
+//   source: "sawtooth"|"sine"|"square"|"triangle"|"noise"|"fm"|"dual",
+//   note, osc?, harmonicity?/modIndex? (fm), type? (noise),
+//   detune?: cents | {from,to},  cutoff?: Hz | {from,to},  gain?: 0..1 | {from,to},  q?,
+//   lfo?: { rate, depth, target:"amp"|"cutoff" },  fade?, volume?, loop?, reverb?
+// }
+// {from,to} values sweep with progress; amp-LFO and progress-gain are mutually exclusive.
+
+export const DRONES = {
+  // probe — clockwise radar sweep: thin scanning pulse, filter brightens as the ring fills.
+  probe:    { source:"sawtooth", note:"A2", cutoff:{ from:300, to:1500 }, q:3,
+              lfo:{ rate:3, depth:0.3, target:"amp" }, volume:-23, fade:0.16 },
+  // xploit — converging brackets: grinding low FM that tightens (filter opens, detune resolves).
+  xploit:   { source:"fm", note:"C2", osc:"square", harmonicity:1.5, modIndex:12,
+              cutoff:{ from:450, to:1700 }, detune:{ from:-25, to:8 }, q:4, volume:-18, fade:0.08 },
+  // dump — wedge facets read in chunks: low data-churn with a fast amp gate.
+  dump:     { source:"square", note:"D2", cutoff:{ from:380, to:760 }, q:2,
+              lfo:{ rate:9, depth:0.4, target:"amp" }, volume:-21, fade:0.14 },
+  // fetch — ripple rings draining: flowing filtered noise that thins (gain + cutoff fall).
+  fetch:    { source:"noise", type:"brown", cutoff:{ from:1900, to:550 }, gain:{ from:0.9, to:0.15 },
+              q:1, volume:-19, fade:0.12 },
+  // mine — crosshair locking on: two detuned tones beating, the beat slowing to zero (lock-on).
+  mine:     { source:"dual", note:"E2", osc:"sawtooth", detune:{ from:42, to:0 }, cutoff:600, q:3,
+              volume:-22, fade:0.12 },
+  // lie-low — clock fast-forward: hushed sub hum + soft tick (rate echoes the 2.5rps minute hand).
+  "lie-low":{ source:"sine", note:"A1", cutoff:320, q:1,
+              lfo:{ rate:2.5, depth:0.25, target:"amp" }, volume:-26, fade:0.22 },
+  // reboot — offline opacity pulse: adversarial slow-pulsing sour drone, loops (no progress sweep).
+  reboot:   { source:"sawtooth", note:"C2", detune:-25, cutoff:520, q:5,
+              lfo:{ rate:0.5, depth:0.5, target:"amp" }, volume:-19, fade:0.35, loop:true },
+};
+
+export const DRONE_IDS = Object.freeze(Object.keys(DRONES));
+
+/**
+ * Map a timed-action id (the ACTION_FEEDBACK `action` field) to a drone id.
+ * @param {string} action
+ * @returns {string|null}
+ */
+export function resolveDrone(action) {
+  return action && Object.prototype.hasOwnProperty.call(DRONES, action) ? action : null;
+}

--- a/js/audio/sfx/engine.js
+++ b/js/audio/sfx/engine.js
@@ -1,0 +1,239 @@
+// @ts-nocheck
+// SFX engine — the only Web Audio boundary for sound effects. Interprets cue specs
+// (sfx/defs.js) into synthesized one-shots, and drone specs (sfx/drones.js) into sustained
+// "action in progress" voices. One-shot voices are disposed after they finish; drones are held
+// until stop() and disposed after their fade-out — so SFX add no long-lived AudioParam
+// accumulation. Cues schedule at currentTime + a small offset (NOT Tone.now()) so they aren't
+// delayed by the music engine's lookahead.
+import * as Tone from "/dist/tone.js";
+
+const MAX_VOICES = 12;
+const OFFSET = 0.02;
+
+// dB → linear gain. Levels are applied with plain Gain nodes, never Tone's `.volume` (a dB-mapped
+// signal whose ~100-200ms realtime startup transient made short cues play full-blast then settle).
+const dbToGain = (db) => Math.pow(10, db / 20);
+
+export function createSfx() {
+  let enabled = true;
+  let master = null, reverb = null;
+  let voices = 0;
+
+  function build() {
+    if (master) return;
+    master = new Tone.Gain(0.9).toDestination();
+    // Reverb is opt-in per cue (spec.reverb) — most cold telemetry cues run dry. The node passes
+    // a dry+wet blend, so opted-in cues keep their direct attack plus a tail.
+    reverb = new Tone.Reverb({ decay: 1.4, wet: 0.3 }).connect(master);
+  }
+
+  // Where a voice connects: dry to master by default, or through the shared reverb if requested.
+  function outFor(spec) { return spec.reverb ? reverb : master; }
+
+  // Dispose the voice's node(s) after lifeSec; keep the live one-shot count bounded.
+  function track(nodes, lifeSec) {
+    voices++;
+    const arr = Array.isArray(nodes) ? nodes : [nodes];
+    setTimeout(() => {
+      for (const n of arr) { try { n.dispose?.(); } catch { /* already gone */ } }
+      voices = Math.max(0, voices - 1);
+    }, lifeSec * 1000);
+  }
+
+  function play(spec) {
+    if (!enabled || !spec) return;
+    build();
+    if (voices >= MAX_VOICES) return;
+    const t = Tone.getContext().currentTime + OFFSET;
+    const dest = outFor(spec);
+    // Level via a linear gain (not synth.volume — see dbToGain note). Short one-shots otherwise
+    // played near full-blast, ignoring their volume spec.
+    const lvl = new Tone.Gain(dbToGain(spec.volume ?? -14)).connect(dest);
+
+    switch (spec.kind) {
+      case "blip": {
+        const decay = spec.decay ?? 0.12;
+        const s = new Tone.Synth({
+          oscillator: { type: spec.osc || "triangle", detune: spec.detune ?? 0 },
+          envelope: { attack: 0.001, decay, sustain: 0, release: 0.05 },
+        }).connect(lvl);
+        s.triggerAttackRelease(spec.note, decay, t);
+        track([s, lvl], decay + 0.2);
+        break;
+      }
+      case "sweep": {
+        const dur = spec.dur ?? 0.18;
+        const s = new Tone.Synth({
+          oscillator: { type: spec.osc || "sawtooth", detune: spec.detune ?? 0 },
+          envelope: { attack: 0.005, decay: dur, sustain: 0.2, release: 0.08 },
+        }).connect(lvl);
+        s.triggerAttack(spec.from, t);
+        s.frequency.rampTo(spec.to, dur, t);
+        s.triggerRelease(t + dur);
+        track([s, lvl], dur + 0.3);
+        break;
+      }
+      case "chord": {
+        const decay = spec.decay ?? 0.35;
+        const strum = spec.strum ?? 0;
+        const notes = spec.notes || [];
+        const hits = Math.max(1, spec.hits ?? 1);   // strike the chord N times (motif)
+        const hitGap = spec.hitGap ?? 0.09;
+        const s = new Tone.PolySynth(Tone.Synth, {
+          oscillator: { type: spec.osc || "triangle", detune: spec.detune ?? 0 },
+          envelope: { attack: 0.005, decay, sustain: 0, release: 0.1 },
+        }).connect(lvl);
+        for (let h = 0; h < hits; h++) {
+          const ht = t + h * hitGap;
+          notes.forEach((n, i) => s.triggerAttackRelease(n, decay, ht + i * strum));
+        }
+        track([s, lvl], (hits - 1) * hitGap + decay + notes.length * strum + 0.3);
+        break;
+      }
+      case "noise": {
+        const dur = spec.dur ?? 0.15;
+        const n = new Tone.NoiseSynth({
+          noise: { type: spec.type || "white" },
+          envelope: { attack: 0.001, decay: dur, sustain: 0, release: 0.05 },
+        });
+        const f = new Tone.Filter({ frequency: spec.cutoff ?? 4000, type: spec.hp ? "highpass" : "lowpass" }).connect(lvl);
+        n.connect(f);
+        n.triggerAttackRelease(dur, t);
+        track([n, f, lvl], dur + 0.2);
+        break;
+      }
+      case "fm": {
+        const decay = spec.decay ?? 0.2;
+        const s = new Tone.FMSynth({
+          harmonicity: spec.harmonicity ?? 3,
+          modulationIndex: spec.modIndex ?? 12,
+          detune: spec.detune ?? 0,
+          envelope: { attack: 0.001, decay, sustain: 0, release: 0.08 },
+        }).connect(lvl);
+        s.triggerAttackRelease(spec.note, decay, t);
+        track([s, lvl], decay + 0.3);
+        break;
+      }
+      default: lvl.dispose(); break;
+    }
+  }
+
+  // ── Sustained "action in progress" drones ───────────────────────────────────
+  // Build a held voice from a drone spec and return a small handle. The chain is:
+  //   source → filter → ampGain (progress / amp-LFO) → fadeGain (click-free in/out) → out
+  // setProgress(p) re-shapes cutoff / detune / gain toward their `to` value (no-op if `loop`).
+  // stop() fades out and disposes everything.
+  const lerp = (a, b, p) => a + (b - a) * Math.max(0, Math.min(1, p));
+  const range = (v, p) => (v && typeof v === "object" ? lerp(v.from, v.to, p) : v);
+
+  function startDrone(spec) {
+    if (!enabled || !spec) return { setProgress() {}, stop() {} };
+    build();
+    const t = Tone.getContext().currentTime + OFFSET;
+    const fade = spec.fade ?? 0.15;
+    const dest = outFor(spec);
+    // Level is applied as a LINEAR gain on the fade stage — NOT via source.volume. Tone's
+    // `.volume` is a dB-mapped signal that starts at 0 dB and only settles to the target after
+    // ~100-200ms in realtime, so a held source played full-blast then dropped — an onset volume
+    // spike on every drone. A plain gain has no such startup transient. (Offline pre-resolves the
+    // volume signal, which is why this never surfaced in offline analysis.)
+    const level = dbToGain(spec.volume ?? -18);
+
+    // Source node(s). `detuneParam` is the AudioParam that setProgress ramps for a detune sweep
+    // (null for noise, which has no detune). "dual" sums two oscillators a beat apart — the second
+    // oscillator's detune sweeps so the beat can slow to zero (lock-on).
+    const sources = [];
+    let detuneParam = null;
+    if (spec.source === "noise") {
+      sources.push(new Tone.Noise({ type: spec.type || "brown" }));
+    } else if (spec.source === "fm") {
+      const s = new Tone.FMOscillator({
+        frequency: spec.note ?? "C2", type: spec.osc || "sine",
+        harmonicity: spec.harmonicity ?? 2, modulationIndex: spec.modIndex ?? 8,
+        detune: range(spec.detune, 0) || 0,
+      });
+      detuneParam = s.detune;
+      sources.push(s);
+    } else if (spec.source === "dual") {
+      const osc1 = new Tone.Oscillator({ frequency: spec.note ?? "C2", type: spec.osc || "sawtooth" });
+      const osc2 = new Tone.Oscillator({ frequency: spec.note ?? "C2", type: spec.osc || "sawtooth", detune: range(spec.detune, 0) || 0 });
+      detuneParam = osc2.detune;
+      sources.push(osc1, osc2);
+    } else {
+      const s = new Tone.Oscillator({ frequency: spec.note ?? "C2", type: spec.source || "sawtooth", detune: range(spec.detune, 0) || 0 });
+      detuneParam = s.detune;
+      sources.push(s);
+    }
+
+    const filter = new Tone.Filter({
+      frequency: range(spec.cutoff, 0) || 1200,
+      type: "lowpass",
+      Q: spec.q ?? 2,
+    });
+    const ampGain = new Tone.Gain(range(spec.gain, 0) ?? 1);
+    const fadeGain = new Tone.Gain(0);
+    for (const s of sources) s.connect(filter);
+    filter.connect(ampGain);
+    ampGain.connect(fadeGain);
+    fadeGain.connect(dest);
+
+    // Optional LFO on amplitude or cutoff (scanning pulse, reboot pulse, lie-low tick).
+    let lfo = null;
+    let lfoStart = t;
+    if (spec.lfo) {
+      const { rate = 4, depth = 0.5, target = "amp" } = spec.lfo;
+      if (target === "amp") {
+        const min = Math.max(0, 1 - depth);
+        // Seat the body at the LFO's mean and DELAY the tremolo until the fade completes. Starting
+        // the LFO at t would let its first peak coincide with the fade reaching unity — an audible
+        // onset volume spike. Fading to the mean first, then modulating, removes that spike.
+        ampGain.gain.value = (min + 1) / 2;
+        lfo = new Tone.LFO({ frequency: rate, min, max: 1 });
+        lfo.connect(ampGain.gain);
+        lfoStart = t + fade;
+      } else {
+        const base = range(spec.cutoff, 0) || 1200;
+        lfo = new Tone.LFO({ frequency: rate, min: base * (1 - depth), max: base });
+        lfo.connect(filter.frequency);
+      }
+    }
+
+    for (const s of sources) s.start(t);
+    lfo?.start(lfoStart);
+    fadeGain.gain.rampTo(level, fade, t);
+
+    let stopped = false;
+    return {
+      setProgress(p) {
+        if (stopped || spec.loop) return;
+        const tt = Tone.getContext().currentTime;
+        if (spec.cutoff && typeof spec.cutoff === "object") filter.frequency.rampTo(range(spec.cutoff, p), 0.12, tt);
+        if (spec.detune && typeof spec.detune === "object" && detuneParam) detuneParam.rampTo(range(spec.detune, p), 0.12, tt);
+        // Progress-driven gain only when no amp-LFO owns that param.
+        if (spec.gain && typeof spec.gain === "object" && !(spec.lfo && (spec.lfo.target ?? "amp") === "amp")) {
+          ampGain.gain.rampTo(range(spec.gain, p), 0.12, tt);
+        }
+      },
+      stop() {
+        if (stopped) return;
+        stopped = true;
+        const tt = Tone.getContext().currentTime;
+        fadeGain.gain.rampTo(0, fade, tt);
+        setTimeout(() => {
+          for (const n of [lfo, ...sources, filter, ampGain, fadeGain]) { try { n?.dispose?.(); } catch { /* gone */ } }
+        }, (fade + 0.1) * 1000);
+      },
+    };
+  }
+
+  return {
+    /** Resume the AudioContext (needs a user gesture) without playing anything. */
+    async unlock() { await Tone.start(); },
+    setEnabled(on) { enabled = !!on; },
+    isEnabled() { return enabled; },
+    play,
+    startDrone,
+    /** Exposed for future routing (e.g. vocal one-shots); null until the first play()/startDrone() builds the bus (unlock() alone does not). */
+    getMasterInput() { return reverb; },
+  };
+}

--- a/js/audio/sfx/playground.js
+++ b/js/audio/sfx/playground.js
@@ -1,0 +1,62 @@
+// @ts-nocheck
+import { createSfx } from "./engine.js";
+import { CUES, CUE_IDS } from "./defs.js";
+import { DRONES, DRONE_IDS } from "./drones.js";
+
+const sfx = createSfx();
+window._sfx = sfx;   // diagnostics handle
+
+const status = document.getElementById("status");
+let unlocked = false;
+async function ensure() {
+  if (unlocked) return;
+  await sfx.unlock();
+  unlocked = true;
+  status.textContent = "ready";
+}
+
+// One-shot cues — click to fire.
+const grid = document.getElementById("cues");
+for (const id of CUE_IDS) {
+  const b = document.createElement("button");
+  b.className = "cue";
+  b.textContent = id;
+  b.onclick = async () => { await ensure(); sfx.play(CUES[id]); };
+  grid.appendChild(b);
+}
+
+// Sustained drones — toggle play/stop; drag the slider to audition progress 0→1.
+const droneGrid = document.getElementById("drones");
+for (const id of DRONE_IDS) {
+  const row = document.createElement("div");
+  row.className = "drone-row";
+
+  const toggle = document.createElement("button");
+  toggle.className = "cue";
+  toggle.textContent = `▶ ${id}`;
+
+  const slider = document.createElement("input");
+  slider.type = "range";
+  slider.min = "0"; slider.max = "1"; slider.step = "0.01"; slider.value = "0";
+  slider.disabled = true;
+
+  let handle = null;
+  toggle.onclick = async () => {
+    await ensure();
+    if (handle) {
+      handle.stop(); handle = null;
+      toggle.textContent = `▶ ${id}`;
+      slider.disabled = true; slider.value = "0";
+    } else {
+      handle = sfx.startDrone(DRONES[id]);
+      handle.setProgress(Number(slider.value));
+      toggle.textContent = `■ ${id}`;
+      slider.disabled = false;
+    }
+  };
+  slider.oninput = () => handle?.setProgress(Number(slider.value));
+
+  row.appendChild(toggle);
+  row.appendChild(slider);
+  droneGrid.appendChild(row);
+}

--- a/js/audio/sfx/renderer.js
+++ b/js/audio/sfx/renderer.js
@@ -1,0 +1,190 @@
+// @ts-check
+import { on, emitEvent, E } from "../../core/events.js";
+import { getState } from "../../core/state.js";
+import { GRADE_INDEX } from "../../core/grades.js";
+import { createSfx } from "./engine.js";
+import { resolveCue } from "./cues.js";
+import { CUES, CUE_IDS } from "./defs.js";
+import { DRONES, resolveDrone } from "./drones.js";
+
+// SFX on/off is a client preference (NOT game state).
+const SFX_PREF_KEY = "starnet:sfx-enabled";
+function loadPref() {
+  try { const v = localStorage.getItem(SFX_PREF_KEY); return v === null ? true : v === "true"; }
+  catch { return true; }
+}
+function savePref(on) { try { localStorage.setItem(SFX_PREF_KEY, String(!!on)); } catch { /* ignore */ } }
+
+let _sfx = null;
+let _enabled = true;
+let _prevHealth = null;
+let _prevDeck = null;
+const _last = {};   // cueId -> last play time (ms), for dedupe
+const _drones = new Map();   // "<nodeId>:<action>" -> active drone handle (timed actions in progress)
+const _reveal = { last: -1e9, count: 0 };   // reveal burst tracker (renderer-only, not game state)
+
+const REVEAL_BURST_MS = 250;   // reveals within this window cascade (ascending run)
+
+// Events routed straight through resolveCue().
+const ROUTED = [
+  E.ACTION_RESOLVED, E.NODE_REVEALED, E.NODE_ACCESSED, E.PLAYER_NAVIGATED,
+  E.ALERT_GLOBAL_RAISED, E.ALERT_COOLED, E.ALERT_TRACE_STARTED, E.ALERT_TRACE_CANCELLED,
+  E.NODE_ALERT_RAISED,
+  E.ICE_DETECT_PENDING, E.ICE_DETECTED, E.ICE_EJECTED, E.ICE_REBOOTED, E.ICE_DISABLED, E.ICE_MOVED,
+  E.RUN_STARTED, E.RUN_ENDED, E.MISSION_COMPLETE, E.EXPLOIT_DISCLOSED, E.EXPLOIT_PARTIAL_BURN,
+];
+
+const nowMs = () => (typeof performance !== "undefined" ? performance.now() : 0);
+
+/**
+ * Play a cue by id, with optional spec overrides. Dedupes identical cues within 50ms unless
+ * `noDedupe` (reveal bursts must cascade, not collapse).
+ */
+function playCueId(id, overrides, { noDedupe = false } = {}) {
+  if (!id || !_sfx) return;
+  const spec = CUES[id];
+  if (!spec) return;
+  const t = nowMs();
+  if (!noDedupe && t - (_last[id] ?? -1e9) < 50) return;
+  _last[id] = t;
+  _sfx.play(overrides ? { ...spec, ...overrides } : spec);
+}
+
+/**
+ * NODE_REVEALED → the "discovery rush". Pitch the reveal blip up by node grade (S brightest), and
+ * step it up further for each reveal in a burst so a cluster of unlocked neighbors ascends into a
+ * rising run. No dedupe — bursts must stack. Pitch is applied as an oscillator `detune` (cents).
+ */
+function playReveal(nodeId) {
+  const t = nowMs();
+  const cascade = t - _reveal.last < REVEAL_BURST_MS ? _reveal.count + 1 : 0;
+  _reveal.last = t;
+  _reveal.count = cascade;
+  const grade = getState()?.nodes?.[nodeId]?.grade;
+  const gradeSemis = GRADE_INDEX[grade] ?? 0;     // F=0 … S=5
+  const semis = gradeSemis + cascade * 2;          // grade lift + whole-step per burst step
+  playCueId("reveal", { detune: semis * 100 }, { noDedupe: true });
+}
+
+/** Stop and forget every active drone (run end, SFX disabled). */
+function stopAllDrones() {
+  for (const h of _drones.values()) h.stop();
+  _drones.clear();
+}
+
+/**
+ * Drive the sustained "action in progress" drones from ACTION_FEEDBACK.
+ * start → begin a drone keyed by node+action; progress → reshape it; complete/cancel → stop it.
+ */
+function handleActionFeedback(payload) {
+  if (!_sfx) return;
+  const { nodeId, action, phase, progress } = payload || {};
+  const key = `${nodeId}:${action}`;
+  if (phase === "start") {
+    if (_drones.has(key)) return;   // already running (e.g. a duplicate start) — don't restart
+    const id = resolveDrone(action);
+    if (!id) return;
+    _drones.set(key, _sfx.startDrone(DRONES[id]));
+  } else if (phase === "progress") {
+    _drones.get(key)?.setProgress(progress ?? 0);
+  } else if (phase === "complete" || phase === "cancel") {
+    _drones.get(key)?.stop();
+    _drones.delete(key);
+  }
+}
+
+/**
+ * Wire the SFX engine to the event bus. Browser-only — do NOT import from headless entry
+ * points (scripts/playtest.js, scripts/bot/cli.js).
+ */
+export function initSfxRenderer() {
+  _sfx = createSfx();
+  _enabled = loadPref();
+  _sfx.setEnabled(_enabled);
+
+  // AudioContext needs a user gesture; unlock on first gesture (independent of music).
+  let armed = false;
+  function arm() {
+    if (armed) return;
+    armed = true;
+    window.removeEventListener("pointerdown", arm);
+    window.removeEventListener("keydown", arm);
+    _sfx.unlock();
+  }
+  window.addEventListener("pointerdown", arm);
+  window.addEventListener("keydown", arm);
+
+  for (const type of ROUTED) {
+    on(type, (payload) => {
+      // Reveal is special: grade pitch + ascending burst cascade, no dedupe.
+      if (type === E.NODE_REVEALED) { playReveal(payload?.nodeId); return; }
+
+      const id = resolveCue(type, payload);
+      if (!id) return;
+      // Pitch the global-alert-escalation cue (an fm growl) up a step at red.
+      if (type === E.ALERT_GLOBAL_RAISED && id === "alert.up") {
+        playCueId("alert.up", { detune: payload?.next === "red" ? 300 : 0 });
+        return;
+      }
+      // Per-node alert: pitch up a step at red.
+      if (type === E.NODE_ALERT_RAISED && id === "node.alert") {
+        playCueId(id, { detune: payload?.next === "red" ? 200 : -100 });
+        return;
+      }
+      // Exploit wear: pitch drops as the card wears down (fewer uses left = lower).
+      if (type === E.EXPLOIT_PARTIAL_BURN && id === "burn") {
+        const left = Math.max(0, payload?.usesRemaining ?? 0);
+        playCueId(id, { detune: -100 * (3 - Math.min(3, left)) });
+        return;
+      }
+      playCueId(id);
+    });
+  }
+
+  // Sustained drones for timed actions in progress.
+  on(E.ACTION_FEEDBACK, handleActionFeedback);
+
+  // Health/deck damage has no event — diff on STATE_CHANGED; rebaseline on run start.
+  on(E.RUN_STARTED, ({ state }) => {
+    stopAllDrones();   // clean slate (a stale drone can't survive into a new run)
+    _prevHealth = state?.player?.health?.current ?? null;
+    _prevDeck = state?.player?.deckIntegrity?.current ?? null;
+  });
+  on(E.RUN_ENDED, stopAllDrones);
+  on(E.STATE_CHANGED, (state) => {
+    if (!state) return;
+    const h = state.player?.health?.current;
+    const d = state.player?.deckIntegrity?.current;
+    if (_prevHealth != null && h != null && h < _prevHealth) playCueId("hurt.health");
+    if (_prevDeck != null && d != null && d < _prevDeck) playCueId("hurt.deck");
+    if (h != null) _prevHealth = h;
+    if (d != null) _prevDeck = d;
+  });
+
+  return _sfx;
+}
+
+/** @returns {boolean} */
+export function isSfxEnabled() { return _enabled; }
+
+/**
+ * Enable/disable SFX, persisted. Emits SFX_CHANGED so the HUD button + console stay in sync.
+ * @param {boolean} on @returns {boolean}
+ */
+export function setSfxEnabled(on) {
+  _enabled = !!on;
+  savePref(_enabled);
+  _sfx?.setEnabled(_enabled);
+  if (!_enabled) stopAllDrones();   // silence any in-progress drones immediately
+  emitEvent(E.SFX_CHANGED, { enabled: _enabled });
+  return _enabled;
+}
+
+/** Flip SFX on/off. @returns {boolean} */
+export function toggleSfx() { return setSfxEnabled(!_enabled); }
+
+/** Play a cue by id (for the console `sfx test` command + harness). @param {string} id */
+export function playCue(id) { playCueId(id); }
+
+/** @returns {string[]} all cue ids */
+export function listCues() { return [...CUE_IDS]; }

--- a/js/core/events.js
+++ b/js/core/events.js
@@ -78,4 +78,5 @@ export const E = Object.freeze({
 
   // Audio (music on/off changed — keeps HUD + console in sync)
   MUSIC_CHANGED:        "audio:music-changed",
+  SFX_CHANGED:          "audio:sfx-changed",
 });

--- a/js/ui/components/starnet-hud.js
+++ b/js/ui/components/starnet-hud.js
@@ -18,6 +18,7 @@ class StarnetHud extends StarnetElement {
     mission: { type: Object },
     menuOpen: { type: Boolean },
     musicEnabled: { type: Boolean },
+    sfxEnabled: { type: Boolean },
   };
 
   constructor() {
@@ -33,6 +34,7 @@ class StarnetHud extends StarnetElement {
     this.mission = null;
     this.menuOpen = false;
     this.musicEnabled = true;
+    this.sfxEnabled = true;
   }
 
   _emit(action, detail = {}) {
@@ -111,6 +113,8 @@ class StarnetHud extends StarnetElement {
                   @click=${() => this._emit("pause")}>${this.paused ? "[ RESUME ]" : "[ PAUSE ]"}</button>
           <button id="music-btn" title="Toggle music"
                   @click=${() => this._emit("toggle-music")}>${this.musicEnabled ? "[ MUSIC: ON ]" : "[ MUSIC: OFF ]"}</button>
+          <button id="sfx-btn" title="Toggle sound effects"
+                  @click=${() => this._emit("toggle-sfx")}>${this.sfxEnabled ? "[ SFX: ON ]" : "[ SFX: OFF ]"}</button>
           <button id="save-btn" title="Save game state to file"
                   @click=${() => this._emit("save")}>[ SAVE ]</button>
           <label id="load-btn" title="Load game state from file">[ LOAD ]

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -9,6 +9,7 @@ import { handleTraceTick } from "../core/alert.js";
 import { initVisualRenderer } from "./visual-renderer.js";
 import { initLogRenderer } from "./log-renderer.js";
 import { initAudioRenderer, toggleMusic, isMusicEnabled } from "../audio/audio-renderer.js";
+import { initSfxRenderer, isSfxEnabled, toggleSfx } from "../audio/sfx/renderer.js";
 import { buildActionContext, initActionDispatcher, buildNodeClickHandler } from "../core/actions/action-context.js";
 import { openDarknetsStore } from "./store.js";
 import { initGraphBridge } from "../core/graph-bridge.js";
@@ -20,6 +21,7 @@ import { initProfileRunCommit } from "./profile-store.js";
 import { initResizers } from "./resizers.js";
 import "./hub-commands.js";
 import "../audio/music-commands.js";
+import "../audio/sfx/commands.js";
 
 import { NAMED_NETWORKS, DEFAULT_NETWORK, buildGenerated } from "../../data/networks/index.js";
 
@@ -70,6 +72,7 @@ function init() {
   initResizers();  // apply saved layout + wire the resize splitters
   initVisualRenderer();  // must subscribe before initGame fires STATE_CHANGED
   const audioEngine = initAudioRenderer();   // browser-only reactive audio; silent until a run starts
+  initSfxRenderer();
   initGraphBridge();
   initDynamicActions();
   initProfileRunCommit();  // wire RUN_ENDED → commit results back to the profile
@@ -116,8 +119,10 @@ function init() {
   let _userPaused = false;
   const hudEl = /** @type {any} */ (document.getElementById("hud"));
   hudEl.musicEnabled = isMusicEnabled();  // reflect the persisted music preference
+  hudEl.sfxEnabled = isSfxEnabled();
   // Keep the menu button in sync however music is toggled (button OR `music` console command).
   on(E.MUSIC_CHANGED, ({ enabled }) => { hudEl.musicEnabled = enabled; });
+  on(E.SFX_CHANGED, ({ enabled }) => { hudEl.sfxEnabled = enabled; });
   hudEl.addEventListener("hud-action", (e) => {
     const { action, file } = e.detail;
     switch (action) {
@@ -142,6 +147,9 @@ function init() {
       }
       case "toggle-music":
         toggleMusic();  // emits MUSIC_CHANGED → the handler above updates the button
+        break;
+      case "toggle-sfx":
+        toggleSfx();  // emits SFX_CHANGED → the handler above updates the button
         break;
     }
   });

--- a/preview/sfx.html
+++ b/preview/sfx.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Starnet audio — SFX harness</title>
+<style>
+  :root { --bg:#0a0a0f; --cyan:#22d3ee; --green:#39ff88; --mag:#ff00aa; --dim:#1b2330; }
+  body { background:var(--bg); color:var(--green); font-family:ui-monospace,monospace; margin:0; padding:2rem; }
+  h1 { color:var(--cyan); font-size:1.1rem; text-shadow:0 0 8px rgba(34,211,238,.5); }
+  .sub { color:#6b7a8d; font-size:.8rem; margin-bottom:1rem; }
+  #cues { display:flex; flex-wrap:wrap; gap:.5rem; max-width:760px; }
+  button.cue { background:transparent; color:var(--cyan); border:1px solid var(--cyan); border-radius:4px;
+    padding:.4rem .7rem; font:inherit; font-size:.8rem; cursor:pointer; text-shadow:0 0 6px rgba(34,211,238,.5); }
+  button.cue:hover { background:rgba(34,211,238,.1); }
+  #status { color:#6b7a8d; font-size:.8rem; margin-left:.5rem; }
+  h2 { color:var(--mag); font-size:.9rem; margin:1.6rem 0 .3rem; text-shadow:0 0 8px rgba(255,0,170,.4); }
+  #drones { display:flex; flex-direction:column; gap:.5rem; max-width:520px; }
+  .drone-row { display:flex; align-items:center; gap:.7rem; }
+  .drone-row button.cue { min-width:9rem; text-align:left; }
+  .drone-row input[type=range] { flex:1; accent-color:var(--mag); }
+</style>
+</head>
+<body>
+  <h1>STARNET // SFX HARNESS <span id="status">click any cue to start</span></h1>
+  <div class="sub">Click a cue to audition it. (Audio unlocks on first click.)</div>
+  <div id="cues"></div>
+  <h2>// ACTION DRONES (sustained)</h2>
+  <div class="sub">Toggle a drone on/off; drag its slider to sweep progress 0→1.</div>
+  <div id="drones"></div>
+  <script type="module" src="/js/audio/sfx/playground.js"></script>
+</body>
+</html>

--- a/tests/sfx-cues.test.js
+++ b/tests/sfx-cues.test.js
@@ -1,0 +1,255 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveCue } from "../js/audio/sfx/cues.js";
+import { E } from "../js/core/events.js";
+import { CUES } from "../js/audio/sfx/defs.js";
+
+// ACTION_RESOLVED — xploit
+test("xploit success -> xploit.ok", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "xploit", success: true }), "xploit.ok");
+});
+
+test("xploit failure -> xploit.fail", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "xploit", success: false }), "xploit.fail");
+});
+
+// ACTION_RESOLVED — mine outcomes (card escalates by rarity)
+test("mine card common -> mine.common", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "card", rarity: "common" } }), "mine.common");
+});
+
+test("mine card uncommon -> mine.uncommon", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "card", rarity: "uncommon" } }), "mine.uncommon");
+});
+
+test("mine card rare -> mine.rare", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "card", rarity: "rare" } }), "mine.rare");
+});
+
+test("mine card with unknown/absent rarity -> mine.common (fallback)", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "card" } }), "mine.common");
+});
+
+test("mine trap outcome -> mine.trap", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "trap" } }), "mine.trap");
+});
+
+test("mine miss outcome -> mine.miss", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "miss" } }), "mine.miss");
+});
+
+test("mine unknown outcome -> null", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "unknown" } }), null);
+});
+
+// ACTION_RESOLVED — fetch (value tiers + trap)
+test("fetch with trap -> fetch.trap", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "fetch", detail: { trap: true } }), "fetch.trap");
+});
+
+test("fetch small haul -> fetch", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "fetch", detail: { total: 500 } }), "fetch");
+});
+
+test("fetch big haul -> fetch.big", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "fetch", detail: { total: 9000 } }), "fetch.big");
+});
+
+test("fetch with no detail -> fetch (small)", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "fetch" }), "fetch");
+});
+
+// ACTION_RESOLVED — simple actions
+test("probe -> probe", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "probe" }), "probe");
+});
+
+test("dump -> dump", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "dump" }), "dump");
+});
+
+test("corrupt -> corrupt", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "corrupt" }), "corrupt");
+});
+
+test("unknown action -> null", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { action: "bogus" }), null);
+});
+
+// ICE_MOVED
+test("ICE_MOVED toVisible:true -> ice.move", () => {
+  assert.equal(resolveCue(E.ICE_MOVED, { toVisible: true }), "ice.move");
+});
+
+test("ICE_MOVED toVisible:false -> null", () => {
+  assert.equal(resolveCue(E.ICE_MOVED, { toVisible: false }), null);
+});
+
+// ALERT_GLOBAL_RAISED
+test("ALERT_GLOBAL_RAISED next:trace -> null", () => {
+  assert.equal(resolveCue(E.ALERT_GLOBAL_RAISED, { next: "trace" }), null);
+});
+
+test("ALERT_GLOBAL_RAISED next:red -> alert.up", () => {
+  assert.equal(resolveCue(E.ALERT_GLOBAL_RAISED, { next: "red" }), "alert.up");
+});
+
+test("ALERT_GLOBAL_RAISED next:yellow -> alert.up", () => {
+  assert.equal(resolveCue(E.ALERT_GLOBAL_RAISED, { next: "yellow" }), "alert.up");
+});
+
+// PLAYER_NAVIGATED
+test("PLAYER_NAVIGATED with nodeId -> navigate", () => {
+  assert.equal(resolveCue(E.PLAYER_NAVIGATED, { nodeId: "n1" }), "navigate");
+});
+
+test("PLAYER_NAVIGATED with null nodeId -> null", () => {
+  assert.equal(resolveCue(E.PLAYER_NAVIGATED, { nodeId: null }), null);
+});
+
+// RUN_ENDED — all outcomes
+test("RUN_ENDED outcome:success -> run.success", () => {
+  assert.equal(resolveCue(E.RUN_ENDED, { outcome: "success" }), "run.success");
+});
+
+test("RUN_ENDED outcome:caught -> run.caught", () => {
+  assert.equal(resolveCue(E.RUN_ENDED, { outcome: "caught" }), "run.caught");
+});
+
+test("RUN_ENDED outcome:burned -> run.burned", () => {
+  assert.equal(resolveCue(E.RUN_ENDED, { outcome: "burned" }), "run.burned");
+});
+
+test("RUN_ENDED outcome:bricked -> run.bricked", () => {
+  assert.equal(resolveCue(E.RUN_ENDED, { outcome: "bricked" }), "run.bricked");
+});
+
+// Direct mappings
+test("NODE_REVEALED -> reveal", () => {
+  assert.equal(resolveCue(E.NODE_REVEALED, {}), "reveal");
+});
+
+test("MISSION_COMPLETE -> mission", () => {
+  assert.equal(resolveCue(E.MISSION_COMPLETE, {}), "mission");
+});
+
+test("EXPLOIT_DISCLOSED -> decay", () => {
+  assert.equal(resolveCue(E.EXPLOIT_DISCLOSED, {}), "decay");
+});
+
+test("NODE_ACCESSED next:open -> access.open", () => {
+  assert.equal(resolveCue(E.NODE_ACCESSED, { next: "open" }), "access.open");
+});
+
+test("NODE_ACCESSED next:owned -> access.owned", () => {
+  assert.equal(resolveCue(E.NODE_ACCESSED, { next: "owned" }), "access.owned");
+});
+
+test("NODE_ALERT_RAISED next:green -> null", () => {
+  assert.equal(resolveCue(E.NODE_ALERT_RAISED, { next: "green" }), null);
+});
+
+test("NODE_ALERT_RAISED next:red -> node.alert", () => {
+  assert.equal(resolveCue(E.NODE_ALERT_RAISED, { next: "red" }), "node.alert");
+});
+
+test("EXPLOIT_PARTIAL_BURN -> burn", () => {
+  assert.equal(resolveCue(E.EXPLOIT_PARTIAL_BURN, { usesRemaining: 1 }), "burn");
+});
+
+test("ALERT_COOLED -> alert.down", () => {
+  assert.equal(resolveCue(E.ALERT_COOLED, {}), "alert.down");
+});
+
+test("ALERT_TRACE_STARTED -> trace.start", () => {
+  assert.equal(resolveCue(E.ALERT_TRACE_STARTED, {}), "trace.start");
+});
+
+test("ALERT_TRACE_CANCELLED -> trace.cancel", () => {
+  assert.equal(resolveCue(E.ALERT_TRACE_CANCELLED, {}), "trace.cancel");
+});
+
+test("ICE_DETECT_PENDING -> ice.pending", () => {
+  assert.equal(resolveCue(E.ICE_DETECT_PENDING, {}), "ice.pending");
+});
+
+test("ICE_DETECTED -> ice.locked", () => {
+  assert.equal(resolveCue(E.ICE_DETECTED, {}), "ice.locked");
+});
+
+test("ICE_EJECTED -> ice.ejected", () => {
+  assert.equal(resolveCue(E.ICE_EJECTED, {}), "ice.ejected");
+});
+
+test("ICE_REBOOTED -> ice.reboot", () => {
+  assert.equal(resolveCue(E.ICE_REBOOTED, {}), "ice.reboot");
+});
+
+test("ICE_DISABLED -> ice.down", () => {
+  assert.equal(resolveCue(E.ICE_DISABLED, {}), "ice.down");
+});
+
+test("RUN_STARTED -> run.start", () => {
+  assert.equal(resolveCue(E.RUN_STARTED, {}), "run.start");
+});
+
+// Unknown event
+test("unknown event type -> null", () => {
+  assert.equal(resolveCue("totally:unknown", {}), null);
+});
+
+// Exhaustiveness: every non-null id resolveCue can return must exist in CUES
+test("all resolvable cue ids exist in CUES", () => {
+  const returnedIds = new Set();
+
+  // Exercise every branch
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "probe" }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "dump" }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "corrupt" }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "xploit", success: true }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "xploit", success: false }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "fetch", detail: { trap: true } }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "fetch", detail: { total: 500 } }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "fetch", detail: { total: 9000 } }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "card", rarity: "common" } }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "card", rarity: "uncommon" } }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "card", rarity: "rare" } }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "trap" } }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "miss" } }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "mine", detail: { outcome: "unknown" } }));
+  returnedIds.add(resolveCue(E.ACTION_RESOLVED, { action: "bogus" }));
+  returnedIds.add(resolveCue(E.NODE_REVEALED, {}));
+  returnedIds.add(resolveCue(E.NODE_ACCESSED, { next: "open" }));
+  returnedIds.add(resolveCue(E.NODE_ACCESSED, { next: "owned" }));
+  returnedIds.add(resolveCue(E.NODE_ALERT_RAISED, { next: "green" }));
+  returnedIds.add(resolveCue(E.NODE_ALERT_RAISED, { next: "red" }));
+  returnedIds.add(resolveCue(E.EXPLOIT_PARTIAL_BURN, { usesRemaining: 1 }));
+  returnedIds.add(resolveCue(E.PLAYER_NAVIGATED, { nodeId: "n1" }));
+  returnedIds.add(resolveCue(E.PLAYER_NAVIGATED, { nodeId: null }));
+  returnedIds.add(resolveCue(E.ALERT_GLOBAL_RAISED, { next: "trace" }));
+  returnedIds.add(resolveCue(E.ALERT_GLOBAL_RAISED, { next: "red" }));
+  returnedIds.add(resolveCue(E.ALERT_COOLED, {}));
+  returnedIds.add(resolveCue(E.ALERT_TRACE_STARTED, {}));
+  returnedIds.add(resolveCue(E.ALERT_TRACE_CANCELLED, {}));
+  returnedIds.add(resolveCue(E.ICE_DETECT_PENDING, {}));
+  returnedIds.add(resolveCue(E.ICE_DETECTED, {}));
+  returnedIds.add(resolveCue(E.ICE_EJECTED, {}));
+  returnedIds.add(resolveCue(E.ICE_REBOOTED, {}));
+  returnedIds.add(resolveCue(E.ICE_DISABLED, {}));
+  returnedIds.add(resolveCue(E.ICE_MOVED, { toVisible: true }));
+  returnedIds.add(resolveCue(E.ICE_MOVED, { toVisible: false }));
+  returnedIds.add(resolveCue(E.RUN_STARTED, {}));
+  returnedIds.add(resolveCue(E.RUN_ENDED, { outcome: "success" }));
+  returnedIds.add(resolveCue(E.RUN_ENDED, { outcome: "caught" }));
+  returnedIds.add(resolveCue(E.RUN_ENDED, { outcome: "burned" }));
+  returnedIds.add(resolveCue(E.RUN_ENDED, { outcome: "bricked" }));
+  returnedIds.add(resolveCue(E.MISSION_COMPLETE, {}));
+  returnedIds.add(resolveCue(E.EXPLOIT_DISCLOSED, {}));
+  returnedIds.add(resolveCue("totally:unknown", {}));
+
+  // Remove nulls; every non-null id must exist in CUES
+  returnedIds.delete(null);
+  for (const id of returnedIds) {
+    assert.ok(id in CUES, `resolveCue returned "${id}" but it is not a key in CUES`);
+  }
+});

--- a/tests/sfx-defs.test.js
+++ b/tests/sfx-defs.test.js
@@ -1,0 +1,89 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CUES, CUE_IDS } from "../js/audio/sfx/defs.js";
+
+const VALID_KINDS = new Set(["blip", "sweep", "chord", "noise", "fm"]);
+
+test("CUE_IDS is non-empty and matches CUES keys", () => {
+  assert.ok(CUE_IDS.length > 0, "CUE_IDS must be non-empty");
+  assert.equal(CUE_IDS.length, Object.keys(CUES).length);
+});
+
+test("every cue has a valid kind", () => {
+  for (const [id, cue] of Object.entries(CUES)) {
+    assert.ok(
+      VALID_KINDS.has(cue.kind),
+      `cue "${id}" has invalid kind: "${cue.kind}"`
+    );
+  }
+});
+
+test("blip and fm cues have a non-empty note string", () => {
+  for (const [id, cue] of Object.entries(CUES)) {
+    if (cue.kind === "blip" || cue.kind === "fm") {
+      assert.equal(typeof cue.note, "string", `cue "${id}" note must be a string`);
+      assert.ok(cue.note.length > 0, `cue "${id}" note must be non-empty`);
+    }
+  }
+});
+
+test("chord cues have a non-empty array of strings for notes", () => {
+  for (const [id, cue] of Object.entries(CUES)) {
+    if (cue.kind === "chord") {
+      assert.ok(Array.isArray(cue.notes), `cue "${id}" notes must be an array`);
+      assert.ok(cue.notes.length > 0, `cue "${id}" notes must be non-empty`);
+      for (const note of cue.notes) {
+        assert.equal(typeof note, "string", `cue "${id}" notes must be strings`);
+      }
+    }
+  }
+});
+
+test("sweep cues have numeric from and to", () => {
+  for (const [id, cue] of Object.entries(CUES)) {
+    if (cue.kind === "sweep") {
+      assert.equal(typeof cue.from, "number", `cue "${id}" from must be a number`);
+      assert.equal(typeof cue.to, "number", `cue "${id}" to must be a number`);
+    }
+  }
+});
+
+test("noise cues have a numeric dur", () => {
+  for (const [id, cue] of Object.entries(CUES)) {
+    if (cue.kind === "noise") {
+      assert.equal(typeof cue.dur, "number", `cue "${id}" dur must be a number`);
+    }
+  }
+});
+
+test("every cue has a numeric volume <= 0", () => {
+  for (const [id, cue] of Object.entries(CUES)) {
+    assert.equal(typeof cue.volume, "number", `cue "${id}" volume must be a number`);
+    assert.ok(cue.volume <= 0, `cue "${id}" volume must be <= 0, got ${cue.volume}`);
+  }
+});
+
+test("optional detune is numeric and reverb is boolean when present", () => {
+  for (const [id, cue] of Object.entries(CUES)) {
+    if ("detune" in cue) assert.equal(typeof cue.detune, "number", `cue "${id}" detune must be a number`);
+    if ("reverb" in cue) assert.equal(typeof cue.reverb, "boolean", `cue "${id}" reverb must be a boolean`);
+  }
+});
+
+test("chord hits/hitGap are positive numbers when present", () => {
+  for (const [id, cue] of Object.entries(CUES)) {
+    if ("hits" in cue) {
+      assert.equal(typeof cue.hits, "number", `cue "${id}" hits must be a number`);
+      assert.ok(cue.hits >= 1, `cue "${id}" hits must be >= 1`);
+    }
+    if ("hitGap" in cue) assert.ok(typeof cue.hitGap === "number" && cue.hitGap > 0, `cue "${id}" hitGap must be > 0`);
+  }
+});
+
+test("spot-check specific cues exist with expected kinds", () => {
+  assert.equal(CUES["xploit.ok"].kind, "chord");
+  assert.equal(CUES["run.bricked"].kind, "fm");
+  assert.equal(CUES["fetch"].kind, "noise");
+  assert.equal(CUES["probe"].kind, "blip");
+  assert.equal(CUES["xploit.fail"].kind, "noise");
+});

--- a/tests/sfx-drones.test.js
+++ b/tests/sfx-drones.test.js
@@ -1,0 +1,73 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { DRONES, DRONE_IDS, resolveDrone } from "../js/audio/sfx/drones.js";
+
+const VALID_SOURCES = new Set(["sawtooth", "sine", "square", "triangle", "noise", "fm", "dual"]);
+// The 7 timed actions that emit ACTION_FEEDBACK (action field) — each must have a drone.
+const TIMED_ACTIONS = ["probe", "xploit", "dump", "fetch", "mine", "lie-low", "reboot"];
+
+test("DRONE_IDS is non-empty and matches DRONES keys", () => {
+  assert.ok(DRONE_IDS.length > 0);
+  assert.equal(DRONE_IDS.length, Object.keys(DRONES).length);
+});
+
+test("every timed action has a drone", () => {
+  for (const action of TIMED_ACTIONS) {
+    assert.ok(DRONES[action], `missing drone for timed action "${action}"`);
+  }
+});
+
+test("every drone has a valid source and numeric volume <= 0", () => {
+  for (const [id, d] of Object.entries(DRONES)) {
+    assert.ok(VALID_SOURCES.has(d.source), `drone "${id}" has invalid source "${d.source}"`);
+    assert.equal(typeof d.volume, "number", `drone "${id}" volume must be a number`);
+    assert.ok(d.volume <= 0, `drone "${id}" volume must be <= 0, got ${d.volume}`);
+  }
+});
+
+test("range params (cutoff/detune/gain) are number or {from,to} of numbers", () => {
+  for (const [id, d] of Object.entries(DRONES)) {
+    for (const key of ["cutoff", "detune", "gain"]) {
+      if (!(key in d)) continue;
+      const v = d[key];
+      if (typeof v === "object") {
+        assert.equal(typeof v.from, "number", `drone "${id}" ${key}.from must be a number`);
+        assert.equal(typeof v.to, "number", `drone "${id}" ${key}.to must be a number`);
+      } else {
+        assert.equal(typeof v, "number", `drone "${id}" ${key} must be a number or {from,to}`);
+      }
+    }
+  }
+});
+
+test("lfo, when present, is well-formed", () => {
+  for (const [id, d] of Object.entries(DRONES)) {
+    if (!d.lfo) continue;
+    assert.equal(typeof d.lfo.rate, "number", `drone "${id}" lfo.rate must be a number`);
+    assert.equal(typeof d.lfo.depth, "number", `drone "${id}" lfo.depth must be a number`);
+    assert.ok(["amp", "cutoff"].includes(d.lfo.target), `drone "${id}" lfo.target must be amp|cutoff`);
+  }
+});
+
+test("amp-LFO and progress-gain are mutually exclusive (engine constraint)", () => {
+  for (const [id, d] of Object.entries(DRONES)) {
+    const ampLfo = d.lfo && (d.lfo.target ?? "amp") === "amp";
+    const progressGain = d.gain && typeof d.gain === "object";
+    assert.ok(!(ampLfo && progressGain), `drone "${id}" can't use an amp-LFO and a progress-gain at once`);
+  }
+});
+
+test("resolveDrone maps timed actions to themselves and unknown actions to null", () => {
+  for (const action of TIMED_ACTIONS) assert.equal(resolveDrone(action), action);
+  assert.equal(resolveDrone("corrupt"), null);   // instant action — no drone
+  assert.equal(resolveDrone("reboot-complete"), null);
+  assert.equal(resolveDrone(undefined), null);
+  assert.equal(resolveDrone(""), null);
+});
+
+test("dual-source drones carry a detune sweep (the beat that resolves to lock-on)", () => {
+  for (const [id, d] of Object.entries(DRONES)) {
+    if (d.source !== "dual") continue;
+    assert.equal(typeof d.detune, "object", `dual drone "${id}" needs a {from,to} detune`);
+  }
+});


### PR DESCRIPTION
Adds a synthesized, event-driven **sound-effects layer** (issue #229) — short one-shot cyberpunk-terminal cues fired on discrete game events, **independent of the reactive music**, on its own always-available audio bus with its own on/off control.

## What it does

- Discrete cues across **6 families** (info / success / reward / failure / danger / relief), 32 cues total, mapped to events across the whole game: core loop (probe/xploit/dump/fetch/mine/corrupt), navigation/reveal/access, alert escalation + cooldown, trace start/cancel, ICE detect/lock/move/reboot/eject/disable, run start/end (per outcome), mission complete, exploit decay, and health/deck damage.
- Works with the music off, and in the hub.
- `SFX: ON / OFF` menu button + `sfx status|on|off|list|test <cue>` console command (GUI/console symmetry), persisted to `starnet:sfx-enabled`.

## Architecture (mirrors the music subsystem)

| File | Role |
|---|---|
| `js/audio/sfx-defs.js` | pure `CUES` catalog + `CUE_IDS` |
| `js/audio/sfx-cues.js` | pure `resolveCue(type, payload) → cueId\|null` |
| `js/audio/sfx.js` | the only Web Audio boundary: 5 primitives (blip/sweep/chord/noise/fm), own master Gain → reverb, schedule at `currentTime+offset`, **dispose-after-play**, voice cap |
| `js/audio/sfx-renderer.js` | browser-only event subscriber; `alert.up` pitch-by-level; health/deck `STATE_CHANGED` diff → `hurt.*`; 50ms dedupe; gesture-arm; pref + `SFX_CHANGED` |
| `js/audio/sfx-commands.js` | `sfx` console command |
| `preview/sfx.html` + `sfx-playground.js` | audition harness (button per cue) |

Dispose-after-play means SFX add **no long-lived AudioParam accumulation** (the bug that caused the music engine's over-time stutter). Browser-only: headless entry points (`scripts/`) never import any of it.

## Test plan

- `make check` green — **1356 tests pass, lint clean**.
- Unit suites: `tests/sfx-defs.test.js` (every cue is a well-formed spec; known primitive kinds) + `tests/sfx-cues.test.js` (mapping key cases + exhaustiveness).
- Headless SFX-free confirmed: `grep -rn "audio/sfx" scripts/` empty.
- **Browser smoke** (headless Chromium): SFX button present in HUD; all 32 cues synthesize via `playCue` with **zero console errors**; toggle flips; `sfx` console command registered.
- Docs updated: `MANUAL.md`, `docs/audio-direction.md`, `CLAUDE.md`.

## Notes

- Cue specs are deliberately **ear-tunable rough drafts** — a by-ear tuning pass via `preview/sfx.html` is the natural follow-up.
- Out of scope for v1: music ducking under SFX; sample/vocal one-shots (#230); positional audio; per-cue volume UI.

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)