### PR TITLE
Audio engine rebuild Phase 1: Strudel + superdough (AGPL), behind a flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,6 +517,10 @@ fresh ad-hoc filter.
   Corporate variants, section-breakdown automation; see `docs/audio-direction.md`
 - Synthesized event SFX (Tone.js): one-shot cues on game events, own always-available bus +
   on/off toggle, independent of music; see `docs/audio-direction.md`
+- Alternate **Strudel + superdough audio engine** (AGPL) behind a boot flag (`audio engine
+  <tone|strudel>`, reload to apply; Tone is still the default): music + one-shot SFX + action
+  drones in one engine, same reactive signals. Phase 1 of the Tone→Strudel migration (issue #254);
+  the game is now AGPL-3.0. See `docs/audio-direction.md` + `js/audio/strudel/`.
 
 ## Out of Scope (Future)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -852,6 +852,20 @@ so you can have effects with the music off, and they play in the hub as well as 
 **SFX commands** (console): `sfx` shows on/off status, `sfx list` lists every cue,
 `sfx test <cue>` auditions one, `sfx on|off` toggles them.
 
+### Audio engine (experimental)
+
+The game ships with two audio engines. **Tone** (the default) is the established engine
+described above. **Strudel** is a newer engine built on [Strudel](https://strudel.cc/) +
+superdough — one engine for music *and* sound effects, the same reactive progress/threat
+design and the same per-action drones. It's behind a flag while it reaches full parity.
+
+**Engine command** (console): `audio` shows the active engine; `audio engine strudel` or
+`audio engine tone` switches it. **The change takes effect after you reload the page.** The
+music and SFX on/off toggles work the same with either engine.
+
+(Because the engine bundles Strudel/superdough, which are AGPL-3.0, the game is licensed
+AGPL-3.0 — see the **source** link in the corner and `LICENSE`.)
+
 **SFX: On / Off** lives in the hamburger menu (`[ ☰ ]`) next to the music toggle. The choice is
 remembered between sessions.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all serve dev lint lint-imports test check bundle-vendor census bot-run generate gen-bot gen-json
 
 # Install dependencies and build vendor bundles
-all: node_modules dist/vendor.js dist/lit.js dist/tone.js
+all: node_modules dist/vendor.js dist/lit.js dist/tone.js dist/strudel.js
 
 node_modules: package.json
 	npm install
@@ -14,6 +14,9 @@ dist/lit.js: js/lit-vendor.js node_modules
 
 dist/tone.js: js/tone-vendor.js node_modules
 	npx esbuild js/tone-vendor.js --bundle --outfile=dist/tone.js --format=esm --platform=browser --minify
+
+dist/strudel.js: js/strudel-vendor.js node_modules
+	npx esbuild js/strudel-vendor.js --bundle --outfile=dist/strudel.js --format=esm --platform=browser --minify
 
 # Start local dev server (open http://localhost:3000)
 serve:
@@ -29,7 +32,7 @@ dev: all serve
 #   fixtures/             (test fixture data)
 lint:
 	npx tsc --noEmit --allowJs --checkJs --target ES2020 --moduleResolution bundler --module ES2020 \
-		$(shell find js -name '*.js' ! -name '*.test.js' ! -path '*/fixtures/*' ! -name 'graph.js' ! -name 'vendor.js' ! -name 'lit-vendor.js' ! -name 'tone-vendor.js')
+		$(shell find js -name '*.js' ! -name '*.test.js' ! -path '*/fixtures/*' ! -name 'graph.js' ! -name 'vendor.js' ! -name 'lit-vendor.js' ! -name 'tone-vendor.js' ! -name 'strudel-vendor.js')
 
 # Guard against absolute "/dist/..." paths in js/ and HTML. They resolve to the
 # domain root and 404 under a deploy subpath (e.g. GitHub Pages /starnet/), where
@@ -50,11 +53,12 @@ test:
 # Full check: imports guard + lint + test
 check: lint-imports lint test
 
-# Bundle vendor dependencies (Cytoscape + layout extensions, Lit, Tone)
+# Bundle vendor dependencies (Cytoscape + layout extensions, Lit, Tone, Strudel)
 bundle-vendor:
 	npx esbuild js/vendor.js --bundle --outfile=dist/vendor.js --format=iife --platform=browser --minify
 	npx esbuild js/lit-vendor.js --bundle --outfile=dist/lit.js --format=esm --platform=browser --minify
 	npx esbuild js/tone-vendor.js --bundle --outfile=dist/tone.js --format=esm --platform=browser --minify
+	npx esbuild js/strudel-vendor.js --bundle --outfile=dist/strudel.js --format=esm --platform=browser --minify
 
 # Shared grade defaults for bot/census/generate targets
 THREAT ?= C

--- a/README.md
+++ b/README.md
@@ -39,3 +39,17 @@ make check    # run tsc type checker (no emit)
 
 See [`CLAUDE.md`](CLAUDE.md) for architecture notes, dev workflow, and design principles.
 See [`docs/SPEC.md`](docs/SPEC.md) for the full game design document.
+
+## License
+
+The Starnet **engine** is licensed under the **GNU Affero General Public License v3.0**
+([`LICENSE`](LICENSE)). The engine bundles [Strudel](https://strudel.cc/) and superdough
+for audio, which are AGPL-3.0; bundling them makes the combined work AGPL-3.0.
+
+Following the **Doom model**, game *content* — future content packs ("wads": songs,
+missions, assets) — is kept as separately-licensed data loaded at runtime, never woven
+into the engine source, so it can carry its own license. The engine being AGPL does not
+force a particular license on the content it loads.
+
+As an AGPL §13 courtesy (and condition), the running game shows a **source** link to this
+public repository.

--- a/css/style.css
+++ b/css/style.css
@@ -1799,3 +1799,24 @@ html, body {
   flex-direction: column;
   gap: 6px;
 }
+
+/* AGPL-3.0 §13 source link — persistent, unobtrusive corner anchor. Stroke + glow,
+   no fill (vector phosphene discipline). Above the graph, below true modals. */
+#source-link {
+  position: fixed;
+  right: 8px;
+  bottom: 6px;
+  z-index: 9;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  color: var(--cyan-dim);
+  text-decoration: none;
+  opacity: 0.5;
+  transition: opacity 0.2s, color 0.2s, text-shadow 0.2s;
+}
+#source-link:hover {
+  opacity: 1;
+  color: var(--cyan);
+  text-shadow: var(--glow-sm) var(--cyan);
+}

--- a/docs/audio-direction.md
+++ b/docs/audio-direction.md
@@ -36,6 +36,42 @@ Chosen over Elementary, SunVox, and Strudel. Rationale:
 SunVox stays a possible *later* hybrid (author set-piece tracks, drive reactive layers from JS)
 if the JS-synth timbre ceiling ever frustrates. Not for v1 — one engine, learn the loop first.
 
+> **⚠️ Superseded — engine migrating to Strudel + superdough (AGPL).** The "MIT, Strudel
+> avoided" call above was reversed after spikes proved Strudel (music) + superdough (SFX) gives
+> one reactive, livecoding-native engine for music *and* SFX, FPS-clean in-game. The game is now
+> **AGPL-3.0** (Strudel/superdough are AGPL; bundling forces it) following the Doom model — open
+> engine, future content packs kept as separately-licensed runtime data. See issue #254 and the
+> "Strudel + superdough engine" section below. **Phase 1** has shipped behind an engine-select
+> flag (`audio engine strudel`; Tone still the default); Phases 2 (re-author the full reactive
+> design + variants) and 3 (flip the default, retire Tone) are follow-on. The two-axis model and
+> everything below still hold — only the output engine changes.
+
+### Strudel + superdough engine (Phase 1, behind a flag)
+
+A second engine lives under `js/audio/strudel/` — a single self-contained module
+(`initStrudelEngine`) that owns music, one-shot SFX, and action drones, selected at boot via the
+`starnet:audio-engine` pref (`audio engine <tone|strudel>`; reload to apply). Tone-default users
+never download its runtime (lazy `import()`).
+
+- **Runtime:** `@strudel/web@1.0.3` vendored offline via esbuild → `dist/strudel.js` (importmap
+  `@strudel/web`), mirroring `dist/tone.js`. Boot polls for the window globals `initStrudel`
+  registers (`runtime.js`); the AudioContext resumes on first gesture.
+- **Reuses `signals.js` unchanged** — `deriveProgress`/`deriveThreat` drive a live `stack()` whose
+  per-layer params are `signal()`-mapped (re-sampled each cycle, no re-eval). The corporate score
+  is DATA (`strudel/data/corporate.js`, 8 **synth-only** voices — no drum samples in Phase 1, so
+  the dirt-sample vendoring is deferred to Phase 2). Interpreter: `strudel/music.js`.
+- **One-shot SFX** are superdough voices from cue DATA (`strudel/data/cues.js`), covering the
+  Phase-1 events; the rest degrade to no cue until a follow-up.
+- **Action drones** can't be superdough one-shots (no live mid-voice sweeps), so they're a faithful
+  **raw-Web-Audio** port of the Tone `startDrone` graph (`strudel/drones.js` + `data/drones.js`),
+  driven by the same `ACTION_FEEDBACK` contract.
+- **Prefs/events:** the Tone renderers still own the music/SFX on-off prefs + `MUSIC_CHANGED`/
+  `SFX_CHANGED` events even when not running, so the HUD buttons + `music`/`sfx` commands work
+  unchanged; the Strudel engine just subscribes.
+- **Perf gate (Phase 1):** main-thread frame pacing under 8 voices + ~9 SFX/s + 4 rolling drones
+  held median **120 FPS** (== idle, on par with Tone) — synthesis is on the worklet thread. See
+  `docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/`.
+
 ### Intensity model: TWO AXES (progress + threat)
 
 The music's state is driven by two **independent** axes that combine:

--- a/docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/notes.md
+++ b/docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/notes.md
@@ -1,0 +1,93 @@
+# Notes — Strudel + superdough audio engine, Phase 1
+
+## What shipped (Phase 1 of issue #254)
+
+A second audio engine under `js/audio/strudel/`, selectable at boot, with Tone still the default.
+One self-contained module owns all **three** audio surfaces:
+
+1. **Reactive music** — one corporate score (DATA, 8 synth voices) → live `stack()` driven by
+   `deriveProgress`/`deriveThreat` via `signal()`.
+2. **One-shot SFX** — superdough voices on the Phase-1 events.
+3. **Action drones** — sustained, progress-driven, raw Web Audio (the surface Les flagged that the
+   issue's Phase-1 list omitted).
+
+Plus: **LICENSE (AGPL-3.0)** + in-game source link; `@strudel/web@1.0.3` vendored offline;
+`audio engine <tone|strudel>` console command (reload to apply).
+
+## How it was driven
+
+Full-auto express → PR (Les's call). I pushed back first — the perf gate is a human GO/NO-GO, the
+drone mapping was an open design question, and bundling had open decisions — and recommended driving
+interactively with checkpoints. Overruled, so the PR is the review point. Executed inline (not
+subagent-driven): the slices build one cohesive engine module where shared runtime understanding
+matters and each slice needs browser verification.
+
+7 vertical slices, one commit each, all browser-verified via Playwright with objective audio
+measurement (tee'd AnalyserNode RMS) rather than "should work":
+
+| Slice | What | Verified |
+|---|---|---|
+| 1 | AGPL LICENSE + source link | lint/test green; license text verbatim |
+| 2 | Vendor runtime + engine flag + boot | offline bundle boots clean, ctx resumes, superdough fires, 0 errors; lazy-load confirmed |
+| 3 | Reactive corporate score | CORPORATE audible (RMS 0.91), music off→silent, on→0.91 |
+| 4 | One-shot SFX | all 7 cues audible (0.77–0.99), sfx off→silent |
+| 5 | Action drones | all 7 drones audible+sweep+stop; full ACTION_FEEDBACK path end-to-end |
+| 6 | Perf gate | 120 FPS under load (== idle, on par with Tone) |
+| 7 | Docs | this + MANUAL + audio-direction |
+
+## Key decisions made autonomously (flagged for PR review)
+
+- **Bundling = vendor offline** (esbuild → `dist/strudel.js`), not CDN. esbuild handled
+  `@strudel/web` cleanly (415KB); worklet/synthesis path works offline in-browser. The "vendor vs
+  CDN" open decision is settled: **vendor**.
+- **Phase-1 score is synth-only** (no drum samples) → the dirt-sample vendoring question is
+  deferred to Phase 2 (no github-at-runtime dependency, perf gate stays clean).
+- **Action drones → raw Web Audio**, not superdough. superdough is a one-shot trigger engine and
+  can't sweep params mid-voice; the drones need live `setProgress` filter/detune/gain ramps. The
+  raw-Web-Audio voice is a faithful 1:1 port of the Tone `startDrone` graph against the shared
+  `getAudioContext()`. (This is the main thing I'd want Les to sanity-check.)
+- **Boot-time flag, no hot-swap.** Switching engines needs a reload (the `audio` command says so).
+  Avoids live Tone↔Strudel teardown complexity.
+- **Tone path left 100% untouched** when the flag is `tone` (zero regression risk). Verified Tone
+  still loads + 0 errors under default.
+
+## Known issues / limitations (Phase 1)
+
+- **Strudel engine still loads the Tone bundle** via static imports in `main.js` (the music/sfx
+  command modules import the Tone renderers). It's idle (no Tone playback), harmless — but the
+  415KB Tone bundle is downloaded needlessly under Strudel. Clean up in **Phase 3** when Tone is
+  removed (or make those imports dynamic if we want it sooner).
+- **`music off` has a ~2–3s tail** under Strudel — the Cyclist scheduler looks ahead ~1 cycle
+  (2s at cpm 30) + reverb tails. Measured: 0.88 RMS @1s after hush → 0 @3s. Not a bug; could
+  tighten with a faster cps or an explicit fade if it feels long.
+- **Phase-1 SFX covers only the 6 named events** (issue scope). Other routed events (navigate,
+  alert-cooled, ICE moved/ejected/rebooted, mining tiers, run-end variants, exploit decay, etc.)
+  resolve to no cue under Strudel — they still fire under Tone. Parity for those is a follow-up.
+- The reveal grade/cascade pitch nicety (Tone path) is **not** ported yet — Phase-1 reveal is flat.
+
+## Verified objectively vs. flagged for Les's ears/eyes at PR
+
+- **Objective (measured):** everything produces/stops audio correctly; FPS holds; lazy-load; the
+  full drone event path; param-mapping unit tests.
+- **Subjective (for Les at PR):** does it *sound good*? — audible progress/threat morph, the SFX
+  feel/mix, drone timbres vs the Tone originals, and the real gate: **no audible dropouts/crackle**
+  under dense play. The headless run measured main-thread pacing (synthesis is on the worklet
+  thread); audibility is a human call.
+
+To A/B: `audio engine strudel`, reload, click in. `audio engine tone` + reload to compare. Music
+and SFX on/off work with either engine.
+
+## Open questions for Les
+
+1. Is the raw-Web-Audio drone approach OK as the long-term shape, or should drones eventually become
+   Strudel patterns too (for consistency / livecoding authorability)?
+2. Should Phase 2 keep the synth-only constraint, or is vendoring the dirt-sample subset worth it
+   for the drum character (the Stripdown reference uses sample drums)?
+3. Tighten the `music off` tail now, or leave it for the Phase-2 re-author?
+
+## Deferred to Phases 2 / 3 (per spec)
+
+- **Phase 2:** re-author the full reactive design — remaining biomes, the 8 corporate variants,
+  section automation; dirt-sample vendoring if we want sample drums; remaining SFX cues at parity.
+- **Phase 3:** flip the default to Strudel, remove `engine.js` / Tone scores / Tone sfx / the
+  `tone` dep + importmap entry; drop the redundant Tone-bundle load.

--- a/docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/perf/strudel-perf.js
+++ b/docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/perf/strudel-perf.js
@@ -1,0 +1,54 @@
+// Strudel engine perf-gate measurement (issue #254 Phase 1).
+//
+// A browser-console / Playwright snippet — paste into the page console (or run via
+// page.evaluate) with the Strudel engine selected and booted (localStorage
+// "starnet:audio-engine"="strudel", reload, click once to resume the AudioContext).
+//
+// It measures main-thread frame pacing (requestAnimationFrame interval) under a dense audio
+// load: the 8-voice reactive music + ~9 one-shot SFX/sec + 4 rolling action drones. This is a
+// PROXY: audio synthesis runs on the AudioWorklet thread, so what this catches is whether
+// Strudel's main-thread scheduling/pattern-query janks the render loop. Audible dropouts/crackle
+// are a separate, human judgment (listen at PR review).
+//
+// Results recorded in notes.md. Re-run after any change to the engine's scheduling or score density.
+
+window.strudelPerf = async function strudelPerf({ loadMs = 10000, idleMs = 5000 } = {}) {
+  const eng = window.strudelEngine;
+  if (!eng?.drones) throw new Error("Strudel engine not booted (select it, reload, click once)");
+  const ctx = eng.rt.ctx;
+  const cmd = window.starnet.cmd;
+
+  const measureFPS = async (ms) => {
+    const iv = []; let last = performance.now(); const s0 = performance.now();
+    await new Promise((res) => {
+      function tick(now) { const dt = now - last; last = now; if (now - s0 > 300) iv.push(dt); if (now - s0 < ms) requestAnimationFrame(tick); else res(); }
+      requestAnimationFrame(tick);
+    });
+    iv.sort((a, b) => a - b);
+    return {
+      medianFPS: +(1000 / iv[Math.floor(iv.length / 2)]).toFixed(1),
+      p95FrameMs: +iv[Math.floor(iv.length * 0.95)].toFixed(1),
+      maxFrameMs: +iv[iv.length - 1].toFixed(1),
+      samples: iv.length,
+    };
+  };
+
+  cmd("music off");
+  await new Promise((r) => setTimeout(r, 2500));
+  const idle = await measureFPS(idleMs);
+
+  cmd("music on");
+  const droneIds = Object.keys(eng.DRONES);
+  const cueIds = ["reveal", "access", "xploit.ok", "ice.detected", "alert.up"];
+  const live = []; const timers = [];
+  timers.push(setInterval(() => eng.sfx.playCue(cueIds[(Math.random() * cueIds.length) | 0]), 110));
+  timers.push(setInterval(() => {
+    if (live.length >= 4) live.shift().stop();
+    live.push(eng.createDroneVoice(ctx, eng.DRONES[droneIds[(Math.random() * droneIds.length) | 0]]));
+  }, 600));
+  await new Promise((r) => setTimeout(r, 1500));
+  const load = await measureFPS(loadMs);
+  timers.forEach(clearInterval); live.forEach((v) => v.stop()); cmd("music off");
+
+  return { idle, load };
+};

--- a/docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/plan.md
+++ b/docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/plan.md
@@ -1,0 +1,359 @@
+# Plan — Phase 1: Strudel + superdough engine (shippable slice)
+
+Implements **issue #254 Phase 1 only** (Phases 2/3 are follow-on). Driving mode: **full-auto
+express → PR** (Les's call; I pushed back re: the perf gate / drone-design / bundling all wanting
+a human checkpoint — overruled, so the PR is the review point).
+
+## Architecture decisions (locked, flagged for PR review)
+
+- **Boot-time engine flag, no hot-swap.** A localStorage pref `starnet:audio-engine` =
+  `"tone"` (default) | `"strudel"`. Read once at boot. `main.js` branches:
+  - `tone` → existing `initAudioRenderer()` + `initSfxRenderer()` **completely untouched**
+    (zero regression risk).
+  - `strudel` → `initStrudelEngine()` — **one** self-contained module doing music + one-shot
+    SFX + action drones (the faithful promotion of `strudel-spike.js`). Tone renderers are NOT
+    initialized.
+  - Switching engines requires a page reload (the `audio` command says so). No live teardown.
+- **Pref + event ownership stays in the Tone renderer modules.** `setMusicEnabled` /
+  `setSfxEnabled` (in `audio-renderer.js` / `sfx/renderer.js`) already write localStorage and
+  emit `E.MUSIC_CHANGED` / `E.SFX_CHANGED` **regardless of which engine is running**. So the HUD
+  buttons + `music`/`sfx` console commands keep working unchanged. The Strudel engine **subscribes
+  to those events** (and reads the same `starnet:music-enabled` / `starnet:sfx-enabled` prefs at
+  boot) to start/stop/mute. No HUD or console refactor needed.
+- **Content as DATA inside the engine module.** Scores, cue specs, and drone specs live as plain
+  data objects (no Strudel/engine imports); the engine interprets them. Keeps the AGPL-engine /
+  separately-licensable-content ("wad") boundary.
+- **Drones → raw Web Audio** against the shared `getAudioContext()` (superdough's one-shot model
+  can't do live mid-voice param sweeps). Faithful to the existing `startDrone(spec)→{setProgress,stop}`
+  contract and the `drones.js` spec shape.
+- **Phase-1 score = synth voices only** (sawtooth/square/triangle/sine — register immediately).
+  **No drum samples** → defers the dirt-sample vendoring question to Phase 2, and keeps the perf
+  gate free of github-streamed assets.
+- **Lazy runtime load.** The vendored Strudel bundle (`dist/strudel.js`) is imported only inside
+  `initStrudelEngine()` (dynamic `import()`), so Tone-default users never download it.
+
+## Module layout (new files, all under the AGPL engine)
+
+```
+LICENSE                         — AGPL-3.0 (top level)
+js/strudel-vendor.js            — re-exports @strudel/web for esbuild → dist/strudel.js
+js/audio/engine-select.js       — pref read/set/list (pure, unit-tested)
+js/audio/strudel/
+  index.js                      — initStrudelEngine(): boot + wire music/sfx/drones + event subs
+  runtime.js                    — boot @strudel/web, poll globals, resume AudioContext (browser)
+  music.js                      — score-DATA interpreter → reactive stack() driven by signal()
+  sfx.js                        — superdough one-shot play(spec) + event→cue wiring
+  drones.js                     — raw-WebAudio startDrone(spec)→{setProgress,stop}
+  data/
+    cues.js                     — one-shot cue DATA (superdough specs) + event→cue resolver
+    drones.js                   — action drone DATA (per timed action)
+    corporate.js                — ONE reactive score as layer DATA
+```
+
+`docs/dev-sessions/.../perf/strudel-perf.mjs` — Playwright perf-gate script (gitignored or kept).
+
+---
+
+## Slice 1 — Licensing & repo hygiene
+
+Independently valuable; unblocks shipping. Docs/infra — **no TDD** (no behavior).
+
+### Files
+- `LICENSE` (new) — full GNU AGPL-3.0 text (verbatim from the canonical SPDX/GNU source).
+- `README.md` — add a "License" section: engine is AGPL-3.0; future content packs ("wad" model)
+  are separately-licensed runtime data. Link the LICENSE.
+- `index.html` — add an in-game **source link** in the footer/hub chrome: a small anchor to the
+  public repo (`https://github.com/lmorchard/starnet`), satisfying AGPL §13's "offer the source"
+  spirit. Style with existing phosphene chrome tokens (stroke/glow, no new fills).
+
+### Key changes
+- `LICENSE`: standard AGPL-3.0 (the unmodified license text — not summarized).
+- Source link: `<a class="source-link" href="https://github.com/lmorchard/starnet" target="_blank" rel="noopener">source</a>` placed in an existing chrome area; minimal CSS reusing `--glow-sm`.
+
+### Verification — automated
+- [x] `make lint` (no JS touched beyond HTML; lint still green)
+- [x] `make test` (1483 pass / 0 fail)
+- [x] `head -3 LICENSE` shows "GNU AFFERO GENERAL PUBLIC LICENSE" + "Version 3"
+
+### Verification — manual
+- [ ] Source link renders in-game and opens the repo
+- [ ] README license section reads correctly
+
+---
+
+## Slice 2 — Strudel runtime vendored + engine flag + booting (no-op) engine
+
+Establishes the foundation: the runtime loads offline, the flag selects it, and a minimal Strudel
+engine boots clean in-game. Proves boot/poll/resume under real game load before any audio content.
+
+### Files
+- `package.json` — add `"@strudel/web": "1.0.3"` to `dependencies`.
+- `js/strudel-vendor.js` (new) — `export { initStrudel, ... } from "@strudel/web";` (re-export the
+  named exports the runtime needs) OR `import "@strudel/web";` if it self-registers. Mirrors
+  `js/tone-vendor.js`.
+- `Makefile` — add `dist/strudel.js` target + add it to `all`, `bundle-vendor`, and `lint`'s
+  excluded-files list (vendor file, like `tone-vendor.js`):
+  ```make
+  dist/strudel.js: js/strudel-vendor.js node_modules
+  	npx esbuild js/strudel-vendor.js --bundle --outfile=dist/strudel.js --format=esm --platform=browser --minify
+  ```
+  Fallback if esbuild chokes on superdough's AudioWorklet asset resolution: copy the package's
+  prebuilt bundle into `dist/strudel.js` via a `cp` recipe instead (documented in notes.md).
+- `index.html` — add importmap entry `"@strudel/web": "./dist/strudel.js"`.
+- `js/audio/engine-select.js` (new) — pure pref module:
+  ```js
+  export const AUDIO_ENGINES = ["tone", "strudel"];
+  export function getAudioEngine();      // localStorage "starnet:audio-engine", default "tone"
+  export function setAudioEngine(name);  // validate against AUDIO_ENGINES, persist, return it
+  ```
+- `js/audio/strudel/runtime.js` (new) — `async function bootStrudel()`: dynamic-import
+  `@strudel/web`, call `initStrudel()`, **poll** for globals (`evaluate`/`superdough`/`stack`/
+  `signal`/`note`/`sound`/`getAudioContext`) with a 10s timeout, then return a handle object
+  `{ ctx, evaluate, superdough, stack, note, sound, signal, hush, samples }`. Does NOT resume the
+  ctx (that needs a gesture — done in index on unlock).
+- `js/audio/strudel/index.js` (new, minimal this slice) — `initStrudelEngine()`: arm on first
+  gesture → `bootStrudel()` → `ctx.resume()`. Logs "[strudel] engine booted". No audio yet.
+- `js/audio/strudel/commands.js` (new) — register the `audio` console command:
+  `audio` / `audio status` → print active engine + "(reload to apply changes)";
+  `audio engine <tone|strudel>` → `setAudioEngine`, log "switched to X — reload to apply".
+- `js/ui/main.js` — branch the audio init:
+  ```js
+  import { getAudioEngine } from "../audio/engine-select.js";
+  ...
+  if (getAudioEngine() === "strudel") {
+    import("../audio/strudel/index.js").then((m) => m.initStrudelEngine());
+  } else {
+    const audioEngine = initAudioRenderer();
+    initSfxRenderer();
+  }
+  ```
+  (Keep `audioEngine` usage downstream guarded — check current uses of the return value.)
+  Add `import "../audio/strudel/commands.js";`
+
+### Key changes
+- The pref module is the only **pure** unit here → TDD it.
+- Everything else (runtime boot, esbuild bundling, importmap) is infra verified in-browser.
+
+### Verification — automated
+- [x] `tests/audio-engine-select.test.js` written test-first (RED: import error), then implemented
+      `engine-select.js` (GREEN: 5 pass) — defaults to tone, persists, rejects invalid, storage-safe.
+- [x] `make bundle-vendor` produces `dist/strudel.js` (415KB, esbuild clean — vendor-offline feasible)
+- [x] `make lint` (clean)
+- [x] `make test`
+- [x] `make check` (1488 pass / 0 fail)
+
+### Verification — manual (Playwright, port 3017)
+- [x] Default boot (tone pref) loads Tone path; `dist/strudel.js` NOT fetched (lazy confirmed via
+      resource timing) — 0 console errors
+- [x] `audio engine strudel` + reload + click → "[strudel] engine booted", 0 errors, `ctx.state`
+      "running", superdough one-shot synthesizes (full offline audio path works)
+- [~] Strudel selected: Tone renderers NOT initialized → no Tone playback. (Known minor: the Tone
+      *bundle* still loads via static imports in main.js, idle/no audio — clean up in Phase 3.)
+
+---
+
+## Slice 3 — Reactive corporate score (music)
+
+The reactive music slice: one score as DATA, interpreted into a live `stack()` whose params are
+driven by `deriveProgress`/`deriveThreat` through `signal()`.
+
+### Files
+- `js/audio/strudel/data/corporate.js` (new) — score DATA:
+  ```js
+  export const CORPORATE = {
+    name: "Corporate — Strudel",
+    bpm: 120,
+    layers: [
+      // axis: "base" | "progress" | "threat"; params name signal-driven ranges
+      { sound: "sawtooth", note: "c2 c2 c2 c2 g1 g1 g1 g1", axis: "threat",
+        lpf: [300, 3500], gain: [0.35, 0.85] },
+      { sound: "triangle", note: "c4 eb4 g4 bb4", axis: "progress",
+        addNote: [0, 12], fast: [1, 2], gain: 0.28, room: 0.4 },
+      { sound: "square", note: "c5 ~ ~ c5 ~ c5 ~ ~", axis: "threat", gain: [0, 0.4], lpf: 4000 },
+      // ...a few more synth-only layers to reach ~6-8 voices for the perf gate
+    ],
+  };
+  ```
+- `js/audio/strudel/music.js` (new) — interpreter:
+  ```js
+  // buildProgram(score, { progressSignal, threatSignal, stack, note, sound, signal })
+  //   → a Strudel pattern (stack of per-layer patterns). For each layer, start from
+  //     note(layer.note).s(layer.sound); apply axis-driven params:
+  //       number      → constant (.gain(x), .lpf(x), .room(x))
+  //       [lo,hi]     → axisSignal.range(lo,hi) (.gain/.lpf), or .add(note(sig.range)) for addNote,
+  //                     .fast(sig.range) for fast
+  //     axis selects which signal (progress vs threat) drives the [lo,hi] params.
+  //   Returns pattern.cpm(score.bpm/4).
+  export function buildProgram(score, ctx);
+  export function createMusic(rt);  // { start(), stop(), setProgress(p), setThreat(t), isStarted() }
+  ```
+  `createMusic` holds live `gProgress`/`gThreat` numbers; `signal(() => gProgress)` re-samples each
+  cycle (no re-eval needed on setProgress/setThreat). `start()` calls `program.play()`; `stop()`
+  calls `rt.hush()`.
+- `js/audio/strudel/index.js` — wire music: on boot, build `createMusic`; subscribe
+  `on(E.STATE_CHANGED, s => { music.setProgress(deriveProgress(s)); music.setThreat(deriveThreat(s)); })`;
+  honor music pref at boot + `on(E.MUSIC_CHANGED, ({enabled}) => enabled ? music.start() : music.stop())`;
+  `on(E.RUN_STARTED/RUN_ENDED)` if we want run-vs-idle gating (Phase 1: start music on first
+  gesture if music-enabled, keep simple — one score, no hub/run swap).
+
+### Key changes
+- `buildProgram` is **pure** given an injected `ctx` of strudel fns → unit-test the param-mapping
+  logic with stub fns (assert which builder methods get called with which ranges). Real audio is
+  browser-verified.
+- Reuse `signals.js` unchanged (import `deriveProgress`/`deriveThreat`).
+
+### Verification — automated
+- [x] `tests/strudel-music.test.js` test-first (RED: module missing) → implemented (GREEN: 6 pass).
+      Covers threat/progress signal routing, constant pass-through, addNote, cpm(bpm/4), layer count.
+- [x] `make check` (1494 pass / 0 fail)
+
+### Verification — manual (Playwright, objective audio measurement via tee'd AnalyserNode)
+- [x] Strudel selected: CORPORATE (8 synth voices) plays from boot — peak RMS 0.91, 0 errors
+- [x] `music off` → silences (decays to 0 within ~3s: Strudel scheduler look-ahead ~1 cycle +
+      reverb tails — measured 0.88@1s → 0@3s); `music on` → restarts (0.91) via MUSIC_CHANGED
+- [~] Audible progress/threat *morph*: param mapping is unit-tested + wired to STATE_CHANGED;
+      audible reactivity is for Les at PR (flagged).
+
+---
+
+## Slice 4 — One-shot SFX (superdough)
+
+### Files
+- `js/audio/strudel/data/cues.js` (new) — cue DATA + resolver:
+  ```js
+  // CUES: event/id → superdough value spec (note, s, cutoff, attack, decay, sustain, release,
+  //   gain, room, resonance). Ported + extended from strudel-spike.js's known-good CUES.
+  // resolveCue(eventType, payload) → spec | null  (handles ACTION_RESOLVED success/fail split,
+  //   the alert-trace suppression at trace, etc. — mirroring the Tone resolveCue's branching for
+  //   the Phase-1 event set).
+  export const CUES; export function resolveCue(type, payload);
+  ```
+  Phase-1 event coverage (per spec): `NODE_REVEALED`, `NODE_ACCESSED`, `ACTION_RESOLVED`
+  (success/fail), `ALERT_GLOBAL_RAISED`, `ICE_DETECTED`, `ALERT_TRACE_STARTED`. (Other routed
+  events degrade gracefully to no cue — extend in a follow-up.)
+- `js/audio/strudel/sfx.js` (new) — `createSfx(rt)`:
+  ```js
+  // play(spec, dur?) → rt.superdough(spec, 0, dur ?? spec._dur ?? 0.2)   (try/catch, drop on fail)
+  // setEnabled(on); a small dedupe (50ms, like the Tone renderer) to avoid machine-gunning.
+  export function createSfx(rt);
+  ```
+- `js/audio/strudel/index.js` — wire one-shots: for the Phase-1 events, `on(type, p => { if (!sfxEnabled) return; const spec = resolveCue(type, p); if (spec) sfx.play(spec); })`. Port the
+  reveal grade/cascade pitch nicety if cheap (detune via note offset); else flat reveal for Phase 1.
+  Honor sfx pref at boot + `on(E.SFX_CHANGED, ({enabled}) => sfxEnabled = enabled)`.
+
+### Verification — automated
+- [x] `tests/strudel-sfx.test.js` test-first (RED) → implemented (GREEN: 5 pass). Covers
+      success/fail split, the named-event mappings, trace suppression, unmapped→null, spec shape.
+- [x] `make check` (1499 pass / 0 fail)
+
+### Verification — manual (Playwright, objective audio measurement)
+- [x] All 7 Phase-1 cues audible when fired via the engine handle (peak RMS 0.77–0.99), 0 errors
+- [x] `sfx off` silences (playCue → peak 0) via SFX_CHANGED
+- [~] Real in-game event firing (probe/xploit/reveal/...) + dedupe feel: wiring is
+      on(type)→resolveCue→play with a 50ms dedupe; verified by parts — confirm in the PR playthrough.
+
+---
+
+## Slice 5 — Action drones (raw Web Audio)
+
+The third surface (the gap Les flagged). Faithful port of `sfx/drones.js` behavior to raw Web
+Audio against the shared AudioContext, wired to `E.ACTION_FEEDBACK`.
+
+### Files
+- `js/audio/strudel/data/drones.js` (new) — drone DATA per timed action + resolver, ported from
+  `js/audio/sfx/drones.js` (same spec fields: `source` osc/noise/fm/dual, `note`, `cutoff`
+  number|`{from,to}`, `detune`, `q`, `lfo {rate,depth,target}`, `gain {from,to}`, `volume`, `fade`,
+  `loop`). Same 7 actions: probe/xploit/dump/fetch/mine/lie-low/reboot.
+  ```js
+  export const DRONES; export function resolveDrone(action); // action if in DRONES else null
+  ```
+- `js/audio/strudel/drones.js` (new) — `createDroneVoice(ctx, spec) → { setProgress(p), stop() }`:
+  build `OscillatorNode`(s)/`AudioBufferSourceNode`(noise)/FM via osc→gain→osc.frequency →
+  `BiquadFilterNode` → ampGain (LFO or progress) → fadeGain → ctx.destination. `setProgress(p)`
+  ramps filter.frequency / detune / gain `{from,to}` via `linearRampToValueAtTime(lerp(from,to,p), now+0.12)`.
+  `stop()` ramps fadeGain to 0 over `fade`, then disconnects. Reboot loops (ignores progress).
+  Direct translation of `sfx/engine.js` lines ~129-227 from Tone nodes to vanilla Web Audio nodes.
+- `js/audio/strudel/index.js` — wire drones: a `Map("<nodeId>:<action>" → voice)`,
+  `on(E.ACTION_FEEDBACK, ({nodeId, action, phase, progress}) => ...)` start/setProgress/stop, plus
+  `stopAllDrones()` on RUN_ENDED + when SFX disabled (port from the Tone renderer's
+  `handleActionFeedback` / `stopAllDrones`).
+
+### Key changes
+- The `lerp(range, p)` / `clamp01` helpers are **pure** → unit-test them. The Web Audio graph is
+  browser-verified.
+
+### Verification — automated
+- [x] `tests/strudel-drones.test.js` test-first (RED) → implemented (GREEN: 5 pass). Covers
+      resolveDrone (7 actions + unknown→null), noteToFreq, droneRange interpolation/clamp, and the
+      amp-LFO/progress-gain mutual-exclusion invariant.
+- [x] `make check` (1504 pass / 0 fail)
+
+### Verification — manual (Playwright, objective audio measurement)
+- [x] All 7 drone voices audible via createDroneVoice (peak 0.55–0.98), setProgress sweeps without
+      error, stop() → silence (0). 0 errors.
+- [x] Full ACTION_FEEDBACK path via the real event bus: start → drone created + audible,
+      progress → sweeps, complete → drone cleared + faded to 0; unknown action → no drone.
+- [~] Reboot-loop feel + cancel-during-action feel: verified by parts (loop spec ignores progress;
+      cancel uses the same stop path as complete) — confirm in the PR playthrough.
+
+---
+
+## Slice 6 — Perf gate (GO/NO-GO)
+
+The spec's gate: dense music (~8 tracks) + rapid SFX/drones, watch FPS / audio dropouts. Automated
+proxy (FPS) since dropout-audibility needs human ears — flagged for PR review.
+
+### Files
+- `docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/perf/strudel-perf.mjs` — Playwright
+  script: set `localStorage["starnet:audio-engine"]="strudel"`, load the game, click-in, start a
+  generated run, drive a burst of actions + repeatedly fire SFX cues, sample `requestAnimationFrame`
+  deltas for ~15s, report median/p95 FPS and AudioContext state. Compare against a Tone-engine
+  baseline run of the same script.
+
+### Verification — automated (Playwright main-thread pacing proxy)
+- [x] `perf/strudel-perf.js` snippet written; measured on port 3017. Results:
+      - **Strudel** — idle: median 120 FPS / p95 9.2ms / max 25.8ms; **under full load**
+        (8 voices + ~9 SFX/s + 4 rolling drones): median **120 FPS** / p95 9.2ms / max 24.3ms.
+        Load == idle — no main-thread regression. 0 console errors.
+      - **Tone** (baseline, same harness) — idle: 120 / 9.3ms / 66.4ms; load: 120 / 9.3ms / 75ms.
+      → Strudel matches Tone on median FPS and has *tighter* worst-frame pacing. Gate PASSED.
+
+### Verification — manual
+- [~] **Les listens** (the real gate): no audible dropouts/crackle with dense music + rapid SFX.
+      Flagged for PR — the autonomous run measured frame pacing only (synthesis is on the worklet
+      thread; audibility needs human ears).
+
+---
+
+## Slice 7 — Docs
+
+### Files
+- `docs/audio-direction.md` — add a "Strudel + superdough engine (Phase 1)" section: the flag,
+  the three ported surfaces, the content-as-data boundary, what's deferred to Phase 2/3.
+- `MANUAL.md` — document the `audio engine <tone|strudel>` console command + that it needs a reload.
+- `notes.md` — session retro: decisions, perf numbers, what's deferred, open questions for Les.
+
+### Verification — automated
+- [ ] `make check` (final green)
+
+### Verification — manual
+- [ ] Docs accurately describe shipped behavior; MANUAL `audio` command matches the implementation
+
+---
+
+## Plan self-review
+
+- **Spec coverage:** LICENSE + source link (Slice 1) ✓; bundle Strudel runtime (Slice 2) ✓;
+  superdough SFX at parity on the named events (Slice 4) ✓; one reactive corporate score driven by
+  derive*/signal() (Slice 3) ✓; engine flag, Tone default, A/B (Slice 2) ✓; perf gate (Slice 6) ✓.
+  **Plus** the session-amendment action-drone surface (Slice 5) ✓.
+- **Deferred (correctly, per spec):** dirt-sample vendoring, remaining cues/scores, 8 corporate
+  variants, section automation, flipping default + retiring Tone (Phases 2/3).
+- **Placeholder scan:** no TBDs; each phase names files, signatures, and concrete test assertions.
+- **Type/name consistency:** `getAudioEngine`/`setAudioEngine`, `bootStrudel`, `createMusic`/
+  `buildProgram`, `createSfx`/`resolveCue`/`CUES`, `createDroneVoice`/`resolveDrone`/`DRONES`,
+  `initStrudelEngine` — used consistently across phases.
+- **TDD opt-outs (explicit):** Slice 1 (docs), and the Strudel/superdough/Web-Audio *runtime*
+  integration in Slices 2-6 (can't run @strudel/web or AudioContext in node) → browser-verified via
+  Playwright. The **pure** pieces (engine-select pref, buildProgram param-mapping, resolveCue,
+  resolveDrone, lerp/clamp) get node unit tests written test-first.

--- a/docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/research.md
+++ b/docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/research.md
@@ -1,0 +1,61 @@
+# Research — current Tone.js audio subsystem
+
+Factual map of the existing engine (the thing being replaced). Three independent
+audio surfaces, all wired to the event bus.
+
+## 1. One-shot SFX cues
+
+- `js/audio/sfx/defs.js` — cue catalog (pure specs: `kind` = blip/sweep/chord/noise/fm + params)
+- `js/audio/sfx/cues.js` — `E.*` event → cue id mapping (lines ~18–60)
+- `js/audio/sfx/renderer.js` — event listener wiring, dedupe (50ms), pitch transforms (lines ~100–165)
+- `js/audio/sfx/engine.js` — Tone synthesis of one-shots (lines ~43–119)
+
+Event→cue highlights: `ACTION_RESOLVED` (probe/dump/corrupt/xploit.ok/xploit.fail/fetch*/mine*),
+`NODE_REVEALED` (pitch by grade + cascade), `NODE_ACCESSED`, `PLAYER_NAVIGATED`,
+`ALERT_GLOBAL_RAISED`/`ALERT_COOLED`/`ALERT_TRACE_STARTED`/`ALERT_TRACE_CANCELLED`,
+`NODE_ALERT_RAISED`, `ICE_*` (pending/detected/ejected/rebooted/disabled/moved),
+`RUN_STARTED`/`RUN_ENDED`, `MISSION_COMPLETE`, `EXPLOIT_DISCLOSED`, `EXPLOIT_PARTIAL_BURN`.
+
+## 2. Two-axis reactive music
+
+- `js/audio/signals.js` — **pure** `deriveProgress(state)` (owned/total nodes), `deriveThreat(state)` (alert ladder + injury). Engine-agnostic. REUSE AS-IS.
+- `js/audio/mixer.js` — **pure** `computeMix(score, progress, threat)` → per-layer gains + master filter
+- `js/audio/engine.js` — Tone music engine + state machine
+- `js/audio/scores/*.js` — score data (8 corporate variants + hub ambient); layers have `axis: base|progress|threat`, smoothstep gating, sections, drone-wander
+- `js/audio/harmony.js`, `rhythm.js` — pure drone-wander + note-grid helpers
+- `js/audio/audio-renderer.js` — bridge: `on(STATE_CHANGED) → engine.setProgress/setThreat`; `RUN_STARTED/ENDED` swap hub↔run; music on/off pref
+
+## 3. Progress-driven ACTION DRONES  ← the surface NOT named in issue #254 Phase 1
+
+- `js/audio/sfx/drones.js` — drone specs per timed action (pure data)
+- `js/audio/sfx/renderer.js` (lines ~75–94) — `on(E.ACTION_FEEDBACK, ...)` → start/setProgress/stop a drone keyed by `${nodeId}:${action}`
+- `js/audio/sfx/engine.js` (lines ~121–227) — `startDrone(spec) → { setProgress(p), stop() }`; sources osc/noise/fm/dual; filter→ampGain(LFO or progress)→fadeGain; param sweeps `{from,to}` lerped by progress with 0.12s ramps; reboot loops (ignores progress)
+
+Drone catalog (`DRONES` in drones.js): `probe`, `xploit`, `dump`, `fetch`, `mine`,
+`lie-low`, `reboot` — each a distinct timbre (cutoff sweep, detune beat, amp LFO, etc.).
+
+### How a drone is driven (the porting contract)
+
+1. Timed-action operator (`js/core/node-graph/operators.js`) ticks every 100ms; sets
+   node attrs (`exploiting`, `_ta_xploit_progress`, `_ta_xploit_duration`) and emits
+   `E.ACTION_FEEDBACK { nodeId, action, phase, progress }`.
+   - `phase: "start"` (progress 0) → renderer calls `startDrone(DRONES[action])`
+   - `phase: "progress"` → `progress = newProgress/duration` (0..1 **fraction**) → `drone.setProgress(p)`
+   - `phase: "complete"|"cancel"` → `drone.stop()`
+2. `js/core/node-graph/timed-actions.js` lists the 7 timed actions + their active attrs.
+
+This is event-driven and engine-agnostic at the contract layer (`ACTION_FEEDBACK`), so a
+superdough/Strudel engine can subscribe the same way — but **sustained, progress-modulated
+drones are not superdough's native one-shot idiom**; approach is an open design question.
+
+## Public surfaces to mirror
+
+- Music engine (`engine.js`): `setScore`, `start(fadeIn)`, `stop(fade)`, `setProgress`, `setThreat`, `isStarted`, `getMasterInput`, `forceWander`, score-list helpers via audio-renderer
+- SFX engine (`sfx/engine.js`): `play(spec)`, `startDrone(spec)→{setProgress,stop}`, `setEnabled`, `unlock`, `getMasterInput`
+- Prefs: music on/off and SFX on/off are localStorage client prefs, never serialized
+
+## Spike reference (to promote)
+
+- Branch `strudel-ingame-spike`, `js/audio/strudel-spike.js`: SFX `CUES` (one-shots) +
+  reactive `stack()` + boot/poll. **Confirm whether the spike covered drones** — likely
+  one-shots + music only, so drones are net-new porting in Phase 1.

--- a/docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/spec.md
+++ b/docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/spec.md
@@ -1,0 +1,98 @@
+# Spec — Audio engine rebuild: Strudel + superdough (AGPL), replacing Tone
+
+> Source: GitHub issue lmorchard/starnet#254 (carries the `<!-- dev-session:spec -->` marker).
+> This file is the issue body verbatim, plus a **Session amendment** at the end capturing
+> the action-drone scope gap surfaced at session start.
+
+**Goal:** Replace the Tone.js audio engine with a **Strudel (music) + superdough (SFX)** engine — one engine, livecoding-native authoring, reactive to game state — and license the game **AGPL-3.0** so it can ship. Validated end-to-end by spikes this session (see Background); FPS held in-game.
+
+## Background — how we got here
+
+Terminal arc of a multi-step exploration (2026-06-29):
+
+1. From #251 (Tone authoring friction) → pivoted to **Strudel** (livecoding fits the hacker aesthetic + authoring loop).
+2. **Capability spike** (`tmp/strudel-spike/`, memory `strudel-superdough-spike`): proved reactive control (`signal()` morphs a live pattern, no restart), superdough SFX one-shots, livecoding feel. ✅
+3. **Analyzer re-target** — merged **PR #253**: `tools/audio-reference` now emits idiomatic Strudel per track + a minimal Strudel player; old Tone player preserved as `tone-player.*`. Hand-translated **Stripdown** is the worked example of good Strudel (FM lead, driven bass, sample drums).
+4. **In-game integration spike** — branch **`strudel-ingame-spike`** (`js/audio/strudel-spike.js`, flag-gated): superdough SFX on real `E.*` cues + a reactive Strudel stack reading the existing signals. Boots clean in-game, reactive bridge tracked real node ownership, SFX path fires, **FPS held**.
+5. **Licensing cleared:** Strudel/superdough is AGPL-3.0 (viral). Decision (memory `starnet-licensing-agpl`): license the **engine AGPL-3.0**, keep future content packs as separately-licensed runtime data (**Doom model**).
+
+## Current state (`js/audio/`, Tone-based, MIT)
+
+- `engine.js` — Tone engine. `scores/` — 8 corporate variants + hub ambient, section automation. `sfx/` — Tone event cues. `mixer.js`/`harmony.js`/`rhythm.js`.
+- `signals.js` — **pure** `deriveProgress(state)` / `deriveThreat(state)`, engine-agnostic.
+- `audio-renderer.js` — bridge: arms audio on first pointer/keydown; `on(E.STATE_CHANGED) → engine.setProgress/setThreat`; `RUN_STARTED`/`RUN_ENDED` swap hub↔run; `setMusicEnabled()` persists a pref + emits `MUSIC_CHANGED`.
+- `tone` bundled via esbuild (`js/tone-vendor.js → dist/tone.js`), mapped in the importmap. Music on/off is a client pref (never serialized).
+
+## Design decisions
+
+- **AGPL-3.0 for the engine.** Strudel/superdough are AGPL; bundling forces the whole game to AGPL. **Doom model:** open engine; future content ("wad") kept as **separately-licensed data loaded at runtime, never woven into engine source.**
+- **Reuse `signals.js` unchanged** as the reactive core — pure, engine-agnostic.
+- **Scores + SFX as DATA files** (the content/code boundary that keeps the "wad" separately licensable). The engine *interprets* them.
+- **Cutover behind an engine-select flag.** Strudel engine lands alongside Tone, A/B-able; Tone stays default until parity, then is retired. Mirror the music on/off pref (localStorage + console command).
+- **Keep the `audio-renderer` bridge shape** — the Strudel engine implements the same surface (`setProgress`/`setThreat`/enable/score-select) so the bridge barely changes.
+
+## Phased plan
+
+### Phase 1 — Foundation + SFX + one reactive score (shippable slice)
+- Add top-level **`LICENSE` (AGPL-3.0)** + an in-game "source" link; confirm repo stays public.
+- Bundle the **Strudel runtime** (open decision: vendor vs CDN).
+- **superdough SFX layer** at parity with current Tone cues, on the same `E.*` events: `NODE_REVEALED`, `NODE_ACCESSED`, `ACTION_RESOLVED` (success/fail), `ALERT_GLOBAL_RAISED`, `ICE_DETECTED`, `ALERT_TRACE_STARTED` (port from `strudel-spike.js`'s `CUES`).
+- **One** reactive Strudel score (corporate biome) as a data file, driven by `deriveProgress`/`deriveThreat` via `signal()`.
+- Behind the **engine flag** (Tone default). A/B-able with the music toggle.
+- **Perf gate:** stress test — dense tracks (~8) + rapid SFX, watch FPS/audio dropouts. The spike proved the floor; this proves the ceiling.
+
+### Phase 2 — Re-author the reactive music design
+- Port the two-axis reactive design, the remaining biome scores + the 8 corporate variants, and section automation to **Strudel pattern data**. Composition, not wiring. Stripdown is the reference for patch quality.
+
+### Phase 3 — Flip default + retire Tone
+- Default to the Strudel engine once at parity; remove `engine.js`/Tone `scores`/`sfx` + the `tone` dependency + importmap entry. Update `docs/audio-direction.md` + `MANUAL.md`.
+
+## Implementation notes — findings carried from the spikes
+
+`@strudel/web@1.0.3` (the runtime the player + spike use):
+- `initStrudel()` returns **undefined** and registers globals **asynchronously** — **poll** for readiness, don't `await`/`.then()` it. AudioContext needs a user-gesture to `resume()`.
+- Run string patterns through **`evaluate(code)`** (the transpiler); for JS-API-built patterns use **`.play()`**. **Not** `new Function`.
+- **Tempo:** no global `setcps`/`setcpm` in 1.0.3 — set it on the pattern with **`.cpm(bpm/4)`** or `.cps()`.
+- **Reactive:** `signal(() => liveValue)` re-samples each cycle; `.range(lo,hi)` maps 0..1.
+- **Timbre:** FM via `.fm(index)` + `.fmh(harmonicity)` + `.fmattack/.fmdecay/.fmsustain`. `.distort(x)` = drive; `.shape`/`.crush`/`.coarse`; `.lpf`/`.cutoff`/`.hpf`/`.resonance`; `.room`/`.delay`/`.pan`; ADSR. **`.rev()` needs parens** in 1.0.3. Mini-notation `< > [ ] * / ! ,` are **string-only** — for whole-pattern alternation use `cat(...)`, to layer use `stack(...)`.
+- Drum samples (`bd`/`sd`/`hh`/…) stream from github via `samples('github:tidalcycles/dirt-samples')` after boot — for a shipped engine, **vendor the sample set** (don't depend on github at runtime). Synth voices register immediately.
+- If a headless Strudel **validator** is reused: node `@strudel/core`+`mini`+`transpiler` **pinned to 1.2.5** — `1.2.6` breaks under node ESM.
+- **MIR octave-tempo:** detected tempos often half the felt rate.
+
+Reference module: `js/audio/strudel-spike.js` on branch `strudel-ingame-spike`.
+
+## What we're NOT doing
+
+- Changing the event bus or `signals.js` (reuse as-is).
+- Gameplay changes.
+- The audio-reference analyzer (separate; shipped in #253).
+- Re-authoring tooling for scores beyond what Phase 2 needs.
+
+## Open decisions (with defaults)
+
+- **Strudel runtime bundling:** vendor into `dist/` via esbuild like `tone.js` (default — offline, shippable sample set), or CDN `@strudel/web` if bundling proves impractical. Phase 1 settles it (incl. how to vendor the dirt-sample subset).
+- **Phase-1 score count:** one (corporate); expand in Phase 2.
+- **Engine flag mechanism:** localStorage pref + console command, mirroring music on/off.
+
+## References
+
+- PR #253 (analyzer → Strudel, merged). Branch `strudel-ingame-spike` (in-game spike).
+- Session docs: `docs/dev-sessions/2026-06-29-1125-audio-strudel-analyzer/`, `docs/dev-sessions/2026-06-29-1550-strudel-ingame-spike/notes.md`.
+- `docs/audio-direction.md`. Stripdown worked example: `tools/audio-reference/docs/agent-side-grinder-stripdown.json`.
+
+---
+
+## Session amendment (2026-06-30) — action-drone scope
+
+Codebase research at session start found **three** audio surfaces in the Tone engine, not two.
+The issue's Phase-1 SFX list names only (a) discrete one-shot cues and (b) the reactive music.
+It does **not** name the third:
+
+**(c) Progress-driven action drones** (`js/audio/sfx/drones.js`): sustained, evolving tones
+that play *during* a timed node action (probe/xploit/dump/fetch/mine/lie-low/reboot), driven by
+`E.ACTION_FEEDBACK { phase, progress: 0..1 }` with live filter/detune/gain sweeps. This is a
+distinct mechanism with its own `startDrone(spec) → {setProgress, stop}` engine surface.
+
+**Decision (Les, session start):** action drones are **in scope for Phase 1** — both the one-shot
+cues AND the progress drones must port to the new engine. See `notes.md` for the open design
+question (drones are not superdough's native one-shot idiom) and the chosen approach.

--- a/index.html
+++ b/index.html
@@ -11,7 +11,8 @@
     { "imports": {
       "lit": "./dist/lit.js",
       "lit/directives/repeat.js": "./dist/lit.js",
-      "tone": "./dist/tone.js"
+      "tone": "./dist/tone.js",
+      "@strudel/web": "./dist/strudel.js"
     } }
   </script>
   <!-- Cytoscape.js + layout extensions (vendor bundle built by: make bundle-vendor) -->
@@ -71,6 +72,10 @@
 
     <starnet-end-screen id="end-screen"></starnet-end-screen>
     <starnet-hub id="overworld-hub"></starnet-hub>
+
+    <!-- AGPL-3.0 §13: a persistent, visible link to the source. This game's engine is
+         AGPL-3.0 (it bundles Strudel/superdough); offering source is a license condition. -->
+    <a id="source-link" href="https://github.com/lmorchard/starnet" target="_blank" rel="noopener">source</a>
 
   </div>
 

--- a/js/audio/engine-select.js
+++ b/js/audio/engine-select.js
@@ -1,0 +1,33 @@
+// @ts-check
+// Audio engine selection — a client preference (NOT game state; audio is never serialized).
+// Chooses between the legacy Tone.js engine (default) and the Strudel + superdough engine.
+// Read once at boot by js/ui/main.js; switching requires a page reload to take effect.
+
+/** @type {readonly ["tone", "strudel"]} */
+export const AUDIO_ENGINES = ["tone", "strudel"];
+
+const ENGINE_PREF_KEY = "starnet:audio-engine";
+const DEFAULT_ENGINE = "tone";
+
+/**
+ * @returns {"tone"|"strudel"} the selected audio engine, defaulting to "tone".
+ */
+export function getAudioEngine() {
+  try {
+    const v = localStorage.getItem(ENGINE_PREF_KEY);
+    return AUDIO_ENGINES.includes(/** @type {any} */ (v)) ? /** @type {any} */ (v) : DEFAULT_ENGINE;
+  } catch {
+    return DEFAULT_ENGINE;
+  }
+}
+
+/**
+ * Persist the audio engine choice. No-ops (but still returns the value) if storage is unavailable.
+ * @param {string} name
+ * @returns {"tone"|"strudel"|null} the validated engine name, or null if invalid.
+ */
+export function setAudioEngine(name) {
+  if (!AUDIO_ENGINES.includes(/** @type {any} */ (name))) return null;
+  try { localStorage.setItem(ENGINE_PREF_KEY, name); } catch { /* ignore */ }
+  return /** @type {any} */ (name);
+}

--- a/js/audio/strudel/commands.js
+++ b/js/audio/strudel/commands.js
@@ -1,0 +1,35 @@
+// @ts-check
+// Console command for audio engine selection. Registered for both engines (so you can switch
+// from either). Mirrors music-commands.js. Imported once from js/ui/main.js.
+import { registerCommand } from "../../core/console-commands/index.js";
+import { emitEvent, E } from "../../core/events.js";
+import { AUDIO_ENGINES, getAudioEngine, setAudioEngine } from "../engine-select.js";
+
+function log(text, type = "meta") { emitEvent(E.LOG_ENTRY, { text, type }); }
+
+registerCommand({
+  verb: "audio",
+  complete(args, partial) {
+    const p = partial.toLowerCase();
+    const pool = args.length === 0 ? ["status", "engine"]
+      : (args[0] === "engine" ? [...AUDIO_ENGINES] : []);
+    const matches = pool.filter((s) => s.startsWith(p));
+    return matches.length ? { insertTexts: matches, displayTexts: matches } : null;
+  },
+  execute(args) {
+    const sub = (args[0] || "").toLowerCase();
+    if (!sub || sub === "status") {
+      log(`[AUDIO] engine: ${getAudioEngine()} (reload to apply a change)`);
+      return;
+    }
+    if (sub === "engine") {
+      const name = (args[1] || "").toLowerCase();
+      if (!name) { log(`[AUDIO] engine: ${getAudioEngine()} — options: ${AUDIO_ENGINES.join(", ")}`); return; }
+      const set = setAudioEngine(name);
+      if (set) log(`[AUDIO] engine → ${set} — reload the page to apply.`);
+      else log(`[AUDIO] unknown engine "${name}" — options: ${AUDIO_ENGINES.join(", ")}`, "error");
+      return;
+    }
+    log("Usage: audio [status | engine <tone|strudel>]", "error");
+  },
+});

--- a/js/audio/strudel/data/corporate.js
+++ b/js/audio/strudel/data/corporate.js
@@ -1,0 +1,32 @@
+// @ts-check
+// Phase-1 reactive score (corporate biome) as DATA. Synth voices only (no drum samples) so the
+// engine ships offline without the dirt-sample set (deferred to Phase 2). Interpreted by music.js.
+//
+// Two axes (see js/audio/signals.js): PROGRESS = LAN ownership (0..1), THREAT = alert+injury (0..1).
+// Layers gate/morph on one axis. C-aeolian-ish dread. ~8 voices to exercise the perf gate.
+//
+// CONTENT (the "wad" boundary): this is data the AGPL engine interprets — kept free of engine/
+// Strudel imports so it can stay separately licensable.
+
+export const CORPORATE = {
+  name: "Corporate — Strudel",
+  bpm: 120,
+  layers: [
+    // Driving bass — always present; filter opens + level rises with THREAT.
+    { sound: "sawtooth", note: "c2 c2 c2 c2 g1 g1 g1 g1", axis: "threat", lpf: [300, 3500], gain: [0.35, 0.85] },
+    // Arp — climbs up to an octave and speeds up as PROGRESS (LAN owned) rises.
+    { sound: "triangle", note: "c4 eb4 g4 bb4", axis: "progress", addNote: [0, 12], fast: [1, 2], gain: 0.28, room: 0.4 },
+    // Ambient pad bed — constant, sets the harmonic floor.
+    { sound: "sawtooth", note: "c3 eb3 g3", axis: "base", gain: 0.12, lpf: 800, room: 0.6 },
+    // Sub pulse — constant low heartbeat.
+    { sound: "sine", note: "c1 ~ c1 ~", axis: "base", gain: 0.2 },
+    // Tension blips — barely there until THREAT climbs.
+    { sound: "square", note: "c5 ~ ~ c5 ~ c5 ~ ~", axis: "threat", gain: [0, 0.4], lpf: 4000 },
+    // Mid stab — opens up (level + filter) with THREAT.
+    { sound: "square", note: "~ c4 ~ eb4", axis: "threat", gain: [0, 0.25], lpf: [600, 2500] },
+    // High shimmer — emerges as PROGRESS rises (sense of opening up the LAN).
+    { sound: "triangle", note: "c6 eb6 g6 c7", axis: "progress", gain: [0, 0.18], room: 0.7, fast: 2 },
+    // Counter-arp — fills in with PROGRESS.
+    { sound: "triangle", note: "g4 f4 eb4 d4", axis: "progress", gain: [0, 0.2], room: 0.4 },
+  ],
+};

--- a/js/audio/strudel/data/cues.js
+++ b/js/audio/strudel/data/cues.js
@@ -1,0 +1,43 @@
+// @ts-check
+// One-shot SFX cue DATA (superdough value specs) + the event→cue resolver. Ported and tuned from
+// the known-good cues in js/audio/strudel-spike.js (branch strudel-ingame-spike).
+//
+// `_dur` is the voice duration passed to superdough(value, 0, dur); the rest of each object is the
+// superdough value (note/s/cutoff/envelope/gain/room/resonance). Phase-1 event coverage per
+// issue #254; other routed events degrade to no cue (extend in a follow-up).
+import { E } from "../../../core/events.js";
+
+export const CUES = {
+  // node discovery — short bright blip
+  reveal:        { note: "c6", s: "square",   cutoff: 3000, attack: 0.001, decay: 0.05, sustain: 0,   release: 0.04, gain: 0.35, _dur: 0.08 },
+  // node access gained — softer chime with a little space
+  access:        { note: "c5", s: "triangle", cutoff: 5000, attack: 0.002, decay: 0.25, sustain: 0,   release: 0.2,  gain: 0.5, room: 0.4, _dur: 0.35 },
+  // exploit resolved — bright on success, low/dark on failure
+  "xploit.ok":   { note: "g4", s: "sawtooth", cutoff: 1800, attack: 0.001, decay: 0.12, sustain: 0,   release: 0.06, gain: 0.5,  _dur: 0.14 },
+  "xploit.fail": { note: "g2", s: "sawtooth", cutoff: 1800, attack: 0.001, decay: 0.12, sustain: 0,   release: 0.06, gain: 0.5,  _dur: 0.14 },
+  // global alert escalation — resonant growl
+  "alert.up":    { note: "a2", s: "sawtooth", cutoff: 900,  resonance: 8,  attack: 0.005, decay: 0.2, sustain: 0.3, release: 0.15, gain: 0.55, _dur: 0.5 },
+  // ICE locked on — sharp square stab
+  "ice.detected":{ note: "d3", s: "square",   cutoff: 1200, attack: 0.001, decay: 0.18, sustain: 0,   release: 0.1,  gain: 0.5,  _dur: 0.2 },
+  // trace started — low ominous square
+  "trace.start": { note: "e2", s: "square",   cutoff: 600,  attack: 0.001, decay: 0.4,  sustain: 0,   release: 0.3,  gain: 0.6,  _dur: 0.5 },
+};
+
+/**
+ * Map a game event to its one-shot cue spec (or null for no cue).
+ * @param {string} type  the E.* event type
+ * @param {any} payload  the event payload
+ * @returns {object|null}
+ */
+export function resolveCue(type, payload) {
+  switch (type) {
+    case E.NODE_REVEALED: return CUES.reveal;
+    case E.NODE_ACCESSED: return CUES.access;
+    case E.ACTION_RESOLVED: return payload?.success === false ? CUES["xploit.fail"] : CUES["xploit.ok"];
+    // Suppress the alert blip when it escalates to trace — trace.start carries that moment.
+    case E.ALERT_GLOBAL_RAISED: return payload?.next === "trace" ? null : CUES["alert.up"];
+    case E.ICE_DETECTED: return CUES["ice.detected"];
+    case E.ALERT_TRACE_STARTED: return CUES["trace.start"];
+    default: return null;
+  }
+}

--- a/js/audio/strudel/data/drones.js
+++ b/js/audio/strudel/data/drones.js
@@ -1,0 +1,48 @@
+// @ts-check
+// Sustained "action in progress" drone DATA — one per timed action, played for the action's
+// duration and reshaped by progress 0→1 (see drones.js, the raw-Web-Audio voice). Keyed by the
+// ACTION_FEEDBACK `action` string. `loop:true` ignores progress (reboot — a system state, not a
+// player sweep). Ported from the Tone drone specs (js/audio/sfx/drones.js); same character.
+//
+// Spec shape (interpreted in drones.js): {
+//   source: "sawtooth"|"sine"|"square"|"triangle"|"noise"|"fm"|"dual",
+//   note, osc?, harmonicity?/modIndex? (fm), type? (noise),
+//   detune?: cents | {from,to},  cutoff?: Hz | {from,to},  gain?: 0..1 | {from,to},  q?,
+//   lfo?: { rate, depth, target:"amp"|"cutoff" },  fade?, volume? (dB), loop?
+// }
+// {from,to} values sweep with progress; amp-LFO and progress-gain are mutually exclusive.
+
+export const DRONES = {
+  // probe — radar sweep: thin scanning pulse, filter brightens as the ring fills.
+  probe:    { source: "sawtooth", note: "A2", cutoff: { from: 300, to: 1500 }, q: 3,
+              lfo: { rate: 3, depth: 0.3, target: "amp" }, volume: -23, fade: 0.16 },
+  // xploit — converging brackets: grinding low FM that tightens (filter opens, detune resolves).
+  xploit:   { source: "fm", note: "C2", osc: "square", harmonicity: 1.5, modIndex: 12,
+              cutoff: { from: 450, to: 1700 }, detune: { from: -25, to: 8 }, q: 4, volume: -18, fade: 0.08 },
+  // dump — facets read in chunks: low data-churn with a fast amp gate.
+  dump:     { source: "square", note: "D2", cutoff: { from: 380, to: 760 }, q: 2,
+              lfo: { rate: 9, depth: 0.4, target: "amp" }, volume: -21, fade: 0.14 },
+  // fetch — ripple rings draining: flowing filtered noise that thins (gain + cutoff fall).
+  fetch:    { source: "noise", type: "brown", cutoff: { from: 1900, to: 550 }, gain: { from: 0.9, to: 0.15 },
+              q: 1, volume: -19, fade: 0.12 },
+  // mine — crosshair locking on: two detuned tones beating, the beat slowing to zero (lock-on).
+  mine:     { source: "dual", note: "E2", osc: "sawtooth", detune: { from: 42, to: 0 }, cutoff: 600, q: 3,
+              volume: -22, fade: 0.12 },
+  // lie-low — clock fast-forward: hushed sub hum + soft tick.
+  "lie-low":{ source: "sine", note: "A1", cutoff: 320, q: 1,
+              lfo: { rate: 2.5, depth: 0.25, target: "amp" }, volume: -26, fade: 0.22 },
+  // reboot — offline pulse: adversarial slow-pulsing sour drone, loops (no progress sweep).
+  reboot:   { source: "sawtooth", note: "C2", detune: -25, cutoff: 520, q: 5,
+              lfo: { rate: 0.5, depth: 0.5, target: "amp" }, volume: -19, fade: 0.35, loop: true },
+};
+
+export const DRONE_IDS = Object.freeze(Object.keys(DRONES));
+
+/**
+ * Map a timed-action id (the ACTION_FEEDBACK `action` field) to a drone id.
+ * @param {string} [action]
+ * @returns {string|null}
+ */
+export function resolveDrone(action) {
+  return action && Object.prototype.hasOwnProperty.call(DRONES, action) ? action : null;
+}

--- a/js/audio/strudel/drones.js
+++ b/js/audio/strudel/drones.js
@@ -1,0 +1,172 @@
+// @ts-nocheck
+// Sustained action drones, raw Web Audio. superdough is a one-shot trigger engine and can't do
+// live mid-voice param sweeps, so action drones are built directly against the shared
+// AudioContext (getAudioContext()) — a faithful port of the Tone drone engine (js/audio/sfx/
+// engine.js startDrone). Chain: source(s) → filter → ampGain (progress / amp-LFO) → fadeGain
+// (click-free in/out) → destination. setProgress(p) reshapes cutoff/detune/gain (no-op if loop).
+
+const NOTE_INDEX = { c: 0, "c#": 1, db: 1, d: 2, "d#": 3, eb: 3, e: 4, f: 5, "f#": 6, gb: 6, g: 7, "g#": 8, ab: 8, a: 9, "a#": 10, bb: 10, b: 11 };
+const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+/** Convert a note name ("A2", "c#3") to a frequency in Hz (A4 = 440). */
+export function noteToFreq(note) {
+  const m = String(note).trim().toLowerCase().match(/^([a-g][#b]?)(-?\d+)$/);
+  if (!m) return 110;
+  const semis = NOTE_INDEX[m[1]] ?? 0;
+  const octave = parseInt(m[2], 10);
+  const midi = (octave + 1) * 12 + semis;
+  return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+/** Interpolate a {from,to} range by progress (clamped), or pass a plain number through. */
+export function droneRange(v, p) {
+  if (v && typeof v === "object") return v.from + (v.to - v.from) * clamp01(p);
+  return v;
+}
+
+const dbToGain = (db) => Math.pow(10, db / 20);
+
+/** Build a looping noise buffer (white or brown). */
+function makeNoiseBuffer(ctx, type) {
+  const len = Math.floor(ctx.sampleRate * 2);
+  const buf = ctx.createBuffer(1, len, ctx.sampleRate);
+  const d = buf.getChannelData(0);
+  if (type === "brown") {
+    let last = 0;
+    for (let i = 0; i < len; i++) { const w = Math.random() * 2 - 1; last = (last + 0.02 * w) / 1.02; d[i] = last * 3.5; }
+  } else {
+    for (let i = 0; i < len; i++) d[i] = Math.random() * 2 - 1;
+  }
+  return buf;
+}
+
+/** Smoothly ramp an AudioParam toward a target over `dur` seconds from now. */
+function rampParam(param, target, ctx, dur = 0.12) {
+  const now = ctx.currentTime;
+  param.cancelScheduledValues(now);
+  param.setValueAtTime(param.value, now);
+  param.linearRampToValueAtTime(target, now + dur);
+}
+
+/**
+ * Start a sustained drone voice. Returns { setProgress(p), stop() }.
+ * @param {AudioContext} ctx
+ * @param {object} spec  a DRONES entry
+ */
+export function createDroneVoice(ctx, spec) {
+  if (!spec) return { setProgress() {}, stop() {} };
+  const t = ctx.currentTime;
+  const fade = spec.fade ?? 0.15;
+  const level = dbToGain(spec.volume ?? -18);
+  const freq = noteToFreq(spec.note ?? "C2");
+
+  const sources = [];   // nodes to start()/stop()
+  const extra = [];     // helper nodes to disconnect on teardown
+  let detuneParam = null;
+
+  if (spec.source === "noise") {
+    const src = ctx.createBufferSource();
+    src.buffer = makeNoiseBuffer(ctx, spec.type || "brown");
+    src.loop = true;
+    sources.push(src);
+  } else if (spec.source === "fm") {
+    const carrier = ctx.createOscillator();
+    carrier.type = spec.osc || "sine";
+    carrier.frequency.value = freq;
+    carrier.detune.value = droneRange(spec.detune, 0) || 0;
+    const modFreq = freq * (spec.harmonicity ?? 2);
+    const mod = ctx.createOscillator();
+    mod.type = "sine";
+    mod.frequency.value = modFreq;
+    const modGain = ctx.createGain();
+    modGain.gain.value = modFreq * (spec.modIndex ?? 8); // peak deviation = index * modFreq
+    mod.connect(modGain);
+    modGain.connect(carrier.frequency);
+    detuneParam = carrier.detune;
+    sources.push(carrier, mod);
+    extra.push(modGain);
+  } else if (spec.source === "dual") {
+    const osc1 = ctx.createOscillator(); osc1.type = spec.osc || "sawtooth"; osc1.frequency.value = freq;
+    const osc2 = ctx.createOscillator(); osc2.type = spec.osc || "sawtooth"; osc2.frequency.value = freq;
+    osc2.detune.value = droneRange(spec.detune, 0) || 0;
+    detuneParam = osc2.detune;
+    sources.push(osc1, osc2);
+  } else {
+    const s = ctx.createOscillator(); s.type = spec.source || "sawtooth"; s.frequency.value = freq;
+    s.detune.value = droneRange(spec.detune, 0) || 0;
+    detuneParam = s.detune;
+    sources.push(s);
+  }
+
+  const filter = ctx.createBiquadFilter();
+  filter.type = "lowpass";
+  filter.frequency.value = droneRange(spec.cutoff, 0) || 1200;
+  filter.Q.value = spec.q ?? 2;
+
+  const ampGain = ctx.createGain();
+  ampGain.gain.value = droneRange(spec.gain, 0) ?? 1;
+  const fadeGain = ctx.createGain();
+  fadeGain.gain.value = 0;
+
+  // The FM carrier (sources[0]) feeds the filter; the modulator feeds carrier.frequency (not the
+  // filter). Non-FM sources all feed the filter.
+  for (const s of (spec.source === "fm" ? [sources[0]] : sources)) s.connect(filter);
+  filter.connect(ampGain);
+  ampGain.connect(fadeGain);
+  fadeGain.connect(ctx.destination);
+
+  // Optional LFO (amp tremolo, cutoff wobble). Web Audio param connections ADD to the param's
+  // intrinsic value, so we seat the offset on the param and connect the scaled LFO osc.
+  let lfoOsc = null;
+  let lfoStart = t;
+  if (spec.lfo) {
+    const { rate = 4, depth = 0.5, target = "amp" } = spec.lfo;
+    lfoOsc = ctx.createOscillator();
+    lfoOsc.type = "sine";
+    lfoOsc.frequency.value = rate;
+    const lfoGain = ctx.createGain();
+    if (target === "amp") {
+      const min = Math.max(0, 1 - depth);
+      ampGain.gain.value = (min + 1) / 2;       // mean
+      lfoGain.gain.value = (1 - min) / 2;        // amplitude
+      lfoOsc.connect(lfoGain); lfoGain.connect(ampGain.gain);
+      lfoStart = t + fade;                        // delay tremolo until fade completes (no onset spike)
+    } else {
+      const base = droneRange(spec.cutoff, 0) || 1200;
+      filter.frequency.value = (base * (1 - depth) + base) / 2;
+      lfoGain.gain.value = (base - base * (1 - depth)) / 2;
+      lfoOsc.connect(lfoGain); lfoGain.connect(filter.frequency);
+    }
+    extra.push(lfoGain);
+  }
+
+  for (const s of sources) { try { s.start(t); } catch (_) {} }
+  if (lfoOsc) { try { lfoOsc.start(lfoStart); } catch (_) {} }
+  fadeGain.gain.setValueAtTime(0, t);
+  fadeGain.gain.linearRampToValueAtTime(level, t + fade);
+
+  let stopped = false;
+  return {
+    setProgress(p) {
+      if (stopped || spec.loop) return;
+      if (spec.cutoff && typeof spec.cutoff === "object") rampParam(filter.frequency, droneRange(spec.cutoff, p), ctx);
+      if (spec.detune && typeof spec.detune === "object" && detuneParam) rampParam(detuneParam, droneRange(spec.detune, p), ctx);
+      // Progress gain only when no amp-LFO owns ampGain.gain.
+      if (spec.gain && typeof spec.gain === "object" && !(spec.lfo && (spec.lfo.target ?? "amp") === "amp")) {
+        rampParam(ampGain.gain, droneRange(spec.gain, p), ctx);
+      }
+    },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      const tt = ctx.currentTime;
+      fadeGain.gain.cancelScheduledValues(tt);
+      fadeGain.gain.setValueAtTime(fadeGain.gain.value, tt);
+      fadeGain.gain.linearRampToValueAtTime(0, tt + fade);
+      setTimeout(() => {
+        for (const s of [...sources, lfoOsc]) { try { s?.stop?.(); } catch (_) {} }
+        for (const n of [...sources, ...extra, filter, ampGain, fadeGain, lfoOsc]) { try { n?.disconnect?.(); } catch (_) {} }
+      }, (fade + 0.1) * 1000);
+    },
+  };
+}

--- a/js/audio/strudel/index.js
+++ b/js/audio/strudel/index.js
@@ -1,0 +1,117 @@
+// @ts-nocheck
+// Strudel + superdough audio engine — the single module that owns music, one-shot SFX, and
+// action drones when the "strudel" engine is selected (js/audio/engine-select.js). The faithful
+// promotion of js/audio/strudel-spike.js (branch strudel-ingame-spike).
+//
+// Browser-only — do NOT import from headless entry points (scripts/playtest.js, bot/cli.js).
+// Tone-default users never load this module (main.js dynamic-imports it only when selected).
+//
+// Pref + event ownership stays in the Tone renderer modules: setMusicEnabled/setSfxEnabled still
+// write localStorage + emit MUSIC_CHANGED/SFX_CHANGED even when the Tone engine isn't running, so
+// the HUD buttons + music/sfx console commands keep working — this engine just listens.
+import { on, E } from "../../core/events.js";
+import { getState } from "../../core/state.js";
+import { deriveProgress, deriveThreat } from "../signals.js";
+import { bootStrudel } from "./runtime.js";
+import { createMusic } from "./music.js";
+import { createSfx } from "./sfx.js";
+import { resolveCue } from "./data/cues.js";
+import { createDroneVoice } from "./drones.js";
+import { DRONES, resolveDrone } from "./data/drones.js";
+import { CORPORATE } from "./data/corporate.js";
+
+// Phase-1 one-shot SFX events (issue #254). Other routed events resolve to no cue for now.
+const SFX_EVENTS = [
+  E.NODE_REVEALED, E.NODE_ACCESSED, E.ACTION_RESOLVED,
+  E.ALERT_GLOBAL_RAISED, E.ICE_DETECTED, E.ALERT_TRACE_STARTED,
+];
+
+let _started = false;
+
+// Client prefs (same keys the Tone renderers use; read directly since those modules aren't inited).
+function loadPref(key, dflt = true) {
+  try { const v = localStorage.getItem(key); return v === null ? dflt : v === "true"; }
+  catch { return dflt; }
+}
+
+/** Wire and boot the Strudel engine. Idempotent. */
+export function initStrudelEngine() {
+  if (_started) return;
+  _started = true;
+
+  // AudioContext needs a user gesture; boot + resume on the first one (pointer or key).
+  function arm() {
+    window.removeEventListener("pointerdown", arm);
+    window.removeEventListener("keydown", arm);
+    bootStrudel()
+      .then((rt) => rt.ctx.resume().then(() => wire(rt)))
+      .catch((e) => console.warn("[strudel] boot failed:", e));
+  }
+  window.addEventListener("pointerdown", arm);
+  window.addEventListener("keydown", arm);
+}
+
+/** Wire music (+ SFX/drones in later slices) once the runtime is live. */
+function wire(rt) {
+  const music = createMusic(rt);
+  let musicEnabled = loadPref("starnet:music-enabled");
+
+  // Seed the axes from current state, then start if enabled.
+  const s = getState();
+  if (s) { music.setProgress(deriveProgress(s)); music.setThreat(deriveThreat(s)); }
+  if (musicEnabled) music.start(CORPORATE);
+
+  on(E.STATE_CHANGED, (state) => {
+    if (!state) return;
+    music.setProgress(deriveProgress(state));
+    music.setThreat(deriveThreat(state));
+  });
+
+  // The HUD music toggle / `music on|off` command emit MUSIC_CHANGED (via the Tone renderer's
+  // setMusicEnabled, which still runs); react to it here.
+  on(E.MUSIC_CHANGED, ({ enabled }) => {
+    musicEnabled = !!enabled;
+    if (musicEnabled) music.start(CORPORATE);
+    else music.stop();
+  });
+
+  // ---- One-shot SFX -----------------------------------------------------------------------------
+  const sfx = createSfx(rt);
+  sfx.setEnabled(loadPref("starnet:sfx-enabled"));
+  for (const type of SFX_EVENTS) {
+    on(type, (payload) => {
+      const spec = resolveCue(type, payload);
+      if (spec) sfx.play(spec);   // dedupe is per-spec (see sfx.js) — variants never collide
+    });
+  }
+  // ---- Action drones (sustained, progress-driven; raw Web Audio) --------------------------------
+  const drones = new Map(); // "<nodeId>:<action>" → voice handle
+  const stopAllDrones = () => { for (const d of drones.values()) d.stop(); drones.clear(); };
+  on(E.ACTION_FEEDBACK, (payload) => {
+    if (!sfx.isEnabled()) return;   // drones are SFX — gated by the SFX pref
+    const { nodeId, action, phase, progress } = payload || {};
+    const key = `${nodeId}:${action}`;
+    if (phase === "start") {
+      if (drones.has(key)) return;  // already running (duplicate start) — don't restart
+      const id = resolveDrone(action);
+      if (!id) return;
+      drones.set(key, createDroneVoice(rt.ctx, DRONES[id]));
+    } else if (phase === "progress") {
+      drones.get(key)?.setProgress(progress ?? 0);
+    } else if (phase === "complete" || phase === "cancel") {
+      drones.get(key)?.stop();
+      drones.delete(key);
+    }
+  });
+  on(E.RUN_ENDED, stopAllDrones);
+
+  // The HUD SFX toggle / `sfx on|off` command emit SFX_CHANGED (via the Tone renderer); react here.
+  on(E.SFX_CHANGED, ({ enabled }) => {
+    sfx.setEnabled(!!enabled);
+    if (!enabled) stopAllDrones();   // silence any in-progress drones immediately
+  });
+
+  // Expose a debug handle for the browser playtest API / perf harness.
+  /** @type {any} */ (window).strudelEngine = { rt, music, sfx, drones, createDroneVoice, DRONES };
+  console.log("[strudel] engine booted (music + sfx + drones live)");
+}

--- a/js/audio/strudel/music.js
+++ b/js/audio/strudel/music.js
@@ -1,0 +1,62 @@
+// @ts-nocheck
+// Score-DATA interpreter → a reactive Strudel pattern. The score is plain data (see
+// data/corporate.js); this module turns it into a live `stack()` whose params are driven by the
+// game's progress/threat signals via signal() (re-sampled each cycle — no re-eval on update).
+//
+// Layer param convention:
+//   number   → constant  (.gain(0.3), .lpf(800), .room(0.6), .fast(2))
+//   [lo,hi]  → axis-driven via signal().range(lo,hi); the layer's `axis` selects which signal
+//              ("progress" or "threat"; anything else uses the progress signal as a neutral base)
+//   addNote  → .add(note(axisSignal.range(lo,hi)))  (semitone transposition that climbs with the axis)
+
+const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+/**
+ * Build a Strudel program (a stacked, tempo-set pattern) from score DATA.
+ * `ctx` supplies the strudel builders + the two reactive signals (injected for testability).
+ * @param {object} score  { bpm, layers: [{ sound, note, axis, gain?, lpf?, hpf?, room?, fast?, addNote? }] }
+ * @param {{ note:Function, stack:Function, progressSignal:object, threatSignal:object }} ctx
+ */
+export function buildProgram(score, ctx) {
+  const { note, stack, progressSignal, threatSignal } = ctx;
+  const layers = score.layers.map((L) => {
+    const sig = L.axis === "threat" ? threatSignal : progressSignal;
+    const ranged = (v) => (Array.isArray(v) ? sig.range(v[0], v[1]) : v);
+    let p = note(L.note);
+    if (L.sound != null) p = p.s(L.sound);
+    if (L.addNote != null) p = p.add(note(ranged(L.addNote)));
+    if (L.fast != null) p = p.fast(ranged(L.fast));
+    if (L.gain != null) p = p.gain(ranged(L.gain));
+    if (L.lpf != null) p = p.lpf(ranged(L.lpf));
+    if (L.hpf != null) p = p.hpf(ranged(L.hpf));
+    if (L.room != null) p = p.room(ranged(L.room));
+    return p;
+  });
+  return stack(...layers).cpm(score.bpm / 4); // 1 cycle = 1 bar (4/4)
+}
+
+/**
+ * Create a music controller bound to the live runtime. Holds the current progress/threat values;
+ * the signals re-sample them every cycle, so set* needs no re-eval.
+ * @param {object} rt  the runtime handle from bootStrudel() (note/stack/signal/hush)
+ */
+export function createMusic(rt) {
+  let gProgress = 0;
+  let gThreat = 0;
+  let started = false;
+  const progressSignal = rt.signal(() => gProgress);
+  const threatSignal = rt.signal(() => gThreat);
+
+  return {
+    start(score) {
+      const program = buildProgram(score, { note: rt.note, stack: rt.stack, progressSignal, threatSignal });
+      rt.hush();
+      program.play();
+      started = true;
+    },
+    stop() { if (typeof rt.hush === "function") rt.hush(); started = false; },
+    setProgress(p) { gProgress = clamp01(p); },
+    setThreat(t) { gThreat = clamp01(t); },
+    isStarted() { return started; },
+  };
+}

--- a/js/audio/strudel/runtime.js
+++ b/js/audio/strudel/runtime.js
@@ -1,0 +1,38 @@
+// @ts-nocheck
+// Strudel runtime boot — browser-only. Dynamically imports the vendored @strudel/web bundle
+// (importmap "@strudel/web" → dist/strudel.js) so Tone-default users never download it.
+//
+// @strudel/web sets window.initStrudel at module load; calling initStrudel() registers the
+// pattern/synth fns (note/sound/stack/signal/superdough/evaluate/hush/getAudioContext/samples)
+// on window ASYNCHRONOUSLY and returns undefined — so we POLL for readiness, never await it.
+// (Findings carried from the spikes; see issue #254 implementation notes.)
+
+let _booting = null;
+
+const REQUIRED = ["evaluate", "superdough", "stack", "note", "sound", "signal", "hush", "getAudioContext"];
+
+/**
+ * Boot the Strudel runtime once (idempotent — returns the same promise on repeat calls).
+ * Does NOT resume the AudioContext (that needs a user gesture; the caller does it).
+ * @returns {Promise<object>} a handle of the live runtime globals + the AudioContext (`ctx`).
+ */
+export function bootStrudel() {
+  if (_booting) return _booting;
+  _booting = (async () => {
+    await import("@strudel/web"); // side effect: registers window.initStrudel
+    if (typeof window.initStrudel !== "function") {
+      throw new Error("[strudel] initStrudel not found after import (bundle problem?)");
+    }
+    window.initStrudel();
+    const t0 = Date.now();
+    while (!REQUIRED.every((k) => typeof window[k] === "function")) {
+      if (Date.now() - t0 > 10000) throw new Error("[strudel] timed out waiting for runtime globals");
+      await new Promise((r) => setTimeout(r, 60));
+    }
+    const rt = {};
+    for (const k of [...REQUIRED, "samples"]) rt[k] = window[k];
+    rt.ctx = window.getAudioContext();
+    return rt;
+  })();
+  return _booting;
+}

--- a/js/audio/strudel/sfx.js
+++ b/js/audio/strudel/sfx.js
@@ -1,0 +1,38 @@
+// @ts-nocheck
+// One-shot SFX engine — fires superdough voices from cue specs. The strudel counterpart to the
+// Tone sfx/engine.js play() path. Browser-only (needs the live runtime + AudioContext).
+import { CUES } from "./data/cues.js";
+
+const nowMs = () => (typeof performance !== "undefined" ? performance.now() : Date.now());
+
+/**
+ * @param {object} rt  runtime handle from bootStrudel() (needs rt.superdough)
+ */
+export function createSfx(rt) {
+  let enabled = true;
+  // Dedupe per distinct cue spec (the CUES entries are stable singletons), so e.g. the
+  // xploit.ok and xploit.fail specs never suppress each other within the window — they're
+  // different objects. Identical specs fired twice within 50ms collapse (anti machine-gun).
+  const lastBySpec = new WeakMap();
+
+  return {
+    setEnabled(on) { enabled = !!on; },
+    isEnabled() { return enabled; },
+
+    /**
+     * Fire a cue spec. Dedupes the same spec within 50ms (avoids machine-gunning identical cues).
+     * @param {object} spec  a CUES entry ({ ...superdoughValue, _dur })
+     */
+    play(spec) {
+      if (!enabled || !spec) return;
+      const t = nowMs();
+      if (t - (lastBySpec.get(spec) ?? -1e9) < 50) return;
+      lastBySpec.set(spec, t);
+      const { _dur, ...value } = spec;
+      try { rt.superdough(value, 0, _dur ?? 0.2); } catch (_) { /* dropped voice */ }
+    },
+
+    /** Fire a cue by id (console `sfx test` / harness). @param {string} id */
+    playCue(id) { this.play(CUES[id]); },
+  };
+}

--- a/js/strudel-vendor.js
+++ b/js/strudel-vendor.js
@@ -1,0 +1,11 @@
+// Vendor entry for the Strudel runtime — bundled by esbuild into dist/strudel.js (ESM).
+// Mirrors js/tone-vendor.js. Strudel + superdough are AGPL-3.0; bundling them makes the
+// combined work AGPL-3.0 (see LICENSE).
+//
+// @strudel/web sets window.initStrudel at module load and, when initStrudel() is called,
+// registers the pattern/synth globals (note/sound/stack/signal/superdough/evaluate/hush/
+// getAudioContext/samples) on window ASYNCHRONOUSLY. The engine boot polls for them
+// (js/audio/strudel/runtime.js) rather than awaiting — initStrudel() returns undefined.
+//
+// Re-export everything so callers may also import named bindings directly if needed.
+export * from "@strudel/web";

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -10,6 +10,7 @@ import { initVisualRenderer } from "./visual-renderer.js";
 import { initLogRenderer } from "./log-renderer.js";
 import { initAudioRenderer, toggleMusic, isMusicEnabled } from "../audio/audio-renderer.js";
 import { initSfxRenderer, isSfxEnabled, toggleSfx } from "../audio/sfx/renderer.js";
+import { getAudioEngine } from "../audio/engine-select.js";
 import { buildActionContext, initActionDispatcher, buildNodeClickHandler } from "../core/actions/action-context.js";
 import { openDarknetsStore } from "./store.js";
 import { initGraphBridge } from "../core/graph-bridge.js";
@@ -22,6 +23,7 @@ import { initResizers } from "./resizers.js";
 import "./hub-commands.js";
 import "../audio/music-commands.js";
 import "../audio/sfx/commands.js";
+import "../audio/strudel/commands.js";   // `audio engine <tone|strudel>` — registered for both engines
 
 import { NAMED_NETWORKS, DEFAULT_NETWORK, buildGenerated } from "../../data/networks/index.js";
 
@@ -71,8 +73,15 @@ function init() {
   initConsole();
   initResizers();  // apply saved layout + wire the resize splitters
   initVisualRenderer();  // must subscribe before initGame fires STATE_CHANGED
-  const audioEngine = initAudioRenderer();   // browser-only reactive audio; silent until a run starts
-  initSfxRenderer();
+  // Audio engine select (boot-time; switching requires a reload). Tone is the default; the
+  // Strudel engine is lazy-imported so Tone users never download its runtime bundle.
+  let audioEngine = null;   // exposed as window.starnet.audio (Tone engine, or null under Strudel)
+  if (getAudioEngine() === "strudel") {
+    import("../audio/strudel/index.js").then((m) => m.initStrudelEngine());
+  } else {
+    audioEngine = initAudioRenderer();   // browser-only reactive audio; silent until a run starts
+    initSfxRenderer();
+  }
   initGraphBridge();
   initDynamicActions();
   initProfileRunCommit();  // wire RUN_ENDED → commit results back to the profile

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "starnet-game-2026",
       "dependencies": {
+        "@strudel/web": "1.0.3",
         "cytoscape": "^3.33.1",
         "cytoscape-cola": "^2.5.1",
         "cytoscape-cose-bilkent": "^4.1.0",
@@ -473,6 +474,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
@@ -488,11 +495,604 @@
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.7.tgz",
+      "integrity": "sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strudel/core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@strudel/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-4Ei55Gj5r+XCLc3L5G8YulnFvyYMZVM21NCnH6gY5NNw/dDZujucS//QoPzrp0z9zrnrIIRVxjfGnjYBdIrLbA==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "fraction.js": "^4.3.7"
+      }
+    },
+    "node_modules/@strudel/mini": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@strudel/mini/-/mini-1.0.1.tgz",
+      "integrity": "sha512-ElS5h3hppVcizm9N5e3egHzDP5eGyEqFGMPpl9EHdu+PzF/vt7uc0STxVN//vhq4A9Lrv3FTWSel5rik2AEwBg==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.0.1"
+      }
+    },
+    "node_modules/@strudel/tonal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@strudel/tonal/-/tonal-1.0.1.tgz",
+      "integrity": "sha512-XtOi0Ac+CUpOpmkqLviwaW7380LDPq/vGgSARIQu67bjv4ELUlM2OuEg8kq3XvrdnrtkikOKPqWZ+0JUmIWqPw==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.0.1",
+        "@tonaljs/tonal": "^4.7.2",
+        "chord-voicings": "^0.0.1",
+        "webmidi": "^3.1.8"
+      }
+    },
+    "node_modules/@strudel/transpiler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@strudel/transpiler/-/transpiler-1.0.1.tgz",
+      "integrity": "sha512-HeWdx6It6mq2+wqWQOMxoTIdvltiAuy6QPqEFOfOR0mausuXhygAWm+HTQ9Wg91kpNNA8bixfM+VMNfM5NcIOA==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.0.1",
+        "@strudel/mini": "1.0.1",
+        "acorn": "^8.11.3",
+        "escodegen": "^2.1.0",
+        "estree-walker": "^3.0.1"
+      }
+    },
+    "node_modules/@strudel/transpiler/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@strudel/web": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@strudel/web/-/web-1.0.3.tgz",
+      "integrity": "sha512-wWavtOcTb8B1ZipuaOZeoWj5tYNWcYW+QtvhY4yVFK1MaFqIenLLkUlPTgiJ/nciQUw/vXIg4Gk1+JMcJLwOKw==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@rollup/plugin-replace": "^5.0.5",
+        "@strudel/core": "1.0.1",
+        "@strudel/mini": "1.0.1",
+        "@strudel/tonal": "1.0.1",
+        "@strudel/transpiler": "1.0.1",
+        "@strudel/webaudio": "1.0.1"
+      }
+    },
+    "node_modules/@strudel/webaudio": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@strudel/webaudio/-/webaudio-1.0.1.tgz",
+      "integrity": "sha512-NpwgdBkuk4emCSn7MrGquE/g7970V3kFl0kDhQVq456vaBLbbVZUHgkG48twVhnnLDpV4Rt3Y4La+XGN3ZX5gg==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.0.1",
+        "superdough": "1.0.1"
+      }
+    },
+    "node_modules/@tonaljs/abc-notation": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/abc-notation/-/abc-notation-4.9.1.tgz",
+      "integrity": "sha512-2fDUdPsFDdgZgyIiZCTYGKy30QiwIQxSXCSN2thGrSMXbQKCp8iTC8haStYcrA+25MPWhWlmvC/pz3tGcTNAqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/array": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/@tonaljs/array/-/array-4.8.4.tgz",
+      "integrity": "sha512-97HVdpZy82PqNBDMM9PRSbO2DUrnxNg3++N4xqLpfby70fKHAHhTWrMXWZK+Dzs76HDPQLd+qhd4cq28eBZzjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/chord": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord/-/chord-4.10.2.tgz",
+      "integrity": "sha512-Zlqtq6c6T4y+EqvwHRQp9icEjHqyniCpnIwwCFg5amgAQwXmWzarouOOSmcdJ1Is92eEvcPVuCoLiVUtajS30A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-detect": "^4.8.1",
+        "@tonaljs/chord-type": "^4.8.2",
+        "@tonaljs/collection": "^4.8.0",
+        "@tonaljs/core": "^4.10.0",
+        "@tonaljs/pcset": "^4.8.2",
+        "@tonaljs/scale-type": "^4.8.2"
+      }
+    },
+    "node_modules/@tonaljs/chord-detect": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-detect/-/chord-detect-4.9.1.tgz",
+      "integrity": "sha512-rV/9+R7aZ9cQorQ3jdNMMMh63onosglYZM71Q0n7KKcWMAGrxF66MzxBG82xy+w1QDMJQslB3iHfDHUiS6wRjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/chord-detect/node_modules/@tonaljs/chord-type": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-5.1.1.tgz",
+      "integrity": "sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/chord-type": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-4.8.2.tgz",
+      "integrity": "sha512-GzSTjQmZjkUdPhyesFDeJbxpW8R7L/bAE34E8ApGAh9FMcKYpRdX3Tn+gkluRsXOiRMfW07p3E0Adx4bjtyN+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/core": "^4.8.0",
+        "@tonaljs/pcset": "^4.8.2"
+      }
+    },
+    "node_modules/@tonaljs/collection": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/collection/-/collection-4.9.0.tgz",
+      "integrity": "sha512-Mk0h7O54nT6PgNVcUYauzxa5KOB23+0AOKudWzRH7JhJIN9vhVIC7PtwZXE+/G051UTbHSFIcN/afkgF4nB/8A==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/core": {
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@tonaljs/core/-/core-4.10.4.tgz",
+      "integrity": "sha512-PhGlQ2Js6rFQ6CufkSiBpEJoPS8QIIhbXSXhT4U+5ffqckli+YBZRN24vjZ4AEKuX8xoYDmCCbl+r6agauvzmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.1",
+        "@tonaljs/pitch-distance": "5.0.2",
+        "@tonaljs/pitch-interval": "5.0.2",
+        "@tonaljs/pitch-note": "5.0.3"
+      }
+    },
+    "node_modules/@tonaljs/core/node_modules/@tonaljs/pitch-distance": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-distance/-/pitch-distance-5.0.2.tgz",
+      "integrity": "sha512-DPxfGJCf4BvfIVRxl2v142tuCKIziM6PomOBT0/s7U5o+Z5qFAIW0tNx/MKyL83guV74p+XIf5VI0w1flmXxDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.1",
+        "@tonaljs/pitch-interval": "5.0.2",
+        "@tonaljs/pitch-note": "5.0.3"
+      }
+    },
+    "node_modules/@tonaljs/core/node_modules/@tonaljs/pitch-note": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-note/-/pitch-note-5.0.3.tgz",
+      "integrity": "sha512-JsPgqPa8VZdZtfwvgoHJz996BZqzvlnRxUF6c/Q9q8E0iq30UHBEid0Y6XldK+h6tuIENsG3a9jyvNNxRqIeYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.1"
+      }
+    },
+    "node_modules/@tonaljs/duration-value": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/duration-value/-/duration-value-4.9.0.tgz",
+      "integrity": "sha512-Muz54HyIe0nMYKWx6wyTa4y17ma29DtpJF4/oqJphy6A124rAVDe/SKit8JGOvDYAQj71FUXqs17sXBxO/ExVw==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/interval": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/interval/-/interval-4.8.2.tgz",
+      "integrity": "sha512-9SEuJuqFdmu9lnvMmJtxbReQcQvZ1YHXhCcxaF6Re23/w+BqiJvvkvNZhfWH+n1+g0uaSdTsuvMfamp7hAvPMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "^5.0.1",
+        "@tonaljs/pitch-distance": "^5.0.2",
+        "@tonaljs/pitch-interval": "^5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/key": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/key/-/key-4.11.2.tgz",
+      "integrity": "sha512-fc1y5+NwS4S3amirzYLLB324PxJDO00oIBbLJclAddc46UBeYnu4FNz+1nZboHCXRQ/06/ftuaWD/l7HrAoulw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/note": "4.12.1",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/roman-numeral": "4.9.1"
+      }
+    },
+    "node_modules/@tonaljs/midi": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/midi/-/midi-4.10.2.tgz",
+      "integrity": "sha512-MPamXhEwPL7L1udLfYMm3Ft8mLYtHr62Zi2w5zYHM2P7YwIvNoiX0+dvAN5is1Wvq4iVRa8AjFHerjOW/SZhGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/mode": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/mode/-/mode-4.9.2.tgz",
+      "integrity": "sha512-Il48fWX9SnGMzwNFVbizkWkr/SJ+aCIIHhjWfSf1agrQAoq81536qBXEyEyvia6aqEXC4OaXAQ5rSoBcmQRj1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/interval": "5.1.0",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/scale-type": "4.9.2"
+      }
+    },
+    "node_modules/@tonaljs/mode/node_modules/@tonaljs/interval": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/interval/-/interval-5.1.0.tgz",
+      "integrity": "sha512-GR9dUjn0j7yhjwjRh8HQxZYXOiVl05WfY3AFyMB9rfg807K4dSJmWfPTULPQXyHJ6NiZOPXcwRs8MxMLDxgdbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "^5.0.2",
+        "@tonaljs/pitch-distance": "^5.0.4",
+        "@tonaljs/pitch-interval": "^6.0.0"
+      }
+    },
+    "node_modules/@tonaljs/mode/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/mode/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/note": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/note/-/note-4.12.1.tgz",
+      "integrity": "sha512-yh6cnhu21bUb0VuIQWxObSbWBVp2cHIkJj4zZ4qsNOW4jSqn74+wHpSbOTDF8q+2hl6upz7TtBRavtqwPtLUCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/midi": "4.10.2",
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/note/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/note/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pcset": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pcset/-/pcset-4.10.1.tgz",
+      "integrity": "sha512-CZG1rpKc38yMfpEJsbDTvsTmQqsek9xxcuMgK64Tr6sP1lEiDuZJbQeKVWWRnreBF2FQ1cEGLmfOpvSO+40csA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/pcset/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/pcset/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pitch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.1.tgz",
+      "integrity": "sha512-5HYkF4hGY0jS2y5V3Hf5gNFXX46kT4cAcI7JLEn+qQb9N1dU9Gz9koI9di0mD1Tbam+kviceiCsJl4WX/FqYjA==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/pitch-distance": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-distance/-/pitch-distance-5.0.5.tgz",
+      "integrity": "sha512-dTfjsU0zyrj5YmiFio5prPaD5w7sBmHp4nnmlEg70nHY+SerAH0KiO9HM9usttVgRFUaXl0Gc7OI8YMGfSFmug==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/pitch-distance/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/pitch-distance/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pitch-interval": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-5.0.2.tgz",
+      "integrity": "sha512-bQmxeenRFNuuABs9mDc+bSUp3ySGw8I49pHMoGDdCcro9n3MDN8IsSwhvKoGOYErFMx76rNn1t+7WL8ukpvX5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.1"
+      }
+    },
+    "node_modules/@tonaljs/pitch-note": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-note/-/pitch-note-6.1.0.tgz",
+      "integrity": "sha512-A4OSLo8DjM38u73862LnDmL4YInDDRBmg0fojXcvu4cyU3oOlqndyeHOra1OVoH/WW46uNIxNs1wJDZNPWL5KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pitch-note/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/progression": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/progression/-/progression-4.9.2.tgz",
+      "integrity": "sha512-1Pmau5tKoWmY2H/fp9WVJ5Qm4c+xlu7IEZb3R3uLbc26kJq97DbuSnfArIAQoZTum2V6lOEN/Dt34E9OrGKnoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord": "6.1.2",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/roman-numeral": "4.9.1"
+      }
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/chord": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord/-/chord-6.1.2.tgz",
+      "integrity": "sha512-39crsPVyBJxdGJ1DGl+4diM+6+mZ/ws6crkQMlqX4zTYHMUVfJOQrko4mPF1CD89AFhHJe1zCT9Js+nNp3Gffg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-detect": "4.9.1",
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/interval": "^5.1.0",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/scale-type": "4.9.2"
+      }
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/chord-type": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-5.1.1.tgz",
+      "integrity": "sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/interval": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/interval/-/interval-5.1.0.tgz",
+      "integrity": "sha512-GR9dUjn0j7yhjwjRh8HQxZYXOiVl05WfY3AFyMB9rfg807K4dSJmWfPTULPQXyHJ6NiZOPXcwRs8MxMLDxgdbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "^5.0.2",
+        "@tonaljs/pitch-distance": "^5.0.4",
+        "@tonaljs/pitch-interval": "^6.0.0"
+      }
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/range": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/range/-/range-4.9.2.tgz",
+      "integrity": "sha512-XhFbCJCrEEIVz3MNmdVp9QUyiJA6eqnNnQeNqto8AuT5BYuffHDoMkBmvvjPuV5Lh8zfF9D0aqglvqPbZ+neKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/midi": "4.10.2"
+      }
+    },
+    "node_modules/@tonaljs/roman-numeral": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/roman-numeral/-/roman-numeral-4.9.1.tgz",
+      "integrity": "sha512-dJGKBNHdPrNTE97ZDk4t6wpNmgYcpHyLkAvWkRP9I/HsDkeTFFQqNXosYIvspPWrFySlRpeqqFwcqV74MYoOag==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/roman-numeral/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/roman-numeral/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/scale": {
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/@tonaljs/scale/-/scale-4.13.4.tgz",
+      "integrity": "sha512-hyilnmsCmoGQiRhYWKM1QPrqaNH3KGEfrSfxeXcicPnEh12yvrVRm4djKmTVw7Rc/5P4GniPAA51+CS0C5dbLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/note": "4.12.1",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/scale-type": "4.9.2"
+      }
+    },
+    "node_modules/@tonaljs/scale-type": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/scale-type/-/scale-type-4.9.2.tgz",
+      "integrity": "sha512-XDRPySg0X6owJ6AVzVRpS4ZpgleAUQakuq5VtfQ0JitnJKGRYo5Y0w7Fl/wEz/X9aEMk2lxcdF8VGGMIsQFo0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/scale/node_modules/@tonaljs/chord-type": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-5.1.1.tgz",
+      "integrity": "sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/time-signature": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/time-signature/-/time-signature-4.9.0.tgz",
+      "integrity": "sha512-zRo8CBqg/2guzTlF2vxyVIuB5gmwWQaxlknJPUSDII8CTdQ/x3a1LlNoMKkvTUnqwCihe3WrNPZ5XUfOOTthYA==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/tonal": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/tonal/-/tonal-4.10.0.tgz",
+      "integrity": "sha512-F2T9Fiy+j0MVped89kCrX1XF68mQOLUnny4pDOHrIf+OkrjtLQOzzaSOrX1tx0o72WUwQm1knz6D1d57b9X1HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/abc-notation": "^4.8.0",
+        "@tonaljs/array": "^4.8.0",
+        "@tonaljs/chord": "^4.8.0",
+        "@tonaljs/chord-type": "^4.8.0",
+        "@tonaljs/collection": "^4.8.0",
+        "@tonaljs/core": "^4.8.0",
+        "@tonaljs/duration-value": "^4.8.0",
+        "@tonaljs/interval": "^4.8.0",
+        "@tonaljs/key": "^4.9.0",
+        "@tonaljs/midi": "^4.8.0",
+        "@tonaljs/mode": "^4.8.0",
+        "@tonaljs/note": "^4.9.0",
+        "@tonaljs/pcset": "^4.8.0",
+        "@tonaljs/progression": "^4.8.0",
+        "@tonaljs/range": "^4.8.0",
+        "@tonaljs/roman-numeral": "^4.8.0",
+        "@tonaljs/scale": "^4.9.0",
+        "@tonaljs/scale-type": "^4.8.0",
+        "@tonaljs/time-signature": "^4.8.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/automation-events": {
       "version": "7.1.19",
@@ -505,6 +1105,15 @@
       },
       "engines": {
         "node": ">=18.2.0"
+      }
+    },
+    "node_modules/chord-voicings": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/chord-voicings/-/chord-voicings-0.0.1.tgz",
+      "integrity": "sha512-SutgB/4ynkkuiK6qdQ/k3QvCFcH0Vj8Ch4t6LbRyRQbVzP/TOztiCk3kvXd516UZ6fqk7ijDRELEFcKN+6V8sA==",
+      "license": "ISC",
+      "dependencies": {
+        "@tonaljs/tonal": "^4.6.5"
       }
     },
     "node_modules/cose-base": {
@@ -674,6 +1283,15 @@
         "lodash": "^4.17.15"
       }
     },
