### PR TITLE
audio-reference player: bound playback load, fix sustained-playback crackle

### DIFF
--- a/tools/audio-reference/player/player.js
+++ b/tools/audio-reference/player/player.js
@@ -22,9 +22,23 @@ const SHORT = { filterFrequency: "freq", filterQ: "Q", reverbSend: "rev", modula
 
 const $ = (id) => document.getElementById(id);
 const warnings = [];
-let built = null;        // { rows, masterGain, reverb }
+let built = null;        // { rows } — per-track nodes for the CURRENT track; rebuilt every switch
+let bus = null;          // { masterGain, eq, comp, limiter, reverb } — built ONCE, reused across switches
+let busPromise = null;   // dedupes concurrent first-build ensureBus() calls
 let currentSlug = null;  // set when loaded from the library; enables Save
 let currentSpec = null;  // {root, mode, bpm} of the loaded track
+// Two pools, separate caps. Sustained/melodic synths are the costly DSP (tight cap); percussion is
+// cheap one-shots and a drum score needs several (kick+snare+hats+…), so it gets its own headroom.
+const PERCUSSION_TYPES = new Set(["MembraneSynth", "MetalSynth", "NoiseSynth"]);
+const TRACK_CAPS = { melodic: 4, perc: 6 };
+// "Chiptune" simplification: the analyses lean on fat oscillators (count 3–8 detuned voices per
+// note) — the biggest per-note DSP cost. Clamp the voice count toward a single oscillator for a
+// leaner, more chip-like sound and far less load. 1 = pure chiptune; 2 keeps a hair of width.
+const MAX_OSC_VOICES = 3;
+const MIX_TARGET = 0.8;   // target combined level; per-track gain = MIX_TARGET/sqrt(active) for headroom
+const poolOf = (row) => (PERCUSSION_TYPES.has(row.type) ? "perc" : "melodic");
+let activateSeq = 0;     // monotonic enable counter; oldest-enabled in a pool is evicted past its cap
+let baseMeta = "";       // meta line text without the live active-count suffix
 
 // Disposing a synth while one of its one-shot sources still has a pending `onended` cleanup
 // throws a benign InvalidAccessError (it disconnects from an already-disposed node), asynchronously.
@@ -43,7 +57,7 @@ function expandOptions(o = {}) {
   if (o.oscillatorType || o.count != null || o.spread != null) {
     out.oscillator = {};
     if (o.oscillatorType) out.oscillator.type = o.oscillatorType;
-    if (o.count != null) out.oscillator.count = o.count;
+    if (o.count != null) out.oscillator.count = Math.min(o.count, MAX_OSC_VOICES);   // chiptune clamp
     if (o.spread != null) out.oscillator.spread = o.spread;
   }
   if (o.attack != null || o.decay != null || o.sustain != null || o.release != null) {
@@ -77,18 +91,23 @@ function effectiveOpts(type, o) {
   return e;
 }
 
+const MAX_POLYPHONY = 16;   // per-PolySynth voice ceiling (Tone default 32) — bounds runaway voice
+                            // stacking without dropping notes in normal use (8 was too low: dense
+                            // chord/pad tracks with long release tails exceeded it -> "note dropped")
+
 function makeSynth(type, opts) {
   const options = expandOptions(effectiveOpts(type, opts));
   try {
     if (type === "PolySynth") {
       const ps = new Tone.PolySynth(Tone.Synth);
-      if (Object.keys(options).length) ps.set(options);
+      ps.maxPolyphony = MAX_POLYPHONY;   // default 32 is absurd for a many-track preview mix; long
+      if (Object.keys(options).length) ps.set(options);   // release tails stack voices without it
       return ps;
     }
     return new Tone[type](options);
   } catch (e) {
     warnings.push(`options rejected for ${type}; using defaults (${e.message})`);
-    if (type === "PolySynth") return new Tone.PolySynth(Tone.Synth);
+    if (type === "PolySynth") { const ps = new Tone.PolySynth(Tone.Synth); ps.maxPolyphony = MAX_POLYPHONY; return ps; }
     return new Tone[type]();
   }
 }
@@ -113,20 +132,24 @@ function triggerStep(synth, type, token, dur, time) {
 const safeDispose = (n) => { try { if (n && n.dispose) n.dispose(); } catch { /* already gone */ } };
 
 // Release voices now, dispose a single track's nodes after its tail settles. Used for the
-// in-place tweaker rebuild (one synth — no stacking risk), NOT for whole-graph teardown.
-function retire(synths, nodes) {
+// in-place tweaker rebuild and the recycler (one synth — no stacking risk), NOT for whole-graph
+// teardown. delayMs should cover the synth's release tail so the swap is click-free.
+function retire(synths, nodes, delayMs = 400) {
   synths.forEach((s) => { try { s.releaseAll?.(); s.triggerRelease?.(); } catch { /* ok */ } });
-  setTimeout(() => { synths.forEach(safeDispose); nodes.forEach(safeDispose); }, 400);
+  setTimeout(() => { synths.forEach(safeDispose); nodes.forEach(safeDispose); }, delayMs);
 }
 
 function disposeBuilt() {
   if (!built) return;
   const old = built;
   built = null;
-  // Dispose the WHOLE graph immediately so only one graph is ever live. Deferring it let heavy
-  // graphs (esp. 13-track stems artifacts, each with its own reverb) overlap on a switch and
-  // pile up CPU into crackle/breakup. A pending one-shot onended may now throw a benign
-  // InvalidAccessError — swallowed by the window handler at the top of this file.
+  // Dispose only the per-track nodes immediately so only one track graph is ever live. The master
+  // bus + reverb are PERSISTENT (see ensureBus) and deliberately NOT torn down here: rebuilding a
+  // convolver-with-rendered-IR on every switch was the accumulating leak — the browser reclaims
+  // those heavyweight audio-thread objects lazily, so churning them piled up into worsening crackle.
+  // Disposing each sendGain disconnects it from the reverb, so the reverb's input count returns to
+  // baseline every switch (no dangling connections accumulate). A pending one-shot onended may throw
+  // a benign InvalidAccessError — swallowed by the window handler at the top of this file.
   old.rows.forEach((r) => {
     if (r.skipped) return;
     safeDispose(r.seq);
@@ -136,23 +159,48 @@ function disposeBuilt() {
     safeDispose(r.gain);
     safeDispose(r.sendGain);
   });
-  safeDispose(old.reverb);   // before the masterGain it feeds
-  safeDispose(old.masterGain);
-  safeDispose(old.eq);
-  safeDispose(old.comp);
-  safeDispose(old.limiter);
+}
+
+// Build the master bus + reverb ONCE and keep them for the life of the page. The reverb's impulse
+// response (rendered via an OfflineAudioContext) and the EQ/comp/limiter are identical for every
+// track, so there's no reason to rebuild — and rebuilding the convolver per switch was the leak.
+function ensureBus() {
+  if (busPromise) return busPromise;
+  busPromise = (async () => {
+    const masterGain = new Tone.Gain(0.9);
+    const eq = new Tone.EQ3({ low: 2, mid: -1, high: 0 });
+    const comp = new Tone.Compressor({ threshold: -18, ratio: 2.5, attack: 0.025, release: 0.18 });
+    const limiter = new Tone.Limiter(-1);
+    masterGain.connect(eq); eq.connect(comp); comp.connect(limiter); limiter.toDestination();
+    const reverb = new Tone.Reverb({ decay: 2.4, wet: 1 });
+    await reverb.generate();
+    reverb.connect(masterGain);
+    bus = { masterGain, eq, comp, limiter, reverb };
+    return bus;
+  })();
+  return busPromise;
 }
 
 // Build a track's instrument + inserts and wire synth -> [drive] -> [chorus] -> gain.
 // Returns { synth, inserts }. (gain, sendGain are stable across rebuilds.)
+// A PolySynth allocates (and later GCs) a voice PER NOTE; several firing at once stutters the main
+// thread. Like the game engine, render a PolySynth track as a cheap mono Synth UNLESS its pattern
+// actually contains chords ("+"-joined tokens). renderType is what we build + trigger; row.type
+// stays as authored (UI + Save). Recomputed here so a live synth-type change re-evaluates it.
+const hasChords = (notes) => (notes || []).some((tok) => typeof tok === "string" && tok.includes("+"));
+function effectiveType(row) {
+  return (row.type === "PolySynth" && !hasChords(row.notes)) ? "Synth" : row.type;
+}
+
 function buildInstrument(row) {
   const o = row.opts;
+  row.renderType = effectiveType(row);
   const inserts = [];
   if (o.drive > 0) inserts.push(new Tone.Distortion(Math.min(1, o.drive)));
   if (o.chorus > 0) inserts.push(new Tone.Chorus({ frequency: 1.5, delayTime: 3.5, depth: 0.7, wet: Math.min(1, o.chorus) }).start());
   const chain = [...inserts, row.gain];
   for (let i = 0; i < chain.length - 1; i++) chain[i].connect(chain[i + 1]);
-  const synth = makeSynth(row.type, o);
+  const synth = makeSynth(row.renderType, o);
   synth.connect(chain[0]);
   return { synth, inserts };
 }
@@ -166,7 +214,40 @@ function rebuildTrack(row) {
   row.inserts = inserts;
   const sendLevel = row.opts.reverbSend != null ? Math.min(1, row.opts.reverbSend) : 0.15;
   row.sendGain.gain.rampTo(sendLevel, 0.05);
-  retire([oldSynth], oldInserts);
+  // Let the old synth ring out its release tail before disposal so the swap is click-free.
+  const tailMs = Math.round((Math.min(Number(row.opts.release) || 0.5, 4) + 0.3) * 1000);
+  retire([oldSynth], oldInserts, Math.max(400, tailMs));
+}
+
+// Param-timeline recycler. Web Audio never prunes past AudioParam automation, so a sequenced
+// synth's frequency timeline grows unbounded as it plays (measured ~4 events/sec → audio-thread
+// cost that compounds into worsening crackle within a minute or two). The cure (as in the game's
+// own engine) is recreating the synth: rebuildTrack swaps in a fresh one with an empty timeline
+// and rings the old out. We do it on a slow rotation — each audible, playing track is pruned
+// ~every RECYCLE_AGE_S — capping swaps per tick so overlaps never bunch up.
+const RECYCLE_CHECK_S = 4;        // recycler tick interval (seconds)
+const RECYCLE_AGE_S = 25;         // recycle a playing track this long after its last recycle
+const MAX_RECYCLE_PER_TICK = 2;   // stagger swaps across ticks
+let recycleTimer = null;
+
+function recycleTick() {
+  if (!built || Tone.Transport.state !== "started") return;
+  const now = Tone.now();
+  let done = 0;
+  for (const row of built.rows) {
+    if (done >= MAX_RECYCLE_PER_TICK) break;
+    if (row.skipped || row.audible === false || !row.dirty) continue;
+    if (row.lastRecycle == null) { row.lastRecycle = now; continue; }  // start this row's clock
+    if (now - row.lastRecycle < RECYCLE_AGE_S) continue;
+    rebuildTrack(row);            // fresh synth → frequency timeline reset to ~0
+    row.dirty = false;
+    row.lastRecycle = now;
+    done++;
+  }
+}
+
+function startRecycler() {
+  if (recycleTimer == null) recycleTimer = setInterval(recycleTick, RECYCLE_CHECK_S * 1000);
 }
 
 let buildGen = 0;   // bumped per build; a build superseded during its async generate() bails
@@ -180,24 +261,14 @@ async function build(spec) {
   Tone.Transport.position = 0;
   Tone.Transport.bpm.value = spec.bpm || 120;
 
-  const masterGain = new Tone.Gain(0.9);
-  const eq = new Tone.EQ3({ low: 2, mid: -1, high: 0 });
-  const comp = new Tone.Compressor({ threshold: -18, ratio: 2.5, attack: 0.025, release: 0.18 });
-  const limiter = new Tone.Limiter(-1);
-  masterGain.connect(eq); eq.connect(comp); comp.connect(limiter); limiter.toDestination();
-
-  const reverb = new Tone.Reverb({ decay: 2.4, wet: 1 });
-  await reverb.generate();
-  // If another build started while we awaited generate(), abandon this one — tear down what we
-  // made and bail WITHOUT setting `built`, so its graph can't be orphaned (left playing) and
-  // accumulate into crackle over repeated fast switches.
-  if (gen !== buildGen) {
-    [reverb, masterGain, eq, comp, limiter].forEach(safeDispose);
-    return null;
-  }
-  reverb.connect(masterGain);
+  const { masterGain, reverb } = await ensureBus();   // built once, reused; awaited only on first build
+  // If another build started while we awaited the (first-build) IR render, abandon this one and bail
+  // WITHOUT setting `built`, so its graph can't be orphaned. The bus is persistent, so nothing to tear
+  // down here — no per-track nodes exist yet at this point.
+  if (gen !== buildGen) return null;
 
   const rows = [];
+  const poolCounts = { melodic: 0, perc: 0 };   // fill each pool to its cap by default; rest start muted
   (spec.tracks || []).forEach((t) => {
     const type = t.synth?.type;
     if (!type || !PALETTE_SET.has(type)) {
@@ -208,23 +279,29 @@ async function build(spec) {
     const gain = new Tone.Gain(1).connect(masterGain);   // per-track level (mute/solo)
     const sendGain = new Tone.Gain(t.synth.options?.reverbSend != null ? Math.min(1, t.synth.options.reverbSend) : 0.15);
     gain.connect(sendGain); sendGain.connect(reverb);
+    const pool = PERCUSSION_TYPES.has(type) ? "perc" : "melodic";
+    const active = poolCounts[pool] < TRACK_CAPS[pool];
+    if (active) poolCounts[pool]++;
     const row = {
       t, type, opts: { ...(t.synth.options || {}) }, gain, sendGain,
-      voice: { synth: null }, inserts: [], muted: false, skipped: false,
+      voice: { synth: null }, inserts: [], muted: !active, skipped: false,
+      _activatedSeq: active ? ++activateSeq : 0,
       grid: t.steps?.grid || "8n", notes: t.steps?.notes || [],
     };
     const inst = buildInstrument(row);
     row.voice.synth = inst.synth; row.inserts = inst.inserts;
     let last = -1;
     row.seq = new Tone.Sequence((time, tok) => {
+      if (row.audible === false) return;   // muted/un-soloed — skip trigger so the track costs ~nothing
       if (time <= last) return;        // skip non-increasing times (scheduler/loop collisions)
       last = time;
-      triggerStep(row.voice.synth, row.type, tok, row.grid, time);
+      if (tok) row.dirty = true;       // played a real note → its param timeline grows → recycler eligible
+      triggerStep(row.voice.synth, row.renderType, tok, row.grid, time);
     }, row.notes, row.grid).start(0);
     rows.push(row);
   });
 
-  built = { rows, masterGain, eq, comp, limiter, reverb };
+  built = { rows };
   return rows;
 }
 
@@ -233,11 +310,50 @@ async function build(spec) {
 function applyMuteSolo() {
   if (!built) return;
   const anySolo = built.rows.some((r) => r.solo);
+  const isAudible = (r) => !r.skipped && (anySolo ? r.solo : !r.muted);
+  // Equal-power level: scale each audible track by 1/sqrt(N) so the summed mix stays ~constant as
+  // tracks are added, instead of piling up and slamming the limiter into distortion ("clipping when
+  // complex"). N audible tracks each at MIX_TARGET/sqrt(N) → combined level ≈ MIX_TARGET.
+  const n = Math.max(1, built.rows.filter(isAudible).length);
+  const level = MIX_TARGET / Math.sqrt(n);
   built.rows.forEach((r) => {
     if (r.skipped) return;
-    const audible = anySolo ? r.solo : !r.muted;
-    r.gain.gain.rampTo(audible ? 1 : 0, 0.05);
+    const audible = isAudible(r);
+    r.audible = audible;   // the sequence callback reads this and SKIPS triggering when false, so a
+                           // muted/un-soloed track stops allocating voices + scheduling automation
+                           // (costs ~nothing) instead of computing silently. Gain ramp still fades
+                           // any currently-ringing voices.
+    r.gain.gain.rampTo(audible ? level : 0, 0.05);
   });
+}
+
+// ---- active-track cap -----------------------------------------------------------------
+// Many sustained synths through one ConvolverNode reverb overruns the audio render thread
+// (crackle that worsens with density). Keep every track loaded + tweakable, but only ever PLAY up
+// to each pool's TRACK_CAPS; the gate makes the rest cost ~0. Enabling one past a pool's cap evicts
+// the oldest-enabled in that pool (FIFO), so you only ever hear that-size combination at once.
+function activeRows() { return built ? built.rows.filter((r) => !r.skipped && !r.muted) : []; }
+
+function enforceCap() {
+  for (const pool of ["melodic", "perc"]) {
+    let active = activeRows().filter((r) => poolOf(r) === pool);
+    if (active.length <= TRACK_CAPS[pool]) continue;
+    active.sort((a, b) => (a._activatedSeq || 0) - (b._activatedSeq || 0));   // oldest enabled first
+    while (active.length > TRACK_CAPS[pool]) active.shift().muted = true;     // evict oldest in this pool
+  }
+}
+
+function syncTrackCheckboxes() {
+  if (!built) return;
+  built.rows.forEach((r) => { if (r._muteCb) r._muteCb.checked = !!r.muted; });
+}
+
+function updateActiveHint() {
+  if (!built) { $("meta").textContent = baseMeta; return; }
+  const a = activeRows();
+  const mel = a.filter((r) => poolOf(r) === "melodic").length;
+  const per = a.filter((r) => poolOf(r) === "perc").length;
+  $("meta").textContent = baseMeta + `  ·  ▶ ${mel} synth (max ${TRACK_CAPS.melodic}) + ${per} perc (max ${TRACK_CAPS.perc}) playing`;
 }
 
 // ---- track cards + instrument controls ------------------------------------------------
@@ -283,12 +399,27 @@ function renderTracks() {
     const head = document.createElement("summary"); head.className = "track-head";
     const name = document.createElement("span"); name.className = "track-name"; name.textContent = row.t.name ?? "";
     head.append(name);
-    head.append(noToggle(selectCtl("synth", PALETTE, row.type, (v) => { row.type = v; rebuildTrack(row); })));
-    ["mute", "solo"].forEach((k) => {
+    // A monophonic PolySynth track is rendered as a mono Synth (no chords) — show that so the
+    // "PolySynth" dropdown value isn't misleading. Badge refreshes when the type/render changes.
+    const modeBadge = document.createElement("span"); modeBadge.className = "ctl"; modeBadge.style.opacity = ".55";
+    const refreshBadge = () => { modeBadge.textContent = (row.renderType && row.renderType !== row.type) ? `→ ${row.renderType} (mono)` : ""; };
+    head.append(noToggle(selectCtl("synth", PALETTE, row.type, (v) => { row.type = v; rebuildTrack(row); refreshBadge(); })));
+    refreshBadge();
+    head.append(noToggle(modeBadge));
+    // label text -> state field. The mute box must write `row.muted` (what applyMuteSolo reads);
+    // a prior `row[k]` wrote `row.mute`, which nothing read, so mute silently did nothing.
+    [["mute", "muted"], ["solo", "solo"]].forEach(([label, key]) => {
       const l = document.createElement("label"); l.className = "ctl";
       const cb = document.createElement("input"); cb.type = "checkbox";
-      cb.addEventListener("change", () => { row[k] = cb.checked; applyMuteSolo(); });
-      l.append(cb, k); head.append(noToggle(l));
+      cb.checked = !!row[key];                 // reflect default state (tracks past the cap start muted)
+      if (key === "muted") row._muteCb = cb;   // ref so cap-eviction can re-check the box
+      cb.addEventListener("change", () => {
+        row[key] = cb.checked;
+        if (key === "muted" && !cb.checked) row._activatedSeq = ++activateSeq;   // newly enabled → newest
+        if (key === "muted") enforceCap();      // may evict the oldest-enabled track
+        applyMuteSolo(); syncTrackCheckboxes(); updateActiveHint();
+      });
+      l.append(cb, label); head.append(noToggle(l));
     });
     card.append(head);
 
@@ -314,8 +445,10 @@ async function loadSpecFromJson(json, label, slug) {
   currentSlug = slug || null;
   if ((await build(spec)) === null) return;   // superseded by a newer load — leave the UI to it
   renderTracks();
+  applyMuteSolo();   // set audible/gain from the default active set (each pool filled to its cap)
   const head = label ? `${label} · ` : "";
-  $("meta").textContent = `${head}${spec.root ?? "?"} ${spec.mode ?? ""} · ${Math.round(spec.bpm ?? 0)} BPM · ${(spec.tracks || []).length} tracks`;
+  baseMeta = `${head}${spec.root ?? "?"} ${spec.mode ?? ""} · ${Math.round(spec.bpm ?? 0)} BPM · ${(spec.tracks || []).length} tracks`;
+  updateActiveHint();
   $("warnings").textContent = warnings.join("\n");
   $("status").textContent = "";
   $("play").disabled = false; $("stop").disabled = false;
@@ -375,9 +508,35 @@ async function initLibrary() {
 }
 initLibrary();
 
+// Auto-pause when the window/tab loses focus. Browsers throttle background-tab timers, which
+// starves Tone's main-thread scheduler → glitches. Rather than fight that, pause cleanly and
+// resume on return. pause() preserves Transport position so playback continues where it left off.
+let userWantsPlay = false;   // intent: did the user hit Play (and not Stop)?
+let autoPaused = false;      // we paused due to lost focus (vs. the user stopping)
+let windowFocused = document.hasFocus();   // tracked via focus/blur events (not polled)
+
+function syncPlayback() {
+  if (!userWantsPlay) return;
+  const activeNow = windowFocused && !document.hidden;
+  if (activeNow && autoPaused) {
+    Tone.getContext().resume();           // context may have been suspended while hidden
+    Tone.Transport.start(); autoPaused = false; $("status").textContent = "";
+  } else if (!activeNow && !autoPaused && Tone.Transport.state === "started") {
+    Tone.Transport.pause(); autoPaused = true; $("status").textContent = "⏸ paused — window not focused";
+  }
+}
+window.addEventListener("blur", () => { windowFocused = false; syncPlayback(); });
+window.addEventListener("focus", () => { windowFocused = true; syncPlayback(); });
+document.addEventListener("visibilitychange", syncPlayback);   // tab hidden/minimized
+
 $("play").addEventListener("click", async () => {
   await Tone.start();
-  Tone.getContext().lookAhead = 0.2;
+  Tone.getContext().lookAhead = 0.2;   // modest runway; the persistent bus removed the build jank this compensated for
+  userWantsPlay = true; autoPaused = false;
   Tone.Transport.start();
+  startRecycler();                      // prune accumulating synth param timelines during sustained play
 });
-$("stop").addEventListener("click", () => { Tone.Transport.stop(); Tone.Transport.position = 0; });
+$("stop").addEventListener("click", () => {
+  userWantsPlay = false; autoPaused = false;
+  Tone.Transport.stop(); Tone.Transport.position = 0;
+});


### PR DESCRIPTION
Follow-up to #242. The Tone.js preview player crackled and degraded the longer it ran (worse when switching tracks), and distorted in dense passages. Diagnosed with in-browser measurement and a Firefox profile: the main thread is mostly Tone scheduling (steady ~14%), so the real costs were **audio-thread DSP**, **gain staging**, and **background-tab timer throttling** — not a single JS leak.

## Fixes (all in `tools/audio-reference/player/player.js`)
- **Persistent master bus + reverb** — built once and reused, instead of re-rendering the `ConvolverNode` impulse response on every track switch (the per-switch accumulating leak).
- **Mute gates computation** — silenced tracks skip triggering (cost ~0). Also fixes a pre-existing bug where the mute box wrote `row.mute` but the code read `row.muted`, so mute did nothing.
- **PolySynth handling** — cap `maxPolyphony` (16); render *monophonic* PolySynth tracks as a cheap mono `Synth` (with a `→ Synth (mono)` badge), keep PolySynth only for real chord pads. Mirrors the game engine.
- **Synth recycler** — periodically swap in a fresh synth to prune Web Audio's un-prunable `AudioParam` timelines (the unbounded over-time growth).
- **Per-pool active-track caps** — `{ melodic: 4, perc: 6 }`. Bounds simultaneous DSP; the cheap drum kit gets its own headroom; enabling past a cap FIFO-evicts within that pool.
- **Chiptune oscillator clamp** — `MAX_OSC_VOICES = 3` collapses fat 3–8-voice oscillators (the biggest per-note cost) toward fewer voices.
- **Equal-power mixing** — each audible track at `MIX_TARGET/√active`, so a dense mix doesn't stack up and slam the limiter into distortion ("clipping when complex").
- **Auto-pause on blur** — pause cleanly when the window/tab loses focus (browser timer throttling starves the scheduler) and resume on return, instead of glitching.

Key thresholds (`TRACK_CAPS`, `MAX_OSC_VOICES`, `MIX_TARGET`, `RECYCLE_*`) are single constants, tuned by ear and easy to adjust.

## Testing
Verified in a headed Firefox via Playwright (real audio context): reverb IR renders once not per-switch; timeline sawtooths instead of growing unbounded; mute drops triggers to zero; caps hold (e.g. Kite 17 tracks → 4 synth + 6 perc); monophonic PolySynth downgrade (12 of 29 corpus tracks); auto-pause toggles Transport on blur/focus; zero console errors throughout. Final sustained-playback feel confirmed by ear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)