### PR TITLE
Graph render perf: static alert border + lighter overlay glow + glow-ownership rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -479,6 +479,31 @@ or raster textures. This governs HUD/UI chrome, not just the graph.
 When in doubt: would an oscilloscope or a vector arcade cabinet draw it that way? If it
 needs a fill, a circle, or a dither, it's the wrong primitive.
 
+### Glow / bloom — one owner per layer, never stacked
+
+The phosphene glow is produced by three different rendering mechanisms (they can't be unified
+into one — different pipelines), so the rule is **one owner per layer, and never two glows on
+the same element**:
+
+- **Graph canvas (`#cy`)** → the heavy `#starnet-bloom` SVG filter (3-pass merge), defined once in
+  `graph.js` `ensureBloomFilter()`. It's suspended during pan/zoom and ramped back (re-rastering
+  a full-screen filter every frame is expensive).
+- **Graph overlays (`#overlay-layer > *`)** → the lighter single-pass `#overlay-bloom`, also in
+  `ensureBloomFilter()`. Overlays animate every frame, so they must use the cheap filter — and an
+  overlay element must **not** carry its own `filter="url(...)"` on top of the layer filter
+  (stacking re-rasterizes two filters per frame; this caused real fps drops — see the
+  `graph-perf` session).
+- **HUD / DOM chrome** → CSS `--glow-sm/--glow-md/--glow-lg` (`style.css`) via `text-shadow` /
+  `box-shadow`. Use these tokens, don't hand-roll blur radii.
+- **Indicator glyphs** (`indicator-glyphs.js`) → the shared `glowDefs()` / `GLOW_BLUR` baked-in
+  `feDropShadow`. One definition; don't re-specify the filter per glyph.
+- **Canvas vitals** (`starnet-waveform.js`) → `ctx.shadowBlur`/`shadowColor`.
+
+**Guardrails:** never apply a continuous `node.animate`/`cy.animate` loop or a heavy filter to an
+element that animates every frame — drive perpetual visual effects off the cy model and off the
+heavy bloom (overlays/canvas, cheap filter). New glow goes through one of the owners above, not a
+fresh ad-hoc filter.
+
 ## What's Shipped (Current Build)
 
 - Probe → Xploit → Dump → Fetch → Jack Out core loop