+    "node_modules/djipevents": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/djipevents/-/djipevents-2.0.7.tgz",
+      "integrity": "sha512-KNFYaU85imxOCKOUsIR70Iz9E19r96/X7LSH+u0tSoZdpWcBdzoqtTsU+wuLhc6GMpSFob+KInkZAbfKi01Bjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -716,6 +1334,77 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/graphlib": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
@@ -723,6 +1412,26 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/jazz-midi": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/jazz-midi/-/jazz-midi-1.7.9.tgz",
+      "integrity": "sha512-c8c4BBgwxdsIr1iVm53nadCrtH7BUlnX3V95ciK/gbvXN/ndE5+POskBalXgqlc/r9p2XUbdLTrgrC6fou5p9w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/jzz": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/jzz/-/jzz-1.9.6.tgz",
+      "integrity": "sha512-J7ENLhXwfm2BNDKRUrL8eKtPhUS/CtMBpiafxQHDBcOWSocLhearDKEdh+ylnZFcr5OXWTed0gj6l/txeQA9vg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "jazz-midi": "^1.7.9"
       }
     },
     "node_modules/klayjs": {
@@ -774,6 +1483,52 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanostores": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.9.5.tgz",
+      "integrity": "sha512-Z+p+g8E7yzaWwOe5gEUB2Ox0rCEeXWYIZWmYvw/ajNYX8DlXdMvMDj8DWfM/subqPAcsf8l8Td4iAwO1DeIIRQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/standardized-audio-context": {
       "version": "25.3.77",
       "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
@@ -783,6 +1538,15 @@
         "@babel/runtime": "^7.25.6",
         "automation-events": "^7.0.9",
         "tslib": "^2.7.0"
+      }
+    },
+    "node_modules/superdough": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/superdough/-/superdough-1.0.1.tgz",
+      "integrity": "sha512-gfTbgOfFamhQzHitG2SW6QhW9c1WoFWHsQ8RpO/HTTXc1My0nDL1w5qQ38fqZ/EjIRy/YykDzdwxWYFaxG7X5w==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "nanostores": "^0.9.5"
       }
     },
     "node_modules/tone": {
@@ -834,6 +1598,21 @@
         "d3-drag": "^1.0.4",
         "d3-shape": "^1.3.5",
         "d3-timer": "^1.0.5"
+      }
+    },
+    "node_modules/webmidi": {
+      "version": "3.1.16",
+      "resolved": "https://registry.npmjs.org/webmidi/-/webmidi-3.1.16.tgz",
+      "integrity": "sha512-I6NnCfBUXNbV8q6EU+DPtr1u1EgjzDrFKHQQS2OgaHzcuQRFhRHgogfKpKSpxD0IgXhZHz8+k/OpGfZoWbvWAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "djipevents": "^2.0.7"
+      },
+      "engines": {
+        "node": ">=8.5"
+      },
+      "optionalDependencies": {
+        "jzz": "^1.8.5"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
+    "@strudel/web": "1.0.3",
     "cytoscape": "^3.33.1",
     "cytoscape-cola": "^2.5.1",
     "cytoscape-cose-bilkent": "^4.1.0",

--- a/tests/audio-engine-select.test.js
+++ b/tests/audio-engine-select.test.js
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { getAudioEngine, setAudioEngine, AUDIO_ENGINES } from "../js/audio/engine-select.js";
+
+// Minimal Map-backed localStorage stub (node has no localStorage).
+function installStorage() {
+  const m = new Map();
+  globalThis.localStorage = {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => m.set(k, String(v)),
+    removeItem: (k) => m.delete(k),
+    clear: () => m.clear(),
+  };
+}
+
+test("AUDIO_ENGINES lists tone and strudel", () => {
+  assert.deepEqual([...AUDIO_ENGINES].sort(), ["strudel", "tone"]);
+});
+
+test("defaults to tone when unset", () => {
+  installStorage();
+  assert.equal(getAudioEngine(), "tone");
+});
+
+test("setAudioEngine persists the choice and returns it", () => {
+  installStorage();
+  assert.equal(setAudioEngine("strudel"), "strudel");
+  assert.equal(getAudioEngine(), "strudel");
+});
+
+test("setAudioEngine rejects an unknown engine and leaves the pref unchanged", () => {
+  installStorage();
+  setAudioEngine("strudel");
+  assert.equal(setAudioEngine("bogus"), null);
+  assert.equal(getAudioEngine(), "strudel");
+});
+
+test("getAudioEngine falls back to tone when storage throws", () => {
+  globalThis.localStorage = {
+    getItem() { throw new Error("blocked"); },
+    setItem() { throw new Error("blocked"); },
+  };
+  assert.equal(getAudioEngine(), "tone");
+  assert.equal(setAudioEngine("strudel"), "strudel"); // returns the value even if persist fails
+});

--- a/tests/strudel-drones.test.js
+++ b/tests/strudel-drones.test.js
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { DRONES, DRONE_IDS, resolveDrone } from "../js/audio/strudel/data/drones.js";
+import { noteToFreq, droneRange } from "../js/audio/strudel/drones.js";
+
+test("resolveDrone maps the 7 timed actions to themselves, unknown → null", () => {
+  for (const id of ["probe", "xploit", "dump", "fetch", "mine", "lie-low", "reboot"]) {
+    assert.equal(resolveDrone(id), id);
+  }
+  assert.equal(resolveDrone("nope"), null);
+  assert.equal(resolveDrone(""), null);
+  assert.equal(resolveDrone(undefined), null);
+});
+
+test("DRONE_IDS covers exactly the 7 timed actions", () => {
+  assert.deepEqual([...DRONE_IDS].sort(), ["dump", "fetch", "lie-low", "mine", "probe", "reboot", "xploit"]);
+});
+
+test("noteToFreq converts note names to Hz", () => {
+  assert.ok(Math.abs(noteToFreq("A4") - 440) < 0.01);
+  assert.ok(Math.abs(noteToFreq("A2") - 110) < 0.01);
+  assert.ok(Math.abs(noteToFreq("A1") - 55) < 0.01);
+  assert.ok(Math.abs(noteToFreq("C2") - 65.41) < 0.1);
+  assert.ok(Math.abs(noteToFreq("E2") - 82.41) < 0.1);
+});
+
+test("droneRange interpolates {from,to} by progress and passes numbers through", () => {
+  assert.equal(droneRange({ from: 300, to: 1500 }, 0), 300);
+  assert.equal(droneRange({ from: 300, to: 1500 }, 1), 1500);
+  assert.equal(droneRange({ from: 300, to: 1500 }, 0.5), 900);
+  assert.equal(droneRange({ from: 0, to: 10 }, 2), 10); // clamps p>1
+  assert.equal(droneRange(600, 0.5), 600); // plain number
+});
+
+test("amp-LFO drones do not also declare a progress-driven gain (engine constraint)", () => {
+  // The two are mutually exclusive — the amp LFO owns ampGain.gain.
+  for (const [id, spec] of Object.entries(DRONES)) {
+    if (spec.lfo && (spec.lfo.target ?? "amp") === "amp") {
+      assert.ok(!(spec.gain && typeof spec.gain === "object"),
+        `${id}: amp-LFO drone must not have a {from,to} gain`);
+    }
+  }
+});

--- a/tests/strudel-music.test.js
+++ b/tests/strudel-music.test.js
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildProgram } from "../js/audio/strudel/music.js";
+
+// Stub Strudel runtime: chainable patterns that record their method calls, and signals whose
+// .range() returns a tagged marker so we can assert which axis drives which param.
+function makeStubCtx() {
+  const mkPattern = (tag) => {
+    const p = { __tag: tag, __chain: [] };
+    for (const m of ["s", "gain", "lpf", "hpf", "room", "add", "fast", "cpm"]) {
+      p[m] = (arg) => { p.__chain.push([m, arg]); return p; };
+    }
+    return p;
+  };
+  const mkSignal = (name) => ({ __sig: name, range: (lo, hi) => ({ __range: [lo, hi], __sig: name }) });
+  return {
+    note: (n) => mkPattern("note:" + n),
+    stack: (...ps) => { const p = mkPattern("stack"); p.__layers = ps; return p; },
+    progressSignal: mkSignal("progress"),
+    threatSignal: mkSignal("threat"),
+  };
+}
+
+function chainGet(pattern, method) {
+  const hit = pattern.__chain.find(([m]) => m === method);
+  return hit ? hit[1] : undefined;
+}
+
+test("a ranged param on a threat layer is driven by the threat signal", () => {
+  const ctx = makeStubCtx();
+  const score = { bpm: 120, layers: [{ sound: "sawtooth", note: "c2", axis: "threat", gain: [0.35, 0.85], lpf: [300, 3500] }] };
+  const prog = buildProgram(score, ctx);
+  const layer = prog.__layers[0];
+  assert.deepEqual(chainGet(layer, "gain"), { __range: [0.35, 0.85], __sig: "threat" });
+  assert.deepEqual(chainGet(layer, "lpf"), { __range: [300, 3500], __sig: "threat" });
+  assert.equal(chainGet(layer, "s"), "sawtooth");
+});
+
+test("a ranged param on a progress layer is driven by the progress signal", () => {
+  const ctx = makeStubCtx();
+  const score = { bpm: 120, layers: [{ sound: "triangle", note: "c4", axis: "progress", gain: [0, 0.2], fast: [1, 2] }] };
+  const layer = buildProgram(score, ctx).__layers[0];
+  assert.deepEqual(chainGet(layer, "gain"), { __range: [0, 0.2], __sig: "progress" });
+  assert.deepEqual(chainGet(layer, "fast"), { __range: [1, 2], __sig: "progress" });
+});
+
+test("a constant (non-array) param is passed through verbatim", () => {
+  const ctx = makeStubCtx();
+  const score = { bpm: 120, layers: [{ sound: "sine", note: "c1", axis: "base", gain: 0.2, room: 0.6 }] };
+  const layer = buildProgram(score, ctx).__layers[0];
+  assert.equal(chainGet(layer, "gain"), 0.2);
+  assert.equal(chainGet(layer, "room"), 0.6);
+});
+
+test("addNote becomes an .add(note(signal.range)) on the layer's axis", () => {
+  const ctx = makeStubCtx();
+  const score = { bpm: 120, layers: [{ sound: "triangle", note: "c4", axis: "progress", addNote: [0, 12] }] };
+  const layer = buildProgram(score, ctx).__layers[0];
+  const added = chainGet(layer, "add");
+  // .add receives a note() pattern; the note() arg should be the progress-ranged marker
+  assert.ok(added && added.__tag.startsWith("note:"), "add should receive a note pattern");
+});
+
+test("tempo is set on the stack via cpm(bpm/4)", () => {
+  const ctx = makeStubCtx();
+  const score = { bpm: 120, layers: [{ sound: "sine", note: "c1", axis: "base", gain: 0.2 }] };
+  const prog = buildProgram(score, ctx);
+  assert.equal(chainGet(prog, "cpm"), 30);
+});
+
+test("stack receives one pattern per layer", () => {
+  const ctx = makeStubCtx();
+  const score = { bpm: 120, layers: [
+    { sound: "sawtooth", note: "c2", axis: "threat", gain: 0.5 },
+    { sound: "triangle", note: "c4", axis: "progress", gain: 0.3 },
+  ] };
+  assert.equal(buildProgram(score, ctx).__layers.length, 2);
+});

