### PR TITLE
Keep VISIT WAN button; stack JACK OUT beneath it under pressure

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -90,10 +90,11 @@ deck integrity falls its edges develop deepening ringing, overshoot and timing/a
 glitches (the amplitude itself stays roughly constant); it flatlines at zero. Hover
 either trace to see the exact value as a percentage.
 
-**Uplink control** — Floating beneath the vital traces (upper-right). Normally shows
+**Uplink control** — Floating beneath the vital traces (upper-right). Shows
 `[ VISIT WAN ]`, which selects the WAN node (useful shortcut to reach the darknet broker,
 lie-low, or disconnect). When the global alert is elevated (not green) or a trace is
-counting down, it switches to a pulsing `[ JACK OUT ]` for instant disconnect.
+counting down, a pulsing `[ JACK OUT ]` for instant disconnect is stacked beneath it —
+`[ VISIT WAN ]` stays available so you can still hop to the WAN to lie low under pressure.
 
 **Resizing the layout** — Two borders are drag-resizable: the border above the log/console
 (graph vs. log height) and the border between the log and the exploit hand (log vs. hand
@@ -331,9 +332,9 @@ Three paths to the same outcome:
 
 - **`jackout` console command** — instant, works any time.
 - **`[ JACK OUT ]` uplink control** — the button floated in the upper-right corner of
-  the graph. It appears in place of `[ VISIT WAN ]` whenever the global alert is elevated
-  (not green) or a trace is counting down; at green alert it shows `[ VISIT WAN ]` instead
-  (which selects the WAN node rather than ending the run).
+  the graph. It appears stacked beneath `[ VISIT WAN ]` whenever the global alert is elevated
+  (not green) or a trace is counting down; at green alert only `[ VISIT WAN ]` shows (which
+  selects the WAN node rather than ending the run).
 - **`exec disconnect`** — the in-fiction path. Target the WAN node and choose DISCONNECT
   from the EXEC submenu in the node inspector (or type `exec disconnect`). Severs the uplink
   and ends the run.

--- a/js/ui/components/starnet-uplink.js
+++ b/js/ui/components/starnet-uplink.js
@@ -1,9 +1,10 @@
 // <starnet-uplink> — Floating uplink control beneath the vital traces.
-// Two modes, driven by visual-renderer from game state:
-//   "visit"   → "[ VISIT WAN ]" selects the WAN node (its inspector exposes
-//               ACCESS DARKNET / LIE LOW / DISCONNECT).
-//   "jackout" → "[ JACK OUT ]" replaces it when alert is elevated or a trace is
-//               counting down — the escape hatch, surfaced exactly when needed.
+// Driven by visual-renderer from game state:
+//   VISIT WAN  → selects the WAN node (its inspector exposes ACCESS DARKNET /
+//                LIE LOW / DISCONNECT). Shown whenever a WAN node exists.
+//   JACK OUT   → the escape hatch, stacked beneath VISIT WAN when alert is
+//                elevated or a trace is counting down. VISIT WAN stays available
+//                so the player can still hop to the WAN to LIE LOW under pressure.
 // Dispatches the shared bubbling `starnet:action` event (forwarded by main.js),
 // so no bespoke wiring is required.
 
@@ -12,14 +13,14 @@ import { StarnetElement } from "./starnet-element.js";
 
 class StarnetUplink extends StarnetElement {
   static properties = {
-    mode: { type: String },        // "visit" | "jackout"
+    danger: { type: Boolean },     // alert elevated or trace counting down
     visible: { type: Boolean },
     wanNodeId: { type: String },
   };
 
   constructor() {
     super();
-    this.mode = "visit";
+    this.danger = false;
     this.visible = false;
     this.wanNodeId = "";
   }
@@ -31,22 +32,19 @@ class StarnetUplink extends StarnetElement {
     }));
   }
 
-  _onClick() {
-    if (this.mode === "jackout") {
-      this._action("jackout");
-    } else if (this.wanNodeId) {
-      this._action("target", { nodeId: this.wanNodeId });
-    }
-  }
-
   render() {
     if (!this.visible) return nothing;
-    const jackout = this.mode === "jackout";
     return html`
-      <button class="uplink-btn ${jackout ? "uplink-danger" : ""}"
-              @click=${() => this._onClick()}>
-        ${jackout ? "[ JACK OUT ]" : "[ VISIT WAN ]"}
-      </button>`;
+      ${this.wanNodeId ? html`
+        <button class="uplink-btn"
+                @click=${() => this._action("target", { nodeId: this.wanNodeId })}>
+          [ VISIT WAN ]
+        </button>` : nothing}
+      ${this.danger ? html`
+        <button class="uplink-btn uplink-danger"
+                @click=${() => this._action("jackout")}>
+          [ JACK OUT ]
+        </button>` : nothing}`;
   }
 }
 

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -397,8 +397,9 @@ function syncVitals(state) {
 }
 
 // ── Uplink control (floats under the vitals) ──────────────
-// VISIT WAN normally (selects the WAN node); JACK OUT when alert is elevated or
-// a trace is counting down — the escape hatch, surfaced exactly when needed.
+// VISIT WAN whenever a WAN node exists (selects it); JACK OUT stacks underneath
+// when alert is elevated or a trace is counting down — the escape hatch is
+// surfaced exactly when needed without hiding the quick hop to the WAN.
 function syncUplink(state) {
   const el = /** @type {any} */ (document.getElementById("uplink-btn"));
   if (!el) return;
@@ -406,7 +407,7 @@ function syncUplink(state) {
   const danger = state.globalAlert !== "green" || state.traceSecondsRemaining !== null;
   const wan = Object.values(state.nodes).find((n) => /** @type {any} */ (n).type === "wan");
   el.wanNodeId = wan?.id || "";
-  el.mode = danger ? "jackout" : "visit";
+  el.danger = danger;
   el.visible = playing && (danger || !!wan);
 }
 


### PR DESCRIPTION
The uplink control previously *replaced* `[ VISIT WAN ]` with `[ JACK OUT ]` whenever the global alert was elevated or a trace was counting down. That hid the quick hop to the WAN exactly when it can still be useful under pressure (e.g. to **LIE LOW** to cool the grid back down).

## Change

Render both buttons independently:

- `[ VISIT WAN ]` — shown whenever a WAN node exists (selects it).
- `[ JACK OUT ]` — pulsing red escape hatch, stacked **beneath** VISIT WAN when in danger (alert not green, or a trace counting down).

`<starnet-uplink>` now takes a `danger` boolean instead of a `mode: "visit"|"jackout"` string; `visual-renderer.syncUplink` sets it from the same alert/trace condition as before. The danger-but-no-WAN edge case still shows JACK OUT alone. Existing full-width (`width:100%`, `margin-top:2px`) button CSS handles the vertical stacking with no style changes.

`MANUAL.md` updated in both places that described the old swap behavior.

## Verification

- `make check` — lint (tsc) clean, all 1310 tests pass.
- Could not produce a live browser screenshot in this environment (no Playwright available; repo has no headless Lit-component harness). Render correctness rests on review of the two-button template plus the green lint/test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)