### PR TITLE
Add lint-imports guard to make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all serve dev lint test check bundle-vendor census bot-run generate gen-bot gen-json
+.PHONY: all serve dev lint lint-imports test check bundle-vendor census bot-run generate gen-bot gen-json
 
 # Install dependencies and build vendor bundles
 all: node_modules dist/vendor.js dist/lit.js dist/tone.js
@@ -31,12 +31,24 @@ lint:
 	npx tsc --noEmit --allowJs --checkJs --target ES2020 --moduleResolution bundler --module ES2020 \
 		$(shell find js -name '*.js' ! -name '*.test.js' ! -path '*/fixtures/*' ! -name 'graph.js' ! -name 'vendor.js' ! -name 'lit-vendor.js' ! -name 'tone-vendor.js')
 
+# Guard against absolute "/dist/..." paths in js/ and HTML. They resolve to the
+# domain root and 404 under a deploy subpath (e.g. GitHub Pages /starnet/), where
+# the 404 page's text/html MIME blocks the module. Use a relative "./dist/..."
+# path or the page import map instead. (See PR #243.)
+lint-imports:
+	@if grep -rn '"/dist/' js *.html; then \
+		echo 'ERROR: absolute "/dist/..." path(s) above — use a relative "./dist/..." path or the import map (breaks under a deploy subpath; see PR #243).'; \
+		exit 1; \
+	else \
+		echo 'lint-imports: no absolute "/dist/" paths'; \
+	fi
+
 # Run unit + integration tests
 test:
 	node --test $(shell find tests js data -name '*.test.js' ! -path '*/fixtures/*' ! -name 'bot-player.test.js')
 
-# Full check: lint + test
-check: lint test
+# Full check: imports guard + lint + test
+check: lint-imports lint test
 
 # Bundle vendor dependencies (Cytoscape + layout extensions, Lit, Tone)
 bundle-vendor:

--- a/js/lit-vendor.js
+++ b/js/lit-vendor.js
@@ -1,6 +1,7 @@
 // Lit vendor bundle entry point.
 // Bundled with esbuild into dist/lit.js (ESM).
-// Game components import from "/dist/lit.js".
+// Game components import the bare specifier "lit", mapped to ./dist/lit.js via
+// the page import map so it resolves under a deploy subpath.
 
 export { LitElement, html, css, nothing } from "lit";
 export { repeat } from "lit/directives/repeat.js";


### PR DESCRIPTION
Follow-up to #243, which fixed an absolute `/dist/tone.js` import that broke under the GitHub Pages `/starnet/` subpath. This adds the guard that catches that class of bug before it ships. (The guard was part of #243 but got left out — that PR was squash-merged from its first commit only.)

## What it does

New `lint-imports` Make target, wired as the first step of `make check`. It greps `js/` and HTML for the quoted absolute form `"/dist/` and fails the build if any appear. Absolute `"/dist/..."` paths resolve to the domain root and 404 under a deploy subpath, where the 404 pages `text/html` MIME blocks the module — exactly the #243 bug.

The pattern matches `"/dist/` but **not** the relative `"./dist/"` the import map uses, so the legitimate import-map entries pass.

Also refreshes the stale `js/lit-vendor.js` header comment, which still described the old absolute-import convention (and would otherwise trip the guard).

## Verification

- `make lint-imports` passes on current `main`
- `make check` green — 1425/1425 tests
- Confirmed separately that the guard fails (exit 1) on an injected `import ... from "/dist/bad.js"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)