### PR TITLE
Flow Subversion Session 1: flow programs (SNIFF/REPLAY) + noise economy

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -489,10 +489,56 @@ around it.
 
 ---
 
+## FLOW PROGRAMS
+
+Some LANs aren't just containers of loot — they're **running machines**, with typed data
+**flowing** along the connections between nodes. Where a network has flows, you'll see packets
+travelling its edges: **money** (gold diamonds), **data** (cyan squares), **audit/alert** (red
+triangles), **control** (amber chevrons), and **credentials** (magenta hexagons). Speed and
+density show volume; the arrow shows which way value (or an alarm) is moving. A **dashed, dim**
+flow is **encrypted** — you can see it exists but not what it carries until you read it.
+
+> Flows currently appear on hand-authored networks (e.g. the Corporate Exchange). Not every LAN
+> is wired this way yet.
+
+Your cyberdeck carries a small always-available kit of **programs** that act on flows. Two ship
+today:
+
+- **SNIFF** — read a flow. Requires the node be **probed** first — a bit of reconnaissance before
+  you can read its traffic (but just a scan, not the full break-in). Target a probed node, choose
+  **SNIFF**, and pick a flow from the list (only flows to nodes you've already revealed appear).
+  Sniffing an **encrypted** flow decrypts it (you can now read its type); sniffing a **credential**
+  flow additionally **captures the token** for later use. Quiet — low noise.
+- **REPLAY** — replay a captured credential into a node that trusts it. Louder than SNIFF.
+
+Console: `sniff <node> [flow]` (no flow argument → lists the node's flows, numbered), `replay <node>`.
+
+### Finesse access — the nodes you can't smash
+
+Most nodes fall to a matching exploit (a **smash**). Some can't: a **finesse-only** node is
+brute-immune — it offers no XPLOIT at all, because it only trusts a **credential that flows in
+from elsewhere**. Probing it tells you which credential it wants.
+
+To own one: find the credential flow feeding it, **probe the node that emits that flow** (SNIFF
+needs recon first), **SNIFF** the flow to capture the token, then **REPLAY** the token into the
+locked node. It jumps straight to **owned** — and whatever it was gating (a firewall's protected
+subnet, say) is revealed. The whole LAN becomes one interlocked puzzle: to open X, find and tap
+what flows toward it.
+
+### Noise feeds the trace
+
+Every program you run adds **noise** to the same trace clock the alert system drives (below).
+Loud programs cost more noise than quiet ones. Enough noise on its own will start a trace — so the
+skill is the **quietest** solution, not the flashiest. Your accumulated noise shows as **NOISE: N**
+beside the alert in the status bar.
+
+---
+
 ## THE ALERT SYSTEM
 
 The LAN watches you through two sensors — a passive security grid and active ICE — both
 feeding one alert ladder. Understanding it is the difference between a clean run and a trace.
+(A third input, **program noise**, feeds the same ladder — see *Flow Programs* above.)
 
 ### Node Alert State
 
@@ -732,6 +778,8 @@ Actions depend on the selected node's type and access level:
 | `dump`         | Node is open or owned, unread                  | Timed scan — reveals macguffins |
 | `fetch`        | Node is owned + has uncollected macguffins     | Timed extraction — collects macguffins for cash |
 | `mine`         | Node is owned and not exhausted                | Timed data-mining — rolls a yield chance for one exploit card targeting the node's own vuln classes; yield decays per attempt; disappears when the node is exhausted |
+| `sniff`        | Probed node with a visible flow touching it    | Opens a flow picker (only flows to already-revealed nodes). Reads a flow (decrypts an encrypted one; captures a credential token from a credential flow). Adds program noise. Needs the node probed first — not available on an unprobed node. |
+| `replay`       | Finesse-locked node you hold its trusted credential for | Replays the captured credential → node jumps to owned (reveals what it gated). Adds program noise. |
 | `exec <script>` | An open/owned node exposes node scripts       | Lists/runs the node's scripts (corrupt, spoof, unlock-vault, cancel-trace, access-darknet, …) |
 | `corrupt`      | IDS node is open or owned                      | Severs event forwarding to security monitor (run via `exec`) |
 | `scrub-logs`   | Security-monitor, open or owned                | Wipes that monitor's accumulated alerts, eases the global alert one level (below trace; run via `exec`) |
@@ -760,6 +808,8 @@ xploit <#|name>        Use exploit card by number or name on targeted node.
 dump [node]            Dump contents of targeted/specified node.
 fetch [node]           Extract macguffins from owned node.
 mine [node]            Data-mine owned node for an exploit card (timed; diminishing returns).
+sniff [node] [flow]    Read a flow on a node (decrypt / capture credential). No flow arg lists the node's flows.
+replay [node]          Replay a captured credential into a finesse node that trusts it.
 exec [<script>]        Run a node script (corrupt, spoof, unlock-vault, disconnect, …). No arg lists scripts.
 kick                   Push ICE off current node to adjacent node.
 reboot [node]          Force ICE home; node goes briefly offline.

--- a/data/networks/corporate-exchange.js
+++ b/data/networks/corporate-exchange.js
@@ -26,7 +26,9 @@ export function buildNetwork() {
   });
   const switch1 = createRouter("switch-1");
   const switch2 = createRouter("switch-2");
-  const fw = createFirewall("fw-1", { grade: "A" });
+  // fw-1 is finesse-only (Flow Subversion Session 1): it can't be brute-forced — it trusts
+  // the credential that flows in from switch-2 (SNIFF that flow → REPLAY the token here).
+  const fw = createFirewall("fw-1", { grade: "A", finesse: { key: "fw-root-key" } });
   const vault = createCryptovault("vault-1", { grade: "A" });
   const wan = createWAN("wan");
 
@@ -123,7 +125,7 @@ export function buildNetwork() {
         { from: "gateway", to: "switch-1", type: "control", rate: 0.4 },
         { from: "office/fileserver", to: "switch-1", type: "data", rate: 0.5 },
         { from: "switch-2", to: "sec/ids", type: "audit", rate: 0.35 },
-        { from: "switch-2", to: "fw-1", type: "credential", rate: 0.25, encrypted: true },
+        { from: "switch-2", to: "fw-1", type: "credential", rate: 0.25, encrypted: true, key: "fw-root-key" },
       ],
     },
   };

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -6,6 +6,15 @@ _Compiled from all dev session notes. Not a prioritized roadmap — just a livin
 
 ## Gameplay Systems
 
+### Flow Subversion — anti-tedium arc (heat + verb variants + flows-as-scouting)
+- Full design captured in `docs/design/flow-subversion.md` → "Anti-tedium arc" section. In brief:
+  collapse Session 1's monotonic `programNoise` into a **decaying heat** meter that feeds the alert
+  **ratchet** (hidden per-network thresholds; alert de-escalates *only* via security-subversion, not
+  passively; `lie-low` → faster heat cooling, not alert); add breadth/speed/stealth **verb variants**
+  to the RAM loadout (PROBE-sweep vs meticulous, parallel vs node-at-a-time XPLOIT); and
+  **flows-as-scouting** (traffic visible into unmapped territory directs exploration). Reverses
+  Session 1's "noise only escalates" — needs a census pass. Framing: *grind ≠ preparation.*
+
 ### Exploit Economy / Card Acquisition
 - **Card restock mid-run** — ~~player has no way to get new cards except cheats~~ darknet store at WAN node is now in. Remaining: loot drops from owned nodes, additional store nodes deeper in a network, or mid-run card crafting
 - **Persistent inventory between runs** — in the overworld context, exploit loadout carries across LANs; crafting/acquiring a better kit is part of the meta-loop

--- a/docs/BOT-PLAYER.md
+++ b/docs/BOT-PLAYER.md
@@ -275,6 +275,12 @@ These omissions are intentional — they make the bot a pessimistic baseline:
   card and can't afford darknet); never pre-mines nodes to stockpile cards
 - **Mine exhausted nodes** — skips nodes where `mine` is no longer available;
   no retry loops
+- **Flow programs (SNIFF / REPLAY)** — the bot doesn't read, sniff, or act on
+  typed flows, and doesn't use the finesse-access path (capture a credential →
+  REPLAY it to own a brute-immune node). It also never accrues program noise.
+  Generated census networks author no flows, so `getProgramActions` returns
+  nothing for the bot regardless. The flow programs are exercised only in the
+  hand-authored `?network=corporate-exchange` demo.
 
 ### What the census therefore cannot validate
 