--- a/tests/strudel-sfx.test.js
+++ b/tests/strudel-sfx.test.js
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { E } from "../js/core/events.js";
+import { CUES, resolveCue } from "../js/audio/strudel/data/cues.js";
+
+test("ACTION_RESOLVED splits success vs failure", () => {
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { success: true }), CUES["xploit.ok"]);
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { success: false }), CUES["xploit.fail"]);
+});
+
+test("NODE_REVEALED / NODE_ACCESSED / ICE_DETECTED / ALERT_TRACE_STARTED map to their cues", () => {
+  assert.equal(resolveCue(E.NODE_REVEALED, {}), CUES.reveal);
+  assert.equal(resolveCue(E.NODE_ACCESSED, {}), CUES.access);
+  assert.equal(resolveCue(E.ICE_DETECTED, {}), CUES["ice.detected"]);
+  assert.equal(resolveCue(E.ALERT_TRACE_STARTED, {}), CUES["trace.start"]);
+});
+
+test("ALERT_GLOBAL_RAISED sounds the alert cue, but is suppressed at trace (trace.start covers it)", () => {
+  assert.equal(resolveCue(E.ALERT_GLOBAL_RAISED, { next: "red" }), CUES["alert.up"]);
+  assert.equal(resolveCue(E.ALERT_GLOBAL_RAISED, { next: "trace" }), null);
+});
+
+test("an unmapped event resolves to null", () => {
+  assert.equal(resolveCue("some:unmapped:event", {}), null);
+});
+
+test("every cue spec carries a positive _dur and a note", () => {
+  for (const [id, spec] of Object.entries(CUES)) {
+    assert.ok(typeof spec._dur === "number" && spec._dur > 0, `${id} needs a positive _dur`);
+    assert.ok(spec.note, `${id} needs a note`);
+  }
+});