--- a/css/style.css
+++ b/css/style.css
@@ -172,8 +172,11 @@ html, body {
 #cy {
   filter: url(#starnet-bloom);
 }
+/* Overlays animate every frame (brackets, sweeps, reticle), so they use the lighter
+   single-pass #overlay-bloom rather than #cy's heavy 3-pass #starnet-bloom — the heavy one
+   re-rasterized per frame during an action animation was tanking the frame rate. */
 #overlay-layer > * {
-  filter: url(#starnet-bloom);
+  filter: url(#overlay-bloom);
 }
 
 #cy {

--- a/docs/dev-sessions/2026-06-30-1158-graph-perf/plan.md
+++ b/docs/dev-sessions/2026-06-30-1158-graph-perf/plan.md
@@ -1,0 +1,105 @@
+# Graph Render Performance — Implementation Plan
+
+**Goal:** Stop alerted nodes from forcing a continuous full-canvas Cytoscape redraw (the
+confirmed ~48%-CPU cause). Replace the perpetual alert-pulse `node.animate` loop with a static
+alert border. Fancier (overlay/CSS) alert representation is deferred per Les.
+
+**Root cause (confirmed):** `redPulse`/`yellowPulse` (`graph.js:110-128`) recurse `node.animate`
+forever while a node stays yellow/red. Cytoscape's animation system redraws the whole canvas
+every frame while any element animates; alerts don't clear below trace, so it never idles.
+`_cy.elements().stop()` restored 110fps in-browser — confirmed.
+
+## Phase 1: Static alert border (drop the perpetual pulse)
+
+**Files:**
+- Modify: `js/ui/graph.js`
+
+**Key changes:**
+- Remove `redPulse` / `yellowPulse` (the two `createPulseAnimator` instances, ~`110-128`) and
+  their membership sets `pulsingNodes` / `yellowPulsingNodes` (`70-71`). Keep `createPulseAnimator`
+  and `rebootPulse` (reboot is transient — out of scope, revisit later).
+- In `updateNodeStyle` (`~688-701`): keep the class management
+  (`removeClass("alert-yellow alert-red")` + conditional `addClass`), and **delete** the
+  `redPulse.start/stop` / `yellowPulse.start/stop` block. Alert state now reads purely from the
+  static class.
+- Bump the static selectors so alerts still read strongly without the strobe peak:
+  - `node.accessible.alert-yellow` (`~533`): `border-color "#ffcc00"`, `border-width 2`.
+  - `node.accessible.alert-red` (`~541`): `border-color "#ff3030"`, `border-width 2`.
+  - Update the "strobe-blinked by JS animation" comments to "static" (no longer animated).
+
+**Verification — automated:**
+- [x] `make check` passes (1465 tests, 0 fail).
+- [x] `grep -n "pulsingNodes\|yellowPulsingNodes\|redPulse\|yellowPulse" js/ui/graph.js` → no hits.
+
+**Verification — manual (with Les, in-browser):** ✅ confirmed — alert fix landed, fps holds.
+- [x] Trigger an alert (fail an exploit, or `cheat alert`) so a node goes yellow/red.
+- [x] The node shows a clear solid colored border (amber/red) glowing under the bloom — no strobe.
+- [x] fps **holds** with the alert active — the drop is gone.
+- [x] `_cy.animated()` is `false` while sitting with an alert up (no perpetual animation).
+
+> TDD opt-out: this is a rendering change in a `@ts-nocheck`, DOM/Cytoscape-coupled module with no
+> pure-logic seam; verified by `make check` (no breakage) + the in-browser perf/visual checks above.
+
+## Phase 2: cheaper overlay glow (fix the xploit/action-animation dip)
+
+Action overlays (esp. exploit-brackets) animate every frame under the heavy `#starnet-bloom`
+(2-radius, 3-pass merge), which re-rasterizes per frame because the bracket geometry changes
+(rotate + converge). Transient dip during the animation; recovers after. Same family as the alert
+bug — an animation re-rasterizing a costly filter every frame.
+
+**Files:** `js/ui/graph.js` (filter def + ), `css/style.css` (overlay filter), `js/ui/overlays/exploit-brackets.js`.
+
+**Key changes:**
+- Add a lighter, color-preserving `#overlay-bloom` filter in `ensureBloomFilter` (single
+  `feGaussianBlur` merged under the source — one blur pass vs three).
+- Point `#overlay-layer > * { filter: ... }` at `#overlay-bloom` (keep `#cy` on the heavy
+  `#starnet-bloom` — it's mostly static now that alerts don't redraw it).
+- exploit-brackets: drop the redundant per-zap `filter="url(#zap-bloom)"` + its `<defs>` (the
+  overlay glow now covers the zaps), and remove the `getBoundingClientRect()` forced reflow in
+  `_fireZap` (a per-zap synchronous layout, ~33×/sec).
+
+**Verification — automated:**
+- [ ] `make check` passes.
+
+**Verification — manual (with Les):** ✅ confirmed — no dramatic xploit dip now.
+- [x] xploit a node: fps **holds** through the bracket animation (no dip), recovers as before.
+- [x] The brackets/zaps still read as glowing magenta vector effects (lighter halo is acceptable).
+- [x] Other overlays (probe sweep, reticle, ICE) still look right with the lighter glow.
+
+## Phase 3: glow consolidation (light) — guardrail + dedupe
+
+A game-wide glow audit found **no remaining double-blooms** (Phase 2 removed the last). Remaining
+work is anti-recurrence + dedupe (the three glow mechanisms can't be unified — different
+pipelines; a full rewrite isn't worth it).
+
+**Files:** `js/ui/indicator-glyphs.js`, `CLAUDE.md`.
+
+**Key changes:**
+- `indicator-glyphs.js`: extract one `glowDefs(color)` + `GLOW_BLUR` token; route `svgWrap` and
+  the two hand-inlined filter `<defs>` (tick meter, access glyph) through it. Unifies the blur
+  (was 1.6/1.6/1.4 → 1.6; access glyph gains a hair of glow, imperceptible). Drops the unused
+  `blur` param on `svgWrap`.
+- `CLAUDE.md`: add a "Glow / bloom — one owner per layer, never stacked" rule documenting the
+  ownership map (`#starnet-bloom`=canvas, `#overlay-bloom`=overlays, `--glow-*`=DOM, `glowDefs`=
+  glyphs, canvas shadow=vitals) and the guardrails (no per-frame animation/heavy-filter on
+  animating elements; no element-filter stacked under a layer-filter).
+
+**Verification — automated:**
+- [x] `make check` passes (1465, 0 fail); no tests assert the old per-glyph blur.
+- [x] `grep "filter id=" js/ui/indicator-glyphs.js` → only the single `glowDefs` definition.
+
+**Verification — manual (with Les):**
+- [ ] HUD indicator glyphs (alert lamp, conn status, tick meter, access glyph) still glow
+      correctly (the access glyph's glow is marginally stronger: blur 1.4→1.6).
+
+## What we're NOT doing
+
+- Not touching the reboot pulse (transient; same pattern but bounded — note for the later revisit).
+- Not building the overlay/CSS pulsing glow yet (deferred design choice).
+- Not changing alert *semantics* — only how an alerted node is drawn.
+
+## Follow-ons (later session)
+
+- Re-represent alert glow as a node-anchored CSS/overlay throb (smooth + cheap), and apply the
+  same treatment to reboot.
+- Re-represent **deck damage** off the cy model (it jitters node positions → same redraw cost).

--- a/docs/dev-sessions/2026-06-30-1158-graph-perf/spec.md
+++ b/docs/dev-sessions/2026-06-30-1158-graph-perf/spec.md
@@ -1,0 +1,79 @@
+# Graph Render Performance — investigation + fix
+
+**Goal:** The game drops to ~40fps (and runs uneven/jaggy) during normal play. Find why and fix
+it, so the graph holds a steady frame rate.
+
+**Source:** User report + DevTools profile `~/Downloads/Trace-20260630T114029.json.gz`
+(2026-06-30). Surfaced while building the flow substrate; flows were ruled out.
+
+## What the profile shows (definitive)
+
+- **Cytoscape's canvas renderer (`i` in `vendor.js`) is ~48% of all CPU self-time** — 28.7s of a
+  ~59s trace. Its children are renderer functions (`Xs.render`, `Ll.drawLayeredElements`,
+  `getPixelRatio`). It sits at the profile **root** (a scheduled callback), i.e. Cytoscape is
+  **redrawing its full canvas every frame, continuously.**
+- Everything else is small by comparison: GC ~950ms (1.6%), Paint 366ms, Layout 310ms,
+  Composite/Layerize ~230ms each. So it is **not** GC, **not** the `#starnet-bloom` filter,
+  **not** paint/composite, **not** the flow layer (≈0 in the trace).
+
+## Ruled out
+
+- **Flow substrate** — `flow-layer.js` ≈0 in the trace; the canvas renderer is unrelated.
+- **Audio** — drop persists with music + SFX disabled.
+- **Selection reticle bloom** — exempting it from the bloom didn't help.
+- **Deck perturbation** — early-returns at deck severity 0 (`deck-perturbation.js:188`); the
+  reported drop happened with **no deck damage**, so it isn't the cause *here*. BUT it remains a
+  known cost when active: it jitters node *positions* every frame, forcing full-canvas redraws —
+  the same mechanism. Re-representing deck damage via an overlay (not cy-model mutation) is in
+  scope as a follow-on.
+
+## Leading hypothesis
+
+Something keeps the Cytoscape canvas **marked dirty every frame**, so the renderer never idles.
+Candidates, in rough priority:
+1. A perpetual **node/element animation** (e.g. an alert pulse loop via `node.animate` in
+   `graph.js:~87`) left running, or `cy.animated()` stuck true.
+2. The **cola layout** not settling / being re-kicked (cola tick fns `overlapX`/`findIter` appear
+   under the redraw, though small).
+3. Some code calling `cy` in a way that requests a render each frame.
+
+`DEFAULT_LAYOUT_ALGO = "cola"` (continuous physics); hand-crafted nets use `preset`, generated
+nets lay out with cola. Whether the trace was a generated or named network matters.
+
+## Immediate next step — pin the trigger in the browser (console probes)
+
+Run with the game open and dropping frames:
+
+```js
+// 1) Is an animation driving renders?
+_cy.animated()
+_cy.nodes().filter(n => n.animated()).map(n => n.id())   // perpetually-animating nodes
+
+// 2) Count actual redraws/sec (idle, no interaction):
+let n=0, r=_cy.renderer(), orig=r.redraw.bind(r);
+r.redraw=(...a)=>{n++;return orig(...a)};
+setTimeout(()=>{ console.log('redraws/sec~', (n/3).toFixed(0)); r.redraw=orig; }, 3000);
+
+// 3) Does stopping element animations recover fps?
+_cy.elements().stop();
+```
+
+- `_cy.animated()` true / `stop()` recovers fps → perpetual element animation (find + bound it).
+- redraws/sec ~ 60 while idle → confirms continuous redraw regardless of trigger.
+- Also note: **generated network (hub) or named (`?network=`)?**
+
+## Desired end state
+
+Cytoscape idles (no redraws) when nothing is changing; steady frame rate during play. Deck-damage
+representation reconsidered if it can't be made cheap. Specifics depend on the trigger found above.
+
+## What we're NOT doing (yet)
+
+- Not rewriting the renderer or swapping Cytoscape.
+- Not touching the flow substrate (separate, parked branch).
+- Not a blanket "disable effects" — fix the specific continuous-redraw cause.
+
+## Open questions
+
+- Exact continuous-redraw trigger — **blocks the fix; resolve via the console probes above.**
+- Was the profile on a generated vs named network — default assumption: generated (cola), confirm.

--- a/js/ui/graph.js
+++ b/js/ui/graph.js
@@ -67,8 +67,6 @@ export function onViewport(fn) { viewportListeners.push(fn); }
 let _reticleOverlay = null;
 /** @param {any} el */
 export function setReticleOverlay(el) { _reticleOverlay = el; }
-const pulsingNodes = new Set();       // nodeIds running red-alert pulse
-const yellowPulsingNodes = new Set(); // nodeIds running yellow-alert pulse
 const rebootingNodes = new Set();     // nodeIds running reboot opacity pulse
 
 // Build a looping node-style pulse. All three pulses share the same shape —
@@ -104,28 +102,11 @@ function createPulseAnimator({ set, frames, clearStyle }) {
   };
 }
 
-// Thin strobe blink (not a fattening breathe): a thin constant-width border that
-// flickers bright→dim, so under the global bloom it reads as a vector alarm
-// strobe rather than a throbbing halo. Red strobes fast (urgent).
-const redPulse = createPulseAnimator({
-  set: pulsingNodes,
-  clearStyle: "border-color border-width",
-  frames: [
-    { style: { "border-color": "#ff3030", "border-width": 1.5 }, duration: 220 },
-    { style: { "border-color": "#5a1010", "border-width": 1.5 }, duration: 420 },
-  ],
-});
-
-// Yellow strobes slower/softer than red (lower urgency), same thin-blink idea.
-const yellowPulse = createPulseAnimator({
-  set: yellowPulsingNodes,
-  clearStyle: "border-color border-width",
-  frames: [
-    { style: { "border-color": "#ffcc00", "border-width": 1.5 }, duration: 480 },
-    { style: { "border-color": "#4a3800", "border-width": 1.5 }, duration: 720 },
-  ],
-});
-
+// Alert state (yellow/red) is shown as a STATIC colored border via the cy stylesheet
+// (node.accessible.alert-yellow / .alert-red), not a JS animation: a perpetual node.animate
+// pulse kept Cytoscape redrawing the whole canvas every frame for the rest of the run (alerts
+// don't clear below trace), which tanked the frame rate. A cheaper animated treatment
+// (CSS/overlay throb off the cy model) is a deferred follow-on.
 const rebootPulse = createPulseAnimator({
   set: rebootingNodes,
   clearStyle: "opacity",
@@ -187,6 +168,14 @@ function ensureBloomFilter() {
     `<feGaussianBlur in="SourceGraphic" stdDeviation="${BLOOM_WIDE * bloomIntensity}" result="b1"/>` +
     `<feGaussianBlur in="SourceGraphic" stdDeviation="${BLOOM_TIGHT * bloomIntensity}" result="b2"/>` +
     '<feMerge><feMergeNode in="b1"/><feMergeNode in="b1"/><feMergeNode in="b2"/><feMergeNode in="SourceGraphic"/></feMerge>' +
+    '</filter>' +
+    // Lighter, color-preserving glow for the OVERLAY layer: a single blur pass under the
+    // source, vs starnet-bloom's three. Overlays animate every frame (brackets, sweeps), so
+    // the filter is re-rasterized continuously — the cheaper one keeps that affordable. #cy
+    // keeps the heavy phosphor bloom (it's mostly static).
+    '<filter id="overlay-bloom" x="-60%" y="-60%" width="220%" height="220%">' +
+    '<feGaussianBlur in="SourceGraphic" stdDeviation="2" result="ob"/>' +
+    '<feMerge><feMergeNode in="ob"/><feMergeNode in="SourceGraphic"/></feMerge>' +
     '</filter>';
   document.body.appendChild(svg);
   // Expose for live experimentation / future deck-damage hookup.
@@ -528,20 +517,20 @@ function buildStylesheet() {
         "text-outline-width": 3,
       },
     },
-    // Alert state: yellow — thin amber border (strobe-blinked by JS animation)
+    // Alert state: yellow — static amber border (lit by the global bloom; no JS animation)
     {
       selector: "node.accessible.alert-yellow",
       style: {
-        "border-color": "#996600",
-        "border-width": 1.5,
+        "border-color": "#ffcc00",
+        "border-width": 2,
       },
     },
-    // Alert state: red — thin red border (strobe-blinked by JS animation)
+    // Alert state: red — static red border (lit by the global bloom; no JS animation)
     {
       selector: "node.accessible.alert-red",
       style: {
-        "border-color": "#cc1100",
-        "border-width": 1.5,
+        "border-color": "#ff3030",
+        "border-width": 2,
       },
     },
     // Obscured — identity hidden behind sig-N alias until probed. Keeps the
@@ -684,22 +673,11 @@ export function updateNodeStyle(nodeId, nodeState) {
       node.addClass(nodeState.accessLevel);
     }
 
-    // Alert state
+    // Alert state — static colored border via the stylesheet (see note at rebootPulse: the
+    // old perpetual node.animate pulse forced a full-canvas redraw every frame).
     node.removeClass("alert-yellow alert-red");
     if (nodeState.alertState === "yellow") node.addClass("alert-yellow");
     if (nodeState.alertState === "red") node.addClass("alert-red");
-
-    // Alert pulse animations (shadow-blur is invalid in Cytoscape; use bg/border instead)
-    if (nodeState.alertState === "red") {
-      if (yellowPulsingNodes.has(nodeId)) yellowPulse.stop(node);
-      redPulse.start(node);
-    } else if (nodeState.alertState === "yellow") {
-      if (pulsingNodes.has(nodeId)) redPulse.stop(node);
-      yellowPulse.start(node);
-    } else {
-      if (pulsingNodes.has(nodeId)) redPulse.stop(node);
-      if (yellowPulsingNodes.has(nodeId)) yellowPulse.stop(node);
-    }
 
     // Glyph by node type — but an obscured node shows the bare dodecagon (no
     // glyph) so its type isn't telegraphed before it's probed. The container

--- a/js/ui/indicator-glyphs.js
+++ b/js/ui/indicator-glyphs.js
@@ -25,19 +25,27 @@ const DIM   = "#2a3a55";
 
 // ── SVG wrapper ───────────────────────────────────────────────────────────────
 
+// Single source for the indicator-glyph phosphene glow. Every glyph's baked-in glow is the
+// named "g" feDropShadow flood-colored to match its stroke — kept here so the blur radius
+// isn't re-specified (and allowed to drift) at each glyph site.
+const GLOW_BLUR = 1.6; // feDropShadow stdDeviation (px)
+
+/** Shared `<defs>` for the named "g" glow filter, flood-colored to the glyph's stroke. */
+const glowDefs = (/** @type {string} */ color) =>
+  `<defs><filter id="g" x="-50%" y="-50%" width="200%" height="200%"><feDropShadow dx="0" dy="0" stdDeviation="${GLOW_BLUR}" flood-color="${color}"/></filter></defs>`;
+
 /**
- * Wrap an SVG body in a full standalone SVG element with stroke defaults and
- * a phosphene glow filter (feDropShadow on a named filter id "g").
+ * Wrap an SVG body in a full standalone SVG element with stroke defaults and the shared
+ * phosphene glow filter.
  *
  * @param {string} viewBox   - e.g. "16 16" -> becomes "0 0 16 16"
  * @param {string} body      - inner SVG elements (no fill overrides)
  * @param {string} color     - stroke color (also used as glow flood-color)
- * @param {number} [blur=1.6] - feDropShadow stdDeviation
  * @returns {string}
  */
-function svgWrap(viewBox, body, color, blur = 1.6) {
+function svgWrap(viewBox, body, color) {
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${viewBox}" fill="none" stroke="${color}" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round">`
-    + `<defs><filter id="g" x="-50%" y="-50%" width="200%" height="200%"><feDropShadow dx="0" dy="0" stdDeviation="${blur}" flood-color="${color}"/></filter></defs>`
+    + glowDefs(color)
     + `<g filter="url(#g)">${body}</g></svg>`;
 }
 
@@ -162,7 +170,7 @@ export function tickMeterSvg(frac, opts = {}) {
 
   // Build SVG manually to allow per-line stroke overrides (no top-level stroke override).
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}" fill="none">`
-    + `<defs><filter id="g" x="-50%" y="-50%" width="200%" height="200%"><feDropShadow dx="0" dy="0" stdDeviation="1.6" flood-color="${color}"/></filter></defs>`
+    + glowDefs(color)
     + `<g filter="url(#g)">${body}</g></svg>`;
 }
 
@@ -251,7 +259,7 @@ export function accessGlyphSvg(accessLevel) {
           + ` stroke-width="${isLit ? 1.8 : 1.4}"/>`;
   }
   return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 18" fill="none" stroke-linecap="round" stroke-linejoin="round">`
-    + `<defs><filter id="g" x="-50%" y="-50%" width="200%" height="200%"><feDropShadow dx="0" dy="0" stdDeviation="1.4" flood-color="${color}"/></filter></defs>`
+    + glowDefs(color)
     + `<g filter="url(#g)">${body}</g></svg>`;
 }
 

--- a/js/ui/overlays/exploit-brackets.js
+++ b/js/ui/overlays/exploit-brackets.js
@@ -40,15 +40,6 @@ class ExploitBracketsOverlay extends NodeOverlay {
   render() {
     return html`
       <svg style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
-        <defs>
-          <filter id="zap-bloom" x="-50%" y="-50%" width="200%" height="200%">
-            <feGaussianBlur in="SourceGraphic" stdDeviation="2.5" result="blur"></feGaussianBlur>
-            <feMerge>
-              <feMergeNode in="blur"></feMergeNode>
-              <feMergeNode in="SourceGraphic"></feMergeNode>
-            </feMerge>
-          </filter>
-        </defs>
         <line class="b-tl-h" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"></line>
         <line class="b-tl-v" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"></line>
         <line class="b-tr-h" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"></line>
@@ -57,10 +48,10 @@ class ExploitBracketsOverlay extends NodeOverlay {
         <line class="b-br-v" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"></line>
         <line class="b-bl-h" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"></line>
         <line class="b-bl-v" stroke="#cc00cc" stroke-width="1.5" stroke-opacity="0.9"></line>
-        <line class="zap exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0" filter="url(#zap-bloom)"></line>
-        <line class="zap exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0" filter="url(#zap-bloom)"></line>
-        <line class="zap exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0" filter="url(#zap-bloom)"></line>
-        <line class="zap exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0" filter="url(#zap-bloom)"></line>
+        <line class="zap exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0"></line>
+        <line class="zap exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0"></line>
+        <line class="zap exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0"></line>
+        <line class="zap exploit-zap" stroke="#ff44ff" stroke-width="0.75" stroke-opacity="0"></line>
       </svg>`;
   }
 
@@ -135,15 +126,16 @@ class ExploitBracketsOverlay extends NodeOverlay {
     const zaps = this._svg()?.querySelectorAll(".zap");
     const el = /** @type {SVGElement} */ (zaps?.[i]);
     if (el) {
+      // Instant-on this frame (transition off), then fade out next frame (transition on).
+      // Deferring to rAF avoids a forced synchronous layout (getBoundingClientRect) per zap.
       el.style.transition = "none";
       el.setAttribute("x1", String(corners[i][0]));
       el.setAttribute("y1", String(corners[i][1]));
       el.setAttribute("x2", String(tx));
       el.setAttribute("y2", String(ty));
       el.setAttribute("stroke-opacity", "0.6");
-      el.getBoundingClientRect();
-      el.style.transition = "";
       requestAnimationFrame(() => {
+        el.style.transition = "";
         el.setAttribute("stroke-opacity", "0");
       });
     }


### PR DESCRIPTION
Fixes a pre-existing performance bug where the graph dropped to ~40fps and ran uneven during normal play. A DevTools profile pinned it: Cytoscape redrawing its whole canvas every frame (~48% CPU) because alerted nodes ran a perpetual `node.animate` strobe that never settles (alerts do not clear below trace).

## Changes
- **Phase 1 — static alert border.** Replace the perpetual yellow/red `node.animate` strobe with a static colored border via the stylesheet. Removes the continuous full-canvas redraw — the fps killer. (~40fps → ~110fps with an alert up.)
- **Phase 2 — lighter overlay glow.** Add a single-pass `#overlay-bloom` for `#overlay-layer` (keep the heavy 3-pass `#starnet-bloom` on the mostly-static `#cy`); drop the exploit-brackets redundant per-zap filter + a per-zap forced reflow. Fixes the transient dip during xploit/probe animations.
- **Phase 3 — glow consolidation.** Dedupe the 3 indicator-glyph drop-shadows into one `glowDefs`/`GLOW_BLUR`, and add a "one glow owner per layer, never stacked" rule to CLAUDE.md so ad-hoc/double blooms do not recur.

## Root cause / lesson (now a CLAUDE.md guardrail)
Continuous visual effects must not be driven through the Cytoscape model or the heavy bloom — any per-frame `node.animate`/`cy.animate` or heavy-filter re-raster pins the renderer.

## Test plan
- `make check` green (1465 tests, 0 fail).
- In-browser (verified): fps holds with an alert active (was ~40, now ~110); no dip during the xploit animation; alert nodes show a clear static glowing border; overlays still glow.
- Rendering-only; no gameplay/balance change — bot/census unaffected.

Session docs: `docs/dev-sessions/2026-06-30-1158-graph-perf/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)