### PR TITLE
Fix Tone.js MIME-type error on GitHub Pages (absolute import path)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,11 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>STARNET</title>
   <link rel="stylesheet" href="css/style.css" />
-  <!-- Import map: bare "lit" specifiers → bundled dist/lit.js -->
+  <!-- Import map: bare specifiers → bundled dist/*. Relative targets so they
+       resolve under a deploy subpath (e.g. GitHub Pages /starnet/). -->
   <script type="importmap">
     { "imports": {
       "lit": "./dist/lit.js",
-      "lit/directives/repeat.js": "./dist/lit.js"
+      "lit/directives/repeat.js": "./dist/lit.js",
+      "tone": "./dist/tone.js"
     } }
   </script>
   <!-- Cytoscape.js + layout extensions (vendor bundle built by: make bundle-vendor) -->

--- a/js/audio/engine.js
+++ b/js/audio/engine.js
@@ -1,6 +1,6 @@
 // @ts-nocheck
 // Tone.js wrapper. The only module that touches Web Audio. Imports the vendored bundle.
-import * as Tone from "/dist/tone.js";
+import * as Tone from "tone";
 import { computeMix } from "./mixer.js";
 import { makeSeededRng, getSeed } from "../core/rng.js";
 import { transposeDiatonic, consonantSteps, pickNextStep } from "./harmony.js";

--- a/js/audio/sfx/engine.js
+++ b/js/audio/sfx/engine.js
@@ -5,7 +5,7 @@
 // until stop() and disposed after their fade-out — so SFX add no long-lived AudioParam
 // accumulation. Cues schedule at currentTime + a small offset (NOT Tone.now()) so they aren't
 // delayed by the music engine's lookahead.
-import * as Tone from "/dist/tone.js";
+import * as Tone from "tone";
 
 const MAX_VOICES = 12;
 const OFFSET = 0.02;

--- a/js/tone-vendor.js
+++ b/js/tone-vendor.js
@@ -1,4 +1,5 @@
 // Tone.js vendor bundle entry point.
 // Bundled with esbuild into dist/tone.js (ESM).
-// Audio modules import from "/dist/tone.js" as: import * as Tone from "/dist/tone.js";
+// Audio modules import the bare specifier "tone", mapped to ./dist/tone.js via the
+// page import map (same indirection as lit) so it resolves under a deploy subpath.
 export * from "tone";

--- a/playground.html
+++ b/playground.html
@@ -11,7 +11,8 @@
   <script type="importmap">
     { "imports": {
       "lit": "./dist/lit.js",
-      "lit/directives/repeat.js": "./dist/lit.js"
+      "lit/directives/repeat.js": "./dist/lit.js",
+      "tone": "./dist/tone.js"
     } }
   </script>
   <script src="dist/vendor.js"></script>

--- a/preview.html
+++ b/preview.html
@@ -8,7 +8,8 @@
   <script type="importmap">
     { "imports": {
       "lit": "./dist/lit.js",
-      "lit/directives/repeat.js": "./dist/lit.js"
+      "lit/directives/repeat.js": "./dist/lit.js",
+      "tone": "./dist/tone.js"
     } }
   </script>
   <style>


### PR DESCRIPTION
The live site at https://lmorchard.github.io/starnet/ logs:

> Loading module from "https://lmorchard.github.io/dist/tone.js" was blocked because of a disallowed MIME type ("text/html").

## Cause

The audio modules imported Tone with an **absolute** path:

```js
import * as Tone from "/dist/tone.js";   // js/audio/engine.js, js/audio/sfx/engine.js
```

A leading `/` resolves to the domain root. GitHub Pages serves this project under `/starnet/`, so the browser requested `https://lmorchard.github.io/dist/tone.js` — which 404s and returns the HTML error page. The module loader then rejects it for a `text/html` MIME type. It worked locally only because the dev server root *is* the project root.

The bundle itself builds and publishes correctly — `https://lmorchard.github.io/starnet/dist/tone.js` returns `200 application/javascript`. Only the import path was wrong.

## Fix

Route Tone through the page **import map** with a relative target, the same indirection `lit` already uses to survive a deploy subpath:

- `js/audio/engine.js`, `js/audio/sfx/engine.js`: `import * as Tone from "tone"` (bare specifier)
- `index.html`, `preview.html`, `playground.html`: add `"tone": "./dist/tone.js"` to the import map (added to all three to match how `lit` is mapped; only `index.html` loads audio today)
- `js/tone-vendor.js` / `js/lit-vendor.js`: refreshed stale doc comments that described the old absolute-import convention

## Guard

Added a `lint-imports` target wired into `make check` that fails on absolute `"/dist/..."` paths in `js/` and HTML — catching this class of bug before it ships. It greps the quoted absolute form (`"/dist/`), which does not match the relative `"./dist/"` the import map uses. Verified it passes on this tree and fails on an injected bad import.

## Verification

- `make check` — imports guard + lint clean, 1425/1425 tests pass
- `make bundle-vendor` still emits `dist/tone.js` (340kb)
- Confirmed the deployed bundle is reachable at the correct subpath; only the request path was wrong

Impact: audio is currently broken on the live site (non-fatal module error); the rest of the game loads. This restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)