### PR DESCRIPTION
## Summary

Phase 1 of the audio engine rebuild (#254): a second audio engine — **Strudel (music) + superdough (SFX)** — lands alongside Tone, selectable at boot, with **Tone still the default**. One self-contained module (`js/audio/strudel/`) owns all three audio surfaces and reuses `js/audio/signals.js` unchanged.

Licensing the engine **AGPL-3.0** ships too (Strudel/superdough are AGPL; bundling forces it), following the Doom model — open engine, future content packs kept as separately-licensed runtime data.

## What's in this PR

- **AGPL-3.0 `LICENSE`** + an in-game **source** link (AGPL §13) + README/CLAUDE notes.
- **`@strudel/web@1.0.3` vendored offline** via esbuild → `dist/strudel.js` (+ importmap), mirroring `dist/tone.js`. Lazy-imported only when the Strudel engine is selected — Tone users download nothing extra.
- **engine-select flag**: `starnet:audio-engine` pref + `audio engine <tone|strudel>` console command (reload to apply).
- **Reactive music**: one corporate score as DATA (8 synth voices, no samples) → live `stack()` driven by `deriveProgress`/`deriveThreat` via `signal()`.
- **One-shot SFX**: superdough voices on the Phase-1 events.
- **Action drones** (the surface flagged at session start as missing from the issue's Phase-1 list): a faithful **raw-Web-Audio** port of the Tone `startDrone` graph, driven by the same `ACTION_FEEDBACK` contract (superdough can't sweep params mid-voice).

## Design decisions (made autonomously — worth a sanity check)

- **Vendor offline, not CDN** — esbuild bundles `@strudel/web` cleanly (415KB); settles the issue's open "vendor vs CDN" question.
- **Phase-1 score is synth-only** → defers dirt-sample vendoring to Phase 2; keeps the perf gate free of github-streamed assets.
- **Drones → raw Web Audio** (the main thing to review) — the most faithful port of the sustained `setProgress`/`stop` contract.
- **Boot-time flag, no hot-swap** — switching engines needs a reload.
- **Tone path untouched** when the flag is `tone` — zero regression risk.

## Verification

- **Unit tests (test-first):** engine-select pref, score param-mapping, `resolveCue`, `resolveDrone`, `noteToFreq`/range. **1504 tests green, lint clean.**
- **Browser (Playwright, objective audio measurement via a tee'd AnalyserNode):** offline bundle boots clean (0 errors), all music + SFX + drones produce/stop audio correctly, full `ACTION_FEEDBACK` drone path works end-to-end, lazy-load confirmed.
- **Perf gate:** 8 voices + ~9 SFX/s + 4 rolling drones held **median 120 FPS (== idle, on par with Tone)** — synthesis is on the worklet thread.

### ⚠️ For human review (couldn't be judged autonomously)

This was driven full-auto, so the **subjective audio** is unverified: does it *sound good* — audible progress/threat morph, SFX feel, drone timbres, and the real perf gate, **no audible dropouts/crackle** under dense play. To A/B: `audio engine strudel`, reload, click in; `audio engine tone` + reload to compare.

Known Phase-1 limitations + open questions are in `notes.md` (notably: the Strudel engine still loads the idle Tone bundle — cleaned up in Phase 3; `music off` has a ~2–3s scheduler/reverb tail; only the 6 named SFX events are covered).

## Deferred (per spec)

- **Phase 2:** re-author the full reactive design (biome/variant scores, section automation), remaining SFX cues, dirt-sample vendoring.
- **Phase 3:** flip default to Strudel, retire `engine.js`/Tone scores/sfx + the `tone` dep.

## References

- Part of #254 (Phase 1 of 3 — does **not** close the issue).
- Spec / plan / research / notes / perf: `docs/dev-sessions/2026-06-30-1413-audio-engine-strudel/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
