### PR TITLE
Vary the music drone chord over a run + hub (#239)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -808,8 +808,12 @@ from layers rather than a fixed loop.
   damage, urgency layers and a filter sweep cut in — fast to rise, slow to ease back down.
 - **Variety.** Each run picks one of several scores (different moods/keys/tempos), and the
   arrangement periodically shifts into breakdowns so a long run never sits still.
-- **The hub has its own calm ambient theme**, separate from the LAN scores. The run's music
-  **fades out** when you jack out, and the hub ambience drifts back in.
+- **A wandering harmonic bed.** The sustained drone chord doesn't hold one note all run — it
+  drifts to neighbouring chords in the score's key every few bars, so the harmony slowly
+  evolves instead of droning on. It always stays in key and consonant.
+- **The hub has its own calm ambient theme**, separate from the LAN scores. Its drone and pad
+  drift together through the key the same way, for more variety while you linger. The run's
+  music **fades out** when you jack out, and the hub ambience drifts back in.
 
 **Music commands** (console): `music` shows what's playing, `music list` lists the scores,
 `music next` switches randomly, `music <name>` picks one (e.g. `music neon`), `music on|off`.

--- a/docs/audio-direction.md
+++ b/docs/audio-direction.md
@@ -234,7 +234,7 @@ stays rhythmically aligned as layers fade in. Progress layers *blossom*; threat 
 
 | Layer | Role / character | Driven by | Anchor |
 |---|---|---|---|
-| **Drone** | wandering detuned pad, always present | baseline + slight ↑ progress | EVE / BoC |
+| **Drone** | wandering detuned pad, always present; harmonically wanders (see below) | baseline + slight ↑ progress | EVE / BoC |
 | **Base perc** | sparse kick + hat, minimal pulse | progress > 0 (early) | Mr. Robot |
 | **Double-time perc** | busier hats/snare | progress ~0.3→0.7 | Mr. Robot |
 | **Bass** | square/sub bassline | progress ~0.2→0.5 | — |
@@ -249,6 +249,28 @@ counts so the music starts unfolding before nodes are fully owned.
 **Threat scalar** = `globalAlert` (green/yellow/red/trace → 0/.33/.66/1) blended with a transient
 bump from recent `ICE_DETECTED` and a term for low health/deck. Smoothed, **fast attack (~0.3s)
 / slow release (~1.5s)** — adrenaline spike, gradual calm-down.
+
+### Drone harmonic wander (#239)
+
+The always-present `drone` no longer holds one chord all run — it **planes to neighbouring
+diatonic degrees** every few bars (`DRONE_BARS_DEFAULT`, currently 4; overridable per score via
+`droneBars`) so the harmonic bed evolves. Algorithmic, not hand-authored:
+
+- **`js/audio/harmony.js`** (pure, Tone-free, unit-tested) — `transposeDiatonic(notes, root, mode,
+  steps)` shifts a chord by `steps` scale degrees within the score's key; `consonantSteps(drone,
+  root, mode)` returns the offsets that keep the drone's perfect fifth perfect (the excluded one
+  is mode-specific — a fixed list is wrong outside aeolian); `pickNextStep(rng, current, steps)`
+  picks the next offset, no immediate repeat.
+- **Score data** — each wandering score declares `root` + `mode`; sustained layers opt in with
+  `wander: true`. Home chord = step 0.
+- **Engine** — an independent seeded RNG (`getSeed()+":drone"`, never gameplay RNG) drives a
+  bar-quantized `Transport.scheduleRepeat`, mirroring the section automation. Each wander layer
+  crossfades on its own `PolySynth` (`triggerRelease` old + `triggerAttack` new) — the slow
+  attack/release envelopes overlap into a gapless morph.
+- **Scope** — only the base `drone` in run scores. The **hub** wanders its `drone` **and** `pad`
+  together (cycling Am7 → Cmaj7 → Dm7 → Em7 → Fmaj7 → G7); the high shimmer stays a static anchor.
+  The threat `tensionDrone` is untouched. Ear-check the cadence/feel via the **WANDER NOW** button
+  in `preview/audio.html` (the hub is selectable there too).
 
 ### Transitions
 

--- a/docs/dev-sessions/2026-06-14-2242-music-drone-variation/notes.md
+++ b/docs/dev-sessions/2026-06-14-2242-music-drone-variation/notes.md
@@ -1,0 +1,49 @@
+# Notes — drone harmonic variation
+
+## Mode analysis per score (from lead/bass note content)
+
+Confirmed by reading each score's authored lead + bass arrays. A couple diverge from the issue's
+sketch — trust the data:
+
+| Score | root | mode | evidence |
+|---|---|---|---|
+| Dread | A | aeolian | A B C D E F G; Bb is the chromatic ♭2 turn, not the mode |
+| Cold | C | **aeolian** | bass `Ab` (♭6) → natural minor, NOT dorian as the issue guessed |
+| Noir | D | dorian | minor (♭3 F), no 6th written; noir-jazz dorian per issue; `Ab` is a blue note |
+| Haze | G | **ionian (major)** | lead `B` (maj3) + `F#` (maj7), `C` natural → G major |
+| Industrial | E | **phrygian** | lead/bass `F` natural (♭2) + `C` (♭6) → E phrygian (matches the menace) |
+| Neon | F# | aeolian | F# A B C# E (minor pentatonic); default natural minor |
+| Pulse | A | **ionian (major)** | lead `C#` (maj3) + `F#` → A major |
+| Vast | A | aeolian | A C E G (Am7), bass `F` (♭6) |
+| Hub | A | aeolian | drone A+E over Cmaj pad = Am7; relative-major shimmer |
+
+## Design correction during execution
+
+A fixed `ALLOWED_STEPS` is mode-specific and WRONG outside aeolian. The diminished diatonic fifth
+sits on a different degree per mode (e.g. E phrygian: the bad offset is step 4, and step 1 is
+fine — the reverse of aeolian). Fix: `consonantSteps(droneNotes, root, mode)` computes, per score,
+the offsets that preserve the drone chord's interval shape (its perfect fifth). The engine picks
+from that per-score set. The pad (hub) follows the drone's steps; its triad is allowed to change
+quality (that's the desired diatonic planing) and stays consonant combined with the drone.
+
+## Bug: "loud crackly static that gets worse over time" (ear-check feedback)
+
+Root-caused with the `superpowers:systematic-debugging` discipline + a temporary in-engine
+diagnostic (`_wanderDebug`) driven via Playwright (measured voice pool size, per-voice param-event
+timeline length, and a master-tap analyser peak across forced wanders).
+
+- **Ruled out:** voice leak (Tone reuses + GCs voices — pool plateaued, didn't run away) and
+  amplitude clipping (master peak stayed ~0.06, flat).
+- **Confirmed:** the v1 wander retriggered ONE long-lived `PolySynth` per layer every few bars.
+  Tone reuses that synth's voices, and Web Audio never prunes their `setValueAtTime`/ramp events,
+  so the per-voice automation timeline (and the voice pool under load) **climbed monotonically**
+  (pool 2→8, maxVoiceEvents 2→5 over 10 wanders) → compounding audio-thread crackle. This is the
+  exact hazard the file already documents for sequenced layers — but sustained layers were exempt
+  from the recycler under a now-false "one trigger" assumption.
+- **Fix:** mint a FRESH synth per wander (`makeSynth` factory); the new synth attacks the new
+  chord while the old releases, then the old is disposed after its release tail (`retireSynth`,
+  cleaned up in `teardown`). Each synth instance is triggered exactly once → no accumulation.
+- **Verified:** same stress test after the fix → pool flat at 2, maxVoiceEvents flat at 2, peak
+  unchanged. Crossfade overlap preserved.
+- **Still pending:** Les's live ear-check (he stepped away) — confirm the crackle is gone by ear
+  and the morph still sounds seamless.

--- a/docs/dev-sessions/2026-06-14-2242-music-drone-variation/plan.md
+++ b/docs/dev-sessions/2026-06-14-2242-music-drone-variation/plan.md
@@ -1,0 +1,62 @@
+# Plan — drone harmonic variation
+
+TDD throughout for the pure module + score data. The Tone-touching engine wander is verified by
+its pure helper (`pickNextStep`) in tests and by ear in the playground.
+
+## Phase 1 — `js/audio/harmony.js` (pure, TDD)
+
+1. Write `tests/audio/harmony.test.js` first (red):
+   - `SCALES` has the modes the scores use.
+   - `scaleNotes("A","aeolian")` → `["A","B","C","D","E","F","G"]`; `scaleNotes("C","dorian")` →
+     `["C","D","Eb","F","G","A","Bb"]`; a sharp key (`F#`...) spells with sharps.
+   - `transposeDiatonic(["A2","E3"],"A","aeolian",0)` === `["A2","E3"]` (identity).
+   - `transposeDiatonic(["A2","E3"],"A","aeolian",2)` === `["C3","G3"]`; `...,6)` === `["G3","D4"]`.
+   - For every `ALLOWED_STEPS` entry, the transposed `["A2","E3"]` is a perfect fifth (+7 semis)
+     and both notes ∈ scale.
+   - `transposeDiatonic(["C4","E4","G4"],"A","aeolian",2)` → `["E4","G4","B4"]` (triad planes).
+   - `pickNextStep`: only emits `ALLOWED_STEPS`; never equals `currentStep`; deterministic per seed.
+2. Implement `harmony.js` to green. Run `make lint` (it's `@ts-check`).
+
+## Phase 2 — score data `root`/`mode` + `wander` flags (TDD)
+
+1. Read each corporate variant's lead/bass notes to confirm mode (aeolian vs dorian vs phrygian).
+   Record the mapping in notes.md.
+2. Write `tests/audio/score-harmony.test.js` first (red): import every score; assert each has
+   `root`+`mode`, `transposeDiatonic(drone.sustain, root, mode, 0)` === `drone.sustain`, and the
+   planed drone fifth is perfect across all `ALLOWED_STEPS`.
+3. Add `root`/`mode` to all 8 corporate scores + hub; add `wander:true` to the `drone` layer
+   (all scores) and the hub `pad` layer. Green.
+
+## Phase 3 — engine wander loop (`js/audio/engine.js`)
+
+1. Stash `wanderHome`/`wander` in `buildLayer` for flagged sustained layers.
+2. Add wander state (`droneRng`, `droneTimerId`, `currentStep`) mirroring the section state; init
+   in `start()` (gated on `score.root && score.mode` && ≥1 wander layer), tear down in `teardown()`.
+3. `wander()`: `pickNextStep` → `transposeDiatonic` each wander layer's home → `triggerRelease`
+   old + `triggerAttack` new on its `sustainSynth`; track current notes per layer.
+4. `make check` green (engine has no new unit test beyond `pickNextStep`; it's `@ts-nocheck`).
+
+## Phase 4 — playground ear-check aid
+
+1. Add a "Wander now" button (+ current-step/chord readout) to `js/audio/playground.js` /
+   `preview/audio.html` that calls a small engine hook to force a wander tick immediately.
+2. Keep it playground-only (like `setMuted`/`setSectionsEnabled`).
+
+## Phase 5 — ear-check + docs
+
+1. **Checkpoint with Les:** `make serve`, listen in a live run and in the hub. Tune `droneBars`
+   and confirm the morph feel + hub consonance (esp. static shimmer vs the planing pad). Adjust
+   constants only.
+2. Update `MANUAL.md` (drone now evolves) and `docs/audio-direction.md` (drone-layer row +
+   deferred list: drone wander shipped for run + hub).
+3. `make check` green; write notes.md summary.
+
+## Risks / watch-items
+
+- **Note spelling** across keys (flats vs sharps) — covered by `scaleNotes` + pitch-class matching.
+- **Teardown leak** — the new `scheduleRepeat` id must be cleared like `sectionTimerId` (the repo
+  has a prior run-start timer-leak regression; mirror the section cleanup exactly).
+- **Determinism** — `:drone` stream only; never call gameplay RNG. Same seed → same wander.
+- **Static shimmer** in the hub may add mild upper tension on Dm7/Fmaj7 — note for the ear-check;
+  fallback is to wander or drop it (cheap follow-up, not blocking).
+- Headless safety unchanged (engine isn't imported by headless entry points).

--- a/docs/dev-sessions/2026-06-14-2242-music-drone-variation/research.md
+++ b/docs/dev-sessions/2026-06-14-2242-music-drone-variation/research.md
@@ -1,0 +1,62 @@
+# Research — drone harmonic variation
+
+## Audio subsystem map (verified at this commit)
+
+- `js/audio/engine.js` — Tone wrapper. Owns master bus, per-layer synths/gains, the
+  **section-automation** loop (the pattern to mirror), and the param-recycle GC. Key bits:
+  - `buildLayer(spec)`: a `spec.sustain` layer becomes a `Tone.PolySynth` stored as
+    `layers[key] = { gain, sustainSynth, sustain }`. Sustained layers are kicked off in
+    `start()` via `sustainSynth.triggerAttack(layer.sustain)`.
+  - Section automation: `sectionRng = makeSeededRng((getSeed()||"audio")+":sections")`,
+    `Tone.Transport.scheduleRepeat(() => advanceSection(), "${bars}m", "${bars}m")`,
+    seeded no-immediate-repeat pick, cleaned up in `teardown()` via `Tone.Transport.clear(id)`.
+  - `recycleTick()` only touches **sequenced** layers (`l.seq`); sustained drone layers are
+    never recycled → wander state on the drone synth is safe across the run.
+  - `teardown()` already resets all section transient state; the drone-wander state must be
+    reset there too, and re-initialised in `start()`.
+- `js/audio/scores/*.js` — pure data. Base `drone` layer is `axis:"base"`, `sustain:[low,fifth]`
+  (root + perfect fifth power voicing). `tensionDrone` is `axis:"threat"` with `[root, ♭2]`
+  (Phrygian menace) — **out of scope**, leave as-is.
+- `js/audio/scores/index.js` — `BIOME_SCORES.corporate` pool + `selectScore(biome)`
+  (independent `:score` seeded RNG). Hub is **not** in the pool; selected directly.
+- `js/audio/audio-renderer.js` — `desiredScore()` returns `HUB_AMBIENT` in the overworld,
+  the per-run score during a run. Same `engine` instance plays both, so a wander mechanism in
+  the engine covers hub + run with no renderer changes.
+- `js/audio/mixer.js` — `computeMix`; `axis:"base"` gain = `baseGain + progressBoost*progress`.
+  Untouched by this work (wander changes pitch, not gain).
+- `js/core/rng.js` — `makeSeededRng(seedString)` + `getSeed()`. Independent of gameplay streams.
+
+## Drone roots/fifths per score (from `sustain` of the `drone` layer)
+
+| Score | drone sustain | root | fifth | mode (to assign) |
+|---|---|---|---|---|
+| Dread (corporate.js) | A2 E3 | A | E | aeolian |
+| Cold | C3 G3 | C | G | dorian |
+| Noir | D3 A3 | D | A | dorian |
+| Haze | G2 D3 | G | D | (derive: aeolian/dorian by lead notes) |
+| Industrial | E2 B2 | E | B | (derive — phrygian-leaning) |
+| Neon | F#2 C#3 | F# | C# | (derive) |
+| Pulse | A2 E3 | A | E | aeolian |
+| Vast | A2 E3 A3 | A | E | aeolian |
+| **Hub** (hub.js) | A2 E3 | A | E | aeolian |
+
+Mode per score will be confirmed during execution by reading each score's lead/bass note
+content (the diatonic content reveals natural-6 dorian vs flat-6 aeolian, etc.).
+
+## Power-fifth consonance check (why exclude degree ii)
+
+Allowed degrees **{i, III, iv, v, VI, VII}** = all diatonic degrees minus **ii**. With a fixed
+**+7 semitone** (perfect-fifth) voicing, every allowed degree keeps **both** notes in-key; only
+ii's diatonic fifth is a tritone / leaves the scale (e.g. A-aeolian ii = B, B+F# pulls F# out of
+the F-natural scale). The home chord equals `chordForDegree(root, mode, i, octave)`, so wandering
+to i returns home — a free invariant to assert in tests.
+
+## Decisions locked by research
+
+- Wander operates on the existing drone `PolySynth` via `triggerRelease(old)` + `triggerAttack(new)`;
+  the drone synth's configured slow attack/release envelopes overlap into a gapless morph.
+- Octave is parsed from the drone layer's home `sustain[0]` (e.g. `"A2"` → 2) — no new score field
+  needed beyond `root`/`mode`.
+- One mechanism, gated on `score.root && score.mode`. Scores without them don't wander (still true
+  for any future opt-out score), but **the hub now opts in** (Les's added requirement; diverges
+  from the issue's "hub stays as-is").

--- a/docs/dev-sessions/2026-06-14-2242-music-drone-variation/spec.md
+++ b/docs/dev-sessions/2026-06-14-2242-music-drone-variation/spec.md
@@ -1,0 +1,119 @@
+# Spec — Vary the music drone chord over a run
+
+GitHub issue: https://github.com/lmorchard/starnet/issues/239
+
+## Problem
+
+Every reactive score holds a single sustained drone power-chord (root + perfect fifth, e.g.
+`A2+E3`) for an entire run. It's monotonous — the same incessant pad start to finish. The
+overworld **hub** ambient has the same problem and was specifically called out as needing more
+variety.
+
+## Goal
+
+The always-present base `drone` layer occasionally shifts its power-chord to another diatonic
+degree, so the harmonic bed slowly evolves. Deterministic per run seed, always consonant, no
+gaps or clicks. Applies to **run scores and the hub** ambient.
+
+## Scope divergence from the issue (approved by Les)
+
+The issue says "the hub ambient stay as-is" and "scores without `root`/`mode` (hub) simply don't
+wander." Les explicitly asked to **also vary the hub** — "we need more variety there" — and chose
+to wander **both the drone and the Cmaj pad together** (the high `shimmer` stays as a static
+anchor). So the hub opts into the same mechanism with two wander targets.
+
+## Refinement of the issue's mechanism: diatonic transposition (not `chordForDegree`)
+
+The issue sketched a `chordForDegree(root, mode, degree, octave)` power-fifth function. Wandering
+the **pad** as well makes a cleaner primitive available: **diatonic transposition of each layer's
+home chord by a shared scale-step offset δ**. This is what the engine actually uses.
+
+- For the drone's power-fifth home (`A+E`), every allowed δ keeps it a **perfect fifth**; the one
+  excluded offset (δ=1, landing the drone on `ii`) is exactly the one that would make it
+  diminished — so the exclusion rule falls out naturally.
+- For the pad's **triad** home (`C-E-G`), diatonic transposition keeps it a diatonic triad.
+- Drone + pad planing together by the same δ yields a clean run of diatonic 7th chords —
+  **Am7 → Cmaj7 → Dm7 → Em7 → Fmaj7 → G7** (δ = 0,2,3,4,5,6) — all consonant and functional, so
+  moving the pad carries no clash risk. δ=0 reproduces the home sound (Am7) exactly.
+
+## Approach
+
+### 1. New pure module `js/audio/harmony.js` (Tone-free, unit-tested)
+
+- `SCALES`: mode name → 7 semitone intervals from the root (`aeolian` `[0,2,3,5,7,8,10]`,
+  `dorian` `[0,2,3,5,7,9,10]`, plus `phrygian`/`mixolydian`/etc. as the scores in play need).
+- `scaleNotes(root, mode) → [7 spelled note names]` — spells the scale so transposition output
+  matches the key's accidental style (flats for C dorian, sharps for F# scores).
+- `transposeDiatonic(notes, root, mode, steps) → notes` — maps each input note to its scale
+  degree + octave **by pitch class** (so `Bb` matches a flat-spelled scale tone), shifts by
+  `steps` scale degrees with octave wrap, re-spells from `scaleNotes`. `steps = 0` is identity.
+- `ALLOWED_STEPS = [0, 2, 3, 4, 5, 6]` — offsets that land the **drone** (home degree i) on
+  `{i, III, iv, v, VI, VII}`; **excludes δ=1 (`ii`)**, the offset that would break the perfect fifth.
+- `pickNextStep(rngFn, currentStep) → step` — equal weight over `ALLOWED_STEPS`, no immediate repeat.
+- note-name ⟷ MIDI helpers (parse/emit `"Bb2"`, `"F#2"`, etc.).
+
+### 2. Score data — add `root` + `mode`, mark wander targets
+
+- All 8 Corporate variants + the hub get `root` (e.g. `"A"`) and `mode` (e.g. `"aeolian"`),
+  derived from existing harmony. A unit test asserts `transposeDiatonic(drone.sustain, root, mode,
+  0)` is the identity and that the drone fifth stays perfect across every allowed step.
+- Mark wandering sustained layers with a `wander: true` flag on the layer spec:
+  - Corporate scores: only `drone`.
+  - Hub: `drone` **and** `pad`. (`shimmer` stays static.)
+- A score with no `root`/`mode` (or no `wander` layers) does not wander — opt-in preserved.
+
+### 3. Engine wander loop (`js/audio/engine.js`) — mirror section automation
+
+- Independent seeded RNG: `makeSeededRng((getSeed()||"audio") + ":drone")` — deterministic per
+  run, never touches gameplay RNG.
+- In `buildLayer`, stash each wander layer's home notes (`layer.wanderHome = spec.sustain`).
+- On `start()`, if the active score has `root && mode` and ≥1 `wander` layer:
+  - `currentStep = 0`; `Tone.Transport.scheduleRepeat(wander, "${bars}m", "${bars}m")` every
+    `score.droneBars ?? DRONE_BARS_DEFAULT` bars (bar-quantized, like sections; default tuned to 4).
+- `wander()`: `currentStep = pickNextStep(rng, currentStep)`; for each wander layer, compute
+  `transposeDiatonic(layer.wanderHome, root, mode, currentStep)` and on its `sustainSynth` call
+  `triggerRelease(currentNotes)` + `triggerAttack(newNotes)`. All wander layers move by the same
+  δ on the same tick. The drone synth's slow attack/release envelopes overlap → gapless morph.
+- Teardown/cleanup mirrors section state: clear the scheduled id, null the rng, reset `currentStep`;
+  re-init on the next `start()`.
+
+### 4. Playground aid (optional, for ear-checking)
+
+Add a "wander now" button (and/or a degree readout) to `js/audio/playground.js` /
+`preview/audio.html` so the morph can be triggered on demand instead of waiting the bar interval.
+
+## Out of scope
+
+- The `tensionDrone` (threat layer, already threat-reactive) — untouched.
+- Per-note sequenced layers, mixer gains, the two-axis model — untouched.
+- Hand-authored alternate chord progressions (this is algorithmic from a scale model).
+
+## Testing
+
+- **`harmony.js` unit tests:** `transposeDiatonic` — `steps=0` is identity; every output note is
+  in `scaleNotes(root, mode)`; the drone power-fifth stays exactly +7 semitones for every
+  `ALLOWED_STEPS` entry; octave wrap is correct; flats/sharps spell per key. `scaleNotes` spells
+  known scales correctly. `pickNextStep` never repeats immediately, only emits `ALLOWED_STEPS`,
+  and is deterministic for a seeded rng.
+- **Score-data invariant test:** for every score with `root`/`mode`, `transposeDiatonic(drone
+  .sustain, root, mode, 0)` equals the drone `sustain`; the planed drone fifth is perfect across
+  all allowed steps. (Confirms each score's `root`/`mode` actually matches its authored harmony.)
+- **Engine test (headless-safe):** the wander step sequence is seeded/deterministic, never repeats
+  immediately, never emits the `ii` offset — tested against `pickNextStep`, not Tone. (Tone calls
+  themselves stay un-unit-tested; verified by ear.)
+- `make check` green (lint + 1310+ tests).
+- **Ear-check checkpoint with Les** in a live run + hub before merge — the one thing tests can't
+  cover. Wander cadence (`DRONE_BARS_DEFAULT`, currently 4), envelope overlap feel, hub consonance against the Cmaj pad.
+
+## Verification / done criteria
+
+- A run's drone audibly shifts chords a few times over a typical run; the hub drifts in the
+  overworld; both stay consonant and gapless.
+- Same seed → same wander sequence (determinism preserved; gameplay RNG untouched).
+- `make check` green; manual ear-check approved by Les; MANUAL.md / audio-direction.md updated.
+
+## Notes
+
+- Branch `music-drone-variation` off `main`; not part of event-SFX work (#229 / PR #237).
+- `docs/audio-direction.md` is the music-subsystem reference; update its drone-layer row +
+  deferred list to reflect that the drone now wanders (run + hub).

--- a/js/audio/engine.js
+++ b/js/audio/engine.js
@@ -3,11 +3,13 @@
 import * as Tone from "/dist/tone.js";
 import { computeMix } from "./mixer.js";
 import { makeSeededRng, getSeed } from "../core/rng.js";
+import { transposeDiatonic, consonantSteps, pickNextStep } from "./harmony.js";
 
 const GRID = "8n";          // default step grid
 const RAMP_UP = 0.3;        // threat fast attack (s)
 const RAMP_DOWN = 1.5;      // threat slow release (s)
 const RAMP_PROGRESS = 1.0;  // progress crossfade (s)
+const DRONE_BARS_DEFAULT = 4; // bars between drone wander steps (if score opts in without specifying)
 
 export function createAudioEngine() {
   let started = false;
@@ -25,6 +27,15 @@ export function createAudioEngine() {
   let sectionRng = null;
   let sectionTimerId = null;
   let maskable = new Set();     // progress-axis layer keys eligible for masking
+
+  // Drone harmonic wander — periodically planes the sustained "wander" layers (drone, +hub pad)
+  // to another diatonic degree so the harmonic bed evolves over a run instead of holding one
+  // chord. Seeded per run (independent of gameplay RNG), bar-quantized, no immediate repeat.
+  let droneRng = null;
+  let droneTimerId = null;
+  let droneStep = 0;            // current diatonic-step offset in effect
+  let droneSteps = null;        // allowed offsets for this score (from consonantSteps)
+  const retiring = new Set();   // { id, synth } — old wander synths fading out, disposed after their tail
 
   // Param-event recycling. Web Audio never prunes past automation events, so a sequenced
   // synth's frequency timeline grows unbounded as it plays (worst on the fast arps) →
@@ -61,13 +72,24 @@ export function createAudioEngine() {
     const grid = spec.grid || GRID;
 
     if (spec.sustain) {
-      // continuously sustained chord, gain-controlled
-      const s = new Tone.PolySynth(Tone.Synth, {
-        oscillator: { type: spec.synth.type || "fatsawtooth", count: spec.synth.count, spread: spec.synth.spread },
-        envelope: { attack: spec.synth.attack ?? 1, decay: 0.3, sustain: 1, release: spec.synth.release ?? 2 },
-      }).connect(gain);
-      if (spec.synth.volume != null) s.volume.value = spec.synth.volume;
-      layers[spec.key] = { gain, sustainSynth: s, sustain: spec.sustain };
+      // continuously sustained chord, gain-controlled. A factory so a wander layer can mint a
+      // FRESH synth per chord change — each instance is triggered exactly once (attack, then one
+      // release), so it never accumulates the unbounded param automation that Web Audio can't
+      // prune (the same compounding-crackle hazard the sequenced-layer recycler exists for).
+      const makeSynth = () => {
+        const s = new Tone.PolySynth(Tone.Synth, {
+          oscillator: { type: spec.synth.type || "fatsawtooth", count: spec.synth.count, spread: spec.synth.spread },
+          envelope: { attack: spec.synth.attack ?? 1, decay: 0.3, sustain: 1, release: spec.synth.release ?? 2 },
+        }).connect(gain);
+        if (spec.synth.volume != null) s.volume.value = spec.synth.volume;
+        return s;
+      };
+      // wander layers remember their home chord so each plane is relative to home (no drift)
+      layers[spec.key] = {
+        gain, sustainSynth: makeSynth(), sustain: spec.sustain,
+        wander: !!spec.wander, wanderHome: spec.sustain, currentNotes: spec.sustain,
+        makeSynth, releaseSec: spec.synth.release ?? 2,
+      };
       return;
     }
 
@@ -156,6 +178,38 @@ export function createAudioEngine() {
     applyMix(false);
   }
 
+  // Dispose a retired wander synth once its release tail has gone silent (click-free) — keeps the
+  // count of live synths bounded so nothing accumulates over a run.
+  function retireSynth(synth, releaseSec) {
+    const rec = { synth };
+    rec.id = setTimeout(() => {
+      try { synth.releaseAll?.(); synth.dispose(); } catch { /* already gone */ }
+      retiring.delete(rec);
+    }, (releaseSec + 1.5) * 1000);
+    retiring.add(rec);
+  }
+
+  // Plane the wander layers to the next diatonic degree. Each layer mints a FRESH synth that
+  // attacks the new chord while the outgoing synth releases the old — the slow attack/release
+  // envelopes overlap on the shared gain into a gapless morph. Recreating (vs. retriggering one
+  // synth) means each instance is triggered exactly once, so no synth accumulates unbounded
+  // param automation — the compounding-crackle hazard Web Audio's un-prunable timelines create.
+  function wanderDrone() {
+    if (!droneSteps || !score?.root || !score?.mode) return;
+    droneStep = pickNextStep(droneRng, droneStep, droneSteps);
+    for (const layer of Object.values(layers)) {
+      if (!layer.wander || !layer.sustainSynth) continue;
+      const next = transposeDiatonic(layer.wanderHome, score.root, score.mode, droneStep);
+      const old = layer.sustainSynth;
+      old.triggerRelease(layer.currentNotes);
+      const fresh = layer.makeSynth();
+      fresh.triggerAttack(next);
+      layer.sustainSynth = fresh;
+      layer.currentNotes = next;
+      retireSynth(old, layer.releaseSec ?? 2);
+    }
+  }
+
   // Recreate a sequenced layer's synth + sequence, clearing its accumulated param
   // automation. The new gain is set instantly to the layer's current target (≈0 for a
   // silent recycle → no click; no rampTo event added). Sustained layers don't accumulate
@@ -200,6 +254,10 @@ export function createAudioEngine() {
     appliedCutoff = -1; appliedQ = -1;
     if (sectionTimerId != null) { Tone.Transport.clear(sectionTimerId); sectionTimerId = null; }
     sectionActive = null; sectionIdx = 0; sectionRng = null; maskable = new Set();
+    if (droneTimerId != null) { Tone.Transport.clear(droneTimerId); droneTimerId = null; }
+    droneRng = null; droneStep = 0; droneSteps = null;
+    for (const rec of retiring) { clearTimeout(rec.id); try { rec.synth.dispose(); } catch { /* already gone */ } }
+    retiring.clear();
     for (const key of Object.keys(layers)) {
       const layer = layers[key];
       layer.seq?.dispose?.();
@@ -259,6 +317,16 @@ export function createAudioEngine() {
       } else {
         sectionActive = null;
       }
+      // drone harmonic wander: opt-in via score.root/mode + at least one `wander` sustained layer
+      const wanderLayers = Object.values(layers).filter((l) => l.wander && l.sustainSynth);
+      const droneHome = layers.drone?.wanderHome ?? wanderLayers[0]?.wanderHome;
+      if (score.root && score.mode && droneHome && wanderLayers.length) {
+        droneSteps = consonantSteps(droneHome, score.root, score.mode);
+        droneStep = 0;
+        droneRng = makeSeededRng((getSeed() || "audio") + ":drone");
+        const dBars = score.droneBars || DRONE_BARS_DEFAULT;
+        droneTimerId = Tone.Transport.scheduleRepeat(() => wanderDrone(), `${dBars}m`, `${dBars}m`);
+      }
       applyMix(true);
       Tone.Transport.start();
       recycleTimer = setInterval(recycleTick, RECYCLE_CHECK_MS);  // prune accumulated synth params
@@ -294,6 +362,19 @@ export function createAudioEngine() {
     setMuted(key, isMuted) { muted[key] = isMuted; if (started) applyMix(false); },
     setSectionsEnabled(on) { sectionsEnabled = !!on; if (started) applyMix(false); },
     isStarted() { return started; },
+
+    /**
+     * Force an immediate drone wander (ear-check aid — skips the bar wait). No-op if the
+     * active score doesn't wander.
+     * @returns {{ step: number, layers: Record<string, string[]> } | null}
+     */
+    forceWander() {
+      if (!started || !droneSteps) return null;
+      wanderDrone();
+      const out = {};
+      for (const [key, l] of Object.entries(layers)) if (l.wander) out[key] = l.currentNotes;
+      return { step: droneStep, layers: out };
+    },
 
     /** Resume the AudioContext (needs a user gesture) WITHOUT starting playback. */
     async unlock() { await Tone.start(); },

--- a/js/audio/harmony.js
+++ b/js/audio/harmony.js
@@ -1,0 +1,139 @@
+// @ts-check
+// Pure music-theory helpers behind the drone harmonic wander. No Tone, no DOM — every
+// musical decision lives here so it can be unit-tested without hearing a note. The engine
+// consumes `transposeDiatonic` + `pickNextStep`; scores declare `root`/`mode`.
+//
+// The wander shifts each sustained chord by a shared diatonic-step offset δ ("planing"):
+// a power fifth stays a perfect fifth and a triad stays a diatonic triad, so drone + pad
+// move in parallel and stay consonant. See docs/audio-direction.md / issue #239.
+
+/** Mode name → 7 semitone intervals from the root (one per scale degree). */
+export const SCALES = Object.freeze({
+  ionian: [0, 2, 4, 5, 7, 9, 11],
+  major: [0, 2, 4, 5, 7, 9, 11],
+  dorian: [0, 2, 3, 5, 7, 9, 10],
+  phrygian: [0, 1, 3, 5, 7, 8, 10],
+  lydian: [0, 2, 4, 6, 7, 9, 11],
+  mixolydian: [0, 2, 4, 5, 7, 9, 10],
+  aeolian: [0, 2, 3, 5, 7, 8, 10],
+  minor: [0, 2, 3, 5, 7, 8, 10],
+});
+
+// Candidate diatonic-step offsets (one octave of degrees). The usable subset is computed
+// per score by consonantSteps() — which offsets keep the drone chord's shape — because the
+// diminished diatonic fifth sits on a different degree in each mode (so a fixed list would be
+// wrong outside aeolian).
+const CANDIDATE_STEPS = Object.freeze([0, 1, 2, 3, 4, 5, 6]);
+
+// Pitch class of each natural letter; index into LETTERS by order from any root.
+const LETTERS = ["C", "D", "E", "F", "G", "A", "B"];
+const LETTER_PC = { C: 0, D: 2, E: 4, F: 5, G: 7, A: 9, B: 11 };
+
+/** @param {string} note scientific-pitch name (e.g. "A2", "Bb1", "F#3") @returns {number} MIDI */
+export function noteToMidi(note) {
+  const m = /^([A-G])(#{1,2}|b{1,2})?(-?\d+)$/.exec(note);
+  if (!m) throw new Error(`bad note name: ${note}`);
+  const [, letter, acc = "", oct] = m;
+  let pc = LETTER_PC[letter];
+  for (const ch of acc) pc += ch === "#" ? 1 : -1;
+  return (Number(oct) + 1) * 12 + pc;
+}
+
+/** @param {number} midi @returns {string} note name spelled with naturals/sharps (flats need a key) */
+export function midiToNote(midi) {
+  const pc = ((midi % 12) + 12) % 12;
+  const oct = Math.floor(midi / 12) - 1;
+  const SHARP = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+  return SHARP[pc] + oct;
+}
+
+/** Letter index (0..6, order C..B) of a root like "A", "F#", "Bb". */
+function rootLetterIndex(root) {
+  const letter = root[0];
+  const i = LETTERS.indexOf(letter);
+  if (i < 0) throw new Error(`bad root: ${root}`);
+  return i;
+}
+
+/** Pitch class of a root like "A", "F#", "Bb". */
+function rootPitchClass(root) {
+  let pc = LETTER_PC[root[0]];
+  for (const ch of root.slice(1)) pc += ch === "#" ? 1 : -1;
+  return ((pc % 12) + 12) % 12;
+}
+
+/**
+ * Spell the 7 scale degrees of `mode` rooted on `root`, using each letter once so accidentals
+ * match the key's style (flats for C dorian, sharps for F# aeolian).
+ * @param {string} root @param {string} mode @returns {string[]} 7 note letters+accidentals
+ */
+export function scaleNotes(root, mode) {
+  const intervals = SCALES[mode];
+  if (!intervals) throw new Error(`unknown mode: ${mode}`);
+  const rootPc = rootPitchClass(root);
+  const li = rootLetterIndex(root);
+  return intervals.map((semi, deg) => {
+    const letter = LETTERS[(li + deg) % 7];
+    const targetPc = (rootPc + semi) % 12;
+    let delta = targetPc - LETTER_PC[letter];
+    if (delta > 6) delta -= 12;
+    if (delta < -6) delta += 12;
+    const acc = delta > 0 ? "#".repeat(delta) : "b".repeat(-delta);
+    return letter + acc;
+  });
+}
+
+/**
+ * Transpose each note by `steps` diatonic scale degrees within `root`/`mode` ("planing").
+ * Notes are matched to the scale by pitch class, so input spelling (Bb vs A#) doesn't matter;
+ * output is spelled per `scaleNotes`. `steps = 0` is the identity.
+ * @param {string[]} notes @param {string} root @param {string} mode @param {number} steps
+ * @returns {string[]}
+ */
+export function transposeDiatonic(notes, root, mode, steps) {
+  const intervals = SCALES[mode];
+  if (!intervals) throw new Error(`unknown mode: ${mode}`);
+  const names = scaleNotes(root, mode);
+  const scalePcs = intervals.map((semi) => (rootPitchClass(root) + semi) % 12);
+  return notes.map((note) => {
+    const midi = noteToMidi(note);
+    const pc = ((midi % 12) + 12) % 12;
+    const deg = scalePcs.indexOf(pc);
+    if (deg < 0) throw new Error(`note ${note} is not in ${root} ${mode}`);
+    const rootBase = midi - intervals[deg]; // the root at this note's octave region
+    const idx = deg + steps;
+    const newDeg = ((idx % 7) + 7) % 7;
+    const extraOct = Math.floor(idx / 7);
+    const newMidi = rootBase + extraOct * 12 + intervals[newDeg];
+    const oct = Math.floor(newMidi / 12) - 1;
+    return names[newDeg] + oct;
+  });
+}
+
+/**
+ * The diatonic-step offsets that keep `droneNotes`' interval shape intact (its perfect fifth
+ * stays perfect) when planed within `root`/`mode`. Computed per score because the diminished
+ * diatonic fifth lands on a different degree in each mode. Step 0 (home) is always included.
+ * @param {string[]} droneNotes @param {string} root @param {string} mode @returns {number[]}
+ */
+export function consonantSteps(droneNotes, root, mode) {
+  if (!Array.isArray(droneNotes) || droneNotes.length < 2) return [...CANDIDATE_STEPS];
+  const lo0 = noteToMidi(droneNotes[0]);
+  const homeShape = droneNotes.map((n) => noteToMidi(n) - lo0);
+  return CANDIDATE_STEPS.filter((step) => {
+    const t = transposeDiatonic(droneNotes, root, mode, step);
+    const lo = noteToMidi(t[0]);
+    return t.every((n, i) => noteToMidi(n) - lo === homeShape[i]);
+  });
+}
+
+/**
+ * Pick the next diatonic-step offset from `steps`: equal weight, never the current one.
+ * @param {() => number} rngFn 0..1 source @param {number} current the step in effect now
+ * @param {number[]} steps allowed offsets (from consonantSteps) @returns {number}
+ */
+export function pickNextStep(rngFn, current, steps) {
+  const pool = steps.filter((s) => s !== current);
+  const choices = pool.length ? pool : steps;
+  return choices[Math.floor(rngFn() * choices.length)];
+}

--- a/js/audio/playground.js
+++ b/js/audio/playground.js
@@ -2,16 +2,20 @@
 import { createAudioEngine } from "./engine.js";
 import { LAYER_KEYS } from "./scores/corporate.js";
 import { ALL_SCORES } from "./scores/index.js";
+import { HUB_AMBIENT } from "./scores/hub.js";
+
+// Hub is included so the drone+pad wander can be ear-checked here too (it isn't in ALL_SCORES).
+const SCORES = [...ALL_SCORES, HUB_AMBIENT];
 
 const engine = createAudioEngine();
-engine.setScore(ALL_SCORES[0]);
+engine.setScore(SCORES[0]);
 /** @type {any} */ (window)._audio = engine;  // diagnostics handle
 
 const status = document.getElementById("status");
 
 // Score selector — switch among all scores; restart if currently playing.
 const scoreSel = document.getElementById("score");
-ALL_SCORES.forEach((s, i) => {
+SCORES.forEach((s, i) => {
   const opt = document.createElement("option");
   opt.value = String(i);
   opt.textContent = s.name ?? s.biome ?? `score ${i}`;
@@ -19,7 +23,7 @@ ALL_SCORES.forEach((s, i) => {
 });
 scoreSel.onchange = async () => {
   // setScore rebuilds the live graph if already playing; await the rebuilt start.
-  await engine.setScore(ALL_SCORES[+scoreSel.value]);
+  await engine.setScore(SCORES[+scoreSel.value]);
   status.textContent = engine.isStarted() ? "playing" : "stopped";
 };
 
@@ -27,6 +31,16 @@ scoreSel.onchange = async () => {
 const secToggle = document.getElementById("sections");
 secToggle.onchange = () => engine.setSectionsEnabled(secToggle.checked);
 engine.setSectionsEnabled(secToggle.checked);
+
+// Wander-now — force an immediate drone (+ hub pad) chord shift, with a readout.
+const wanderBtn = document.getElementById("wander");
+const wanderVal = document.getElementById("wanderVal");
+wanderBtn.onclick = () => {
+  const r = engine.forceWander();
+  wanderVal.textContent = r
+    ? `step ${r.step} — ` + Object.entries(r.layers).map(([k, n]) => `${k}: ${n.join("+")}`).join("  ")
+    : "drone: (this score doesn't wander — press PLAY first)";
+};
 
 document.getElementById("play").onclick = async () => {
   try { await engine.start(); status.textContent = "playing"; }

--- a/js/audio/scores/corporate-cold.js
+++ b/js/audio/scores/corporate-cold.js
@@ -67,11 +67,12 @@ const urgencyArp = [
 export const CORPORATE_COLD = Object.freeze({
   biome: "corporate",
   name: "Corporate — Cold",
+  root: "C", mode: "aeolian",  // drone harmonic wander (#239)
   bpm: 138,
   masterFilter: { cutoffLo: 600, cutoffHi: 8600, qLo: 0.7, qHi: 4.0 },
   layers: [
     // base
-    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.2,
+    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.2, wander: true,
       sustain: ["C3", "G3"], synth: { type: "fatsawtooth", count: 3, spread: 16, attack: 2, release: 3, volume: -16 } },
     // progress (blossom — mechanical, cold)
     { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,

--- a/js/audio/scores/corporate-haze.js
+++ b/js/audio/scores/corporate-haze.js
@@ -70,11 +70,12 @@ const urgencyArp = [
 export const CORPORATE_HAZE = Object.freeze({
   biome: "corporate",
   name: "Corporate — Haze",
+  root: "G", mode: "ionian",  // drone harmonic wander (#239)
   bpm: 84,
   masterFilter: { cutoffLo: 500, cutoffHi: 8000, qLo: 0.7, qHi: 3.0 },
   layers: [
     // base
-    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.15,
+    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.15, wander: true,
       sustain: ["G2", "D3"], synth: { type: "fatsawtooth", count: 3, spread: 20, attack: 3, release: 4, volume: -17 } },
     // progress (blossom — warm, hazy, nostalgic)
     { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,

--- a/js/audio/scores/corporate-industrial.js
+++ b/js/audio/scores/corporate-industrial.js
@@ -67,11 +67,12 @@ const urgencyArp = [
 export const CORPORATE_INDUSTRIAL = Object.freeze({
   biome: "corporate",
   name: "Corporate — Industrial",
+  root: "E", mode: "phrygian",  // drone harmonic wander (#239)
   bpm: 100,
   masterFilter: { cutoffLo: 450, cutoffHi: 6500, qLo: 0.8, qHi: 4.0 },
   layers: [
     // base
-    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.2,
+    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.2, wander: true,
       sustain: ["E2", "B2"], synth: { type: "fatsawtooth", count: 3, spread: 18, attack: 2, release: 3, volume: -14 } },
     // progress (blossom — industrial, heavy)
     { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,

--- a/js/audio/scores/corporate-neon.js
+++ b/js/audio/scores/corporate-neon.js
@@ -66,11 +66,12 @@ const urgencyArp = [
 export const CORPORATE_NEON = Object.freeze({
   biome: "corporate",
   name: "Corporate — Neon",
+  root: "F#", mode: "aeolian",  // drone harmonic wander (#239)
   bpm: 128,
   masterFilter: { cutoffLo: 700, cutoffHi: 9000, qLo: 0.7, qHi: 4.5 },
   layers: [
     // base
-    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.2,
+    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.2, wander: true,
       sustain: ["F#2", "C#3"], synth: { type: "fatsawtooth", count: 3, spread: 18, attack: 2, release: 3, volume: -15 } },
     // progress (blossom — aggressive, neon)
     { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,

--- a/js/audio/scores/corporate-noir.js
+++ b/js/audio/scores/corporate-noir.js
@@ -60,10 +60,11 @@ const urgencyArp = [
 export const CORPORATE_NOIR = Object.freeze({
   biome: "corporate",
   name: "Corporate — Noir",
+  root: "D", mode: "dorian",  // drone harmonic wander (#239)
   bpm: 84,
   masterFilter: { cutoffLo: 500, cutoffHi: 7000, qLo: 0.7, qHi: 3.5 },
   layers: [
-    { key: "drone",        axis: "base",     baseGain: 0.5, progressBoost: 0.2,
+    { key: "drone",        axis: "base",     baseGain: 0.5, progressBoost: 0.2, wander: true,
       sustain: ["D3","A3"], synth: { type: "fatsawtooth", count: 3, spread: 14, attack: 2.5, release: 4, volume: -17 } },
     { key: "basePerc",     axis: "progress", lo: 0.0,  hi: 0.05, pattern: basePerc,
       synth: { kind: "drums", volume: -7 } },

--- a/js/audio/scores/corporate-pulse.js
+++ b/js/audio/scores/corporate-pulse.js
@@ -68,11 +68,12 @@ const urgencyArp = [
 export const CORPORATE_PULSE = Object.freeze({
   biome: "corporate",
   name: "Corporate — Pulse",
+  root: "A", mode: "ionian",  // drone harmonic wander (#239)
   bpm: 120,
   masterFilter: { cutoffLo: 700, cutoffHi: 9500, qLo: 0.7, qHi: 4.0 },
   layers: [
     // base
-    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.2,
+    { key: "drone", axis: "base", baseGain: 0.5, progressBoost: 0.2, wander: true,
       sustain: ["A2", "E3"], synth: { type: "fatsawtooth", count: 3, spread: 16, attack: 2, release: 3, volume: -16 } },
     // progress (blossom — propulsive, bright)
     { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,

--- a/js/audio/scores/corporate-vast.js
+++ b/js/audio/scores/corporate-vast.js
@@ -59,11 +59,12 @@ const urgencyArp = [
 export const CORPORATE_VAST = Object.freeze({
   biome: "corporate",
   name: "Corporate — Vast",
+  root: "A", mode: "aeolian",  // drone harmonic wander (#239)
   bpm: 72,
   masterFilter: { cutoffLo: 500, cutoffHi: 9000, qLo: 0.7, qHi: 3.5 },
   layers: [
     // base — always-on low pad
-    { key: "drone", axis: "base", baseGain: 0.6, progressBoost: 0.2,
+    { key: "drone", axis: "base", baseGain: 0.6, progressBoost: 0.2, wander: true,
       sustain: ["A2","E3","A3"], synth: { type: "fatsawtooth", count: 3, spread: 20, attack: 4.0, release: 5.0, volume: -16 } },
     // progress (blossom — sparse percussion first, then melody and pads layer in)
     { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,

--- a/js/audio/scores/corporate.js
+++ b/js/audio/scores/corporate.js
@@ -36,7 +36,7 @@ const lead = [
   "E4", K, K, "A4", K, K, "C5", K,
   K, "B4", K, "A4", K, K, K, K,
   "E4", K, "G4", K, "A4", K, K, K,
-  "Bb4", K, "A4", K, "E4", K, K, K,
+  "Bb4", K, K, "A4", "E4", K, K, K,
 ];
 // Triad stabs: Am held three bars, Bb (♭2) on bar 4. Chords as arrays.
 const backup = [
@@ -64,11 +64,12 @@ const progArp = [
 export const CORPORATE_SCORE = Object.freeze({
   biome: "corporate",
   name: "Corporate — Dread",
+  root: "A", mode: "aeolian",  // drone harmonic wander (#239)
   bpm: 120,
   masterFilter: { cutoffLo: 600, cutoffHi: 8600, qLo: 0.7, qHi: 4.7 },
   layers: [
     // base
-    { key: "drone", axis: "base", baseGain: 0.55, progressBoost: 0.2,
+    { key: "drone", axis: "base", baseGain: 0.55, progressBoost: 0.2, wander: true,
       sustain: ["A2", "E3"], synth: { type: "fatsawtooth", count: 3, spread: 18, attack: 2, release: 3, volume: -16 } },
     // progress (blossom — bolder, earlier, opens up celebratory toward the top)
     { key: "basePerc", axis: "progress", lo: 0.0, hi: 0.05, pattern: basePerc,

--- a/js/audio/scores/hub.js
+++ b/js/audio/scores/hub.js
@@ -5,13 +5,16 @@
 export const HUB_AMBIENT = Object.freeze({
   biome: "hub",
   name: "Hub Ambient",
+  root: "A", mode: "aeolian",  // drone + pad harmonic wander (#239)
   bpm: 70,
   masterFilter: { cutoffLo: 2200, cutoffHi: 7000, qLo: 0.7, qHi: 1.5 },
   layers: [
-    { key: "drone", axis: "base", baseGain: 0.6,
+    // drone + pad plane together by the same diatonic step; the high shimmer stays a static
+    // anchor. Combined they cycle Am7 → Cmaj7 → Dm7 → Em7 → Fmaj7 → G7. (#239)
+    { key: "drone", axis: "base", baseGain: 0.6, wander: true,
       sustain: ["A2", "E3"],
       synth: { type: "fatsawtooth", count: 3, spread: 22, attack: 3, release: 4, volume: -15 } },
-    { key: "pad", axis: "base", baseGain: 0.5,
+    { key: "pad", axis: "base", baseGain: 0.5, wander: true,
       sustain: ["C4", "E4", "G4"],
       synth: { type: "fatsawtooth", count: 3, spread: 26, attack: 4, release: 5, volume: -19 } },
     { key: "shimmer", axis: "base", baseGain: 0.32,

--- a/preview/audio.html
+++ b/preview/audio.html
@@ -33,6 +33,8 @@
       <select id="score"></select></label></div>
     <div class="row"><label style="font-size:.8rem;color:#8aa;display:flex;align-items:center;gap:.4rem">
       <input type="checkbox" id="sections" checked /> SECTION BREAKDOWNS</label></div>
+    <div class="row"><button id="wander">↻ WANDER NOW</button>
+      <span id="wanderVal" style="color:#a78bfa;font-size:.8rem">drone: home</span></div>
     <div class="row" id="tracks"></div>
     <div class="row"><label class="slider">PROGRESS <span class="val" id="progressVal">0.00</span>
       <input type="range" id="progress" min="0" max="100" value="0" /></label></div>

--- a/tests/audio-harmony.test.js
+++ b/tests/audio-harmony.test.js
@@ -1,0 +1,118 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  SCALES,
+  consonantSteps,
+  scaleNotes,
+  transposeDiatonic,
+  pickNextStep,
+  noteToMidi,
+  midiToNote,
+} from "../js/audio/harmony.js";
+
+// Pure music-theory module behind the drone wander. No Tone, no DOM — fully unit-testable,
+// the one layer either collaborator can verify without hearing it.
+
+test("SCALES includes the modes the scores use", () => {
+  // The set actually assigned across the corporate scores + hub (see audio-score-harmony.test.js).
+  for (const m of ["aeolian", "dorian", "phrygian", "ionian"]) {
+    assert.ok(Array.isArray(SCALES[m]) && SCALES[m].length === 7, `mode ${m}`);
+    assert.equal(SCALES[m][0], 0, `${m} starts on the root`);
+  }
+});
+
+test("consonantSteps for an aeolian tonic power fifth excludes the ii offset (1)", () => {
+  // A aeolian drone A+E: step 1 would plane to B+F (diminished) → excluded.
+  assert.deepEqual(consonantSteps(["A2", "E3"], "A", "aeolian"), [0, 2, 3, 4, 5, 6]);
+});
+
+test("consonantSteps is mode-specific — phrygian excludes a different offset", () => {
+  // E phrygian drone E+B: the diminished fifth lands on step 4 (B+F), and step 1 is fine.
+  const steps = consonantSteps(["E2", "B2"], "E", "phrygian");
+  assert.ok(!steps.includes(4), "step 4 (B+F diminished) excluded in phrygian");
+  assert.ok(steps.includes(1), "step 1 is consonant in phrygian (unlike aeolian)");
+  for (const s of steps) {
+    const [lo, hi] = transposeDiatonic(["E2", "B2"], "E", "phrygian", s);
+    assert.equal(noteToMidi(hi) - noteToMidi(lo), 7, `phrygian step ${s} perfect fifth`);
+  }
+});
+
+test("noteToMidi / midiToNote round-trip standard pitches", () => {
+  assert.equal(noteToMidi("A4"), 69);
+  assert.equal(noteToMidi("C4"), 60);
+  assert.equal(noteToMidi("A2"), 45);
+  assert.equal(noteToMidi("Bb1"), 34);
+  assert.equal(noteToMidi("F#2"), 42);
+  assert.equal(midiToNote(69), "A4");
+  assert.equal(midiToNote(60), "C4");
+});
+
+test("scaleNotes spells diatonic scales with correct accidentals", () => {
+  assert.deepEqual(scaleNotes("A", "aeolian"), ["A", "B", "C", "D", "E", "F", "G"]);
+  assert.deepEqual(scaleNotes("C", "dorian"), ["C", "D", "Eb", "F", "G", "A", "Bb"]);
+  assert.deepEqual(scaleNotes("D", "dorian"), ["D", "E", "F", "G", "A", "B", "C"]);
+  // sharp key spells with sharps, one letter per degree
+  assert.deepEqual(scaleNotes("F#", "aeolian"), ["F#", "G#", "A", "B", "C#", "D", "E"]);
+});
+
+test("transposeDiatonic step 0 is the identity", () => {
+  assert.deepEqual(transposeDiatonic(["A2", "E3"], "A", "aeolian", 0), ["A2", "E3"]);
+  assert.deepEqual(transposeDiatonic(["C4", "E4", "G4"], "A", "aeolian", 0), ["C4", "E4", "G4"]);
+});
+
+test("transposeDiatonic planes a power fifth, keeping octave correctness", () => {
+  assert.deepEqual(transposeDiatonic(["A2", "E3"], "A", "aeolian", 2), ["C3", "G3"]);
+  assert.deepEqual(transposeDiatonic(["A2", "E3"], "A", "aeolian", 6), ["G3", "D4"]);
+});
+
+test("transposeDiatonic planes a triad diatonically", () => {
+  assert.deepEqual(transposeDiatonic(["C4", "E4", "G4"], "A", "aeolian", 2), ["E4", "G4", "B4"]);
+});
+
+test("drone power fifth stays a perfect fifth (+7 semitones) for every consonant step", () => {
+  const steps = consonantSteps(["A2", "E3"], "A", "aeolian");
+  for (const step of steps) {
+    const [lo, hi] = transposeDiatonic(["A2", "E3"], "A", "aeolian", step);
+    assert.equal(noteToMidi(hi) - noteToMidi(lo), 7, `step ${step} stays a perfect fifth`);
+  }
+});
+
+test("every transposed note stays in the scale", () => {
+  const inScale = new Set(scaleNotes("C", "aeolian"));
+  for (const step of consonantSteps(["C3", "G3"], "C", "aeolian")) {
+    for (const n of transposeDiatonic(["C3", "G3"], "C", "aeolian", step)) {
+      assert.ok(inScale.has(n.replace(/\d+$/, "")), `${n} in C aeolian`);
+    }
+  }
+});
+
+test("pickNextStep only emits allowed steps and never repeats immediately", () => {
+  const steps = consonantSteps(["A2", "E3"], "A", "aeolian");
+  // deterministic rng: cycle through a fixed value table
+  let i = 0;
+  const vals = [0.0, 0.16, 0.33, 0.5, 0.66, 0.83, 0.99, 0.4, 0.7, 0.1];
+  const rng = () => vals[i++ % vals.length];
+  let cur = 0;
+  for (let n = 0; n < 50; n++) {
+    const next = pickNextStep(rng, cur, steps);
+    assert.ok(steps.includes(next), `emitted ${next}`);
+    assert.notEqual(next, cur, "no immediate repeat");
+    cur = next;
+  }
+});
+
+test("pickNextStep is deterministic for a given rng sequence", () => {
+  const make = () => {
+    const seq = [0.1, 0.9, 0.5, 0.3, 0.7];
+    let k = 0;
+    return () => seq[k++ % seq.length];
+  };
+  const steps = consonantSteps(["A2", "E3"], "A", "aeolian");
+  const a = [];
+  const b = [];
+  // run two identical rng streams in parallel — same picks
+  const r1 = make(), r2 = make();
+  let c1 = 0, c2 = 0;
+  for (let n = 0; n < 10; n++) { a.push(c1 = pickNextStep(r1, c1, steps)); b.push(c2 = pickNextStep(r2, c2, steps)); }
+  assert.deepEqual(a, b);
+});

--- a/tests/audio-score-harmony.test.js
+++ b/tests/audio-score-harmony.test.js
@@ -1,0 +1,57 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { ALL_SCORES } from "../js/audio/scores/index.js";
+import { HUB_AMBIENT } from "../js/audio/scores/hub.js";
+import { transposeDiatonic, consonantSteps, SCALES } from "../js/audio/harmony.js";
+
+// Every wandering score must declare a root/mode that actually matches its authored drone
+// harmony, and have enough consonant offsets to be worth wandering. Catches a mislabelled
+// mode or a typo that the ear-check might miss.
+
+const WANDERING = [...ALL_SCORES, HUB_AMBIENT];
+
+for (const score of WANDERING) {
+  const label = score.name ?? score.biome;
+  const drone = score.layers.find((l) => l.key === "drone");
+
+  test(`[${label}] declares a valid root + mode`, () => {
+    assert.ok(typeof score.root === "string" && score.root.length > 0, "root");
+    assert.ok(score.mode in SCALES, `mode ${score.mode} is a known scale`);
+  });
+
+  test(`[${label}] drone home chord is in the declared key (step 0 = identity)`, () => {
+    assert.ok(drone && Array.isArray(drone.sustain), "drone sustain");
+    assert.deepEqual(
+      transposeDiatonic(drone.sustain, score.root, score.mode, 0),
+      drone.sustain,
+    );
+  });
+
+  test(`[${label}] drone has ≥4 consonant wander offsets, all perfect-fifth-preserving`, () => {
+    const steps = consonantSteps(drone.sustain, score.root, score.mode);
+    assert.ok(steps.length >= 4, `only ${steps.length} consonant steps`);
+    assert.ok(steps.includes(0), "home (step 0) always available");
+  });
+
+  test(`[${label}] the drone layer opts into wander`, () => {
+    assert.equal(drone.wander, true);
+  });
+}
+
+test("hub also wanders its pad layer (drone + pad), per Les's requirement", () => {
+  const pad = HUB_AMBIENT.layers.find((l) => l.key === "pad");
+  assert.ok(pad, "hub has a pad layer");
+  assert.equal(pad.wander, true);
+  // the pad triad must be in the hub's key so it planes diatonically
+  assert.deepEqual(
+    transposeDiatonic(pad.sustain, HUB_AMBIENT.root, HUB_AMBIENT.mode, 0),
+    pad.sustain,
+  );
+});
+
+test("run scores wander ONLY the drone (no stray wander flags)", () => {
+  for (const score of ALL_SCORES) {
+    const wanderers = score.layers.filter((l) => l.wander).map((l) => l.key);
+    assert.deepEqual(wanderers, ["drone"], `${score.name} wanderers`);
+  }
+});


### PR DESCRIPTION
Closes #239.

Varies the sustained music drone over a run so the harmonic bed evolves instead of holding one chord the whole time. **Scope note:** per Les, this also varies the **overworld hub** (the issue originally said the hub should stay as-is) — the hub wanders its drone **and** pad together.

## Approach

Algorithmic, from a scale model — refined from the issue's `chordForDegree` sketch into **diatonic transposition** so the pad can plane in parallel with the drone.

- **`js/audio/harmony.js`** (new, pure, Tone-free, unit-tested) — `transposeDiatonic(notes, root, mode, steps)` planes a chord by `steps` scale degrees within the key; `consonantSteps(drone, root, mode)` returns the offsets that keep the drone's perfect fifth perfect; `pickNextStep(rng, current, steps)` picks the next offset (no immediate repeat). `consonantSteps` is **mode-aware** — a fixed allowed-steps list is wrong outside aeolian (the diminished diatonic fifth lands on a different degree per mode; e.g. Industrial is E phrygian).
- **Scores** — each wandering score gains `root` + `mode`; sustained layers opt in with `wander: true`. Modes were derived from each score's authored harmony, so a couple diverge from the issue's sketch (Cold is aeolian not dorian; Haze/Pulse are major; Industrial phrygian — see `notes.md`).
- **Engine** — an independent seeded `:drone` RNG (never gameplay RNG) drives a bar-quantized `Transport.scheduleRepeat`, mirroring the existing section automation. Each wander **mints a fresh synth** that attacks the new chord while the outgoing one releases — a gapless crossfade.
- **Playground** — a **WANDER NOW** button + the hub added to the score selector in `preview/audio.html` for ear-checking.

The hub drone+pad cycle a clean run of diatonic 7th chords: **Am7 → Cmaj7 → Dm7 → Em7 → Fmaj7 → G7**.

## Crackle fix (found during ear-check)

The first cut retriggered one long-lived `PolySynth` per layer, whose reused voices accumulated un-prunable Web Audio param automation → **compounding crackle that worsened over time** (the same hazard the sequenced-layer recycler already guards against; sustained layers were exempt under a now-false "one trigger" assumption). Root-caused with a temporary in-engine diagnostic driven via Playwright (voice-pool size, per-voice param-event count, master-tap peak):

| | poolSize | per-voice events | master peak |
|---|---|---|---|
| before | 2 → 8 (climbing) | 2 → 5 (climbing) | ~0.06 flat |
| after | **2 flat** | **2 flat** | ~0.06 flat |

Fix: recreate the synth per wander and dispose the old after its release tail, so each instance is triggered exactly once.

## Testing

- `make check` green — **1360 tests** (50 new across `audio-harmony` + `audio-score-harmony`), lint clean.
- In-browser Playwright smoke: run-score + hub drone/pad wander correctly, 0 console errors.

## ⚠️ Still pending — live ear-check

I can't hear the output, so this needs a **listen in a live run + the hub** before merge: confirm the crackle is gone, the morph sounds seamless, and the cadence (`DRONE_BARS_DEFAULT`, currently 4 bars) feels right. Also open: the hub's high **shimmer** is left static against the planing pad — wander/drop it if it clashes on Dm7/Fmaj7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