@@ -287,6 +293,12 @@ and curve-correct — but **nothing about whether it's balanced or a meaningful
 choice**. That judgment needs a human or LLM player (issues #122 and #86). When adding a mechanic that's a
 deliberate escape hatch rather than a primary path, don't expect the census to
 gate it.
+
+The **flow programs + noise economy** (SNIFF/REPLAY, Flow Subversion Session 1)
+are the same shape: the bot doesn't use them, so census only confirms the
+existing loop is un-regressed — it says nothing about whether the noise costs or
+thresholds (`PROGRAM_NOISE_COST` / `PROGRAM_NOISE_THRESHOLD` in `balance.js`) are
+tuned right. Those are feel-tuned with a human on the demo network.
 
 ---
 

--- a/docs/design/flow-subversion.md
+++ b/docs/design/flow-subversion.md
@@ -161,6 +161,110 @@ lock" doesn't.
 
 ---
 
+## Anti-tedium arc — heat, verb variants, flows-as-scouting
+
+**Status:** designed, not built (captured from a 2026-06-30/07-01 playtest + design conversation
+with Les, mid Session 1). This arc targets the *root* felt problem that seeded the whole pillar —
+the `probe → xploit → xploit → xploit → dump → fetch → mine → repeat` grind — and the tension that
+surfaced when Session 1's finesse loop risked re-importing that grind as a *prerequisite* to the
+elegant part.
+
+**Framing principle — grind ≠ preparation.** Gating a payoff behind *work* is fine; gating it
+behind *rote repetition* is the tedium. Grind = repeating a decision-free action (xploit×3 up one
+node's ladder). Preparation = a meaningful act that earns the payoff (a scan, a read, positioning).
+Every access gate should be a preparation act, not a grind act. First instance already shipped:
+**SNIFF is gated on `probed`, not `open`** — one recon act, not the XPLOIT climb (`getProgramActions`
+in `js/core/actions/program-actions.js`).
+
+### 1. Two layers — **heat** (fast, decaying meter) feeds **alert** (slow ratchet)
+
+Session 1 shipped `programNoise` as a **monotonic accumulator** (only climbs below trace).
+Replace it with a two-layer model:
+
+- **Heat** — a single blurry, unified measure of the *notice* any network activity raises (probe,
+  xploit, programs, sweeps — all add heat), which **decays over time**. This is the meter the
+  player actively manages. A **burst** spikes it; **spreading the same actions out** lets it cool
+  between them and stay under the bar. Pacing is a real playstyle.
+- **Alert** — the existing `green → yellow → red → trace` ladder becomes the **ratchet**. When heat
+  spikes over a network's (hidden, §2) threshold, it **commits a permanent step up** the alert
+  ladder. Alert does **not** decay — an alarm isn't un-rung. Heat is recoverable; alert is not
+  (passively).
+
+So heat is the fast, forgiving, felt layer; alert is the slow, sticky consequence. This is one
+managed meter (heat) driving the ladder we already have — it honors Session 1's "feed the existing
+clock, don't add a parallel resource" principle. It **reverses** Session 1's "noise only escalates"
+decision (right for a monotonic accumulator, wrong for decaying heat) → this arc needs a census pass.
+
+**Alert comes down only by subverting security systems** — never passively, and (see §4) *not* via
+lie-low. Corrupt the IDS, own + `scrub-logs` the monitor, `cancel-trace` — the existing
+security-subversion toolkit becomes the **only** lever on the ratchet. This gives those mechanics a
+much stronger reason to exist and **drives a play direction**: get too hot and your only way back
+down is to go take out the network's watchers. (Today `scrub-logs`/`lie-low` both cool the grid;
+this arc splits their jobs — subversion → alert, lie-low → heat.)
+
+### 2. Heat thresholds are **hidden** (heat is felt, not read)
+
+The player never sees a network's exact heat threshold, and heat itself reads **imprecisely**
+(qualitative/blurry, not a bare `NOISE: 6`). Judging how much a network will absorb is a skill.
+Later tools might *approximate* a network's sensitivity, but it's never direct knowledge.
+(This supersedes Session 1's numeric `NOISE: N` HUD readout — that's provisional to the monotonic
+model and gets replaced by an imprecise indicator here.)
+
+### 3. Per-network **heat sensitivity**
+
+The alarm threshold is per-network (threat-grade-scaled, a `balance.js` table like the existing
+trace thresholds). A low-threat LAN has a high bar → it can **absorb a burst** (a PROBE-sweep spike
+is survivable); a hardened LAN has a low bar → any burst trips it. This is what makes breadth tools
+(below) a *situational* choice rather than a strict upgrade.
+
+### 4. **lie-low → active accelerated *heat* cooling** (not alert)
+
+Reframe the existing `lie-low` as *the* action that decays **heat** faster than passive cooling —
+you deliberately spend time to shed heat. Because time is itself a cost (ICE keeps moving, the run
+clock runs), this turns waiting from dead boredom into a *choice*: eat the time to cool, or push on
+hot.
+
+Crucially, under the two-layer model **lie-low no longer lowers alert** — it only cools heat, which
+prevents the *next* ratchet. It can't undo a ratchet that already fired. So "does lie-low still help
+once we have heat?" → yes, but only as a heat-management tool (avoid the next step-up); to walk back
+an alert level you *already* took, you must subvert a security system (§1). This is a change from
+today, where `lie-low` calms the grid to green — that alert-calming moves to the subversion levers.
+
+### 5. **Verb variants in the RAM loadout** (breadth / speed / stealth)
+
+Each core verb becomes a *family* of loadout-selectable variants along a small triangle —
+**breadth** (one node ↔ sweep), **speed**, **stealth (heat)**:
+
+- **PROBE-sweep** (scan many nodes at once, big heat spike) vs **meticulous PROBE** (one node,
+  slow, low heat).
+- **Parallel XPLOIT sweep** vs **node-at-a-time XPLOIT**, trading heat/risk for reach.
+
+The RAM loadout decision becomes *"what's my playstyle for this network — meticulous ghost, or
+smash-and-grab?"* — a strong pre-run layer that feeds the Session 3 store/RAM economy. Heat is the
+shared cost model that makes the tradeoffs bite (breadth = heat spikes, viable only where the
+threshold absorbs them or after cooling).
+
+**Cautions:** (a) variants must be **true tradeoffs, not upgrades** — a parallel XPLOIT sweep needs
+real shared risk (e.g. one failure trips the whole target set), or it's just "buy it once, always
+better." (b) **Multi-node targeting is new UI plumbing** — Sessions 0/1 deliberately avoided
+multi-select; a target-set selection model is the non-trivial part.
+
+**Honest scope note:** verb-variants are a *palliative* for the current extraction loop (fewer
+keystrokes, more choice) — they don't change what *winning* is. The flow-**reconfiguration** loop
+is the structural cure. Both are worth doing; don't mistake shipping SWEEP for fixing the grind.
+
+### 6. **Flows-as-scouting** (the structural cure for exploration grind)
+
+The flow loop is only as un-grindy as the *exploration* that feeds it. Today, finding flows is
+gated behind access-climbing (routers reveal at open, firewalls at owned) — so discovery itself is
+a grind. Invert it: **traffic on an edge leading into unmapped territory is visible** (its
+*existence* and rough volume, type/contents concealed until SNIFFed). Reading the flows then
+*directs* exploration — "money's pouring toward something behind that firewall — go find out what" —
+replacing "probe everything to map the net" with "follow the load-bearing flows." Deduction, not
+grind. (Re-touches the fog-of-war rule Session 1 tightened, so it's a deliberate, tested change.)
+
+---
+
 ## Relationship to existing systems
 
 - **Alert/trace** (`js/core/alert.js`) — the noise economy plugs into this clock;
@@ -182,11 +286,12 @@ Each ships and is testable on its own. The old loop keeps working throughout.
 
 | # | Session | Ships | Risk |
 |---|---|---|---|
-| **0** | **Flow substrate** | nodes emit/consume typed packets on existing edges; particles render (mixed types/edge); fully state-encapsulated & serializable; preview-harness demo. *No new player verbs.* | Low — pure infra, no balance change |
-| **1** | **Flow-acting programs + noise** | `SNIFF` `SPLICE` `TAP` `SPOOF` as loadout items; noise meter wired into the trace clock | Med |
-| **2** | **Skim objective + scoring** | one hand-authored financial LAN playable to a payout; win/lose/jack-out | Med — first real validation |
+| **0** | **Flow substrate** | ✅ shipped (#256). Typed packets on existing edges; particles render (mixed types/edge); serializable; preview demo. *No new verbs.* | Low |
+| **1** | **Flow-acting programs + noise** | ✅ shipped. `SNIFF` (reveal/decrypt + capture credential) + `REPLAY` (finesse access) as a fixed kit; `programNoise` third alert sensor; finesse-only nodes; numeric NOISE readout. (`SPLICE`/`TAP` deferred to S2; program named `REPLAY` not `SPOOF` — id collision.) | Med |
+| **2** | **Skim objective + scoring** | one hand-authored financial LAN playable to a payout; `TAP`/`SPLICE`; win/lose/jack-out | Med — first real validation |
 | **3** | **Cyberdeck RAM loadout + store** | pre-run loadout UI, RAM capacity, store reframed around programs | Med |
-| later | finesse-access (credentials), more objectives (repair/dismantle), flow fog-of-war polish, ICE-damages-programs, procgen flow puzzles | — | — |
+| **anti-tedium arc** | **Heat + verb variants + flows-as-scouting** | collapse noise → decaying **heat** feeding the alert **ratchet** (hidden thresholds; alert down only via subversion; lie-low → heat cooling); breadth/speed/stealth verb variants in the loadout; flows-as-scouting. See the section above. | Med–High — reverses "noise only escalates", needs census |
+| later | finesse-access depth (credential rotation/expiry, multi-hop chains), more objectives (repair/dismantle), ICE-damages-programs, procgen flow puzzles | — | — |
 
 This is **feel-driven** in its visual layer (particle look, density, cadence): build
 substrate logic test-first, but tune the *rendering* in a disposable harness with Les

--- a/docs/dev-sessions/2026-06-30-1512-flow-programs-noise/notes.md
+++ b/docs/dev-sessions/2026-06-30-1512-flow-programs-noise/notes.md
@@ -1,0 +1,61 @@
+# Session 1: Flow Programs + Noise Economy — notes
+
+## Outcome: functionally complete, pending browser verification + feel-tuning
+
+Branch `flow-programs-noise`. All 5 planned phases shipped, `make check` green throughout
+(1498 tests, was 1483 on main → +15 flow-program/flow-layer tests). Reach the loop via
+`?network=corporate-exchange`.
+
+The shipped loop: probe/reveal `switch-2` + `fw-1` → the encrypted `switch-2→fw-1` **credential**
+flow renders → **SNIFF** it (decrypts on the graph + captures `fw-root-key`) → **REPLAY** the
+token into finesse-only `fw-1` → owned (vault beyond reveals). Each program play adds **noise**
+that climbs the shared trace ladder; **NOISE: N** shows beside the alert.
+
+## Phases
+
+- **P1** — data + noise sensor: `Flow.key/revealed`, `PlayerState.capturedCredentials`,
+  `GameState.programNoise` (serializable + healed); `recordProgramNoise` third sensor in
+  `alert.js` (same ladder + trace clock, tunable thresholds in `balance.js`).
+- **P2** — SNIFF: `js/core/programs.js` (sniffFlow/incidentFlows) + `js/core/actions/program-actions.js`
+  (injected into `getAvailableActions`); node-anchored flow picker (`flow-packet` render in
+  starnet-action-choices from single-sourced glyph geometry); console `sniff` + playtest + log.
+- **P3** — finesse node + REPLAY: `finesse-access` trait (finesseLocked/trustsCredential);
+  `EXPLOIT_ACTION.requires += not finesseLocked`; `createFirewall({ finesse:{ key } })`; fw-1
+  authored finesse in corporate-exchange; REPLAY replicates `applyCombatResult`'s access-gain
+  side-effects (reveal-beyond).
+- **P4** — HUD numeric `NOISE: N` beside the alert (reuses hud-label/value; no new chrome).
+- **P5** — flow-layer honours `revealed` (sniff decrypts on graph); preview REVEALED toggle;
+  MANUAL.md + BOT-PLAYER.md; census SEEDS=10 clean.
+
+## Deviations from the plan (all deliberate, all sound)
+
+1. **REPLAY, not SPOOF.** `A.SPOOF`/"spoof" is already the security-monitor recalibrate + a trap
+   action — a console/dispatch collision. Design doc sanctions "SPOOF/REPLAY" as synonyms, so the
+   credential-replay program is **REPLAY** (`A.REPLAY`). Les approved.
+2. **Programs are injected node actions, not traits and not EXEC scripts.** The kit is player-owned
+   (not node-intrinsic), and EXEC executes a script immediately on pick — it can't host SNIFF's
+   flow picker. So SNIFF/REPLAY are in `CORE_NODE_VERBS` (top-level, like probe/xploit) and injected
+   by `getProgramActions` in `node-actions.js`. Availability the graph's `requires` can't express
+   (incident flows, held credentials) is filtered there — mirrors the KICK filter.
+3. **Flow-layer decrypt (P5) was a real gap.** Session 0's layer keyed only off `encrypted`; a
+   SNIFFed flow wouldn't visually decrypt. Fixed: signature includes `revealed`; concealed only
+   while `encrypted && !revealed`.
+4. **Skipped two speculative preview widgets** (captured-credential indicator, finesse-node marker)
+   — Session 1 has no such graph visuals (credentials → log; finesse → no-XPLOIT + node panel), so
+   they'd be dead demo code. The real new visuals (sniff-decrypt, picker glyph) are covered.
+
+## Still to do (needs Les + a browser — Playwright won't launch here)
+
+- **Browser verification** of the whole loop on `?network=corporate-exchange`: SNIFF picker glyphs;
+  encrypted→decrypted flow render after sniff; NOISE readout climbing; fw-1 offers no XPLOIT and
+  owns via REPLAY; the alert lamp escalating with noise.
+- **Feel-tuning the noise numbers** (`PROGRAM_NOISE_COST` / `PROGRAM_NOISE_THRESHOLD` in
+  `balance.js`). Current placeholders: sniff 1 / replay 3; yellow 2 / red 4 / trace 6. Intent:
+  the intended quiet solution (a couple of sniffs + a replay + probing) stays below trace, while
+  loud over-use reaches it. Tune by playing, not autonomously.
+
+## Follow-ups noted (out of scope, Session 2+)
+
+- TAP/SPLICE + skim/scoring (S2); RAM loadout + store reframe (S3).
+- Named networks (incl. corporate-exchange) aren't hub-reachable (issue #261) — the loop is only
+  reachable via `?network=`.

--- a/docs/dev-sessions/2026-06-30-1512-flow-programs-noise/plan.md
+++ b/docs/dev-sessions/2026-06-30-1512-flow-programs-noise/plan.md
@@ -1,0 +1,414 @@
+# Flow Programs + Noise Economy (Session 1) Implementation Plan
+
+**Goal:** Ship `SNIFF` + `REPLAY` (credential replay) as a complete finesse-access loop, with a
+third "program noise" alert sensor feeding the existing trace clock, on the `corporate-exchange`
+demo.
+
+**Approach:** Programs are a fixed always-available kit injected as node-contextual actions (not
+node traits), aimed via a node-anchored flow picker mirroring the XPLOIT picker. Noise is a third
+sensor (`recordProgramNoise`) accumulating `state.programNoise` and climbing the same
+`green->yellow->red->trace` ladder. One hand-authored finesse-only node (`fw-1`) is brute-immune
+and unlocked by replaying a sniffed credential. Old smash loop untouched.
+
+**Tech stack:** Vanilla ES modules, JSDoc `@ts-check`, Lit components, node:test.
+
+**Naming note:** the spec says "SPOOF", but `A.SPOOF` ("spoof") is already the security-monitor
+recalibrate / a trap action (`action-ids.js:30`, `data/biomes/corporate-pieces/traps.js:43`). The
+credential-replay program is therefore **`REPLAY`** (`A.REPLAY = "replay"`) — the design doc lists
+"SPOOF/REPLAY" as synonyms. Player-facing label may read "REPLAY".
+
+---
+
+## Phase 1: Flow/player/noise data + noise sensor (foundation, no UI)
+
+Extend the serializable data shapes and add the third alert sensor so the noise economy works
+end-to-end at the state layer. No verbs/UI yet.
+
+**Files:**
+- Modify: `js/core/types.js` — extend `Flow`, `PlayerState`, `GameState` typedefs.
+- Modify: `js/core/state/index.js` — init `capturedCredentials`/`programNoise`; heal on load.
+- Create: `js/core/state/flow.js` — flow mutations (`setFlowRevealed`).
+- Modify: `js/core/state/player.js` — `addCapturedCredential(key)`.
+- Modify: `js/core/state.js` — re-export the new setters.
+- Modify: `js/core/balance.js` — `PROGRAM_NOISE_THRESHOLD`, `PROGRAM_NOISE_COST`.
+- Modify: `js/core/alert.js` — `recordProgramNoise(amount)`.
+- Modify: `js/core/events.js` — `E.PROGRAM_NOISE`, `E.FLOW_SNIFFED`, `E.CREDENTIAL_CAPTURED`,
+  `E.CREDENTIAL_REPLAYED`.
+- Test: `tests/flow-programs.test.js` (new) — serialization + noise sensor.
+
+**Key changes:**
+- `Flow` gains `key?: string` (credential token) and `revealed?: boolean`.
+- `PlayerState` gains `capturedCredentials: string[]`.
+- `GameState` gains `programNoise: number`.
+- Init (`state/index.js`, in the player block ~:168 and top-level ~:166):
+  ```js
+  player: { ..., capturedCredentials: [...(meta.startCredentials ?? [])] },
+  // top-level, beside flows:
+  programNoise: 0,
+  ```
+- Heal (`state/index.js` ~:388):
+  ```js
+  if (!ctx.state.flows) ctx.state.flows = [];
+  if (!ctx.state.player.capturedCredentials) ctx.state.player.capturedCredentials = [];
+  if (typeof ctx.state.programNoise !== "number") ctx.state.programNoise = 0;
+  ```
+- `state/flow.js` — defines the canonical flow-id helper (single source; Phase 2 imports it) +
+  the reveal mutation:
+  ```js
+  import { mutate } from "./index.js";
+  /** Stable per-run address for a flow. The ONE definition of the scheme. */
+  export const flowId = (f) => `${f.from}>${f.to}#${f.type}`;
+  /** Marks the flow with this id as revealed (decrypts its render). */
+  export function setFlowRevealed(id) {
+    mutate((s) => { const f = s.flows.find((fl) => flowId(fl) === id); if (f) f.revealed = true; });
+  }
+  ```
+- `state/player.js` `addCapturedCredential(key)`:
+  ```js
+  export function addCapturedCredential(key) {
+    mutate((s) => { if (key && !s.player.capturedCredentials.includes(key)) s.player.capturedCredentials.push(key); });
+  }
+  ```
+- `balance.js` (placeholder values, feel-tuned in Phase 5):
+  ```js
+  // Program noise: each program play adds heat; crossing thresholds steps the shared alert
+  // ladder; the trace threshold starts the same trace clock. Tuned by feel (Phase 5).
+  export const PROGRAM_NOISE_COST = { sniff: 1, replay: 3 };
+  // Cumulative noise at which the ladder reaches yellow / red / trace.
+  export const PROGRAM_NOISE_THRESHOLD = { yellow: 2, red: 4, trace: 6 };
+  ```
+- `alert.js` `recordProgramNoise(amount)` — mirrors `recordMonitorAlert` (`alert.js:138-160`):
+  ```js
+  import { PROGRAM_NOISE_THRESHOLD } from "./balance.js";
+  import { addProgramNoise } from "./state/index.js"; // mutate-wrapped, added here or in state
+  /**
+   * Third alert sensor: program plays add heat that climbs the SAME ladder + trace clock.
+   * @param {number} amount
+   */
+  export function recordProgramNoise(amount) {
+    const total = addProgramNoise(amount); // returns new state.programNoise
+    emitEvent(E.PROGRAM_NOISE, { amount, total });
+    const t = PROGRAM_NOISE_THRESHOLD;
+    if (total >= t.trace) { if (getState().traceSecondsRemaining === null) startTraceCountdown(); return; }
+    // Step the ladder to the highest level the accumulated noise has crossed (capped below trace).
+    const target = total >= t.red ? "red" : total >= t.yellow ? "yellow" : "green";
+    const order = ["green","yellow","red","trace"];
+    const cur = getState().globalAlert;
+    if (order.indexOf(target) > order.indexOf(cur)) {
+      setGlobalAlert(target); emitEvent(E.ALERT_GLOBAL_RAISED, { prev: cur, next: target });
+    }
+  }
+  ```
+  (`addProgramNoise` is a small `mutate`-wrapped setter returning the new total; add to
+  `state/index.js` or `state/game.js` and re-export.)
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] New test: `Flow.key`/`revealed`, `capturedCredentials`, `programNoise` survive
+      serialize -> deserialize unchanged; a pre-field save heals to defaults.
+- [ ] New test: `recordProgramNoise` steps green->yellow->red by accumulated total and starts the
+      trace exactly at the `trace` threshold (assert `traceSecondsRemaining !== null`).
+- [ ] `make check` passes
+
+**Verification — manual:**
+- [ ] None (no UI in this phase).
+
+---
+
+## Phase 2: SNIFF program (reveal + capture) — picker, console, playtest
+
+Add the SNIFF verb end-to-end: a node-contextual program (injected, not a trait), a flow picker,
+console + playtest commands, log events. Acts on the demo's existing flows.
+
+**Files:**
+- Modify: `js/core/action-ids.js` — `SNIFF: "sniff"`.
+- Create: `js/core/programs.js` — pure program logic (`sniffFlow`).
+- Create: `js/core/actions/program-actions.js` — SNIFF ActionDef + `getFlowChoices`/`getFlowEmptyReason` + injector.
+- Modify: `js/ui/flow-glyphs.js` — export raw glyph geometry (`flowGlyphGeom(type) -> {color,pts,closed}`) so the picker can render a lit `<svg>` without a string-injection directive (`unsafeSVG` is NOT in the lit bundle). Keep the module lit-free/pure.
+- Modify: `js/core/actions/node-actions.js` — inject program actions in `getAvailableActions`.
+- Modify: `js/core/actions/action-context.js` — wire `ctx.sniffFlow`; thread followup payload to program `execute`.
+- Modify: `js/ui/components/starnet-action-choices.js` — add `render: "flow-packet"` case (uses `flowSvg`).
+- Modify: `js/core/console-commands/commands.js` — `sniff <node> [flowId|index]`.
+- Modify: `scripts/playtest.js` — `sniff` command.
+- Modify: `js/ui/log-renderer.js` — log `E.FLOW_SNIFFED` / `E.CREDENTIAL_CAPTURED` / `E.PROGRAM_NOISE`.
+- Test: `tests/flow-programs.test.js` — SNIFF behavior + GUI/console parity.
+
+**Key changes:**
+- Flow id helper (shared): `flowId(f) => `${f.from}>${f.to}#${f.type}`` — export from `programs.js`.
+- `programs.js`:
+  ```js
+  import { setFlowRevealed, flowId } from "./state/flow.js"; // flowId single-sourced in flow.js
+  import { addCapturedCredential } from "./state/player.js";
+  import { recordProgramNoise } from "./alert.js";
+  import { PROGRAM_NOISE_COST } from "./balance.js";
+  import { emitEvent, E } from "./events.js";
+  /** Find flows incident to nodeId. */
+  export const incidentFlows = (state, nodeId) => state.flows.filter((f) => f.from === nodeId || f.to === nodeId);
+  /** SNIFF a flow: reveal its render; capture a credential token if it carries one. */
+  export function sniffFlow(state, nodeId, id) {
+    const f = state.flows.find((fl) => flowId(fl) === id);
+    if (!f) return;
+    setFlowRevealed(id);
+    emitEvent(E.FLOW_SNIFFED, { nodeId, flowId: id, type: f.type });
+    if (f.type === "credential" && f.key) {
+      addCapturedCredential(f.key);
+      emitEvent(E.CREDENTIAL_CAPTURED, { nodeId, key: f.key });
+    }
+    recordProgramNoise(PROGRAM_NOISE_COST.sniff);
+  }
+  ```
+- `program-actions.js`:
+  ```js
+  import { A } from "../action-ids.js";
+  import { incidentFlows, flowId } from "../programs.js";
+  // No glyph import here: getFlowChoices builds plain choice DATA (core stays UI-free);
+  // the picker component renders the glyph from flow-glyphs geometry (see flow-packet below).
+  export function getFlowChoices(node, state) {
+    return incidentFlows(state, node.id).map((f) => ({
+      id: flowId(f), payloadKey: "flowId", render: "flow-packet",
+      data: { type: f.type, encrypted: f.encrypted && !f.revealed, revealed: f.revealed, dir: f.from === node.id ? "out" : "in" },
+    }));
+  }
+  export const getFlowEmptyReason = () => "No flows on this node.";
+  /** @type {import('../types.js').ActionDef} */
+  export const SNIFF_ACTION = {
+    id: A.SNIFF, label: "SNIFF",
+    desc: "Read a data flow on this node; capture a credential if it carries one.",
+    hasFollowup: true,
+    followup: { title: (n) => `SNIFF ${n.id}`, choices: getFlowChoices, empty: getFlowEmptyReason },
+    execute: (node, state, ctx, payload) => ctx.sniffFlow(node.id, payload.flowId),
+  };
+  /** Programs available on this node, given player kit + flow/credential context. */
+  export function getProgramActions(node, state) {
+    const out = [];
+    if (node.visibility === "accessible" && incidentFlows(state, node.id).length > 0) out.push(SNIFF_ACTION);
+    return out; // REPLAY added in Phase 3
+  }
+  ```
+- `node-actions.js` `getAvailableActions` — after building `wrapped`, before EXEC grouping:
+  ```js
+  import { getProgramActions } from "./program-actions.js";
+  const programs = getProgramActions(node, state);
+  const result = [...global, ...wrapped, ...programs];
+  ```
+  (Programs are scripts by `isScriptAction` since their ids aren't in `CORE_NODE_VERBS`, so they
+  group under EXEC automatically — acceptable for S1; revisit surfacing in S3.)
+- `action-context.js` — add `sniffFlow` to the ctx object and ensure followup payload reaches
+  `execute`. The dispatcher already calls `action.execute(node, state, ctx, { nodeId, ...payload })`
+  for actions carrying an `execute` fn (global actions); program actions define `execute`, so
+  `payload.flowId` threads through with no special-casing (unlike XPLOIT, which is timed and
+  bypasses). Wire:
+  ```js
+  import { sniffFlow } from "../programs.js";
+  // in the ctx object:
+  sniffFlow: (nodeId, id) => sniffFlow(getState(), nodeId, id),
+  ```
+- `starnet-action-choices.js` `_renderChoice` — new case. Render the glyph with lit's `svg`
+  template from exported geometry (NOT `unsafeSVG` — it isn't bundled). Add `import { svg } from "lit"`
+  and `import { flowGlyphGeom, ENCRYPTED_COLOR } from "../flow-glyphs.js"`:
+  ```js
+  if (choice.render === "flow-packet") {
+    const d = choice.data;
+    const g = flowGlyphGeom(d.type);
+    const pts = g.pts.map(([x, y]) => `${x + 6},${y + 6}`).join(" ");
+    const stroke = d.encrypted ? ENCRYPTED_COLOR : g.color;
+    const shape = d.encrypted
+      ? svg`<text x="6" y="9" font-size="9" text-anchor="middle" fill=${stroke}>?</text>`
+      : g.closed
+        ? svg`<polygon points=${pts} fill="none" stroke=${stroke} stroke-width="0.7"/>`
+        : svg`<polyline points=${pts} fill="none" stroke=${stroke} stroke-width="0.7"/>`;
+    return html`<button class="ctx-item flow-choice" @click=${() => this._pick(choice)}>
+      <svg viewBox="0 0 12 12" class="flow-glyph" width="14" height="14">${shape}</svg>
+      ${d.encrypted ? "ENCRYPTED" : d.type.toUpperCase()} ${d.dir === "in" ? "←" : "→"}
+    </button>`;
+  }
+  ```
+  (Geometry is single-sourced in `flow-glyphs.js`; the component only draws it. Stroke-only +
+  glow via the existing HUD `--glow-*` tokens — no fills, per the vector-UI rule.)
+- `commands.js` `sniff`: resolve node (targeted or arg), list incident flows if no flow arg,
+  else dispatch `starnet:action {actionId:"sniff", nodeId, flowId}`. Mirror existing `xploit`
+  command resolution.
+- `playtest.js`: add `sniff` to the inline dispatch; `sniff <node> <flowId|index>` -> dispatch.
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] New test: SNIFF the encrypted `switch-2>fw-1#credential` flow -> that flow's `revealed===true`,
+      `player.capturedCredentials` contains its key, `programNoise` increased by `PROGRAM_NOISE_COST.sniff`.
+- [ ] New test: SNIFF a non-credential flow -> `revealed===true`, no credential captured, noise added.
+- [ ] New test (GUI/console parity): dispatching `{actionId:"sniff", nodeId, flowId}` and the
+      console `sniff` path produce identical `state.flows`/`capturedCredentials`.
+- [ ] `make check` passes
+
+**Verification — manual:**
+- [ ] `make serve` + `?network=corporate-exchange`: reveal switch-2/fw-1, SNIFF picker lists the
+      incident flows with correct glyphs; sniffing the encrypted credential flow reveals it and
+      logs a capture entry.
+
+---
+
+## Phase 3: Finesse node + REPLAY program (loop closes)
+
+Make `fw-1` brute-immune and unlockable only by replaying the captured credential.
+
+**Files:**
+- Modify: `js/core/action-ids.js` — `REPLAY: "replay"`.
+- Modify: `js/core/node-graph/traits.js` — register `finesse-access` trait.
+- Modify: `js/core/node-graph/action-templates.js` — add `not finesseLocked` to `EXPLOIT_ACTION.requires`.
+- Modify: `js/core/programs.js` — `replayCredential(state, nodeId)`.
+- Modify: `js/core/actions/program-actions.js` — `REPLAY_ACTION` + inject when finesse + holds key.
+- Modify: `js/core/actions/action-context.js` — wire `ctx.replayCredential`.
+- Modify: `js/core/node-graph/node-factories.js` — `createFirewall` accepts a `finesse` option that adds the trait + attrs.
+- Modify: `data/networks/corporate-exchange.js` — make `fw-1` finesse-only; give the `switch-2>fw-1` credential flow a `key`.
+- Modify: `js/core/console-commands/commands.js` + `scripts/playtest.js` — `replay <node>`.
+- Test: `tests/flow-programs.test.js` — finesse gating + full loop.
+
+**Key changes:**
+- `traits.js`:
+  ```js
+  registerTrait("finesse-access", {
+    attributes: { finesseLocked: true, trustsCredential: null },
+    operators: [],
+    actions: [], // REPLAY is injected as a program, not a trait action
+  });
+  ```
+- `action-templates.js` `EXPLOIT_ACTION.requires` — append:
+  ```js
+  { type: "not", condition: { type: "node-attr", attr: "finesseLocked", eq: true } },
+  ```
+  (Harmless on every non-finesse node — `finesseLocked` is undefined there, reads as not-true.)
+- `programs.js` — REPLAY must replicate the **access-gain side-effects** that
+  `applyCombatResult` performs (`combat.js:250-277`), or fw-1 goes "owned" without revealing the
+  vault beyond it. Reuse the same node-state setters combat imports
+  (`setNodeAccessLevel`, `setNodeAlertState`, `setNodeVisible`, `setNodeProbed`, `revealNeighbors`):
+  ```js
+  import { setNodeAccessLevel, setNodeAlertState, setNodeVisible, setNodeProbed } from "./state/node.js";
+  import { revealNeighbors } from "./state.js"; // exported from state/index.js:276; combat.js imports it the same way
+  export function replayCredential(state, nodeId) {
+    const node = state.nodes[nodeId];
+    const key = node?.trustsCredential;
+    if (!key || !state.player.capturedCredentials.includes(key)) return;
+    if (node.accessLevel === "owned") return;
+    const prev = node.accessLevel;
+    setNodeAccessLevel(nodeId, "owned");
+    setNodeAlertState(nodeId, "green");
+    setNodeVisible(nodeId, "accessible");
+    setNodeProbed(nodeId);
+    revealNeighbors(nodeId);            // owned reveals what the firewall gated
+    emitEvent(E.CREDENTIAL_REPLAYED, { nodeId, key });
+    emitEvent(E.NODE_ACCESSED, { nodeId, label: node.label, prev, next: "owned" });
+    recordProgramNoise(PROGRAM_NOISE_COST.replay);
+  }
+  ```
+  (During execute, confirm `revealNeighbors`/`setNodeVisible` import paths against `combat.js`'s
+  import block; if combat sources `revealNeighbors` elsewhere, match that source. Consider
+  extracting a shared `grantOwnedAccess(nodeId)` helper if duplication feels fragile — but keep it
+  minimal: this is the only second caller.)
+- `program-actions.js`:
+  ```js
+  export const REPLAY_ACTION = {
+    id: A.REPLAY, label: "REPLAY",
+    desc: "Replay a captured credential to gain trusted access.",
+    execute: (node, state, ctx) => ctx.replayCredential(node.id),
+  };
+  // in getProgramActions, after SNIFF:
+  const key = node.trustsCredential;
+  if (node.finesseLocked && key && state.player.capturedCredentials.includes(key)
+      && node.accessLevel !== "owned") out.push(REPLAY_ACTION);
+  ```
+  (Mirrors the KICK global-state filter in `node-actions.js:37-40`: availability that the graph's
+  `requires` can't express — here, player-held credentials — is filtered at the action-query layer.)
+- `node-factories.js` `createFirewall(id, config)` — when `config.finesse` is set:
+  ```js
+  const traits = ["graded", "hackable", "rebootable", "gate"];
+  if (config.finesse) traits.push("finesse-access");
+  // ...and set attributes.trustsCredential = config.finesse.key, finesseLocked stays true.
+  ```
+- `corporate-exchange.js`:
+  ```js
+  const fw = createFirewall("fw-1", { grade: "A", finesse: { key: "fw-root-key" } });
+  // and in meta.flows, the credential flow gains the matching key:
+  { from: "switch-2", to: "fw-1", type: "credential", rate: 0.25, encrypted: true, key: "fw-root-key" },
+  ```
+- `commands.js`/`playtest.js`: `replay <node>` -> dispatch `starnet:action {actionId:"replay", nodeId}`.
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] New test: on a `finesseLocked` node, `getAvailableActions` does NOT include `xploit`.
+- [ ] New test: REPLAY is absent until the matching credential is captured; present after.
+- [ ] New test (full loop): SNIFF `switch-2>fw-1#credential` -> capture `fw-root-key` -> REPLAY on
+      `fw-1` -> `fw-1.accessLevel === "owned"`; assert `programNoise` == sniff+replay cost.
+- [ ] New test: REPLAY without the credential is a no-op (access unchanged, no noise).
+- [ ] `make check` passes
+
+**Verification — manual:**
+- [ ] `?network=corporate-exchange`: probe `fw-1` shows it offers no XPLOIT and states the
+      credential requirement; after sniff+replay it becomes owned and the vault beyond reveals.
+
+---
+
+## Phase 4: HUD numeric noise readout
+
+Surface accumulated program noise as a numeric readout beside the alert.
+
+**Files:**
+- Modify: `js/ui/visual-renderer.js` — feed `programNoise` to the HUD component.
+- Modify: `js/ui/components/starnet-hud.js` — render `NOISE: N` beside the alert (`:88-99` region).
+- Modify: `css/style.css` — minimal style for the noise readout (reuse `--glow-*` tokens; stroke/text only, no fill).
+- Test: HUD prop wiring (light) — assert the renderer passes `programNoise`.
+
+**Key changes:**
+- `visual-renderer.js`: where it sets HUD props from state, add `hud.programNoise = state.programNoise`.
+- `starnet-hud.js`: add a `programNoise: Number` property and render (only when `phase==="playing"`):
+  ```js
+  html`<span id="noise-readout" class="noise">NOISE: ${this.programNoise ?? 0}</span>`
+  ```
+  Placed beside `#alert-level`. Text + glow only (vector-UI rule: no fills/lamps).
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] `make check` passes
+
+**Verification — manual:**
+- [ ] `?network=corporate-exchange`: NOISE reads 0 at start, increments on each SNIFF/REPLAY, and
+      the alert lamp climbs as noise crosses thresholds (and reaches TRACE if pushed past `trace`).
+
+---
+
+## Phase 5: Preview demo, docs, census, feel-tuning checkpoint
+
+Add the new visual states to the preview harness, update the manual + bot docs, confirm no
+balance regression, and feel-tune the noise numbers WITH Les (not autonomously).
+
+**Files:**
+- Modify: `js/ui/preview.js` / `preview.html` — add: a revealed/sniffed flow state toggle, a
+  captured-credential indicator, and a finesse-node marker, in the existing "Flow Substrate" panel.
+- Modify: `MANUAL.md` — new "Flow Programs" section (SNIFF/REPLAY), "Finesse access" under access
+  levels, the noise sensor under "The Alert System", node-actions reference + console commands rows.
+- Modify: `docs/BOT-PLAYER.md` — "What the bot does NOT do": flow programs (SNIFF/REPLAY); census
+  validates no-regression of the existing loop only.
+- Modify: `js/ui/console.js` (if needed) — register `sniff`/`replay` tab-completion alongside other verbs.
+
+**Key changes:**
+- Preview: reuse `flowSvg(type, { encrypted })` for the sniffed-vs-encrypted A/B; a small stroked
+  hexagon "credential captured" indicator; a stroked marker badge on the finesse node demo.
+- MANUAL.md: describe noise as the third sensor feeding the same trace clock; document that quiet
+  solutions are the skill; document the fixed kit (no loadout yet).
+
+**Verification — automated:**
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] `make check` passes
+- [ ] `make census SEEDS=10` then a same-seed run on `origin/main`: `successRate`/`traceFiredRate`
+      unchanged within noise (bot doesn't use programs, so the existing loop must be unaffected).
+
+**Verification — manual:**
+- [ ] Preview harness shows the sniffed/encrypted flow A/B, the captured-credential indicator, and
+      the finesse-node marker; all stroke-only/glow (vector-UI rule).
+- [ ] MANUAL.md re-read: programs, finesse access, noise sensor, console commands all match behavior.
+- [ ] **Feel-tuning checkpoint with Les:** play the loop on `?network=corporate-exchange`; tune
+      `PROGRAM_NOISE_COST` / `PROGRAM_NOISE_THRESHOLD` in `balance.js` by feel so the intended quiet
+      solution stays below trace and loud over-use reaches it. (Numbers are NOT locked autonomously.)

--- a/docs/dev-sessions/2026-06-30-1512-flow-programs-noise/research.md
+++ b/docs/dev-sessions/2026-06-30-1512-flow-programs-noise/research.md
@@ -1,0 +1,108 @@
+# Session 1 — codebase research (integration points)
+
+Findings from a documentarian sweep of the worktree, plus direct reads. `file:line`
+refs are as of branch `flow-programs-noise` off `origin/main` @ a630db7.
+
+## 1. Flow typedef + `state.flows`
+
+- **`Flow` typedef:** `js/core/types.js:308-319` —
+  `{ from, to, type:('money'|'data'|'audit'|'control'|'credential'), rate:number, encrypted?:boolean }`.
+  (CLAUDE.md still says `js/types.js`; the real path post-reorg is `js/core/types.js`.)
+- **Init from `meta.flows`:** `js/core/state/index.js:166` —
+  `flows: (meta.flows ?? []).map((f) => ({ ...f }))` (shallow-clone per flow; in-run
+  mutation must not write back into the network def).
+- **Heal on load:** `js/core/state/index.js:388-389` — `if (!ctx.state.flows) ctx.state.flows = []`.
+  Flows ride `...rest` through `serializeState`.
+- **Authored flows (demo):** `data/networks/corporate-exchange.js:120-127`. Already includes
+  `{ from:"switch-2", to:"fw-1", type:"credential", rate:0.25, encrypted:true }` (line 126) —
+  the firewall already *receives* an encrypted credential flow. Also a money artery
+  `switch-1->gateway->wan`, a mixed gateway<->switch-1 edge, audit toward `sec/ids`.
+
+## 2. Node action / script definition + dispatch
+
+- **Action-id catalog:** `js/core/action-ids.js` (`A.PROBE`, `A.XPLOIT`, `A.CORRUPT`,
+  `A.SCRUB_LOGS`, `A.LIE_LOW`, ...). New programs add ids here.
+- **Script vs core classification:** `js/core/actions/scripts.js:17-19` — `isScriptAction(id)`
+  returns `!CORE_NODE_VERBS.has(id)`. Non-core actions get grouped under the synthetic EXEC.
+- **EXEC grouping:** `js/core/actions/node-actions.js:46-49` + `buildExecAction(scripts)`.
+- **Dispatch path:** DOM `starnet:action {actionId, nodeId?, ...payload}` -> `js/ui/main.js:106-107`
+  -> `js/core/actions/action-context.js:61-91` ->
+  `getAvailableActions(node,state).find(a=>a.id===actionId).execute(node,state,ctx,{nodeId,...payload})`.
+  Single `STATE_CHANGED` per cycle, version-gated.
+- **ActionContext (ctx) surface:** `js/core/types.js:243-251` — `getState, selectNode,
+  deselectNode, ejectIce, jackOut, cancelTrace, openDarknetsStore`. The node-graph ctx
+  (`js/core/node-graph/game-ctx.js:64-65`) wires methods like `reconfigureNode`, `lieLow`,
+  `scrubLogs`, `startExploit`, `abortTimedAction` — `effects:[{effect:"ctx-call",method,args}]`
+  is how an ActionDef invokes them.
+
+### Example — an `exec` script action end-to-end (SCRUB_LOGS / LIE_LOW)
+- **ActionDef:** `action-templates.js:258-285` (`SCRUB_LOGS_ACTION`, `LIE_LOW_ACTION`).
+  `requires` = `Condition[]` (e.g. accessLevel open|owned); `effects` set attrs and/or
+  `ctx-call`. LIE_LOW is timed: it sets `lyingLow:true` + the progress attr.
+- **Operator (timed):** `action-templates.js:298-305` `LIE_LOW_OPERATOR` —
+  `{ name:"timed-action", action:"lie-low", activeAttr:"lyingLow", durationTable:{...ticks},
+  onComplete:[{effect:"ctx-call",method:"lieLow",args:["$nodeId"]}] }`.
+- **Trait pairing:** the operator + action live on a trait (`darknet`/`security`) in
+  `js/core/node-graph/traits.js`; factories select traits.
+- **Template registry:** `action-templates.js:309-324` `ACTION_TEMPLATES` — new templates register here.
+
+## 3. Trait system + attribute gating + timed actions
+
+- **Registry:** `js/core/node-graph/traits.js:38-51` — `registerTrait`, `getTrait`,
+  `resolveTraits(nodeDef)` (merge attributes/operators/actions left->right).
+- **Availability gating:** each ActionDef has `requires: Condition[]`; `getAvailableActions(nodeId)`
+  filters via `requiresPass` (`js/core/node-graph/actions.js:45-46`). Conditions: `node-attr`
+  (`attr`,`eq`), `not`, `any-of`. `enabledAttr` pattern names an attr that turns an
+  operator/trigger on/off.
+- **NOT_BUSY:** `action-templates.js:38-41` — spread into every startable action; requires
+  all timed-action flags + `rebooting` be falsy (one timed action per node).
+- **Timed-action attr naming:** `js/core/node-graph/timed-actions.js:46-53` — standard
+  `_ta_<action>_progress` / `_ta_<action>_duration`; active flags are explicit
+  (`probing`,`exploiting`,`reading`,`looting`,`mining`,`lyingLow`,`rebooting`). New timed
+  actions register in the TIMED_ACTIONS registry, not ad hoc.
+
+## 4. XPLOIT followup picker (pattern for the flow picker)
+
+- **Followup field:** `action-templates.js:101-105` (`EXPLOIT_ACTION.followup`) —
+  `{ title:(node)=>..., choices:getExploitChoices, empty:getExploitEmptyReason }`.
+- **Choices source:** `getExploitChoices`/`getExploitEmptyReason` from `js/core/exploits.js`.
+- **UI:** `js/ui/components/starnet-context-menu.js:52-66` — an action with `hasFollowup`
+  dispatches `starnet:open-choices` instead of `starnet:action`; picking a choice re-dispatches
+  `starnet:action` with the choice payload (e.g. `{exploitId}`), routed by the dispatcher.
+  Hand/console supply the payload directly and skip the picker.
+
+## 5. HUD alert/trace display
+
+- **`starnet-hud.js:76-127`** — alert lamp `#alert-dot` = `alertLampDataUri(this.alert)`
+  (lines 88-92); alert level text `#alert-level`; trace countdown `#trace-countdown`
+  `TRACE: ${traceSeconds}s` shown only when `traceSeconds!==null && phase==="playing"`
+  (lines 97-99). Props fed by `visual-renderer.js`. A numeric NOISE readout sits in this
+  header region beside the alert.
+
+## 6. balance.js thresholds
+
+`js/core/balance.js:62-71`:
+    export const DETECTION_TRACE_THRESHOLD = { S:1, A:1, B:2, C:2, D:3, F:3 };
+    export const MONITOR_TRACE_THRESHOLD  = { S:4, A:5, B:7, C:9, D:12, F:15 };
+    export const TRACE_SECONDS            = { S:30, A:40, B:45, C:60, D:75, F:90 };
+New program-noise thresholds live here too.
+
+## 7. playtest.js + bot
+
+- **playtest dispatch:** `scripts/playtest.js` — inline command parsing (~lines 110-300),
+  monolithic switch; new commands are added inline (no external registry). Shares
+  `buildActionContext` + `initActionDispatcher` with `main.js`.
+- **bot strategies:** `scripts/bot/run.js:20-30` registers `DEFAULT_STRATEGIES`
+  (explore/loot/security/traps/evasion/cards/mine/puzzle). Heuristics read state directly
+  (`node.type`, `accessLevel`, `world.availableActions.get(nodeId)`) and emit scored
+  `{action, nodeId, score, reason, strategy}` — e.g. `scripts/bot/heuristics/security.js:19-96`.
+  No hardcoded KNOWN_ACTIONS set found; the bot ignores actions no strategy proposes.
+
+## 8. Player state shape
+
+- **Typedef:** `js/core/types.js:145-152` — `PlayerState { cash, hand, health, deckIntegrity }`.
+- **Init:** `js/core/state/index.js:168-178`.
+- **Mutations:** `js/core/state/player.js` — `addCash`, `addCardToHand`, `damagePlayerHealth`, ...
+  all via `mutate()`. New serializable field: add to typedef, init in `initGame`, add a
+  `mutate()`-wrapped setter, re-export through `js/core/state.js`. Deserialize reconstructs
+  from JSON; add a heal line if older saves must round-trip.

--- a/docs/dev-sessions/2026-06-30-1512-flow-programs-noise/spec.md
+++ b/docs/dev-sessions/2026-06-30-1512-flow-programs-noise/spec.md
@@ -1,0 +1,150 @@
+# Flow Programs + Noise Economy (Flow Subversion Session 1) Spec
+
+**Goal:** Turn the declarative flow substrate (Session 0) into gameplay: ship the first
+two flow-acting programs — `SNIFF` and `SPOOF` — as a complete **finesse-access loop**,
+with a **noise-feeds-the-trace** economy, so a player can own a node that can't be brute-forced
+by capturing a credential off a flow and replaying it.
+
+**Source:** User request 2026-06-30 (brainstorm with Les). North star: `docs/design/flow-subversion.md`
+(roadmap row "Session 1"). Builds on Session 0 (`docs/dev-sessions/2026-06-29-1211-flow-substrate/`).
+
+## Current state
+
+See `research.md` for `file:line` detail. Load-bearing facts:
+
+- **Flows are declarative, serializable state** (`Flow` typedef `js/core/types.js:308-319`;
+  init `js/core/state/index.js:166`; heal `:388-389`). No program acts on them yet.
+  `corporate-exchange` already authors an **encrypted credential flow** `switch-2 -> fw-1`
+  (`data/networks/corporate-exchange.js:126`).
+- **Actions are declarative ActionDefs** on node traits, dispatched via `starnet:action`
+  (`action-context.js:61-91`). `exec` scripts (corrupt/scrub-logs/lie-low) are the model for
+  new node verbs; timed actions follow the `LIE_LOW_OPERATOR` pattern
+  (`action-templates.js:298-305`). Multi-step actions use `followup` (XPLOIT picker,
+  `action-templates.js:101-105`) rendered by `starnet-context-menu.js:52-66`.
+- **Alert is two sensors, one ladder** (`js/core/alert.js`): `recordMonitorAlert` and
+  `recordIceDetection` each accumulate a count, step `green->yellow->red->trace`, and start the
+  shared trace clock at a grade-scaled threshold (`balance.js:62-71`). HUD renders the ladder +
+  `TRACE: Ns` (`starnet-hud.js:88-99`).
+- **Player state** = `{cash, hand, health, deckIntegrity}` (`types.js:145-152`), mutated via
+  `mutate()` setters in `state/player.js`.
+- **Three engine entry points** share dispatch: `js/ui/main.js`, `scripts/playtest.js`,
+  `scripts/bot/`.
+
+## Desired end state
+
+A player on the `corporate-exchange` demo (`?network=corporate-exchange`) can:
+
+1. Reveal `switch-2` and `fw-1` so the encrypted `switch-2 -> fw-1` credential flow renders.
+2. `SNIFF` that flow: it **reveals** (decrypts the render) and **captures the credential** into
+   the player's kit. A small amount of noise is added.
+3. Probe `fw-1` (or read its panel): it is **finesse-only** — XPLOIT is not offered; the panel
+   states it **trusts credential `<key>`**.
+4. `SPOOF` the captured credential into `fw-1` -> `fw-1` becomes **owned** (gaining the vault
+   beyond it through the existing smash/loot loop). More noise than SNIFF.
+5. The accumulated **program noise** climbs the existing alert ladder; enough loud play on its
+   own reaches TRACE. A **numeric NOISE readout** sits beside the alert in the HUD.
+
+`SNIFF`/`SPOOF` are usable from a **fixed always-available kit** (no acquisition economy this
+session), via GUI (node-anchored flow picker) and console (`sniff`/`spoof`), with identical
+outcomes and log entries. Everything survives a serialize -> deserialize round-trip.
+
+### Data shape
+
+- `Flow` gains: `key?: string` (credential token a `credential` flow carries) and
+  `revealed?: boolean` (set true once SNIFFed; persists/serializes). Encrypted flows start
+  concealed; SNIFF flips `revealed`.
+- `PlayerState` gains: `capturedCredentials: string[]` (serializable; healed on load).
+- Global noise: `state.programNoise: number` (serializable; healed on load), plus the new
+  third sensor.
+- Finesse node: a `finesse-access` trait/attrs — `finesseLocked: true` (suppresses XPLOIT) and
+  `trustsCredential: <key>`; probe surfaces the requirement; SPOOF action appears when the
+  player holds a matching captured credential.
+
+## Design decisions
+
+- **Decision:** Spine = the **SNIFF + SPOOF finesse-access loop**; defer TAP/SPLICE entirely
+  to Session 2.
+  - **Why:** finesse-access is complete and testable using the *existing* node-access scoring;
+    it needs neither skim payout (S2) nor the loadout/store (S3). TAP/SPLICE on a money flow
+    bank nothing until scoring exists — shipping them inert would violate the project's "no dead
+    mechanics / every visual event logged / test-honesty" rules.
+  - **Rejected:** all-four-programs-shallow (two would be hollow); read-only-only (no acting
+    verb to demonstrate the combo).
+- **Decision:** Programs come from a **fixed, always-available kit**; no RAM/loadout/store yet.
+  - **Why:** lets us tune the verbs in isolation and cleanly defers the acquisition economy to
+    Session 3. - **Rejected:** authored-per-network grant and mini-loadout — both pre-build S3
+    surface we'd partly redo.
+- **Decision:** Aim programs via a **node-anchored flow picker** mirroring the XPLOIT card picker.
+  - **Why:** zero new graph-interaction plumbing (Session 0 shipped no edge-level interaction);
+    keeps GUI/console symmetric. - **Rejected:** direct edge selection (new UI surface, risk);
+    global program panel (new surface).
+- **Decision:** Noise is a **third alert sensor** — `recordProgramNoise(amount)` in `alert.js`
+  accumulating `state.programNoise`, crossing tunable thresholds (`balance.js`) to step the
+  SAME `green->yellow->red->trace` ladder and start the SAME trace clock. Noise can reach trace
+  on its own (a real stealth budget). Per-program noise cost in `balance.js` (SNIFF cheap, SPOOF
+  dearer). - **Why:** the design doc demands noise feed the existing clock, not a parallel
+  resource; this is architecturally identical to the two existing sensors and fully serializable.
+  - **Rejected:** one-ladder-step-per-play (too coarse — traces a 2-3 step combo instantly);
+    noise-caps-below-trace (weak stealth-budget pressure).
+- **Decision:** Finesse appears only on **hand-authored finesse-only nodes** (here, `fw-1` in
+  `corporate-exchange`, which already receives the credential flow). Brute-immunity is hard:
+  XPLOIT is not offered. Every other node keeps the existing smash loop untouched.
+  - **Why:** lowest blast radius; demonstrates the loop on authored content; honors "old loop
+    stays fully playable." - **Rejected:** universal access-path on all nodes (touches all
+    authoring + procgen now); finesse-as-better-odds (blurs the "can't smash this" clarity the
+    combo depends on).
+- **Decision:** A **numeric NOISE readout** beside the alert in the HUD now; a richer
+  graph/vital-waveform treatment is a noted future hook, not built this session.
+  - **Why:** Les wants noise legible immediately without committing to a waveform design yet.
+
+## Patterns to follow
+
+- **New verb (timed or immediate) as an ActionDef + ctx-call:** mirror `SCRUB_LOGS_ACTION` /
+  `LIE_LOW_ACTION` + `LIE_LOW_OPERATOR` (`action-templates.js:258-305`); register in
+  `ACTION_TEMPLATES` (`:309-324`); add ids to `js/core/action-ids.js`. Decide SNIFF/SPOOF
+  immediate vs timed during planning (default: immediate, like CORRUPT/SCRUB).
+- **Followup flow picker:** mirror `EXPLOIT_ACTION.followup` (`action-templates.js:101-105`) +
+  `starnet-context-menu.js:52-66`. `choices` = flows incident to the node; selecting one
+  re-dispatches `starnet:action` with `{flowId|flowKey, nodeId}`.
+- **Third alert sensor:** mirror `recordMonitorAlert` (`js/core/alert.js:138-160`) exactly —
+  accumulate, step ladder capped below trace, start trace at threshold. Emit a typed event
+  (e.g. `E.PROGRAM_NOISE` / reuse `ALERT_GLOBAL_RAISED`) so the log + HUD update.
+- **New serializable player field:** typedef (`types.js:145-152`) + init
+  (`state/index.js:168-178`) + `mutate()` setter (`state/player.js`) + heal-on-load
+  (`state/index.js:388-389` neighborhood) + re-export shim.
+- **Finesse trait:** register via `registerTrait` (`traits.js:38-51`); gate XPLOIT off with a
+  `requires` condition on `finesseLocked` (or by omitting the exploit trait on that node — pick
+  the smaller change in planning).
+- **Preview demo:** add the revealed/sniffed flow state, captured-credential indicator, and
+  finesse-node marker to `js/ui/preview.js` / `preview.html` (project Design Principle).
+- **Three entry points:** add `sniff`/`spoof` to `scripts/playtest.js` inline dispatch; document
+  the bot's non-use in `docs/BOT-PLAYER.md`.
+
+## What we're NOT doing
+
+- **No TAP / SPLICE / REROUTE / THROTTLE / CUT / JAM / CORRUPT-flow / INJECT / DECRYPT-as-separate-verb.**
+  (SNIFF subsumes reveal/decrypt.)
+- **No skim / scoring / payout** of any kind (Session 2).
+- **No RAM loadout UI, RAM capacity, or store reframe** (Session 3).
+- **No procedural generation of finesse nodes or flows** — one hand-authored demo node only.
+- **No credential expiry / rotation / multi-hop key chains** (later finesse-depth).
+- **No ICE-damages-programs** threat axis (later).
+- **No noise vital-waveform / graph** — numeric readout only this session.
+- **No change to the existing smash/extraction loop, ICE, or the two existing alert sensors'
+  numbers.** The bot does not learn programs (census confirms no-regression only).
+- **No edge-selection UI** — flows are reached through the node-anchored picker.
+
+## Open questions
+
+- **SNIFF/SPOOF immediate vs timed action?** Default: **immediate** (like CORRUPT/SCRUB-LOGS) for
+  S1 simplicity; revisit timing/feel later. Plan proceeds under "immediate". (If timed, follow the
+  LIE_LOW operator pattern.)
+- **How to address a flow in payload/console?** Default: flows get a stable per-run **id** derived
+  at init (e.g. `from>to#type`); picker passes the id, console accepts `sniff <node> <id|index>`.
+  Plan pins the exact scheme.
+- **XPLOIT suppression mechanism on finesse nodes:** Default: add a `not finesseLocked` condition
+  to `EXPLOIT_ACTION.requires` (one-line, global, harmless to non-finesse nodes). Plan confirms vs
+  trait-omission.
+- **Noise threshold values + per-program costs:** Default: author placeholder values in
+  `balance.js` tuned so SNIFF+SPOOF+a probe stays below trace but a few loud plays reach it; these
+  are **feel-tuned** with Les after the loop works (do NOT lock in autonomous execution).

--- a/js/core/action-ids.js
+++ b/js/core/action-ids.js
@@ -24,6 +24,11 @@ export const A = Object.freeze({
   KICK: "kick",
   REBOOT: "reboot",
 
+  // Flow-manipulation programs (Session 1). Top-level verbs (host their own
+  // pickers / consume captured state), not EXEC scripts.
+  SNIFF: "sniff",
+  REPLAY: "replay",
+
   // Node-specific actions
   EXEC: "exec",
   CORRUPT: "corrupt",

--- a/js/core/actions/node-actions.js
+++ b/js/core/actions/node-actions.js
@@ -13,6 +13,7 @@
 /** @typedef {import('../types.js').GameState} GameState */
 
 import { getGlobalActions } from "./global-actions.js";
+import { getProgramActions } from "./program-actions.js";
 import { A } from "../action-ids.js";
 import { activeIceInstances } from "../state/ice.js";
 import { isScriptAction } from "./scripts.js";
@@ -43,9 +44,13 @@ export function getAvailableActions(node, state) {
   // Wrap each graph ActionDef into a game-compatible ActionDef
   const wrapped = filtered.map(ga => wrapGraphAction(ga));
 
+  // Flow programs: a fixed player-owned kit injected as top-level node actions (not scripts,
+  // so they stay out of the EXEC submenu — SNIFF needs its own flow picker).
+  const programs = getProgramActions(node, state);
+
   // Group non-core node actions (scripts) under a synthetic EXEC follow-up action.
   const scripts = wrapped.filter(a => isScriptAction(a.id));
-  const result = [...global, ...wrapped];
+  const result = [...global, ...wrapped, ...programs];
   if (scripts.length > 0) result.push(buildExecAction(scripts));
   return result;
 }

--- a/js/core/actions/program-actions.js
+++ b/js/core/actions/program-actions.js
@@ -1,0 +1,80 @@
+// @ts-check
+/**
+ * Flow-program actions (Session 1). Programs are a fixed always-available kit surfaced as
+ * node-contextual actions — NOT node traits (the kit is player-owned, not node-intrinsic) and
+ * NOT EXEC scripts (SNIFF hosts its own flow picker, which EXEC can't nest). getProgramActions
+ * is injected into getAvailableActions; availability that the node-graph's `requires` can't
+ * express (incident flows, player-held credentials) is filtered here — mirroring the KICK filter.
+ */
+
+/** @typedef {import('../types.js').ActionDef} ActionDef */
+/** @typedef {import('../types.js').NodeState} NodeState */
+/** @typedef {import('../types.js').GameState} GameState */
+
+import { A } from "../action-ids.js";
+import { visibleIncidentFlows, flowId, sniffFlow, replayCredential } from "../programs.js";
+
+/**
+ * Flow choices for the SNIFF picker — plain DATA (core stays UI-free). The picker component
+ * (starnet-action-choices) renders the glyph from flow-glyphs geometry.
+ * @param {NodeState} node @param {GameState} state
+ */
+export function getFlowChoices(node, state) {
+  return visibleIncidentFlows(state, node.id).map((f) => ({
+    id: flowId(f),
+    payloadKey: "flowId",
+    render: "flow-packet",
+    data: {
+      type: f.type,
+      encrypted: !!f.encrypted && !f.revealed,
+      revealed: !!f.revealed,
+      dir: f.from === node.id ? "out" : "in",
+    },
+  }));
+}
+
+export const getFlowEmptyReason = () => "No flows on this node.";
+
+/** @type {ActionDef} */
+export const SNIFF_ACTION = {
+  id: A.SNIFF,
+  label: "SNIFF",
+  available: () => true,
+  desc: () => "Read a data flow on this node; capture a credential if it carries one.",
+  followup: { title: (node) => `SNIFF ${node.id}`, choices: getFlowChoices, empty: getFlowEmptyReason },
+  execute: (node, state, _ctx, payload) => sniffFlow(state, node.id, payload?.flowId),
+};
+
+/** @type {ActionDef} */
+export const REPLAY_ACTION = {
+  id: A.REPLAY,
+  label: "REPLAY",
+  available: () => true,
+  desc: () => "Replay a captured credential to gain trusted access.",
+  execute: (node, state, _ctx) => replayCredential(state, node.id),
+};
+
+/**
+ * Programs available on this node given the player's kit + flow/credential context.
+ * @param {NodeState | null} node @param {GameState} state @returns {ActionDef[]}
+ */
+export function getProgramActions(node, state) {
+  /** @type {ActionDef[]} */
+  const out = [];
+  if (!node || node.visibility !== "accessible") return out;
+
+  // SNIFF: requires the node be PROBED — a measure of careful preparation (you scan/fingerprint
+  // the node before reading its traffic), but a single recon act, NOT the locked→open→owned
+  // XPLOIT climb (that climb is the grind the flow loop exists to avoid). Plus a VISIBLE incident
+  // flow to read (fog-of-war: don't offer SNIFF for a flow to an unrevealed node).
+  if (node.probed && visibleIncidentFlows(state, node.id).length > 0) out.push(SNIFF_ACTION);
+
+  // REPLAY: a finesse-locked node that trusts a credential the player has captured,
+  // not already owned. (Player-held-credential check can't be a node-graph `requires`.)
+  const key = node.trustsCredential;
+  if (node.finesseLocked && key && node.accessLevel !== "owned"
+      && state.player.capturedCredentials.includes(key)) {
+    out.push(REPLAY_ACTION);
+  }
+  return out;
+}

--- a/js/core/actions/scripts.js
+++ b/js/core/actions/scripts.js
@@ -11,6 +11,9 @@ export const CORE_NODE_VERBS = new Set([
   A.PROBE, A.XPLOIT, A.DUMP, A.FETCH, A.MINE, A.KICK,
   A.REBOOT, A.ABORT, A.TARGET, A.UNTARGET, A.JACKOUT,
   A.EXEC, // synthetic submenu action — not itself a script
+  // Flow programs stay top-level: SNIFF hosts its own flow picker (EXEC can't nest a
+  // followup), and both are core player verbs rather than node-authored scripts.
+  A.SNIFF, A.REPLAY,
 ]);
 
 /** @param {string} id @returns {boolean} */

--- a/js/core/alert.js
+++ b/js/core/alert.js
@@ -6,9 +6,10 @@
 import { getState, endRun } from "./state.js";
 import { setGlobalAlert, setTraceCountdown, setTraceTimerId, decrementTraceCountdown } from "./state/alert.js";
 import { setIceDetectedAt, incrementIceDetectionCount, activeIceInstances } from "./state/ice.js";
+import { addProgramNoise } from "./state/flow.js";
 import { emitEvent, E } from "./events.js";
 import { scheduleRepeating, cancelEvent, TIMER } from "./timers.js";
-import { DETECTION_TRACE_THRESHOLD, MONITOR_TRACE_THRESHOLD, TRACE_SECONDS } from "./balance.js";
+import { DETECTION_TRACE_THRESHOLD, MONITOR_TRACE_THRESHOLD, TRACE_SECONDS, PROGRAM_NOISE_THRESHOLD } from "./balance.js";
 
 /** @type {GlobalAlertLevel[]} */
 const GLOBAL_ALERT_ORDER = ["green", "yellow", "red", "trace"];
@@ -156,6 +157,34 @@ export function recordMonitorAlert(monitorId) {
     const next = GLOBAL_ALERT_ORDER[idx + 1];
     setGlobalAlert(next);
     emitEvent(E.ALERT_GLOBAL_RAISED, { prev, next });
+  }
+}
+
+// ── Program noise (third sensor; Session 1) ───────────────
+
+/**
+ * Record program-noise heat — the third alert sensor. The counterpart to recordIceDetection
+ * (active ICE) and recordMonitorAlert (passive grid): each program play adds heat that
+ * accumulates on state.programNoise and climbs the SAME green→yellow→red→trace ladder, starting
+ * the SAME trace clock once the cumulative `trace` threshold is crossed. Noise can reach trace on
+ * its own — a real stealth budget. Escalation-only (never lowers the alert). See MANUAL.md.
+ * @param {number} amount
+ */
+export function recordProgramNoise(amount) {
+  const total = addProgramNoise(amount);
+  emitEvent(E.PROGRAM_NOISE, { amount, total });
+  const t = PROGRAM_NOISE_THRESHOLD;
+  if (total >= t.trace) {
+    if (getState().traceSecondsRemaining === null) startTraceCountdown();
+    return;
+  }
+  // Step the ladder up to the highest level the accumulated noise has crossed (capped below
+  // trace; trace is threshold-gated above). Escalation-only — never step down.
+  const target = total >= t.red ? "red" : total >= t.yellow ? "yellow" : "green";
+  const cur = getState().globalAlert;
+  if (GLOBAL_ALERT_ORDER.indexOf(target) > GLOBAL_ALERT_ORDER.indexOf(cur)) {
+    setGlobalAlert(target);
+    emitEvent(E.ALERT_GLOBAL_RAISED, { prev: cur, next: target });
   }
 }
 

--- a/js/core/balance.js
+++ b/js/core/balance.js
@@ -70,6 +70,14 @@ export const MONITOR_TRACE_THRESHOLD = { S: 4, A: 5, B: 7, C: 9, D: 12, F: 15 };
 /** Trace countdown duration (seconds) scales with network threat grade. */
 export const TRACE_SECONDS = { S: 30, A: 40, B: 45, C: 60, D: 75, F: 90 };
 
+// ── Program noise (third alert sensor; Session 1) ────────────────────────────
+// Each flow-program play adds heat; crossing the cumulative thresholds steps the
+// SAME green→yellow→red→trace ladder, and the trace threshold starts the SAME
+// trace clock. Quiet solutions are the skill. PLACEHOLDER VALUES — tuned by feel
+// with Les (the bot doesn't use programs, so census only confirms no-regression).
+export const PROGRAM_NOISE_COST = { sniff: 1, replay: 3 };
+export const PROGRAM_NOISE_THRESHOLD = { yellow: 2, red: 4, trace: 6 };
+
 // ── ICE movement / detection ─────────────────────────────────────────────────
 
 // Grade → movement interval (ms); must be longer than the corresponding DWELL_TIMES entry.

--- a/js/core/console-commands/commands.js
+++ b/js/core/console-commands/commands.js
@@ -13,6 +13,7 @@ import {
   resolveNode, resolveImplicitNode, resolveCard, dispatch, resolveWanAccess,
 } from "./resolvers.js";
 import { isObscured } from "../state/node.js";
+import { visibleIncidentFlows, flowId } from "../programs.js";
 import { A } from "../action-ids.js";
 import {
   cmdStatusSummary, cmdStatusFull, cmdStatusIce, cmdStatusHand,
@@ -29,6 +30,25 @@ const CHEAT_POOLS      = ["health", "deck"];
 const CHEAT_RARITIES   = ["common", "uncommon", "rare"];
 const CHEAT_ALERTS     = ["green", "yellow", "red", "trace"];
 const CHEAT_TRACE_SUBS = ["start", "end"];
+
+// ── Flow-program command helpers ──────────────────────────────────────────────
+
+/** One-line description of a flow relative to a node (for the `sniff` listing). */
+function flowDesc(f, nodeId) {
+  const other = f.from === nodeId ? f.to : f.from;
+  const dir = f.from === nodeId ? "→" : "←";
+  const conceal = f.encrypted && !f.revealed ? " [encrypted]" : "";
+  const type = f.encrypted && !f.revealed ? "?????" : f.type;
+  return `${type} ${dir} ${other}${conceal}`;
+}
+
+/** Resolve a flow reference (1-based index, type name, or full flow id) against a node's flows. */
+function resolveFlow(flows, ref) {
+  const n = Number(ref);
+  if (Number.isInteger(n) && n >= 1 && n <= flows.length) return flows[n - 1];
+  const lc = String(ref).toLowerCase();
+  return flows.find((f) => f.type === lc) || flows.find((f) => flowId(f).toLowerCase() === lc) || null;
+}
 
 // ── Command definitions ───────────────────────────────────────────────────────
 
@@ -86,6 +106,45 @@ export const COMMANDS = [
   },
 
   // kick — dynamically discovered from graph available actions
+
+  // ── flow programs (SNIFF / REPLAY) ───────────────────────────────────────────
+  // Not dynamically discovered: they're actions-layer injections, not graph actions,
+  // and SNIFF takes a flow argument (like xploit takes a card).
+  { verb: "sniff",
+    complete(args, partial, state) {
+      if (args.length === 0 && !state.selectedNodeId) return fromNodes(state.nodes, partial);
+      return null;
+    },
+    execute(args) {
+      const s = getState();
+      let node = null, ref = null;
+      if (args.length >= 2)              { node = resolveNode(args[0]); ref = args.slice(1).join(" "); }
+      else if (args.length === 1 && s.selectedNodeId) { node = resolveImplicitNode(); ref = args[0]; }
+      else if (args.length === 1)        { node = resolveNode(args[0]); }        // sniff <node> → list
+      else if (s.selectedNodeId)         { node = resolveImplicitNode(); }        // sniff → list
+      else { addLogEntry("Usage: sniff <node> [flow]  (or select a node: sniff [flow])", "error"); return; }
+      if (!node) return;
+      const flows = visibleIncidentFlows(s, node.id);
+      if (flows.length === 0) { addLogEntry(`no flows on ${node.id}.`, "meta"); return; }
+      if (!ref) {
+        addLogEntry(`flows on ${node.id}:`, "meta");
+        flows.forEach((f, i) => addLogEntry(`  ${i + 1}. ${flowDesc(f, node.id)}`, "meta"));
+        return;
+      }
+      const flow = resolveFlow(flows, ref);
+      if (!flow) { addLogEntry(`sniff: no flow "${ref}" on ${node.id}.`, "error"); return; }
+      dispatch(A.SNIFF, { nodeId: node.id, flowId: flowId(flow) });
+    },
+  },
+
+  { verb: "replay",
+    complete: completeNodeArg,
+    execute(args) {
+      const node = args.length >= 1 ? resolveNode(args[0]) : resolveImplicitNode();
+      if (!node) { addLogEntry("Usage: replay <node>  (or select a node first)", "error"); return; }
+      dispatch(A.REPLAY, { nodeId: node.id });
+    },
+  },
 
   // ── exec — run a node script (grouped non-core node actions) ─────────────────
   { verb: "exec",

--- a/js/core/events.js
+++ b/js/core/events.js
@@ -45,6 +45,11 @@ export const E = Object.freeze({
   ALERT_TRACE_STARTED:   "alert:trace-started",
   ALERT_TRACE_CANCELLED: "alert:trace-cancelled",
   ALERT_PROPAGATED:      "alert:propagated",
+  PROGRAM_NOISE:         "alert:program-noise",
+
+  FLOW_SNIFFED:          "flow:sniffed",
+  CREDENTIAL_CAPTURED:   "flow:credential-captured",
+  CREDENTIAL_REPLAYED:   "flow:credential-replayed",
 
   PLAYER_NAVIGATED:     "player:navigated",
 

--- a/js/core/node-graph/action-templates.js
+++ b/js/core/node-graph/action-templates.js
@@ -97,6 +97,10 @@ const EXPLOIT_ACTION = {
     // Owned nodes are already at max access — don't offer XPLOIT at all (the
     // hand stays a full-agency override for a deliberate re-exploit).
     { type: "not", condition: { type: "node-attr", attr: "accessLevel", eq: "owned" } },
+    // Finesse-locked nodes can't be brute-forced — they only trust a captured
+    // credential replayed in (REPLAY program). Harmless on ordinary nodes, where
+    // finesseLocked is undefined and reads as not-true.
+    { type: "not", condition: { type: "node-attr", attr: "finesseLocked", eq: true } },
   ],
   followup: {
     title: (node) => `XPLOIT ${node.id}`,

--- a/js/core/node-graph/node-factories.js
+++ b/js/core/node-graph/node-factories.js
@@ -20,6 +20,8 @@
  * @property {string} [label]
  * @property {string} [grade]
  * @property {Record<string, any>} [attributes]
+ * @property {{ key: string }} [finesse] Firewall-only: makes the node finesse-locked
+ *   (brute-immune), trusting the credential `key` (REPLAY it in to gain access).
  */
 
 /**
@@ -149,14 +151,21 @@ export function createCryptovault(id, config = {}) {
  * @returns {NodeDef}
  */
 export function createFirewall(id, config = {}) {
+  // A finesse firewall can't be brute-forced — it only trusts a captured credential
+  // replayed in (config.finesse = { key }). The finesse-access trait supplies
+  // finesseLocked (suppresses XPLOIT); trustsCredential names the required token.
+  const finesse = config.finesse;
+  const traits = ["graded", "hackable", "rebootable", "gate"];
+  if (finesse) traits.push("finesse-access");
   return {
     id,
     type: "firewall",
-    traits: ["graded", "hackable", "rebootable", "gate"],
+    traits,
     attributes: {
       label: config.label || id,
       grade: config.grade || "A",
       gateAccess: "owned",
+      ...(finesse ? { trustsCredential: finesse.key } : {}),
       ...config.attributes,
     },
   };

--- a/js/core/node-graph/traits.js
+++ b/js/core/node-graph/traits.js
@@ -304,6 +304,17 @@ registerTrait("darknet", {
   actions: [ACTION_TEMPLATES.ACCESS_DARKNET, ACTION_TEMPLATES.LIE_LOW, ACTION_TEMPLATES.DISCONNECT],
 });
 
+// Finesse access (Flow Subversion Session 1): a node that CANNOT be brute-forced —
+// it only trusts a credential that flows in from elsewhere. `finesseLocked` suppresses
+// XPLOIT (see EXPLOIT_ACTION.requires); `trustsCredential` names the token a captured
+// credential must match. Owning it is the REPLAY program (injected in program-actions.js),
+// not a trait action. Apply via createFirewall({ finesse: { key } }).
+registerTrait("finesse-access", {
+  attributes: { finesseLocked: true, trustsCredential: null },
+  operators: [],
+  actions: [],
+});
+
 // ── New traits (stress-test the system) ─────────────────────
 
 registerTrait("hardened", {

--- a/js/core/programs.js
+++ b/js/core/programs.js
@@ -1,0 +1,82 @@
+// @ts-check
+/**
+ * Flow-manipulation programs (Flow Subversion Session 1). Pure game logic that acts on
+ * state.flows + player state. Programs are a fixed always-available kit (no loadout economy
+ * yet — that's Session 3); they surface as node-contextual actions via program-actions.js.
+ *
+ * Each program play adds noise to the shared trace clock (recordProgramNoise). Quiet,
+ * minimal solutions are the skill.
+ */
+
+/** @typedef {import('./types.js').GameState} GameState */
+
+import { setFlowRevealed, flowId } from "./state/flow.js";
+import { addCapturedCredential } from "./state/player.js";
+import { setNodeAccessLevel, setNodeAlertState, setNodeVisible, setNodeProbed } from "./state/node.js";
+import { revealNeighbors } from "./state.js";
+import { recordProgramNoise } from "./alert.js";
+import { PROGRAM_NOISE_COST } from "./balance.js";
+import { emitEvent, E } from "./events.js";
+
+export { flowId };
+
+/**
+ * Flows incident to a node (either endpoint). The player reads/acts on a flow through a node
+ * it can reach at either end.
+ * @param {GameState} state @param {string} nodeId
+ */
+export const incidentFlows = (state, nodeId) =>
+  state.flows.filter((f) => f.from === nodeId || f.to === nodeId);
+
+/**
+ * Incident flows the player can currently SEE — the other endpoint must be revealed (not hidden),
+ * matching the flow-layer's fog-of-war rule (a flow renders only once both endpoints are present).
+ * SNIFF availability, the flow picker, and the console listing all use this so the menu never
+ * leaks hidden topology.
+ * @param {GameState} state @param {string} nodeId
+ */
+export const visibleIncidentFlows = (state, nodeId) =>
+  incidentFlows(state, nodeId).filter((f) => {
+    const other = state.nodes[f.from === nodeId ? f.to : f.from];
+    return other && other.visibility !== "hidden";
+  });
+
+/**
+ * SNIFF a flow: reveal its render (decrypts an encrypted flow) and, if it carries a credential
+ * token, capture it into the player's kit. Adds sniff noise. No-op on an unknown id.
+ * @param {GameState} state @param {string} nodeId @param {string} id flow id (see flowId)
+ */
+export function sniffFlow(state, nodeId, id) {
+  const f = state.flows.find((fl) => flowId(fl) === id);
+  if (!f) return;
+  setFlowRevealed(id);
+  emitEvent(E.FLOW_SNIFFED, { nodeId, flowId: id, type: f.type });
+  if (f.type === "credential" && f.key) {
+    addCapturedCredential(f.key);
+    emitEvent(E.CREDENTIAL_CAPTURED, { nodeId, key: f.key });
+  }
+  recordProgramNoise(PROGRAM_NOISE_COST.sniff);
+}
+
+/**
+ * REPLAY a captured credential into a finesse node that trusts it → owned. No-op unless the
+ * node is finesse-locked, trusts a key the player holds, and isn't already owned. Replicates
+ * the access-gain side-effects of a successful exploit (applyCombatResult) so a firewall's
+ * gated neighbors reveal. Adds replay noise.
+ * @param {GameState} state @param {string} nodeId
+ */
+export function replayCredential(state, nodeId) {
+  const node = state.nodes[nodeId];
+  const key = node?.trustsCredential;
+  if (!key || !state.player.capturedCredentials.includes(key)) return;
+  if (node.accessLevel === "owned") return;
+  const prev = node.accessLevel;
+  setNodeAccessLevel(nodeId, "owned");
+  setNodeAlertState(nodeId, "green");
+  setNodeVisible(nodeId, "accessible");
+  setNodeProbed(nodeId);
+  revealNeighbors(nodeId); // owned reveals what the firewall/gate concealed
+  emitEvent(E.CREDENTIAL_REPLAYED, { nodeId, key });
+  emitEvent(E.NODE_ACCESSED, { nodeId, label: node.label, prev, next: "owned" });
+  recordProgramNoise(PROGRAM_NOISE_COST.replay);
+}

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -36,7 +36,12 @@ export {
 
 export {
   addCash, setCash, addCardToHand, setMissionComplete, applyCardDecay,
+  addCapturedCredential,
 } from "./state/player.js";
+
+export {
+  flowId, setFlowRevealed, addProgramNoise,
+} from "./state/flow.js";
 
 export {
   setSelectedNode, setPhase, setRunOutcome, toggleMenuOpen, toggleHandCollapsed,

--- a/js/core/state/flow.js
+++ b/js/core/state/flow.js
@@ -1,0 +1,36 @@
+// @ts-check
+// Pure flow-substrate state mutations. No event emission, no orchestration.
+// Flows are first-class serializable state (state.flows); see js/core/types.js Flow.
+
+import { mutate, getState } from "./index.js";
+
+/**
+ * Stable per-run address for a flow. The ONE definition of the scheme — every
+ * program, picker, and console command addresses flows through this.
+ * @param {{ from: string, to: string, type: string }} f
+ * @returns {string}
+ */
+export const flowId = (f) => `${f.from}>${f.to}#${f.type}`;
+
+/**
+ * Marks the flow with this id as revealed (decrypts its render, persists in state).
+ * @param {string} id
+ */
+export function setFlowRevealed(id) {
+  mutate((s) => {
+    const f = s.flows.find((fl) => flowId(fl) === id);
+    if (f) f.revealed = true;
+  });
+}
+
+/**
+ * Adds program noise heat to the shared alert ladder's accumulator.
+ * @param {number} amount
+ * @returns {number} the new accumulated programNoise total
+ */
+export function addProgramNoise(amount) {
+  mutate((s) => {
+    s.programNoise += amount;
+  });
+  return getState().programNoise;
+}

--- a/js/core/state/index.js
+++ b/js/core/state/index.js
@@ -164,6 +164,9 @@ export function initGame(buildNetworkFn, seedString, opts = {}) {
     // in-run mutation (future rerouting / encryption reveal) never writes back into the source
     // network definition's meta.flows — same fresh-objects contract as the player hand above.
     flows: (meta.flows ?? []).map((f) => ({ ...f })),
+    // Accumulated program-noise heat — the third alert sensor (js/core/alert.js
+    // recordProgramNoise) climbs the shared ladder off this. Serializable.
+    programNoise: 0,
     nodeGraph: graph,
     player: {
       cash: meta.startCash ?? 1000,
@@ -175,6 +178,8 @@ export function initGame(buildNetworkFn, seedString, opts = {}) {
         : generateStartingHand(meta.startHand),
       health:        { current: meta.startHealth        ?? 100, max: meta.startHealth        ?? 100 },
       deckIntegrity: { current: meta.startDeckIntegrity ?? 100, max: meta.startDeckIntegrity ?? 100 },
+      // Credential tokens captured off flows via SNIFF; consumed by REPLAY. Serializable.
+      capturedCredentials: [...(meta.startCredentials ?? [])],
     },
     globalAlert: "green",
     traceSecondsRemaining: null,
@@ -387,6 +392,9 @@ export function deserializeState(snapshot, opts = {}) {
   if (!ctx.state.ui) ctx.state.ui = { menuOpen: false, handCollapsed: false };
   // Heal saves that predate state.flows — the flow renderer reads getState().flows directly.
   if (!ctx.state.flows) ctx.state.flows = [];
+  // Heal saves that predate the flow-program fields (Session 1).
+  if (typeof ctx.state.programNoise !== "number") ctx.state.programNoise = 0;
+  if (ctx.state.player && !ctx.state.player.capturedCredentials) ctx.state.player.capturedCredentials = [];
   deserializeTimers(_timers);   // writes into ctx.timers
   if (_rng) deserializeRng(_rng);
   else initRng(gameState.seed ?? undefined);

--- a/js/core/state/player.js
+++ b/js/core/state/player.js
@@ -24,6 +24,13 @@ export function addCardToHand(card) {
   });
 }
 
+/** Captures a credential token (from a SNIFFed flow). De-dupes; ignores empty. */
+export function addCapturedCredential(key) {
+  mutate((s) => {
+    if (key && !s.player.capturedCredentials.includes(key)) s.player.capturedCredentials.push(key);
+  });
+}
+
 /** Marks the current mission as complete. */
 export function setMissionComplete() {
   mutate((s) => {

--- a/js/core/types.js
+++ b/js/core/types.js
@@ -148,6 +148,7 @@
  *   hand: ExploitCard[],
  *   health: { current: number, max: number },
  *   deckIntegrity: { current: number, max: number },
+ *   capturedCredentials: string[],
  * }} PlayerState
  */
 
@@ -315,6 +316,8 @@
  *   type: ('money'|'data'|'audit'|'control'|'credential'),
  *   rate: number,
  *   encrypted?: boolean,
+ *   key?: string,
+ *   revealed?: boolean,
  * }} Flow
  */
 
@@ -329,6 +332,7 @@
  *   nodes: Object.<string, NodeState>,
  *   adjacency: Object.<string, string[]>,
  *   flows: Flow[],
+ *   programNoise: number,
  *   player: PlayerState,
  *   globalAlert: GlobalAlertLevel,
  *   traceSecondsRemaining: number|null,

--- a/js/ui/components/starnet-action-choices.js
+++ b/js/ui/components/starnet-action-choices.js
@@ -8,6 +8,7 @@ import { html, nothing } from "lit";
 import { StarnetElement } from "./starnet-element.js";
 import { exploitCardBody } from "./exploit-card-view.js";
 import { wearFraction } from "../../core/exploits.js";
+import { flowGlyphDataUri } from "../flow-glyphs.js";
 
 class StarnetActionChoices extends StarnetElement {
   static properties = {
@@ -82,6 +83,18 @@ class StarnetActionChoices extends StarnetElement {
           [ ${choice.data.label} ]${choice.data.desc
             ? html`<span class="ctx-item-desc">${choice.data.desc}</span>`
             : nothing}
+        </button>`;
+    }
+    if (choice.render === "flow-packet") {
+      // Glyph via data-URI <img> (the HUD indicator-glyph pattern) — the local lit bundle has
+      // no `svg` tag. Stroke-only + glow, per the vector-UI rule. Encrypted-and-unrevealed
+      // flows show a dim "?".
+      const d = choice.data;
+      const label = d.encrypted ? "ENCRYPTED" : d.type.toUpperCase();
+      return html`
+        <button class="ctx-item flow-choice" @click=${() => this._pick(choice)}>
+          <img class="flow-glyph" alt=${d.type} src=${flowGlyphDataUri(d.type, { encrypted: d.encrypted })}>
+          [ ${label} ${d.dir === "in" ? "←" : "→"} ]
         </button>`;
     }
     return nothing;

--- a/js/ui/components/starnet-hud.js
+++ b/js/ui/components/starnet-hud.js
@@ -9,6 +9,7 @@ class StarnetHud extends StarnetElement {
   static properties = {
     alert: { type: String },
     cash: { type: Number },
+    programNoise: { type: Number },
     traceSeconds: { type: Number },
     connectionStatus: { type: String },
     connectionLabel: { type: String },
@@ -25,6 +26,7 @@ class StarnetHud extends StarnetElement {
     super();
     this.alert = "green";
     this.cash = 0;
+    this.programNoise = 0;
     this.traceSeconds = null;
     this.connectionStatus = "";
     this.connectionLabel = "PASSIVE SCAN";
@@ -89,6 +91,10 @@ class StarnetHud extends StarnetElement {
         <img class="hud-lamp" id="alert-dot" alt="alert ${this.alert}" src=${alertLampDataUri(this.alert)}>
         <span class="hud-label">ALERT:</span>
         <span class="hud-value" id="alert-level" style="color:${alertColor}">${this.alert.toUpperCase()}</span>
+        ${this.phase === "playing" ? html`
+          <span class="hud-label">NOISE:</span>
+          <span class="hud-value" id="noise-level">${this.programNoise ?? 0}</span>
+        ` : nothing}
       </div>
 
       <span class="hud-label">WALLET:</span>

--- a/js/ui/flow-glyphs.js
+++ b/js/ui/flow-glyphs.js
@@ -55,6 +55,7 @@ export function flowGlyphFor(type) {
   return FLOW_GLYPHS[type] ?? { color: ENCRYPTED_COLOR, body: "" };
 }
 
+
 /**
  * Inner glyph markup (no <svg> wrapper), 0 0 12 12 space. When `encrypted`, a dim "?" replaces
  * the type glyph. Single source of the encrypted treatment, shared by flowSvg and the layer.
@@ -76,6 +77,17 @@ export function flowGlyphBody(type, opts = {}) {
  */
 export function flowSvg(type, opts = {}) {
   return `<svg viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">${flowGlyphBody(type, opts)}</svg>`;
+}
+
+/**
+ * Packet glyph as an `<img src>`-ready data URI (matches the HUD indicator-glyph pattern).
+ * Lets DOM/Lit consumers show the glyph without lit's `svg` tag (not in the local lit bundle).
+ * @param {string} type
+ * @param {{ encrypted?: boolean }} [opts]
+ * @returns {string}
+ */
+export function flowGlyphDataUri(type, opts = {}) {
+  return "data:image/svg+xml," + encodeURIComponent(flowSvg(type, opts));
 }
 
 /**

--- a/js/ui/log-renderer.js
+++ b/js/ui/log-renderer.js
@@ -142,6 +142,16 @@ export function initLogRenderer() {
   on(E.ALERT_PROPAGATED,    (/** @type {AlertPropagatedPayload} */   { fromLabel, toLabel }) =>
     add(`[ALERT] Event forwarded: ${fromLabel} → ${toLabel}`, "meta"));
 
+  // ── Flow programs (Session 1) ────────────────────────────
+  on(E.FLOW_SNIFFED, ({ nodeId, type }) =>
+    add(`[SNIFF] ${nodeId}: ${type} flow read.`, "info"));
+  on(E.CREDENTIAL_CAPTURED, ({ key }) =>
+    add(`[SNIFF] Credential captured: ${key}.`, "success"));
+  on(E.CREDENTIAL_REPLAYED, ({ nodeId, key }) =>
+    add(`[REPLAY] ${nodeId}: credential ${key} accepted — trusted access.`, "success"));
+  on(E.PROGRAM_NOISE, ({ total }) =>
+    add(`[NOISE] Program noise: ${total}.`, "meta"));
+
   // ── Mission / run events ─────────────────────────────────
   on(E.MISSION_STARTED,  (/** @type {MissionStartedPayload} */  { targetName }) => add(`[MISSION] Objective: retrieve ${targetName}.`, "info"));
   on(E.MISSION_COMPLETE, (/** @type {MissionCompletePayload} */ { targetName }) => add(`[MISSION] ★ Target acquired: ${targetName}.`, "success"));

--- a/js/ui/overlays/flow-layer.js
+++ b/js/ui/overlays/flow-layer.js
@@ -51,12 +51,14 @@ export function renderableFlows(flows, presentNodeIds) {
  * Stable string key for a set of flows. The layer rebuilds only when this changes, so frequent
  * STATE_CHANGED events that don't alter the flow set (e.g. a timed action ticking) don't reset
  * the packets. Pure.
- * @param {Array<{from:string,to:string,type:string,rate:number,encrypted?:boolean}>} flows
+ * @param {Array<{from:string,to:string,type:string,rate:number,encrypted?:boolean,revealed?:boolean}>} flows
  * @returns {string}
  */
 export function flowsSignature(flows) {
   return (flows || [])
-    .map((f) => `${f.from}>${f.to}:${f.type}:${f.rate}:${f.encrypted ? 1 : 0}`)
+    // `revealed` is in the key so SNIFFing an encrypted flow (which flips revealed) changes the
+    // signature and rebuilds the layer — the packet re-renders as its true type instead of "?".
+    .map((f) => `${f.from}>${f.to}:${f.type}:${f.rate}:${f.encrypted ? 1 : 0}:${f.revealed ? 1 : 0}`)
     .join("|");
 }
 
@@ -109,7 +111,7 @@ export class FlowLayer {
   /**
    * Rebuild the packet set from the current flows + graph, skipping when the renderable set is
    * unchanged (so STATE_CHANGED storms during a timed action don't reset packet phases).
-   * @param {Array<{from:string,to:string,type:string,rate:number,encrypted?:boolean}>} flows
+   * @param {Array<{from:string,to:string,type:string,rate:number,encrypted?:boolean,revealed?:boolean}>} flows
    * @param {any} cy
    */
   refresh(flows, cy) {
@@ -122,7 +124,7 @@ export class FlowLayer {
     this._build(renderable);
   }
 
-  /** @param {Array<{from:string,to:string,type:string,rate:number,encrypted?:boolean}>} flows */
+  /** @param {Array<{from:string,to:string,type:string,rate:number,encrypted?:boolean,revealed?:boolean}>} flows */
   _build(flows) {
     this.flows = [];
     const cy = this.cy;
@@ -150,7 +152,8 @@ export class FlowLayer {
         a: cy ? cy.getElementById(f.from) : null,
         b: cy ? cy.getElementById(f.to) : null,
         type: f.type,
-        encrypted: !!f.encrypted,
+        // Concealed only while encrypted AND not yet SNIFFed. Once revealed, draw the true glyph.
+        encrypted: !!f.encrypted && !f.revealed,
         laneOffset,
         packets,
       });

--- a/js/ui/preview.js
+++ b/js/ui/preview.js
@@ -316,15 +316,19 @@ function rebuildFlows() {
   const density = parseFloat($("flow-density").value) || 0;
   $("flow-density-val").textContent = density.toFixed(2);
   const encrypted = $("flow-encrypted").checked;
+  // "revealed" models a flow that was encrypted but has been SNIFFed: it renders as its true
+  // type again. Only meaningful alongside ENCRYPTED (the sniff-decrypt A/B).
+  const revealed = $("flow-revealed").checked;
   const types = [...document.querySelectorAll(".flow-type")]
     .map((c) => /** @type {HTMLInputElement} */ (c))
     .filter((c) => c.checked)
     .map((c) => c.value);
-  const flows = types.map((type) => ({ from: "flow-src", to: "flow-dst", type, rate: density, encrypted }));
+  const flows = types.map((type) => ({ from: "flow-src", to: "flow-dst", type, rate: density, encrypted, revealed }));
   flowLayer.refresh(flows, cy);
 }
 flowToggles.addEventListener("change", rebuildFlows);
 $("flow-encrypted").addEventListener("change", rebuildFlows);
+$("flow-revealed").addEventListener("change", rebuildFlows);
 $("flow-density").addEventListener("input", rebuildFlows);
 rebuildFlows();
 

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -426,6 +426,7 @@ function syncHud(state) {
   if (hudEl) {
     hudEl.alert = state.globalAlert;
     hudEl.cash = state.player.cash;
+    hudEl.programNoise = state.programNoise;
     hudEl.traceSeconds = state.traceSecondsRemaining;
     hudEl.isCheating = state.isCheating;
     hudEl.phase = state.phase;

--- a/preview.html
+++ b/preview.html
@@ -215,6 +215,7 @@
         <div class="btn-row" id="flow-type-toggles"></div>
         <div class="btn-row">
           <label><input type="checkbox" id="flow-encrypted"> ENCRYPTED</label>
+          <label><input type="checkbox" id="flow-revealed"> REVEALED (sniffed)</label>
         </div>
         <div class="btn-row">
           <label>DENSITY</label>

--- a/scripts/playtest.js
+++ b/scripts/playtest.js
@@ -207,6 +207,10 @@ if (jsonMode) {
   on(E.ALERT_TRACE_STARTED,   ({ seconds })               => out(`[ALERT] ⚠ TRACE INITIATED — ${seconds}s`));
   on(E.ALERT_TRACE_CANCELLED, ()                          => out(`[ALERT] Trace cancelled. Alert: RED`));
   on(E.ALERT_PROPAGATED,     ({ fromLabel, toLabel })    => out(`[ALERT] ${fromLabel} → ${toLabel}: alert propagated.`));
+  on(E.FLOW_SNIFFED,         ({ nodeId, type })          => out(`[SNIFF] ${nodeId}: ${type} flow read.`));
+  on(E.CREDENTIAL_CAPTURED,  ({ key })                   => out(`[SNIFF] Credential captured: ${key}.`));
+  on(E.CREDENTIAL_REPLAYED,  ({ nodeId, key })           => out(`[REPLAY] ${nodeId}: credential ${key} accepted — trusted access.`));
+  on(E.PROGRAM_NOISE,        ({ total })                 => out(`[NOISE] Program noise: ${total}.`));
   on(E.ICE_MOVED,            ({ fromLabel, toLabel, fromVisible, toVisible }) => {
     if (fromVisible || toVisible) out(`[ICE] Moving: ${fromLabel} → ${toLabel}`);
   });

--- a/tests/flow-layer.test.js
+++ b/tests/flow-layer.test.js
@@ -44,3 +44,9 @@ test("flowsSignature changes when any field changes", () => {
   assert.notEqual(base, flowsSignature([{ from: "x", to: "y", type: "audit", rate: 0.5 }]));
   assert.notEqual(base, flowsSignature([{ from: "x", to: "y", type: "money", rate: 0.5, encrypted: true }]));
 });
+
+test("flowsSignature changes when an encrypted flow is revealed (SNIFF decrypts on the graph)", () => {
+  const enc = flowsSignature([{ from: "x", to: "y", type: "credential", rate: 0.5, encrypted: true }]);
+  const revealed = flowsSignature([{ from: "x", to: "y", type: "credential", rate: 0.5, encrypted: true, revealed: true }]);
+  assert.notEqual(enc, revealed);
+});

--- a/tests/flow-programs.test.js
+++ b/tests/flow-programs.test.js
@@ -1,0 +1,247 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { initGame, getState, serializeState, deserializeState } from "../js/core/state.js";
+import { setFlowRevealed, flowId, addProgramNoise } from "../js/core/state/flow.js";
+import { addCapturedCredential } from "../js/core/state/player.js";
+import { recordProgramNoise } from "../js/core/alert.js";
+import { PROGRAM_NOISE_THRESHOLD, PROGRAM_NOISE_COST } from "../js/core/balance.js";
+import { sniffFlow, incidentFlows, replayCredential } from "../js/core/programs.js";
+import { setNodeVisible, setNodeProbed } from "../js/core/state/node.js";
+import { getProgramActions, getFlowChoices } from "../js/core/actions/program-actions.js";
+import { getAvailableActions } from "../js/core/actions/node-actions.js";
+import { isScriptAction } from "../js/core/actions/scripts.js";
+import { buildActionContext, initActionDispatcher } from "../js/core/actions/action-context.js";
+import { A } from "../js/core/action-ids.js";
+import { clearHandlers, emitEvent } from "../js/core/events.js";
+import { clearAll } from "../js/core/timers.js";
+import { buildNetwork as buildCorporateExchange } from "../data/networks/corporate-exchange.js";
+
+/** Reveal switch-2 and fw-1 so their incident credential flow is workable, and give it a key. */
+function armCredentialFlow(key = "cred-key") {
+  const s = getState();
+  const cred = s.flows.find((f) => f.type === "credential");
+  cred.key = key; // Phase 3 authors this into the network; set here to test sniff in isolation.
+  return { cred, id: flowId(cred) };
+}
+
+afterEach(() => { clearHandlers(); clearAll(); });
+
+describe("flow programs — data shape + serialization", () => {
+  it("Flow.key / revealed, capturedCredentials, and programNoise survive a round-trip", () => {
+    initGame(() => buildCorporateExchange(), "flow-seed-1");
+    const s = getState();
+
+    // The demo authors an encrypted credential flow switch-2 -> fw-1.
+    const cred = s.flows.find((f) => f.type === "credential");
+    assert.ok(cred, "demo network has a credential flow");
+    const id = flowId(cred);
+
+    setFlowRevealed(id);
+    addCapturedCredential("test-key");
+    addProgramNoise(3);
+
+    const snap = JSON.parse(JSON.stringify(serializeState()));
+    deserializeState(snap);
+    const r = getState();
+
+    const credAfter = r.flows.find((f) => flowId(f) === id);
+    assert.equal(credAfter.revealed, true, "revealed flag round-trips");
+    assert.deepEqual(r.player.capturedCredentials, ["test-key"], "captured credentials round-trip");
+    assert.equal(r.programNoise, 3, "programNoise round-trips");
+  });
+
+  it("heals a save that predates the new fields", () => {
+    initGame(() => buildCorporateExchange(), "flow-seed-2");
+    const snap = JSON.parse(JSON.stringify(serializeState()));
+    delete snap.programNoise;
+    delete snap.player.capturedCredentials;
+
+    deserializeState(snap);
+    const r = getState();
+    assert.equal(r.programNoise, 0, "programNoise heals to 0");
+    assert.deepEqual(r.player.capturedCredentials, [], "capturedCredentials heals to []");
+  });
+
+  it("addCapturedCredential de-dupes", () => {
+    initGame(() => buildCorporateExchange(), "flow-seed-3");
+    addCapturedCredential("k");
+    addCapturedCredential("k");
+    assert.deepEqual(getState().player.capturedCredentials, ["k"]);
+  });
+});
+
+describe("program noise sensor", () => {
+  it("steps the shared alert ladder by accumulated noise and starts the trace at threshold", () => {
+    initGame(() => buildCorporateExchange(), "flow-seed-4");
+    const t = PROGRAM_NOISE_THRESHOLD;
+    assert.equal(getState().globalAlert, "green");
+
+    recordProgramNoise(t.yellow);            // reach yellow threshold
+    assert.equal(getState().globalAlert, "yellow");
+
+    recordProgramNoise(t.red - t.yellow);    // reach red threshold
+    assert.equal(getState().globalAlert, "red");
+
+    assert.equal(getState().traceSecondsRemaining, null, "no trace before the trace threshold");
+    recordProgramNoise(t.trace - t.red);     // reach trace threshold
+    assert.notEqual(getState().traceSecondsRemaining, null, "trace countdown started at threshold");
+    assert.equal(getState().globalAlert, "trace");
+  });
+
+  it("noise only escalates (never lowers the alert)", () => {
+    initGame(() => buildCorporateExchange(), "flow-seed-5");
+    recordProgramNoise(PROGRAM_NOISE_THRESHOLD.red); // to red
+    assert.equal(getState().globalAlert, "red");
+    recordProgramNoise(0); // no-op amount must not lower it
+    assert.equal(getState().globalAlert, "red");
+  });
+});
+
+describe("SNIFF program", () => {
+  it("reveals a flow, captures its credential, and adds sniff noise", () => {
+    initGame(() => buildCorporateExchange(), "sniff-seed-1");
+    const { cred, id } = armCredentialFlow("fw-key");
+    const noiseBefore = getState().programNoise;
+
+    sniffFlow(getState(), cred.from, id);
+
+    const after = getState().flows.find((f) => flowId(f) === id);
+    assert.equal(after.revealed, true, "flow revealed");
+    assert.deepEqual(getState().player.capturedCredentials, ["fw-key"], "credential captured");
+    assert.equal(getState().programNoise, noiseBefore + PROGRAM_NOISE_COST.sniff, "sniff noise added");
+  });
+
+  it("sniffing a non-credential flow reveals it and adds noise but captures nothing", () => {
+    initGame(() => buildCorporateExchange(), "sniff-seed-2");
+    const money = getState().flows.find((f) => f.type === "money");
+    const id = flowId(money);
+    sniffFlow(getState(), money.from, id);
+    assert.equal(getState().flows.find((f) => flowId(f) === id).revealed, true);
+    assert.deepEqual(getState().player.capturedCredentials, []);
+    assert.equal(getState().programNoise, PROGRAM_NOISE_COST.sniff);
+  });
+
+  it("offers SNIFF as a top-level (non-script) action on a PROBED node with visible flows", () => {
+    initGame(() => buildCorporateExchange(), "sniff-seed-3");
+    // Preparation required: SNIFF taps a node's traffic, so the node must be probed first.
+    setNodeProbed("gateway");
+    const gateway = getState().nodes["gateway"];
+    assert.ok(incidentFlows(getState(), "gateway").length > 0, "gateway has incident flows");
+    const programs = getProgramActions(gateway, getState());
+    assert.ok(programs.some((a) => a.id === A.SNIFF), "SNIFF injected on a probed node");
+    assert.equal(isScriptAction(A.SNIFF), false, "SNIFF is a core verb (top-level, hosts its own picker)");
+    const all = getAvailableActions(gateway, getState());
+    assert.ok(all.some((a) => a.id === A.SNIFF), "SNIFF surfaces in getAvailableActions");
+  });
+
+  it("does NOT offer SNIFF on an unprobed node — SNIFF needs recon prep first, appears after PROBE", () => {
+    initGame(() => buildCorporateExchange(), "sniff-seed-locked");
+    const gateway = () => getState().nodes["gateway"]; // accessible + unprobed at start
+    assert.equal(gateway().probed, false);
+    assert.equal(getProgramActions(gateway(), getState()).some((a) => a.id === A.SNIFF), false, "not before probe");
+    setNodeProbed("gateway");
+    assert.ok(getProgramActions(gateway(), getState()).some((a) => a.id === A.SNIFF), "offered once probed");
+  });
+
+  it("hides flows whose other endpoint isn't revealed (fog-of-war parity with the graph)", () => {
+    initGame(() => buildCorporateExchange(), "sniff-seed-fog");
+    // switch-2 accessible, but fw-1 still hidden → the switch-2→fw-1 credential flow must not leak.
+    setNodeVisible("switch-2", "accessible");
+    assert.equal(getState().nodes["fw-1"].visibility, "hidden", "fw-1 starts hidden");
+    const choices = getFlowChoices(getState().nodes["switch-2"], getState());
+    assert.equal(
+      choices.some((c) => c.data.type === "credential"),
+      false,
+      "credential flow to hidden fw-1 is not offered",
+    );
+    // Reveal fw-1 → the flow becomes sniffable.
+    setNodeVisible("fw-1", "revealed");
+    const after = getFlowChoices(getState().nodes["switch-2"], getState());
+    assert.ok(after.some((c) => c.data.type === "credential"), "flow appears once fw-1 is revealed");
+  });
+
+  it("does not offer SNIFF on a node with no incident flows", () => {
+    initGame(() => buildCorporateExchange(), "sniff-seed-4");
+    // vault-1 has no authored flow incident to it.
+    assert.equal(incidentFlows(getState(), "vault-1").length, 0);
+    const programs = getProgramActions(getState().nodes["vault-1"], getState());
+    assert.equal(programs.some((a) => a.id === A.SNIFF), false);
+  });
+
+  it("GUI/console parity: dispatching a sniff action produces the same state as calling sniffFlow", () => {
+    // Path A: direct sniffFlow.
+    initGame(() => buildCorporateExchange(), "parity-seed");
+    const a = armCredentialFlow("pk");
+    setNodeVisible(a.cred.from, "accessible"); // reachable endpoint
+    setNodeProbed(a.cred.from);                // prep: SNIFF needs the node probed
+    setNodeVisible(a.cred.to, "revealed");     // other endpoint visible (fog-of-war: both must show)
+    sniffFlow(getState(), a.cred.from, a.id);
+    const direct = JSON.stringify({ noise: getState().programNoise, creds: getState().player.capturedCredentials, revealed: getState().flows.find((f) => flowId(f) === a.id).revealed });
+
+    // Path B: same seed, via the action dispatcher (exercises availability gating + execute).
+    initGame(() => buildCorporateExchange(), "parity-seed");
+    const b = armCredentialFlow("pk");
+    setNodeVisible(b.cred.from, "accessible");
+    setNodeProbed(b.cred.from);
+    setNodeVisible(b.cred.to, "revealed");
+    initActionDispatcher(buildActionContext());
+    emitEvent("starnet:action", { actionId: A.SNIFF, nodeId: b.cred.from, flowId: b.id, fromConsole: true });
+    const viaDispatch = JSON.stringify({ noise: getState().programNoise, creds: getState().player.capturedCredentials, revealed: getState().flows.find((f) => flowId(f) === b.id).revealed });
+
+    assert.equal(viaDispatch, direct, "both channels produce identical state");
+  });
+});
+
+describe("finesse access + REPLAY program", () => {
+  it("fw-1 is finesse-locked: probing offers no XPLOIT, and it names its trusted credential", () => {
+    initGame(() => buildCorporateExchange(), "finesse-seed-1");
+    setNodeVisible("fw-1", "accessible");
+    const fw = getState().nodes["fw-1"];
+    assert.equal(fw.finesseLocked, true, "fw-1 is finesse-locked");
+    assert.ok(fw.trustsCredential, "fw-1 names a trusted credential");
+    const actions = getAvailableActions(fw, getState());
+    assert.equal(actions.some((a) => a.id === A.XPLOIT), false, "no XPLOIT on a finesse node");
+  });
+
+  it("REPLAY is absent without the credential and present once captured", () => {
+    initGame(() => buildCorporateExchange(), "finesse-seed-2");
+    setNodeVisible("fw-1", "accessible");
+    const before = getAvailableActions(getState().nodes["fw-1"], getState());
+    assert.equal(before.some((a) => a.id === A.REPLAY), false, "no REPLAY without the credential");
+
+    addCapturedCredential(getState().nodes["fw-1"].trustsCredential);
+    const after = getAvailableActions(getState().nodes["fw-1"], getState());
+    assert.ok(after.some((a) => a.id === A.REPLAY), "REPLAY appears once the credential is held");
+  });
+
+  it("full loop: SNIFF the credential flow → REPLAY fw-1 → owned", () => {
+    initGame(() => buildCorporateExchange(), "finesse-seed-3");
+    const { id } = { id: flowId(getState().flows.find((f) => f.type === "credential")) };
+    setNodeVisible("switch-2", "accessible");
+    setNodeVisible("fw-1", "accessible");
+
+    // SNIFF the credential off the flow.
+    sniffFlow(getState(), "switch-2", id);
+    const key = getState().nodes["fw-1"].trustsCredential;
+    assert.ok(getState().player.capturedCredentials.includes(key), "captured the fw-1 credential");
+    const noiseAfterSniff = getState().programNoise;
+
+    // REPLAY it into fw-1.
+    const replay = getAvailableActions(getState().nodes["fw-1"], getState()).find((a) => a.id === A.REPLAY);
+    assert.ok(replay, "REPLAY available");
+    replay.execute(getState().nodes["fw-1"], getState(), buildActionContext(), { nodeId: "fw-1" });
+
+    assert.equal(getState().nodes["fw-1"].accessLevel, "owned", "fw-1 owned via replay");
+    assert.equal(getState().programNoise, noiseAfterSniff + PROGRAM_NOISE_COST.replay, "replay noise added");
+  });
+
+  it("REPLAY without the credential is a no-op (access unchanged, no noise)", () => {
+    initGame(() => buildCorporateExchange(), "finesse-seed-4");
+    setNodeVisible("fw-1", "accessible");
+    const before = getState().nodes["fw-1"].accessLevel;
+    const noiseBefore = getState().programNoise;
+    replayCredential(getState(), "fw-1");
+    assert.equal(getState().nodes["fw-1"].accessLevel, before, "access unchanged");
+    assert.equal(getState().programNoise, noiseBefore, "no noise added");
+  });
+});


### PR DESCRIPTION
## Summary
- Turns the Session 0 flow substrate into gameplay: the first flow-manipulation programs (**SNIFF**, **REPLAY**) plus a **noise economy** wired into the existing trace clock.
- Demonstrated as a complete **finesse-access loop** on `?network=corporate-exchange`: probe a node → **SNIFF** a flow it touches (decrypts an encrypted flow; captures a credential token) → **REPLAY** the token into a finesse-only, brute-immune node → owned (revealing what it gated). Every program play adds noise that climbs the shared `green→yellow→red→trace` ladder — quiet, minimal solutions are the skill.

## Design Decisions
- **Spine = the SNIFF + REPLAY finesse loop; TAP/SPLICE deferred to Session 2.** It's complete/testable using existing node-access scoring — no skim payout (S2) or loadout UI (S3) needed. Shipping two *real* verbs beats four where two are hollow (avoids dead mechanics).
- **Programs are a fixed always-available kit, injected as top-level node actions** — not traits (the kit is player-owned, not node-intrinsic) and not EXEC scripts (SNIFF needs its own flow picker, which EXEC can't nest). No acquisition economy yet — that's the Session 3 RAM/loadout arc.
- **SNIFF requires the node be PROBED, not open/owned.** Probing is a single recon act (*preparation*), not the `locked→open→owned` XPLOIT climb (*grind*) — gating the elegant loop behind that climb would re-import the exact tedium the pillar exists to remove. REPLAY, by contrast, targets the **locked** finesse node — it's the one action available on a node you have no other way into.
- **Noise is a third alert sensor** (`recordProgramNoise`) alongside the grid and ICE, feeding the *same* ladder + trace clock rather than a parallel resource. Monotonic this session (a decaying-**heat** refinement is designed for a later arc — see the design doc).
- **Naming: the credential-replay program is `REPLAY`, not `SPOOF`** — `A.SPOOF`/`"spoof"` was already taken (security-monitor recalibrate + a trap action); the design doc lists them as synonyms.

## Changes
- **State/data:** `Flow.key`/`revealed`, `PlayerState.capturedCredentials`, `GameState.programNoise` (serializable + healed on load); `state/flow.js` (flow-id + reveal + noise setters).
- **Programs:** `js/core/programs.js` (sniff/replay logic + fog-of-war-aware `visibleIncidentFlows`); `js/core/actions/program-actions.js` (SNIFF/REPLAY ActionDefs + injector).
- **Alert:** `recordProgramNoise` third sensor; `PROGRAM_NOISE_COST`/`PROGRAM_NOISE_THRESHOLD` in `balance.js` (placeholder values, feel-tuned later).
- **Finesse:** `finesse-access` trait; `createFirewall({ finesse: { key } })`; `fw-1` authored finesse in corporate-exchange; `EXPLOIT_ACTION` gains a `not finesseLocked` requirement.
- **UI:** node-anchored flow picker (`flow-packet` render via a data-URI `<img>`), numeric `NOISE` HUD readout, flow layer honours `revealed` (SNIFF decrypts on the graph), preview REVEALED toggle.
- **Entry points:** console `sniff`/`replay`, playtest event output; bot documented as not using programs.
- **Docs:** MANUAL.md (Flow Programs, finesse access, noise), BOT-PLAYER.md, and a captured **anti-tedium arc** design (heat/alert ratchet, verb variants, flows-as-scouting) in `docs/design/flow-subversion.md`.

## Test Plan
- [x] `make check` green (1500 tests; +17 flow-program/flow-layer, incl. serialize round-trip, noise→trace thresholds, finesse gating, full sniff→replay loop, fog-of-war, GUI/console parity)
- [x] Playtest harness smoke: `sniff`/`replay` via the real console→dispatch path
- [x] `make census SEEDS=10` clean (bot action set unchanged — generated nets author no flows; `not finesseLocked` is a no-op on ordinary nodes)
- [ ] **Browser walk-through** (`?network=corporate-exchange`): reveal fw-1, SNIFF the credential flow (decrypts + NOISE climbs), fw-1 offers no XPLOIT, REPLAY owns it and reveals the vault
- [ ] **Feel-tuning** the noise numbers in `balance.js` with a human (placeholders; bot can't validate)

## References
- Spec: `docs/dev-sessions/2026-06-30-1512-flow-programs-noise/spec.md`
- Plan: `docs/dev-sessions/2026-06-30-1512-flow-programs-noise/plan.md`
- Notes (deviations, TODO): `docs/dev-sessions/2026-06-30-1512-flow-programs-noise/notes.md`
- Design pillar + next-arc capture: `docs/design/flow-subversion.md`
- Follow-ups: the numeric `NOISE` readout is provisional to the monotonic model — the designed heat arc replaces it with an imprecise/qualitative indicator. Named networks (incl. corporate-exchange) aren't hub-reachable (#261), so the loop is reachable only via `?network=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
