### PR TITLE
Reactive Strudel song playback: runtime, signals, GeneralUser GS, preview tool

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all serve dev lint lint-imports test check bundle-vendor census bot-run generate gen-bot gen-json
 
 # Install dependencies and build vendor bundles
-all: node_modules dist/vendor.js dist/lit.js dist/tone.js
+all: node_modules dist/vendor.js dist/lit.js dist/tone.js dist/strudel.js
 
 node_modules: package.json
 	npm install
@@ -14,6 +14,9 @@ dist/lit.js: js/lit-vendor.js node_modules
 
 dist/tone.js: js/tone-vendor.js node_modules
 	npx esbuild js/tone-vendor.js --bundle --outfile=dist/tone.js --format=esm --platform=browser --minify
+
+dist/strudel.js: js/strudel-vendor.js node_modules
+	npx esbuild js/strudel-vendor.js --bundle --outfile=dist/strudel.js --format=esm --platform=browser --minify
 
 # Start local dev server (open http://localhost:3000)
 serve:
@@ -29,7 +32,7 @@ dev: all serve
 #   fixtures/             (test fixture data)
 lint:
 	npx tsc --noEmit --allowJs --checkJs --target ES2020 --moduleResolution bundler --module ES2020 \
-		$(shell find js -name '*.js' ! -name '*.test.js' ! -path '*/fixtures/*' ! -name 'graph.js' ! -name 'vendor.js' ! -name 'lit-vendor.js' ! -name 'tone-vendor.js')
+		$(shell find js -name '*.js' ! -name '*.test.js' ! -path '*/fixtures/*' ! -name 'graph.js' ! -name 'vendor.js' ! -name 'lit-vendor.js' ! -name 'tone-vendor.js' ! -name 'strudel-vendor.js')
 
 # Guard against absolute "/dist/..." paths in js/ and HTML. They resolve to the
 # domain root and 404 under a deploy subpath (e.g. GitHub Pages /starnet/), where
@@ -50,11 +53,12 @@ test:
 # Full check: imports guard + lint + test
 check: lint-imports lint test
 
-# Bundle vendor dependencies (Cytoscape + layout extensions, Lit, Tone)
+# Bundle vendor dependencies (Cytoscape + layout extensions, Lit, Tone, Strudel)
 bundle-vendor:
 	npx esbuild js/vendor.js --bundle --outfile=dist/vendor.js --format=iife --platform=browser --minify
 	npx esbuild js/lit-vendor.js --bundle --outfile=dist/lit.js --format=esm --platform=browser --minify
 	npx esbuild js/tone-vendor.js --bundle --outfile=dist/tone.js --format=esm --platform=browser --minify
+	npx esbuild js/strudel-vendor.js --bundle --outfile=dist/strudel.js --format=esm --platform=browser --minify
 
 # Shared grade defaults for bot/census/generate targets
 THREAT ?= C

--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ make check    # run tsc type checker (no emit)
 
 See [`CLAUDE.md`](CLAUDE.md) for architecture notes, dev workflow, and design principles.
 See [`docs/SPEC.md`](docs/SPEC.md) for the full game design document.
+
+## License
+
+The Starnet **engine** is licensed under the **GNU Affero General Public License v3.0**
+([`LICENSE`](LICENSE)). It bundles [Strudel](https://strudel.cc/) + superdough for audio, which are
+AGPL-3.0; bundling them makes the combined work AGPL-3.0.
+
+Following the **Doom model**, game *content* — future content packs ("wads": songs, missions,
+assets under `audio-content/`) — is kept as separately-licensed data loaded at runtime, never woven
+into the engine source, so it can carry its own license. As an AGPL §13 courtesy, the running app
+shows a **source** link to this public repository.

--- a/audio-content/README.md
+++ b/audio-content/README.md
@@ -1,0 +1,20 @@
+# audio-content
+
+Runtime-loaded audio **content** for the Strudel song engine — kept separate from the engine
+source (the "wad" boundary; see the AGPL/Doom-model note in the repo LICENSE + `docs/audio-direction.md`).
+
+## soundfonts/
+
+- **`GeneralUser-GS.sf2`** — the game's vendored General MIDI soundfont (S. Christian Collins /
+  mrbumpy409 fork). Its 287 presets are registered by `js/audio/strudel/soundfont.js` as distinct
+  **`gus_*`** named Strudel sounds (e.g. `gus_warm_pad`, `gus_tine_electric_piano`). These are a
+  **separate, non-fungible instrument set** — deliberately NOT aliased to strudel.cc's `gm_*` (those
+  are a different soundfont; do not treat them as interchangeable).
+- **`GeneralUser-GS.LICENSE.txt`** — its license: free for any use (private/commercial), modifiable,
+  bundlable. Clean to ship. (Chosen over strudel.cc's default WebAudioFont `gm_*`, whose provenance
+  is murky — WebAudioFont is itself derived from GeneralUser GS + FluidR3; we use the clean source.)
+
+## Authoring parity
+
+To hear in strudel.cc what the game will play, load the same soundfont there and reference the same
+`gus_*` names. (The published manifest + authoring prelude land with the preview tool / linter.)

--- a/audio-content/songs/demo.strudel
+++ b/audio-content/songs/demo.strudel
@@ -1,0 +1,14 @@
+// Starnet demo song — reactive to game signals. Authored in strudel.cc against the game's kosher
+// set (gus_* instruments + the progress/threat signals), so it carries into the game unchanged.
+//   progress = fraction of the LAN owned   |   threat = alert ladder + injury
+setcpm(60/4)
+
+$: note("<c2 c2 g1 c2>").s("gus_synth_bass_1")
+     .lpf(threat.range(300, 3000))            // filter opens as THREAT climbs
+     .gain(0.6)
+
+$: note("c4 eb4 g4 bb4").s("gus_warm_pad")
+     .gain(progress.range(0.1, 0.6))          // pad swells as you own more of the LAN
+     .room(0.5)
+
+$: sound("bd sd").gain(threat.range(0, 0.85)) // the beat drops in under threat

--- a/audio-content/soundfonts/GeneralUser-GS.LICENSE.txt
+++ b/audio-content/soundfonts/GeneralUser-GS.LICENSE.txt
@@ -1,0 +1,47 @@
+*** GeneralUser GS v2.0.3 ***
+***      License v2.0     ***
+
+** License of the complete work **
+You may use GeneralUser GS without restriction for your own music creation,
+private or commercial. This SoundFont bank is provided to the community free of
+charge. Please feel free to use it in your software projects, and to modify the
+SoundFont bank or its packaging to suit your needs.
+
+** License of contained samples **
+GeneralUser GS inherits the usage rights of the samples contained within, all of
+which allow full use in music production, including the ability to make profit
+from musical recordings created with GeneralUser GS.
+
+Many of the samples are original, but some were taken from other banks freely
+(and legally) available on the Internet from various SoundFont websites. Because
+GeneralUser GS originated as a personal project with no intention for
+publication, I cannot be 100% sure where all of the samples originated, although
+I do know that none of them came from commercially published SoundFont packages
+or sample CDs. Regardless, many "free" SoundFonts available on the web may
+indeed contain samples of questionable origin. My understanding of the
+copyrights of all samples is only as good as the information provided by the
+original sources. If you become aware of any restricted samples being used in
+GeneralUser GS, please let me know so I can replace them.
+
+This uncertainty may concern you if you intend to use GeneralUser GS in a
+commercial software product. That being said, I have never received any
+complaint regarding sample ownership since I published the original GeneralUser
+GS back in 2000, and as far as I am aware, neither have any of the companies
+creating commercial software products using GeneralUser GS.
+
+** More info **
+If you plan to feature GeneralUser GS on your own website, please do not link
+directly to my download files. Either link to my website, or provide your own
+local copy instead.
+
+I hope you enjoy GeneralUser GS! This SoundFont bank is the product of many
+years of hard work.
+
+You can find updates to GeneralUser GS and more of my virtual instruments at:
+http://www.schristiancollins.com
+
+I can be reached via the contact page on my website here:
+https://www.schristiancollins.com/contact
+
+Thank you!
+-~Chris

--- a/css/style.css
+++ b/css/style.css
@@ -1799,3 +1799,20 @@ html, body {
   flex-direction: column;
   gap: 6px;
 }
+
+/* AGPL-3.0 §13 source link — persistent, unobtrusive corner anchor. Stroke + glow, no fill
+   (vector phosphene discipline). The engine bundles AGPL Strudel/superdough (see LICENSE). */
+#source-link {
+  position: fixed;
+  right: 8px;
+  bottom: 6px;
+  z-index: 9;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  color: var(--cyan-dim);
+  text-decoration: none;
+  opacity: 0.5;
+  transition: opacity 0.2s, color 0.2s, text-shadow 0.2s;
+}
+#source-link:hover { opacity: 1; color: var(--cyan); text-shadow: var(--glow-sm) var(--cyan); }

--- a/docs/dev-sessions/2026-07-01-1012-strudel-song-playback/notes.md
+++ b/docs/dev-sessions/2026-07-01-1012-strudel-song-playback/notes.md
@@ -14,7 +14,22 @@
 - **Slice D** — permanent song preview harness (`song-preview.html` + `js/ui/song-preview.js`):
   editor, per-signal sliders, 287-instrument palette, in-set linter.
 
-## OPEN BUG (not fixed): soundfont songs don't STOP + degrade over time — Firefox
+## RESOLVED: soundfont songs don't STOP + degrade over time — Firefox
+
+**Fixed** (commit "fix STOP (Firefox + repl)"). Three causes, three fixes:
+1. **Primary:** the bare global `window.hush()` does NOT clear `$:` multi-patterns (they live in
+   the repl) → song looped forever + replays stacked (the "degradation"). Fix: stop via
+   `window.evaluate("hush()")` (runs hush through the repl). Verified: bare hush leaves it at 0.84;
+   `evaluate("hush()")` → 0.
+2. Firefox lacks `cancelAndHoldAtTime` → polyfill in runtime.js (soundfont voices now release).
+3. superdough bails on our soundfont handle (node undefined) → schedule the note-off ourselves in
+   soundfont.js (`stop(time+value.duration)`).
+Result (Firefox): STOP decays the song to silence; no replay accumulation. Residual tail = the
+warm pad's natural release at the demo's slow tempo, not a bug.
+
+Historical detail below (kept for the record):
+
+### Original diagnosis
 
 Les (Firefox) reported: STOP doesn't stop the audio, and playback degrades over time. Root-caused,
 partially patched (uncommitted), NOT resolved. Findings:

--- a/docs/dev-sessions/2026-07-01-1012-strudel-song-playback/notes.md
+++ b/docs/dev-sessions/2026-07-01-1012-strudel-song-playback/notes.md
@@ -1,0 +1,60 @@
+# Notes — Strudel song playback
+
+## Shipped this session (committed on `strudel-song-playback`)
+
+- **Slice A** — vendored `@strudel/web@1.3.0` (strudel.cc-parity runtime). Native `$:`/`setcpm`/
+  `arrange` via `evaluate()`, no shims. Browser-verified.
+- **Slice B** — expandable signal registry (`js/audio/signal-registry.js`) + injection bridge
+  (`js/audio/strudel/signal-bridge.js`): `progress`/`threat` exposed as live global Strudel signals,
+  refreshed on STATE_CHANGED; `setLive()` for preview sliders. Unit-tested + browser-verified
+  (song reacts to a signal by ear — Les confirmed).
+- **Slice C** — vendored GeneralUser GS soundfont (`audio-content/soundfonts/`, committed, clean
+  license) registered as 287 distinct `gus_*` sounds (NOT aliased to `gm_*` — non-fungible by
+  design). `js/audio/strudel/soundfont.js`.
+- **Slice D** — permanent song preview harness (`song-preview.html` + `js/ui/song-preview.js`):
+  editor, per-signal sliders, 287-instrument palette, in-set linter.
+
+## OPEN BUG (not fixed): soundfont songs don't STOP + degrade over time — Firefox
+
+Les (Firefox) reported: STOP doesn't stop the audio, and playback degrades over time. Root-caused,
+partially patched (uncommitted), NOT resolved. Findings:
+
+1. **Firefox lacks `AudioParam.cancelAndHoldAtTime`.** **sfumato** (the SF2 player in
+   `@strudel/soundfonts`) calls it raw in its `dahdsr` release (`sfumato/dist/sfumato.js`) → every
+   soundfont **note-off throws** in Firefox → voices never release → don't stop + pile up (the
+   degradation). Confirmed: Playwright Firefox 151, `cancelAndHoldAtTime` undefined; note-off threw.
+   - **superdough** emulates it internally (`superdough/superdoughoutput.mjs:111`) so *synth/sample*
+     voices are fine — only *soundfont* (sfumato) voices break.
+   - **Why strudel.cc works in Firefox:** it runs on **`standardized-audio-context`** (implements
+     `cancelAndHoldAtTime`); our boot uses the **native** Firefox AudioContext (doesn't). Les wasn't
+     lucky — strudel.cc has the Firefox workaround; our bare bundle didn't.
+2. **superdough bails on our soundfont handle.** `superdough.mjs` ~L574: if the sound handle's
+   `node` is `undefined` (ours is), it `return`s early and never schedules the note-off. So even
+   without the FF bug, our `registerSound(...)` voices wouldn't self-stop. We hand-roll registration
+   instead of using `@strudel/soundfonts`'s own `registerSoundfonts()`.
+3. **`hush()` may not clear `$:` multi-patterns** — UNVERIFIED hypothesis. The demo uses three `$:`
+   patterns; `hush()` is the documented stop but the song kept sounding after it even with a
+   `cancelAndHoldAtTime` polyfill on a fresh page. Needs isolation: `$: sound("bd*4")` (samples, no
+   soundfont) → `hush()` → do hits continue? (Distinguishes hush/$: from soundfont-release.)
+
+### Uncommitted partial patches (in the working tree — reconsider vs. the canonical fix)
+- `js/audio/strudel/runtime.js`: `polyfillCancelAndHold()` at boot (standard hold-current-value
+  shim). Removes the note-off throw; single soundfont note now releases. Did NOT make the full song
+  stop (see #3).
+- `js/audio/strudel/soundfont.js`: schedule `stop(time + value.duration)` in the trigger (because of
+  superdough's early-return, #2).
+
+## Recommended next step (Les's instinct — align to strudel.cc's well-trod code)
+
+Rather than our polyfill + hand-rolled registration, do it the way strudel.cc does:
+1. **Boot on `standardized-audio-context`** (or `initStrudel` options that select it) so
+   `cancelAndHoldAtTime` exists natively in Firefox → sfumato release works, no polyfill.
+2. **Register the soundfont via `@strudel/soundfonts`'s `registerSoundfonts()` / their loader**, not
+   our custom `registerSound` loop → avoids the superdough early-return (#2). Keep the `gus_*`
+   distinct-naming requirement (no `gm_*` alias) on top.
+3. **Verify STOP** with the drums-only `$:` isolation (#3) on a FRESH page (this session's live-test
+   page is contaminated with accumulated stuck voices — start clean).
+4. Confirm on both Firefox and Chrome.
+
+We ARE using @strudel/web's canonical API (`initStrudel`/`evaluate`/`hush` per its README) — the gap
+is the audio-context + soundfont-registration mechanics one level down.

--- a/docs/dev-sessions/2026-07-01-1012-strudel-song-playback/notes.md
+++ b/docs/dev-sessions/2026-07-01-1012-strudel-song-playback/notes.md
@@ -59,6 +59,18 @@ partially patched (uncommitted), NOT resolved. Findings:
 - `js/audio/strudel/soundfont.js`: schedule `stop(time + value.duration)` in the trigger (because of
   superdough's early-return, #2).
 
+## SFX independence + superdough timing (for the eventual SFX/drone port to 1.3.0)
+
+- **SFX are isolated from songs** (verified): the single-program repl limit applies only to Strudel
+  *patterns* (a song). Sound effects are direct `superdough(...)` one-shots that bypass the repl, so
+  they play with/without a song and survive `hush()`-ing the song. Two-layer model like the Tone
+  engine's separate music/SFX buses. Measured: SFX 0.98 alone AND after the song is hushed; song 0
+  when stopped.
+- **superdough `t` must be `ctx.currentTime`, not `0`, on @strudel/web 1.3.0.** superdough skips haps
+  scheduled in the past (`ac.currentTime > t` → skip), so `superdough(value, 0, dur)` (what the #262
+  SFX code uses on 1.0.3) is silently dropped on 1.3.0. Port fix: `superdough(value, ctx.currentTime
+  (+ small lookahead), dur)`.
+
 ## Recommended next step (Les's instinct — align to strudel.cc's well-trod code)
 
 Rather than our polyfill + hand-rolled registration, do it the way strudel.cc does:

--- a/docs/dev-sessions/2026-07-01-1012-strudel-song-playback/research.md
+++ b/docs/dev-sessions/2026-07-01-1012-strudel-song-playback/research.md
@@ -1,0 +1,57 @@
+# Research — Strudel song playback (live-verified this session, 2026-06-30/07-01)
+
+Empirically verified in-browser against the vendored `@strudel/web@1.0.3` → `dist/strudel.js`
+(the Phase-1 runtime), plus prototypes in `tmp/song-player.html` + `tmp/stripdown-cover.js`.
+
+## Runtime capabilities (work today)
+- `evaluate(codeString)` runs the transpiler. Works: bare expressions, `let`, `arrange()`,
+  `stack()`, `note()`, `s()`, `.lpf/.fm/.fmh/.gain/.room/.pan/.distort/.echo/.vib/.vibmod/.superimpose/.slow/.fast/.add`.
+- **`signal(() => liveValue)`** — reactive; `.range(lo,hi)`. A live JS value drives pattern params
+  each cycle, no re-eval. **This is the signal-injection primitive.** Verified by ear: Les's gThreat
+  slider reshapes a *playing* song responsively.
+- `superdough(value,t,dur)` one-shots honor `s` (incl. `white/pink/brown` noise), `note`, `cutoff`
+  (static lowpass; chain is source→gain→filter), `resonance`, `fm`+`fmh` (FM confirmed), ADSR,
+  `room`, `pan`. (Analyser filter measurement is unreliable — gain precedes filter in the chain.)
+- `samples('github:…' | url)` works — loads custom/dirt samples at runtime.
+- `.play()` uses a **single scheduler slot** (`ai.setPattern` replaces). Multiple independent
+  simultaneous patterns are NOT supported via `.play()`; combine with `stack()`/`$:`.
+
+## Gaps vs. full strudel.cc (the compat delta — small but real)
+- **`$:` multi-pattern label** → `evaluate()` REJECTS it ("unexpected ast format without body
+  expression"). The only pure-syntax gap. Single `$:` works by stripping the label; multiple need
+  converting to a `stack(...)`.
+- **`setcpm`/`setcps`** → not globals in 1.0.3 (undefined). Songs using them error. Shim, or rewrite
+  to `.cpm()`.
+- **GM soundfonts (`gm_*`)** → NOT vendored. `@strudel/soundfonts` (AGPL; deps `sfumato`+`soundfont2`;
+  pulls `@strudel/core 1.2.6` — newer than our 1.0.x) loads `gm_*` from
+  `felixroos.github.io/webaudiofontdata` (WebAudioFont). `setSoundfontUrl()` can repoint to a
+  vendored copy.
+- **Dirt/drum samples** (`bd/sd/hh`) → load from github at runtime; not vendored offline.
+
+## Licensing (the "friendly" gate)
+- `@strudel/soundfonts`: **AGPL-3.0-or-later** (fine — engine is AGPL).
+- WebAudioFont data: `felixroos/webaudiofontdata` mirror = **MIT** (packaging only?); origin
+  `surikov/webaudiofont` = **GPL-3.0**; underlying samples = mixed free soundfonts (FluidR3, …).
+  Murky provenance → **not clean enough to vendor**.
+- Cleaner: **GeneralUser GS** (explicit permissive, bundling-OK) or **FluidR3_GM** (MIT-style).
+  Decide in spec.
+
+## Existing structures to build on / reconcile
+- `js/audio/strudel/` (Phase-1 engine, PR #262): `runtime.js` (boot/poll), `music.js` (bespoke
+  score-DATA interpreter, `buildProgram`), `index.js` (music+sfx+drones wiring), `data/*`.
+- `js/audio/signals.js` — `deriveProgress`/`deriveThreat` (pure). The game-signal source.
+- `preview.html` + `js/ui/preview.js` — SHIPPED visual-effects preview harness. **Precedent for a
+  permanent preview tool.**
+- `tmp/song-player.html` — this session's prototype (load song → compat shims → play +
+  gProgress/gThreat sliders). Proves the concept; to be promoted to a permanent tool.
+
+## New framing (Les, this session) — the load-bearing goals
+1. **strudel.cc is the game's music content tool.** Songs are authored there.
+2. **Bidirectional sample parity.** Songs must be constrained to the game's *kosher* sample set so
+   what's heard while composing in strudel.cc == what plays in-game. Requires: (a) the kosher set
+   loadable in strudel.cc (a published/importable manifest) AND vendored offline in-game; (b) a way
+   to constrain/validate that a song only uses in-set sounds.
+3. **Fidelity / no drift** between strudel.cc and the in-game engine is the governing constraint —
+   it pushes toward runtime + sample-set alignment, not a diverging bespoke interpreter.
+4. **Reactive via signal injection** (already proven).
+5. **Permanent preview tool** rigging songs to game variables.

--- a/docs/dev-sessions/2026-07-01-1012-strudel-song-playback/spec.md
+++ b/docs/dev-sessions/2026-07-01-1012-strudel-song-playback/spec.md
@@ -1,0 +1,106 @@
+# Spec — Reactive Strudel song playback (strudel.cc as the content tool)
+
+## Goal
+
+Make the Strudel audio engine play & automate **real strudel.cc-authored songs** as game content,
+with **game signals injected** for reactivity, and **bidirectional sample parity** (what you hear
+composing in strudel.cc is what plays in-game). Establish **strudel.cc as the game's music
+content-authoring tool**, and ship a **permanent song-preview harness**. Keep licensing clean
+(AGPL engine; friendly-licensed sample set; songs as separately-licensed "wad" content).
+
+## Background / current state
+
+- **Phase 1 (PR #262):** vendored `@strudel/web@1.0.3` engine behind an engine-select flag; a
+  bespoke score-DATA interpreter (`js/audio/strudel/music.js` `buildProgram`) driving ONE reactive
+  corporate score; superdough SFX + action drones; `js/audio/signals.js`
+  (`deriveProgress`/`deriveThreat`).
+- **Proven this session (see `research.md`):** signal injection works — a `gThreat` slider reshapes
+  a *playing* song by ear; Les's own "Stripdown intro" cover plays via `tmp/song-player.html` with
+  compat shims; the gaps are small and enumerated.
+
+## Desired end state
+
+- The engine runs full strudel.cc songs faithfully — **no drift** between strudel.cc and in-game.
+- Songs are content files authored in strudel.cc against the game's **kosher sample set**.
+- A **published sample manifest** = the same sounds in strudel.cc (authoring) and in-game (offline
+  vendored), guaranteeing the sound carries both ways.
+- Game signals exposed as **named, expandable** Strudel signals (progress/threat now) that a
+  composer can wire into any pattern param.
+- A **permanent standalone preview/authoring harness** (like `preview.html`): load a song, a slider
+  per exposed signal, play/stop, and an in-set linter.
+
+## Design decisions (with reasoning)
+
+1. **Upgrade the game runtime to `@strudel/web@1.3.0`.** The browser/esbuild bundle builds clean
+   (verified — 644KB) and brings native `$:` (via the newer transpiler) + `setcpm`, so strudel.cc
+   songs run unmodified → *no drift*, the governing constraint. The node-ESM breakage is precisely
+   `@strudel/core@1.2.6` → `@kabelsalat/web@0.4.1` (no `SalatRepl` named export under node ESM); it
+   affects only **node-side tooling**, not the browser game. Isolate any node validator via
+   pin-`1.2.5` / pre-bundle / headless-browser.
+2. **Songs are raw strudel.cc code, run via `evaluate()`** — no bespoke DSL. The engine interprets
+   real Strudel. (`let`/`arrange`/`stack`/expressions already work; the upgrade adds `$:`/`setcpm`.)
+3. **Bidirectional sample parity via a published manifest.** The kosher set is hosted as a
+   Strudel-loadable sample manifest (`samples('<game-set-url>')`, one import line authors add in
+   strudel.cc) AND vendored offline in-game as the identical files → parity by construction. An
+   **in-set linter** flags any sound outside the set so an authored song is guaranteed to carry.
+4. **Signals as an expandable registry.** A single registry maps `name → derive(state)`; the engine
+   exposes each as a global Strudel signal (`signal(() => value)`). Ship `progress` + `threat`;
+   adding a variable later = one registry entry. Reuses `signals.js`; the STATE_CHANGED bridge
+   updates the live values.
+5. **Permanent standalone preview harness**, sibling to `preview.html`: load/paste a song, a slider
+   per registered signal, play/stop, in-set linter. Usable without a running game; grows with the
+   signal registry. (Promotes `tmp/song-player.html`.)
+6. **Instrument source — clean-licensed, bidirectional (OPEN, recommend at plan).** Options:
+   GeneralUser GS (permissive) or FluidR3_GM (MIT-style) as SF2 via `@strudel/soundfonts`+`sfumato`
+   (adds a version-reconcile), OR export the needed instruments as **superdough sample-maps**
+   loaded via `samples()` (fits the manifest path, no SF2 loader, no extra version conflict). **Lean:
+   sample-map via `samples()` for the first instruments** (bidirectional-native); evaluate SF2 if
+   breadth is needed. Decide at plan time with size/fidelity data.
+
+## Patterns to follow
+
+- `js/audio/strudel/runtime.js` — boot/poll; extend for the upgraded runtime + manifest load.
+- `js/audio/signals.js` — `derive*` fns feed the signal registry.
+- `js/audio/audio-renderer.js` — the STATE_CHANGED → live-signal bridge.
+- `preview.html` + `js/ui/preview.js` — structural precedent for the preview harness (CLAUDE.md
+  already mandates a preview harness for new visual effects; this is the audio analog).
+- `tmp/song-player.html` — working prototype to promote (compat + per-signal sliders).
+- `Makefile` `dist/*.js` vendor targets + `index.html` importmap — the vendoring pattern.
+
+## What we're NOT doing (scope lock)
+
+- **Not** replacing the game's run/hub music-selection wiring in the first slices — target the engine
+  capability + preview tool + one authored song first; wiring songs as actual in-game run music is a
+  later slice.
+- **Not** retiring the Phase-1 bespoke score interpreter in this arc (coexists; its fate is a later
+  call once songs are the primary path). **PR #262 lands first.**
+- **Not** building an in-app song editor — strudel.cc IS the editor.
+- **Not** vendoring full GM breadth up front — only the instruments the first songs need.
+- **Not** solving simultaneous multi-song scheduling — one song at a time (+ SFX/drones on their own
+  path, unaffected).
+
+## Phasing (proposed)
+
+- **A. Runtime upgrade** — `@strudel/web@1.3.0` behind the existing engine flag; re-verify Phase-1
+  music/SFX/drones; confirm `$:`/`setcpm`/`arrange` work natively.
+- **B. Signal registry** — expandable registry; expose `progress`/`threat` as named globals; wire the
+  STATE_CHANGED bridge.
+- **C. Kosher sample set** — pick + vendor a friendly-licensed set; publish the manifest; load offline
+  in-game; document the strudel.cc import line.
+- **D. Preview harness** — permanent standalone tool: load song + per-signal sliders + play + in-set
+  linter.
+- **E. Acceptance demo** — Les's Stripdown cover plays faithfully end-to-end (real instruments via the
+  kosher set + reactive signals).
+
+## Open decisions (resolve at plan)
+
+- Instrument source + mechanism (SF2 via sfumato vs sample-map via `samples()`) + which friendly license.
+- Manifest hosting (repo GitHub Pages? an `/audio-content/` path served with the game?).
+- Node validator/linter approach (pin 1.2.5 / pre-bundle / headless).
+- **Sequencing vs. finishing #262's superdough-drone rework** (still pending Les's lab tuning).
+
+## Readiness notes
+
+- **Feel/authoring-driven:** the preview harness is the iteration vehicle (per the "feel-driven →
+  prototype" rule); song authoring itself is Les's creative work in strudel.cc.
+- Acceptance is concrete (Slice E: the cover plays faithfully + reacts), so the arc has a clear "done".

--- a/index.html
+++ b/index.html
@@ -73,6 +73,10 @@
     <starnet-end-screen id="end-screen"></starnet-end-screen>
     <starnet-hub id="overworld-hub"></starnet-hub>
 
+    <!-- AGPL-3.0 §13: a persistent, visible link to the source. The engine is AGPL-3.0 (it bundles
+         Strudel/superdough); offering source is a license condition. -->
+    <a id="source-link" href="https://github.com/lmorchard/starnet" target="_blank" rel="noopener">source</a>
+
   </div>
 
   <script type="module" src="js/ui/components/starnet-log.js"></script>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,8 @@
     { "imports": {
       "lit": "./dist/lit.js",
       "lit/directives/repeat.js": "./dist/lit.js",
-      "tone": "./dist/tone.js"
+      "tone": "./dist/tone.js",
+      "@strudel/web": "./dist/strudel.js"
     } }
   </script>
   <!-- Cytoscape.js + layout extensions (vendor bundle built by: make bundle-vendor) -->

--- a/js/audio/signal-registry.js
+++ b/js/audio/signal-registry.js
@@ -1,0 +1,38 @@
+// @ts-check
+// Expandable registry of game signals exposed to Strudel songs. Each entry maps a signal NAME
+// (referenced in a song, e.g. `progress`/`threat`) to a pure derive(state)->0..1 function.
+//
+// To expose a new game variable to music, add ONE entry here (and it appears in the preview tool
+// automatically). Pure — no runtime/DOM. The browser-side bridge (js/audio/strudel/signal-bridge.js)
+// installs each as a live Strudel signal and refreshes them on STATE_CHANGED.
+import { deriveProgress, deriveThreat } from "./signals.js";
+
+/** @typedef {import('../core/types.js').GameState} GameState */
+
+const clamp01 = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
+
+/** @type {Record<string, (state: GameState) => number>} */
+export const SIGNAL_REGISTRY = {
+  progress: deriveProgress,
+  threat: deriveThreat,
+};
+
+/** @returns {string[]} the registered signal names. */
+export function signalNames() {
+  return Object.keys(SIGNAL_REGISTRY);
+}
+
+/**
+ * Compute every registered signal's value (0..1) from a game-state snapshot.
+ * Returns 0 for each when state is missing.
+ * @param {GameState|null|undefined} state
+ * @returns {Record<string, number>}
+ */
+export function computeSignals(state) {
+  /** @type {Record<string, number>} */
+  const out = {};
+  for (const [name, derive] of Object.entries(SIGNAL_REGISTRY)) {
+    out[name] = state ? clamp01(derive(state)) : 0;
+  }
+  return out;
+}

--- a/js/audio/strudel/runtime.js
+++ b/js/audio/strudel/runtime.js
@@ -11,6 +11,22 @@ let _booting = null;
 
 const REQUIRED = ["evaluate", "superdough", "stack", "note", "sound", "signal", "hush", "getAudioContext", "samples"];
 
+// Firefox does not implement AudioParam.cancelAndHoldAtTime, which sfumato (the SF2 player inside
+// @strudel/soundfonts) calls on every soundfont note-off. Without it, note-offs THROW in Firefox →
+// soundfont voices never release → songs don't stop and voices pile up (audible degradation).
+// Polyfill it (standard "hold current value" approximation) so soundfont instruments release
+// correctly. No-op where the browser already implements it (Chrome). Install once, before boot.
+function polyfillCancelAndHold() {
+  if (typeof AudioParam === "undefined") return;
+  if (typeof AudioParam.prototype.cancelAndHoldAtTime === "function") return;
+  AudioParam.prototype.cancelAndHoldAtTime = function (t) {
+    const held = this.value;
+    try { this.cancelScheduledValues(t); } catch (_) { /* ignore */ }
+    try { this.setValueAtTime(held, t); } catch (_) { /* ignore */ }
+    return this;
+  };
+}
+
 /**
  * Boot the Strudel runtime once (idempotent — same promise on repeat calls).
  * Does NOT resume the AudioContext (needs a user gesture; the caller does it).
@@ -19,6 +35,7 @@ const REQUIRED = ["evaluate", "superdough", "stack", "note", "sound", "signal", 
 export function bootStrudel() {
   if (_booting) return _booting;
   _booting = (async () => {
+    polyfillCancelAndHold(); // Firefox soundfont-release fix — must be installed before any playback
     await import("@strudel/web"); // side effect: registers window.initStrudel
     if (typeof window.initStrudel !== "function") {
       throw new Error("[strudel] initStrudel not found after import (bundle problem?)");

--- a/js/audio/strudel/runtime.js
+++ b/js/audio/strudel/runtime.js
@@ -51,6 +51,9 @@ export function bootStrudel() {
     rt.setcpm = window.setcpm; // may be transpiler-injected only; keep a ref if present
     rt.ctx = window.getAudioContext();
     return rt;
-  })();
+  })().catch((e) => {
+    _booting = null; // reset on failure so BOOT can be retried after a transient error (no page reload)
+    throw e;
+  });
   return _booting;
 }

--- a/js/audio/strudel/runtime.js
+++ b/js/audio/strudel/runtime.js
@@ -1,0 +1,39 @@
+// @ts-nocheck
+// Strudel runtime boot — browser-only. Dynamically imports the vendored @strudel/web bundle
+// (importmap "@strudel/web" → dist/strudel.js) so non-Strudel paths never download it.
+//
+// @strudel/web@1.3.0 matches the strudel.cc dialect. initStrudel() registers the pattern/synth
+// globals (note/sound/stack/signal/superdough/evaluate/hush/getAudioContext/samples/setcpm) on
+// window ASYNCHRONOUSLY and returns undefined — POLL for readiness, never await it.
+// (Findings carried from the audio-engine spikes.)
+
+let _booting = null;
+
+const REQUIRED = ["evaluate", "superdough", "stack", "note", "sound", "signal", "hush", "getAudioContext", "samples"];
+
+/**
+ * Boot the Strudel runtime once (idempotent — same promise on repeat calls).
+ * Does NOT resume the AudioContext (needs a user gesture; the caller does it).
+ * @returns {Promise<object>} handle of the live runtime globals + the AudioContext (`ctx`).
+ */
+export function bootStrudel() {
+  if (_booting) return _booting;
+  _booting = (async () => {
+    await import("@strudel/web"); // side effect: registers window.initStrudel
+    if (typeof window.initStrudel !== "function") {
+      throw new Error("[strudel] initStrudel not found after import (bundle problem?)");
+    }
+    window.initStrudel();
+    const t0 = Date.now();
+    while (!REQUIRED.every((k) => typeof window[k] === "function")) {
+      if (Date.now() - t0 > 10000) throw new Error("[strudel] timed out waiting for runtime globals");
+      await new Promise((r) => setTimeout(r, 60));
+    }
+    const rt = {};
+    for (const k of REQUIRED) rt[k] = window[k];
+    rt.setcpm = window.setcpm; // may be transpiler-injected only; keep a ref if present
+    rt.ctx = window.getAudioContext();
+    return rt;
+  })();
+  return _booting;
+}

--- a/js/audio/strudel/signal-bridge.js
+++ b/js/audio/strudel/signal-bridge.js
@@ -24,7 +24,9 @@ export function installGameSignals(rt) {
     window[name] = rt.signal(() => live[name] ?? 0);
   }
 
-  on(E.STATE_CHANGED, (state) => { if (state) live = computeSignals(state); });
+  // Recompute unconditionally: computeSignals(null) → defaults (0), so signals reset between runs
+  // instead of getting stuck at the last run's values.
+  on(E.STATE_CHANGED, (state) => { live = computeSignals(state); });
 
   return {
     names: Object.keys(SIGNAL_REGISTRY),

--- a/js/audio/strudel/signal-bridge.js
+++ b/js/audio/strudel/signal-bridge.js
@@ -1,0 +1,34 @@
+// @ts-nocheck
+// Installs the registered game signals (js/audio/signal-registry.js) as live global Strudel
+// signals a song can reference by name (e.g. `progress`, `threat`), and refreshes their values on
+// STATE_CHANGED. Browser-only.
+//
+// A song authored in strudel.cc references the same names; there the author fakes them (a prelude
+// of `let progress = signal(() => ...)` or slider-driven values). In-game / in the preview tool
+// these are the REAL game values — that's the injection point. Bidirectional by shared naming.
+import { on, E } from "../../core/events.js";
+import { getState } from "../../core/state.js";
+import { SIGNAL_REGISTRY, computeSignals } from "../signal-registry.js";
+
+/**
+ * @param {object} rt runtime handle from bootStrudel() (needs rt.signal)
+ * @returns {{ getLive: () => Record<string, number>, setLive: (name: string, v: number) => void, names: string[] }}
+ *   `setLive` lets the preview tool drive signals from sliders (no game running).
+ */
+export function installGameSignals(rt) {
+  /** @type {Record<string, number>} live 0..1 values the Strudel signals sample each cycle */
+  let live = computeSignals(getState());
+
+  for (const name of Object.keys(SIGNAL_REGISTRY)) {
+    // window.<name> is a Strudel signal re-sampling the live value every cycle — songs use it directly.
+    window[name] = rt.signal(() => live[name] ?? 0);
+  }
+
+  on(E.STATE_CHANGED, (state) => { if (state) live = computeSignals(state); });
+
+  return {
+    names: Object.keys(SIGNAL_REGISTRY),
+    getLive: () => ({ ...live }),
+    setLive: (name, v) => { if (name in live) live[name] = v; },
+  };
+}

--- a/js/audio/strudel/soundfont.js
+++ b/js/audio/strudel/soundfont.js
@@ -1,0 +1,63 @@
+// @ts-nocheck
+// Loads the vendored GeneralUser GS soundfont (audio-content/soundfonts/) and registers ALL of its
+// presets as distinct `gus_*` named Strudel sounds — a separate, NON-FUNGIBLE instrument set, NOT
+// aliased to strudel.cc's `gm_*` (deliberately: these are different sounds, do not substitute).
+//
+// Songs reference them via `.s("gus_warm_pad")` etc., in-game AND in strudel.cc (loading the same
+// SF2), so the sound carries both ways. Clean license: audio-content/soundfonts/*.LICENSE.txt.
+//
+// Browser-only. Uses the bundled soundfont loader (window.__soundfonts, attached by
+// js/strudel-vendor.js) + registerSound/noteToMidi (registered by initStrudel).
+
+export const GAME_SOUNDFONT_URL = "audio-content/soundfonts/GeneralUser-GS.sf2";
+const PREFIX = "gus_"; // GeneralUser GS
+
+/** Preset display name → a distinct `gus_*` sound name (lowercased, non-alnum → `_`). Exported for tests. */
+export function sanitize(name, i) {
+  const cleaned = String(name || "").toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  return PREFIX + (cleaned || "preset_" + i);
+}
+
+let _names = null; // registered sound names (the kosher instrument palette)
+
+/**
+ * Load the game soundfont and register every preset as a `gus_*` sound. Idempotent.
+ * @param {string} [url]
+ * @returns {Promise<string[]>} the registered instrument names
+ */
+export async function loadGameSoundfont(url = GAME_SOUNDFONT_URL) {
+  if (_names) return _names;
+  const sfMod = window.__soundfonts;
+  const registerSound = window.registerSound;
+  const noteToMidi = window.noteToMidi;
+  if (!sfMod?.loadSoundfont || typeof registerSound !== "function") {
+    throw new Error("[soundfont] Strudel runtime not ready (boot first)");
+  }
+  const sf = await sfMod.loadSoundfont(url);
+  const used = new Set();
+  const names = [];
+  sf.presets.forEach((preset, i) => {
+    let name = sanitize(preset.header?.name, i);
+    if (used.has(name)) { let n = 2; const base = name; while (used.has(name)) name = base + "_" + n++; }
+    used.add(name);
+    registerSound(
+      name,
+      (time, value) => {
+        const ctx = window.getAudioContext();
+        const note = value?.note ?? "c3";
+        const midi = typeof note === "number" ? note : noteToMidi(note);
+        const stop = sfMod.startPresetNote(ctx, preset, midi, time);
+        return { node: undefined, stop };
+      },
+      { type: "soundfont", prebake: false },
+    );
+    names.push(name);
+  });
+  _names = names;
+  return names;
+}
+
+/** @returns {string[]} the registered `gus_*` instrument names (empty until loaded). */
+export function soundfontNames() {
+  return _names ? [..._names] : [];
+}

--- a/js/audio/strudel/soundfont.js
+++ b/js/audio/strudel/soundfont.js
@@ -47,6 +47,12 @@ export async function loadGameSoundfont(url = GAME_SOUNDFONT_URL) {
         const note = value?.note ?? "c3";
         const midi = typeof note === "number" ? note : noteToMidi(note);
         const stop = sfMod.startPresetNote(ctx, preset, midi, time);
+        // superdough bails early on a soundfont handle (node is undefined) and never schedules the
+        // note-off, so the voice would ring forever — schedule it ourselves from the hap duration
+        // (value.duration = hapDuration). This is what sfumato's own .soundfont() method does, and
+        // it makes hush()/stop actually silence the song (voices self-terminate; no new triggers).
+        const dur = typeof value?.duration === "number" ? value.duration : 0.5;
+        stop(time + dur);
         return { node: undefined, stop };
       },
       { type: "soundfont", prebake: false },

--- a/js/strudel-vendor.js
+++ b/js/strudel-vendor.js
@@ -11,3 +11,12 @@
 // (not the browser). esbuild bundles it fine for the browser. Any node-side song validator must
 // pin @strudel/* to 1.2.5, pre-bundle, or run headless — see the song-playback session notes.
 export * from "@strudel/web";
+
+// Bundle @strudel/soundfonts TOGETHER with @strudel/web so they share the same @strudel/core +
+// @strudel/webaudio singletons (separate bundles would each get their own copies, and the sound
+// registry / audio context wouldn't be shared). Attach the loader to window for the runtime to use.
+// GeneralUser GS (clean license) is loaded via loadSoundfont(); presets are registered under
+// distinct game-specific names (NOT strudel.cc's gm_* — a separate, non-fungible instrument set).
+import * as __soundfonts from "@strudel/soundfonts";
+if (typeof window !== "undefined") window.__soundfonts = __soundfonts;
+

--- a/js/strudel-vendor.js
+++ b/js/strudel-vendor.js
@@ -1,0 +1,13 @@
+// Vendor entry for the Strudel runtime — bundled by esbuild into dist/strudel.js (ESM).
+// Mirrors js/tone-vendor.js. Strudel + superdough are AGPL-3.0; bundling them makes the
+// combined work AGPL-3.0 (see LICENSE).
+//
+// @strudel/web@1.3.0 (matches the strudel.cc dialect: native `$:`, `setcpm`, the current
+// transpiler) — chosen for no-drift between strudel.cc authoring and in-game playback. Its
+// initStrudel() registers the pattern/synth globals on window ASYNCHRONOUSLY; the engine boot
+// polls for them (js/audio/strudel/runtime.js) rather than awaiting.
+//
+// NOTE: @strudel/core@1.2.6 depends on @kabelsalat/web, whose ESM named export fails under *node*
+// (not the browser). esbuild bundles it fine for the browser. Any node-side song validator must
+// pin @strudel/* to 1.2.5, pre-bundle, or run headless — see the song-playback session notes.
+export * from "@strudel/web";

--- a/js/ui/song-preview.js
+++ b/js/ui/song-preview.js
@@ -1,0 +1,118 @@
+// @ts-nocheck
+// Song Preview Harness — the permanent authoring/preview tool for reactive Strudel songs.
+// The audio analog of preview.html (visual effects). Load a strudel.cc song, hear it through the
+// game's own runtime + vendored gus_* instruments, drive the game signals (progress/threat/…) with
+// sliders to hear reactivity, and lint the song against the kosher sound set.
+//
+// Browser-only. Wires the shipped engine pieces: runtime boot, game soundfont, signal bridge.
+import { bootStrudel } from "../audio/strudel/runtime.js";
+import { loadGameSoundfont, soundfontNames } from "../audio/strudel/soundfont.js";
+import { installGameSignals } from "../audio/strudel/signal-bridge.js";
+import { signalNames } from "../audio/signal-registry.js";
+
+// Drum sample names currently loaded from the dirt-samples set (NOT yet vendored/offline — a
+// follow-up; the linter treats these as allowed for now). Synth waveforms are always allowed.
+const WAVEFORMS = ["sawtooth", "square", "triangle", "sine", "white", "pink", "brown"];
+const DRUMS = ["bd", "sd", "hh", "oh", "cp", "rim", "lt", "mt", "ht", "cr", "rd", "sh", "cb", "perc", "misc"];
+
+const DEMO = `// Song Preview demo — game-signal reactivity + vendored gus_* instruments.
+// Drag the PROGRESS / THREAT sliders to hear the song respond.
+setcpm(60/4)
+
+$: note("<c2 c2 g1 c2>").s("gus_synth_bass_1")
+     .lpf(threat.range(300, 3000))          // filter opens as THREAT climbs
+     .gain(0.6)
+
+$: note("c4 eb4 g4 bb4").s("gus_warm_pad")
+     .gain(progress.range(0.1, 0.6))        // pad swells as you own more of the LAN
+     .room(0.5)
+
+$: sound("bd sd").gain(threat.range(0, 0.85))  // beat drops in under threat
+`;
+
+let _rt = null;
+let _signals = null;
+let _allowed = new Set();
+
+const $ = (id) => document.getElementById(id);
+const setStatus = (t, ok = true) => { const el = $("sp-status"); el.textContent = t; el.style.color = ok ? "var(--green)" : "#ff5a5a"; };
+
+async function boot() {
+  setStatus("booting runtime…");
+  _rt = await bootStrudel();
+  await _rt.ctx.resume();
+  setStatus("loading instruments (32MB soundfont)…");
+  const names = await loadGameSoundfont();
+  setStatus("loading drums…");
+  try { await _rt.samples("github:tidalcycles/dirt-samples"); } catch (_) { /* offline: drums silent */ }
+  _signals = installGameSignals(_rt);
+  _allowed = new Set([...names, ...WAVEFORMS, ...DRUMS]);
+  $("sp-boot").classList.add("hidden");
+  $("sp-app").classList.remove("hidden");
+  buildSignalSliders();
+  buildPalette(names);
+  $("sp-code").value = DEMO;
+  setStatus(`ready — ${names.length} gus_ instruments loaded`);
+}
+
+function buildSignalSliders() {
+  const box = $("sp-signals");
+  box.innerHTML = "";
+  for (const name of signalNames()) {
+    const row = document.createElement("div");
+    row.className = "sp-sig";
+    row.innerHTML = `<label>${name}</label><input type="range" min="0" max="1" step="0.01" value="0"><b>0.00</b>`;
+    const [slider, val] = [row.querySelector("input"), row.querySelector("b")];
+    slider.addEventListener("input", () => { _signals.setLive(name, parseFloat(slider.value)); val.textContent = (+slider.value).toFixed(2); });
+    box.appendChild(row);
+  }
+}
+
+function buildPalette(names) {
+  const list = $("sp-palette");
+  const render = (filter) => {
+    const f = filter.toLowerCase();
+    list.innerHTML = names.filter((n) => n.includes(f)).map((n) => `<span class="sp-inst" title="click to copy .s(&quot;${n}&quot;)">${n}</span>`).join("");
+    list.querySelectorAll(".sp-inst").forEach((el) => el.onclick = () => navigator.clipboard?.writeText(`.s("${el.textContent}")`));
+  };
+  $("sp-filter").addEventListener("input", (e) => render(e.target.value));
+  $("sp-count").textContent = names.length;
+  render("");
+}
+
+/** Lint a song: warn about sound names not in the kosher set (so it carries to the game). */
+function lint(code) {
+  const refs = new Set();
+  for (const m of code.matchAll(/\b(?:s|sound)\(\s*[`"']([^`"']+)[`"']/g)) {
+    // a sound arg can be a mini-notation pattern ("bd sd", "gus_pad*2") — split into tokens
+    for (const tok of m[1].split(/[\s<>\[\]()*!/,~.]+/).filter(Boolean)) {
+      if (!/^[a-z]/i.test(tok)) continue; // skip numbers/mult factors
+      refs.add(tok);
+    }
+  }
+  const unknown = [...refs].filter((r) => !_allowed.has(r));
+  return unknown;
+}
+
+function play() {
+  const code = $("sp-code").value;
+  const unknown = lint(code);
+  const warn = $("sp-lint");
+  if (unknown.length) {
+    warn.textContent = `⚠ not in the kosher set (won't carry to the game): ${unknown.join(", ")}`;
+    warn.style.color = "#ffb400";
+  } else {
+    warn.textContent = "✓ all sounds in the kosher set";
+    warn.style.color = "var(--green)";
+  }
+  try { window.hush(); window.evaluate(code); setStatus("playing ▶"); }
+  catch (e) { setStatus("error: " + (e && e.message || e), false); }
+}
+
+function stop() { window.hush(); setStatus("stopped ■"); }
+
+export function initSongPreview() {
+  $("sp-boot").onclick = () => boot().catch((e) => setStatus("boot failed: " + (e && e.message || e), false));
+  $("sp-play").onclick = play;
+  $("sp-stop").onclick = stop;
+}

--- a/js/ui/song-preview.js
+++ b/js/ui/song-preview.js
@@ -105,11 +105,15 @@ function play() {
     warn.textContent = "✓ all sounds in the kosher set";
     warn.style.color = "var(--green)";
   }
-  try { window.hush(); window.evaluate(code); setStatus("playing ▶"); }
+  // evaluate() replaces the whole $: program (no stacking on replay).
+  try { window.evaluate(code); setStatus("playing ▶"); }
   catch (e) { setStatus("error: " + (e && e.message || e), false); }
 }
 
-function stop() { window.hush(); setStatus("stopped ■"); }
+// The bare global hush() does NOT clear `$:` patterns (they live in the repl); running hush()
+// THROUGH the repl via evaluate() does. (Soundfont voices then release via the runtime's
+// cancelAndHoldAtTime polyfill + the scheduled note-off in soundfont.js.)
+function stop() { window.evaluate("hush()"); setStatus("stopped ■"); }
 
 export function initSongPreview() {
   $("sp-boot").onclick = () => boot().catch((e) => setStatus("boot failed: " + (e && e.message || e), false));

--- a/js/ui/song-preview.js
+++ b/js/ui/song-preview.js
@@ -44,9 +44,13 @@ async function boot() {
   setStatus("loading instruments (32MB soundfont)…");
   const names = await loadGameSoundfont();
   setStatus("loading drums…");
-  try { await _rt.samples("github:tidalcycles/dirt-samples"); } catch (_) { /* offline: drums silent */ }
+  let drumsOk = true;
+  try { await _rt.samples("github:tidalcycles/dirt-samples"); } catch (_) { drumsOk = false; }
   _signals = installGameSignals(_rt);
-  _allowed = new Set([...names, ...WAVEFORMS, ...DRUMS]);
+  // Only whitelist drum names if the sample set actually loaded — otherwise the linter would pass a
+  // song whose drums won't sound (offline/CORS), giving false "carries to the game" confidence.
+  _allowed = new Set([...names, ...WAVEFORMS, ...(drumsOk ? DRUMS : [])]);
+  if (!drumsOk) setStatus("(drums failed to load — drum sounds will be flagged by the linter)", false);
   $("sp-boot").classList.add("hidden");
   $("sp-app").classList.remove("hidden");
   buildSignalSliders();

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "starnet-game-2026",
       "dependencies": {
+        "@strudel/web": "1.3.0",
         "cytoscape": "^3.33.1",
         "cytoscape-cola": "^2.5.1",
         "cytoscape-cose-bilkent": "^4.1.0",
@@ -473,6 +474,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@kabelsalat/core": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@kabelsalat/core/-/core-0.4.0.tgz",
+      "integrity": "sha512-5zV8nh8HffW8aexObXs5pE0xgL0jb1cHc3o8UN6AvK0mBt87fjZvW65E4rMslHyq+OuCscoBJW7B3MbYfWrwMQ==",
+      "license": "AGPL-3.0-or-later"
+    },
+    "node_modules/@kabelsalat/lib": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@kabelsalat/lib/-/lib-0.4.1.tgz",
+      "integrity": "sha512-gBCjrZKD9huTKNJuBC6BXM4PMQSg8otL8A/vp8j98P9v6yWTX1TuyaqdLg/1PrIAMV4hlWoav9ZD3YMFlrvouw==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@kabelsalat/core": "0.4.0"
+      }
+    },
+    "node_modules/@kabelsalat/web": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@kabelsalat/web/-/web-0.4.1.tgz",
+      "integrity": "sha512-ASkFhePJLx3GjadYOueI7sHKXBbRPk/a1pfslFeQNI9gU7yZq/KrnkmOmLrgrtixAsy7gyi1vWqkmRRvH3Ki6w==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@kabelsalat/core": "0.4.0",
+        "@kabelsalat/lib": "0.4.1"
+      }
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
@@ -488,11 +514,584 @@
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
+    "node_modules/@strudel/core": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@strudel/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-FA5Kxv3U+UhNRLIeuEpXck2o2J5AjHZbkAdSAK9Q2N3Az1G9Vnc+bXXfgDFyY3yRH9mXXQvTerz8jr876pGGng==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@kabelsalat/web": "^0.4.1",
+        "fraction.js": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@strudel/draw": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@strudel/draw/-/draw-1.2.6.tgz",
+      "integrity": "sha512-7UPJ4xgDi2bt12KWSVAEt4rZjcOajxhHBJikvNA3LQT5IA/FTfD+TRSNu0CSB7zhmFM0Njgq6t7ttgsC8fdKCg==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@strudel/mini": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@strudel/mini/-/mini-1.2.6.tgz",
+      "integrity": "sha512-I5GFPLHI3TPcJuD2RdDcurA+lTogaSQ0TB+EimKTgEtSAbU6ZMEkSUOXZIFO5eaAcJcMucgKaBcmTKpD4oZjPA==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@strudel/tonal": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@strudel/tonal/-/tonal-1.2.6.tgz",
+      "integrity": "sha512-I2ev0IJFmqvDt/vFkL8vIDXNanK5EZF+MNhlio3nHt1d6ngZZJyCNzC1OxoaiQKxZNN7+mpGIC3Cx/zcBC3weQ==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.6",
+        "@tonaljs/tonal": "^4.10.0",
+        "chord-voicings": "^0.0.1",
+        "webmidi": "^3.1.12"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@strudel/transpiler": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@strudel/transpiler/-/transpiler-1.2.6.tgz",
+      "integrity": "sha512-NzmyQDS4BqjafOPzHGFowxILDx3ZRAPD47YszxNaPB7PggMA2rMo9t3rLz80G0GxA0ZAyMbVMR3px9jDWnJ5hg==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.6",
+        "@strudel/mini": "1.2.6",
+        "acorn": "^8.14.0",
+        "escodegen": "^2.1.0",
+        "estree-walker": "^3.0.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@strudel/web": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@strudel/web/-/web-1.3.0.tgz",
+      "integrity": "sha512-iob9+OrZMM5oMQmDNQAXc6+CYnzKaOUeARs8fcRRxDDSvCxewmZf/ancwyqVSCJsVzgCgw+I9PkpFyhSpLS3FQ==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.6",
+        "@strudel/mini": "1.2.6",
+        "@strudel/tonal": "1.2.6",
+        "@strudel/transpiler": "1.2.6",
+        "@strudel/webaudio": "1.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@strudel/webaudio": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@strudel/webaudio/-/webaudio-1.3.0.tgz",
+      "integrity": "sha512-H23KJfxA5l2woG0TwNf+VMvjbj9SwR1y1qgzJW26Z35/9c5pbVs2IHPUpFwP0dWoA/4dmG2cmTMwI1e/TL8kGA==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.6",
+        "@strudel/draw": "1.2.6",
+        "superdough": "1.3.0",
+        "supradough": "1.2.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@tonaljs/abc-notation": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/abc-notation/-/abc-notation-4.9.1.tgz",
+      "integrity": "sha512-2fDUdPsFDdgZgyIiZCTYGKy30QiwIQxSXCSN2thGrSMXbQKCp8iTC8haStYcrA+25MPWhWlmvC/pz3tGcTNAqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/array": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/@tonaljs/array/-/array-4.8.4.tgz",
+      "integrity": "sha512-97HVdpZy82PqNBDMM9PRSbO2DUrnxNg3++N4xqLpfby70fKHAHhTWrMXWZK+Dzs76HDPQLd+qhd4cq28eBZzjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/chord": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord/-/chord-4.10.2.tgz",
+      "integrity": "sha512-Zlqtq6c6T4y+EqvwHRQp9icEjHqyniCpnIwwCFg5amgAQwXmWzarouOOSmcdJ1Is92eEvcPVuCoLiVUtajS30A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-detect": "^4.8.1",
+        "@tonaljs/chord-type": "^4.8.2",
+        "@tonaljs/collection": "^4.8.0",
+        "@tonaljs/core": "^4.10.0",
+        "@tonaljs/pcset": "^4.8.2",
+        "@tonaljs/scale-type": "^4.8.2"
+      }
+    },
+    "node_modules/@tonaljs/chord-detect": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-detect/-/chord-detect-4.9.1.tgz",
+      "integrity": "sha512-rV/9+R7aZ9cQorQ3jdNMMMh63onosglYZM71Q0n7KKcWMAGrxF66MzxBG82xy+w1QDMJQslB3iHfDHUiS6wRjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/chord-detect/node_modules/@tonaljs/chord-type": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-5.1.1.tgz",
+      "integrity": "sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/chord-type": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-4.8.2.tgz",
+      "integrity": "sha512-GzSTjQmZjkUdPhyesFDeJbxpW8R7L/bAE34E8ApGAh9FMcKYpRdX3Tn+gkluRsXOiRMfW07p3E0Adx4bjtyN+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/core": "^4.8.0",
+        "@tonaljs/pcset": "^4.8.2"
+      }
+    },
+    "node_modules/@tonaljs/collection": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/collection/-/collection-4.9.0.tgz",
+      "integrity": "sha512-Mk0h7O54nT6PgNVcUYauzxa5KOB23+0AOKudWzRH7JhJIN9vhVIC7PtwZXE+/G051UTbHSFIcN/afkgF4nB/8A==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/core": {
+      "version": "4.10.4",
+      "resolved": "https://registry.npmjs.org/@tonaljs/core/-/core-4.10.4.tgz",
+      "integrity": "sha512-PhGlQ2Js6rFQ6CufkSiBpEJoPS8QIIhbXSXhT4U+5ffqckli+YBZRN24vjZ4AEKuX8xoYDmCCbl+r6agauvzmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.1",
+        "@tonaljs/pitch-distance": "5.0.2",
+        "@tonaljs/pitch-interval": "5.0.2",
+        "@tonaljs/pitch-note": "5.0.3"
+      }
+    },
+    "node_modules/@tonaljs/core/node_modules/@tonaljs/pitch-distance": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-distance/-/pitch-distance-5.0.2.tgz",
+      "integrity": "sha512-DPxfGJCf4BvfIVRxl2v142tuCKIziM6PomOBT0/s7U5o+Z5qFAIW0tNx/MKyL83guV74p+XIf5VI0w1flmXxDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.1",
+        "@tonaljs/pitch-interval": "5.0.2",
+        "@tonaljs/pitch-note": "5.0.3"
+      }
+    },
+    "node_modules/@tonaljs/core/node_modules/@tonaljs/pitch-note": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-note/-/pitch-note-5.0.3.tgz",
+      "integrity": "sha512-JsPgqPa8VZdZtfwvgoHJz996BZqzvlnRxUF6c/Q9q8E0iq30UHBEid0Y6XldK+h6tuIENsG3a9jyvNNxRqIeYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.1"
+      }
+    },
+    "node_modules/@tonaljs/duration-value": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/duration-value/-/duration-value-4.9.0.tgz",
+      "integrity": "sha512-Muz54HyIe0nMYKWx6wyTa4y17ma29DtpJF4/oqJphy6A124rAVDe/SKit8JGOvDYAQj71FUXqs17sXBxO/ExVw==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/interval": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/interval/-/interval-4.8.2.tgz",
+      "integrity": "sha512-9SEuJuqFdmu9lnvMmJtxbReQcQvZ1YHXhCcxaF6Re23/w+BqiJvvkvNZhfWH+n1+g0uaSdTsuvMfamp7hAvPMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "^5.0.1",
+        "@tonaljs/pitch-distance": "^5.0.2",
+        "@tonaljs/pitch-interval": "^5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/key": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/key/-/key-4.11.2.tgz",
+      "integrity": "sha512-fc1y5+NwS4S3amirzYLLB324PxJDO00oIBbLJclAddc46UBeYnu4FNz+1nZboHCXRQ/06/ftuaWD/l7HrAoulw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/note": "4.12.1",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/roman-numeral": "4.9.1"
+      }
+    },
+    "node_modules/@tonaljs/midi": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/midi/-/midi-4.10.2.tgz",
+      "integrity": "sha512-MPamXhEwPL7L1udLfYMm3Ft8mLYtHr62Zi2w5zYHM2P7YwIvNoiX0+dvAN5is1Wvq4iVRa8AjFHerjOW/SZhGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/mode": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/mode/-/mode-4.9.2.tgz",
+      "integrity": "sha512-Il48fWX9SnGMzwNFVbizkWkr/SJ+aCIIHhjWfSf1agrQAoq81536qBXEyEyvia6aqEXC4OaXAQ5rSoBcmQRj1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/interval": "5.1.0",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/scale-type": "4.9.2"
+      }
+    },
+    "node_modules/@tonaljs/mode/node_modules/@tonaljs/interval": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/interval/-/interval-5.1.0.tgz",
+      "integrity": "sha512-GR9dUjn0j7yhjwjRh8HQxZYXOiVl05WfY3AFyMB9rfg807K4dSJmWfPTULPQXyHJ6NiZOPXcwRs8MxMLDxgdbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "^5.0.2",
+        "@tonaljs/pitch-distance": "^5.0.4",
+        "@tonaljs/pitch-interval": "^6.0.0"
+      }
+    },
+    "node_modules/@tonaljs/mode/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/mode/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/note": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/note/-/note-4.12.1.tgz",
+      "integrity": "sha512-yh6cnhu21bUb0VuIQWxObSbWBVp2cHIkJj4zZ4qsNOW4jSqn74+wHpSbOTDF8q+2hl6upz7TtBRavtqwPtLUCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/midi": "4.10.2",
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/note/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/note/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pcset": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pcset/-/pcset-4.10.1.tgz",
+      "integrity": "sha512-CZG1rpKc38yMfpEJsbDTvsTmQqsek9xxcuMgK64Tr6sP1lEiDuZJbQeKVWWRnreBF2FQ1cEGLmfOpvSO+40csA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/pcset/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/pcset/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pitch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.1.tgz",
+      "integrity": "sha512-5HYkF4hGY0jS2y5V3Hf5gNFXX46kT4cAcI7JLEn+qQb9N1dU9Gz9koI9di0mD1Tbam+kviceiCsJl4WX/FqYjA==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/pitch-distance": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-distance/-/pitch-distance-5.0.5.tgz",
+      "integrity": "sha512-dTfjsU0zyrj5YmiFio5prPaD5w7sBmHp4nnmlEg70nHY+SerAH0KiO9HM9usttVgRFUaXl0Gc7OI8YMGfSFmug==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/pitch-distance/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/pitch-distance/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pitch-interval": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-5.0.2.tgz",
+      "integrity": "sha512-bQmxeenRFNuuABs9mDc+bSUp3ySGw8I49pHMoGDdCcro9n3MDN8IsSwhvKoGOYErFMx76rNn1t+7WL8ukpvX5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.1"
+      }
+    },
+    "node_modules/@tonaljs/pitch-note": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-note/-/pitch-note-6.1.0.tgz",
+      "integrity": "sha512-A4OSLo8DjM38u73862LnDmL4YInDDRBmg0fojXcvu4cyU3oOlqndyeHOra1OVoH/WW46uNIxNs1wJDZNPWL5KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/pitch-note/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/progression": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/progression/-/progression-4.9.2.tgz",
+      "integrity": "sha512-1Pmau5tKoWmY2H/fp9WVJ5Qm4c+xlu7IEZb3R3uLbc26kJq97DbuSnfArIAQoZTum2V6lOEN/Dt34E9OrGKnoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord": "6.1.2",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/roman-numeral": "4.9.1"
+      }
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/chord": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord/-/chord-6.1.2.tgz",
+      "integrity": "sha512-39crsPVyBJxdGJ1DGl+4diM+6+mZ/ws6crkQMlqX4zTYHMUVfJOQrko4mPF1CD89AFhHJe1zCT9Js+nNp3Gffg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-detect": "4.9.1",
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/interval": "^5.1.0",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/scale-type": "4.9.2"
+      }
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/chord-type": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-5.1.1.tgz",
+      "integrity": "sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/interval": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/interval/-/interval-5.1.0.tgz",
+      "integrity": "sha512-GR9dUjn0j7yhjwjRh8HQxZYXOiVl05WfY3AFyMB9rfg807K4dSJmWfPTULPQXyHJ6NiZOPXcwRs8MxMLDxgdbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "^5.0.2",
+        "@tonaljs/pitch-distance": "^5.0.4",
+        "@tonaljs/pitch-interval": "^6.0.0"
+      }
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/progression/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/range": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/range/-/range-4.9.2.tgz",
+      "integrity": "sha512-XhFbCJCrEEIVz3MNmdVp9QUyiJA6eqnNnQeNqto8AuT5BYuffHDoMkBmvvjPuV5Lh8zfF9D0aqglvqPbZ+neKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/midi": "4.10.2"
+      }
+    },
+    "node_modules/@tonaljs/roman-numeral": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/roman-numeral/-/roman-numeral-4.9.1.tgz",
+      "integrity": "sha512-dJGKBNHdPrNTE97ZDk4t6wpNmgYcpHyLkAvWkRP9I/HsDkeTFFQqNXosYIvspPWrFySlRpeqqFwcqV74MYoOag==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2",
+        "@tonaljs/pitch-interval": "6.1.0",
+        "@tonaljs/pitch-note": "6.1.0"
+      }
+    },
+    "node_modules/@tonaljs/roman-numeral/node_modules/@tonaljs/pitch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch/-/pitch-5.0.2.tgz",
+      "integrity": "sha512-mxaXJPPe+LIJdjzpZEl8I8Wx3dEvlzkBbsr2Ltwc2dTAdnErAZ5R0TxVq2egF27lMvQN2QPQPWI9iDPPdVUmrg==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/roman-numeral/node_modules/@tonaljs/pitch-interval": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/pitch-interval/-/pitch-interval-6.1.0.tgz",
+      "integrity": "sha512-9ZMxA7V4UgySnOKPIG6HECzhDb8mbiTCIdNNIzCIfz5XpjUmohku2YZpVVWMacLHgyeQicJzNoRiPel5oSAn4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pitch": "5.0.2"
+      }
+    },
+    "node_modules/@tonaljs/scale": {
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/@tonaljs/scale/-/scale-4.13.4.tgz",
+      "integrity": "sha512-hyilnmsCmoGQiRhYWKM1QPrqaNH3KGEfrSfxeXcicPnEh12yvrVRm4djKmTVw7Rc/5P4GniPAA51+CS0C5dbLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/chord-type": "5.1.1",
+        "@tonaljs/collection": "4.9.0",
+        "@tonaljs/note": "4.12.1",
+        "@tonaljs/pcset": "4.10.1",
+        "@tonaljs/pitch-distance": "5.0.5",
+        "@tonaljs/pitch-note": "6.1.0",
+        "@tonaljs/scale-type": "4.9.2"
+      }
+    },
+    "node_modules/@tonaljs/scale-type": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@tonaljs/scale-type/-/scale-type-4.9.2.tgz",
+      "integrity": "sha512-XDRPySg0X6owJ6AVzVRpS4ZpgleAUQakuq5VtfQ0JitnJKGRYo5Y0w7Fl/wEz/X9aEMk2lxcdF8VGGMIsQFo0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/scale/node_modules/@tonaljs/chord-type": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@tonaljs/chord-type/-/chord-type-5.1.1.tgz",
+      "integrity": "sha512-ti4WzRYvvjH7to0G3zlJFq7WsjHqmcqbk8Jv98aZSR5YumLdY/ua2yOPPyoPq82n6vfgjZsacnAZ3v8/SodOcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/pcset": "4.10.1"
+      }
+    },
+    "node_modules/@tonaljs/time-signature": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/time-signature/-/time-signature-4.9.0.tgz",
+      "integrity": "sha512-zRo8CBqg/2guzTlF2vxyVIuB5gmwWQaxlknJPUSDII8CTdQ/x3a1LlNoMKkvTUnqwCihe3WrNPZ5XUfOOTthYA==",
+      "license": "MIT"
+    },
+    "node_modules/@tonaljs/tonal": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@tonaljs/tonal/-/tonal-4.10.0.tgz",
+      "integrity": "sha512-F2T9Fiy+j0MVped89kCrX1XF68mQOLUnny4pDOHrIf+OkrjtLQOzzaSOrX1tx0o72WUwQm1knz6D1d57b9X1HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tonaljs/abc-notation": "^4.8.0",
+        "@tonaljs/array": "^4.8.0",
+        "@tonaljs/chord": "^4.8.0",
+        "@tonaljs/chord-type": "^4.8.0",
+        "@tonaljs/collection": "^4.8.0",
+        "@tonaljs/core": "^4.8.0",
+        "@tonaljs/duration-value": "^4.8.0",
+        "@tonaljs/interval": "^4.8.0",
+        "@tonaljs/key": "^4.9.0",
+        "@tonaljs/midi": "^4.8.0",
+        "@tonaljs/mode": "^4.8.0",
+        "@tonaljs/note": "^4.9.0",
+        "@tonaljs/pcset": "^4.8.0",
+        "@tonaljs/progression": "^4.8.0",
+        "@tonaljs/range": "^4.8.0",
+        "@tonaljs/roman-numeral": "^4.8.0",
+        "@tonaljs/scale": "^4.9.0",
+        "@tonaljs/scale-type": "^4.8.0",
+        "@tonaljs/time-signature": "^4.8.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/automation-events": {
       "version": "7.1.19",
@@ -505,6 +1104,15 @@
       },
       "engines": {
         "node": ">=18.2.0"
+      }
+    },
+    "node_modules/chord-voicings": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/chord-voicings/-/chord-voicings-0.0.1.tgz",
+      "integrity": "sha512-SutgB/4ynkkuiK6qdQ/k3QvCFcH0Vj8Ch4t6LbRyRQbVzP/TOztiCk3kvXd516UZ6fqk7ijDRELEFcKN+6V8sA==",
+      "license": "ISC",
+      "dependencies": {
+        "@tonaljs/tonal": "^4.6.5"
       }
     },
     "node_modules/cose-base": {
@@ -674,6 +1282,15 @@
         "lodash": "^4.17.15"
       }
     },
+    "node_modules/djipevents": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/djipevents/-/djipevents-2.0.7.tgz",
+      "integrity": "sha512-KNFYaU85imxOCKOUsIR70Iz9E19r96/X7LSH+u0tSoZdpWcBdzoqtTsU+wuLhc6GMpSFob+KInkZAbfKi01Bjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.20.6"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -716,6 +1333,80 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/graphlib": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
@@ -723,6 +1414,26 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/jazz-midi": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/jazz-midi/-/jazz-midi-1.7.9.tgz",
+      "integrity": "sha512-c8c4BBgwxdsIr1iVm53nadCrtH7BUlnX3V95ciK/gbvXN/ndE5+POskBalXgqlc/r9p2XUbdLTrgrC6fou5p9w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/jzz": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/jzz/-/jzz-1.9.6.tgz",
+      "integrity": "sha512-J7ENLhXwfm2BNDKRUrL8eKtPhUS/CtMBpiafxQHDBcOWSocLhearDKEdh+ylnZFcr5OXWTed0gj6l/txeQA9vg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "jazz-midi": "^1.7.9"
       }
     },
     "node_modules/klayjs": {
@@ -774,6 +1485,31 @@
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
+    "node_modules/nanostores": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-0.11.4.tgz",
+      "integrity": "sha512-k1oiVNN4hDK8NcNERSZLQiMfRzEGtfnvZvdBvey3SQbgn8Dcrk0h1I6vpxApjb10PFUflZrgJ2WEZyJQ+5v7YQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/standardized-audio-context": {
       "version": "25.3.77",
       "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
@@ -784,6 +1520,25 @@
         "automation-events": "^7.0.9",
         "tslib": "^2.7.0"
       }
+    },
+    "node_modules/superdough": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/superdough/-/superdough-1.3.0.tgz",
+      "integrity": "sha512-LhmsrErcv9EMFNb79+3tvn6h7WgzKp4yRe1XtT2+eRY9oEpV4Jz0nb9Dxil3OLaNhQ6V2FuwPWBLQJb2aVtwuQ==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@kabelsalat/lib": "^0.4.1",
+        "nanostores": "^0.11.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/supradough": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/supradough/-/supradough-1.2.4.tgz",
+      "integrity": "sha512-/v3cL9fq05QCQVwbttLHNZcjyyFFz5wdKvg3j6V6moRXpDlQG89l8dQtUIpQvHsxYI5sXNod9rh5bf+Y4NMGeA==",
+      "license": "AGPL-3.0-or-later"
     },
     "node_modules/tone": {
       "version": "15.1.22",
@@ -834,6 +1589,21 @@
         "d3-drag": "^1.0.4",
         "d3-shape": "^1.3.5",
         "d3-timer": "^1.0.5"
+      }
+    },
+    "node_modules/webmidi": {
+      "version": "3.1.16",
+      "resolved": "https://registry.npmjs.org/webmidi/-/webmidi-3.1.16.tgz",
+      "integrity": "sha512-I6NnCfBUXNbV8q6EU+DPtr1u1EgjzDrFKHQQS2OgaHzcuQRFhRHgogfKpKSpxD0IgXhZHz8+k/OpGfZoWbvWAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "djipevents": "^2.0.7"
+      },
+      "engines": {
+        "node": ">=8.5"
+      },
+      "optionalDependencies": {
+        "jzz": "^1.8.5"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "starnet-game-2026",
       "dependencies": {
+        "@strudel/soundfonts": "1.3.0",
         "@strudel/web": "1.3.0",
         "cytoscape": "^3.33.1",
         "cytoscape-cola": "^2.5.1",
@@ -546,6 +547,21 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@strudel/core": "1.2.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@strudel/soundfonts": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@strudel/soundfonts/-/soundfonts-1.3.0.tgz",
+      "integrity": "sha512-gr92e5gC+57KKqRolZYu0Qf7McKfrY9URHCp7UxpMhnd39utKekfBnD8WLnvv5jrYmbBuKvx/IYpaIxo51CgXQ==",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@strudel/core": "1.2.6",
+        "@strudel/webaudio": "1.3.0",
+        "sfumato": "^0.1.2",
+        "soundfont2": "^0.5.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1499,6 +1515,27 @@
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
+    },
+    "node_modules/sfumato": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/sfumato/-/sfumato-0.1.2.tgz",
+      "integrity": "sha512-j2s5BLUS5VUNtaK1l+v+yal3XjjV7JXCQIwE5Xs4yiQ3HJ+2Fc/dd3IkkrVHn0AJO2epShSWVoP3GnE0TvPdMg==",
+      "license": "ISC",
+      "dependencies": {
+        "soundfont2": "^0.4.0"
+      }
+    },
+    "node_modules/sfumato/node_modules/soundfont2": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/soundfont2/-/soundfont2-0.4.0.tgz",
+      "integrity": "sha512-537WiurDBRbDLVhJMxXLE06D6yWxJCidfPClnibZ0f8dKMDpv+0fIfwCQ8pELE0JqKX05SOJosNJgKzQobaAEA==",
+      "license": "MIT"
+    },
+    "node_modules/soundfont2": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/soundfont2/-/soundfont2-0.5.0.tgz",
+      "integrity": "sha512-dcmNVtHT/Y8BOOrtmjt7hn6Bk6bB1g+O2bWB9fa6emW7kfwiEiEL4VvGQfwVt8g0m58LyoqVyuQ4ZFukMLwGHQ==",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "cytoscape-spread": "^3.0.0",
     "lit": "^3.3.2",
     "tone": "^15.1.22",
-    "@strudel/web": "1.3.0"
+    "@strudel/web": "1.3.0",
+    "@strudel/soundfonts": "1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "cytoscape-klay": "^3.1.4",
     "cytoscape-spread": "^3.0.0",
     "lit": "^3.3.2",
-    "tone": "^15.1.22"
+    "tone": "^15.1.22",
+    "@strudel/web": "1.3.0"
   }
 }

--- a/song-preview.html
+++ b/song-preview.html
@@ -15,22 +15,22 @@
   </script>
   <style>
     * { box-sizing: border-box; }
-    body { margin: 0; background: #0a0a0f; color: var(--green); font-family: var(--font-mono); font-size: 12px; }
+    body { margin: 0; background: #0a0a0f; color: var(--green); font-family: var(--font-mono); font-size: 15px; }
     header { display: flex; align-items: center; gap: 14px; padding: 10px 14px; border-bottom: 1px solid #1a2b2b; }
-    header h1 { color: var(--cyan); font-size: 14px; margin: 0; text-shadow: var(--glow-sm) var(--cyan); }
-    #sp-status { color: #fa0; font-size: 11px; }
+    header h1 { color: var(--cyan); font-size: 17px; margin: 0; text-shadow: var(--glow-sm) var(--cyan); }
+    #sp-status { color: #fa0; font-size: 14px; }
     .btn { background: #111; color: var(--cyan); border: 1px solid var(--cyan); padding: 6px 14px; font-family: var(--font-mono); cursor: pointer; }
     .btn:hover { box-shadow: var(--glow-sm) var(--cyan); }
-    #sp-boot { font-size: 14px; padding: 10px 20px; }
+    #sp-boot { font-size: 17px; padding: 12px 24px; }
     .hidden { display: none; }
     #sp-app { display: flex; gap: 14px; padding: 14px; height: calc(100vh - 52px); }
     #sp-left { flex: 1.4; display: flex; flex-direction: column; gap: 8px; min-width: 0; }
     #sp-right { flex: 1; display: flex; flex-direction: column; gap: 12px; min-width: 0; }
-    #sp-code { flex: 1; background: #080810; color: #0f4; border: 1px solid #234; font-family: var(--font-mono); font-size: 12px; padding: 8px; resize: none; }
+    #sp-code { flex: 1; background: #080810; color: #0f4; border: 1px solid #234; font-family: var(--font-mono); font-size: 15px; padding: 8px; resize: none; }
     .controls { display: flex; align-items: center; gap: 8px; }
-    #sp-lint { font-size: 11px; min-height: 15px; }
+    #sp-lint { font-size: 14px; min-height: 15px; }
     fieldset { border: 1px solid #234; padding: 8px 10px; }
-    legend { color: var(--cyan); font-size: 11px; }
+    legend { color: var(--cyan); font-size: 14px; }
     .sp-sig { display: flex; align-items: center; gap: 8px; margin: 4px 0; }
     .sp-sig label { width: 72px; color: #9ab; }
     .sp-sig input { flex: 1; }
@@ -38,9 +38,9 @@
     #sp-palette-box { flex: 1; display: flex; flex-direction: column; min-height: 0; }
     #sp-filter { background: #111; color: var(--green); border: 1px solid #345; font-family: var(--font-mono); padding: 4px 6px; margin-bottom: 6px; }
     #sp-palette { overflow-y: auto; display: flex; flex-wrap: wrap; gap: 4px 8px; align-content: flex-start; }
-    .sp-inst { color: #6cf; cursor: pointer; font-size: 11px; white-space: nowrap; }
+    .sp-inst { color: #6cf; cursor: pointer; font-size: 14px; white-space: nowrap; }
     .sp-inst:hover { color: var(--cyan); text-shadow: var(--glow-sm) var(--cyan); }
-    .hint { color: #678; font-size: 10px; }
+    .hint { color: #678; font-size: 13px; }
     a { color: #6cf; }
   </style>
 </head>

--- a/song-preview.html
+++ b/song-preview.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>STARNET — Song Preview Harness</title>
+  <link rel="stylesheet" href="css/style.css">
+  <!-- Import map: bare specifiers → bundled dist/*. @strudel/web is the vendored song runtime. -->
+  <script type="importmap">
+    { "imports": {
+      "lit": "./dist/lit.js",
+      "lit/directives/repeat.js": "./dist/lit.js",
+      "tone": "./dist/tone.js",
+      "@strudel/web": "./dist/strudel.js"
+    } }
+  </script>
+  <style>
+    * { box-sizing: border-box; }
+    body { margin: 0; background: #0a0a0f; color: var(--green); font-family: var(--font-mono); font-size: 12px; }
+    header { display: flex; align-items: center; gap: 14px; padding: 10px 14px; border-bottom: 1px solid #1a2b2b; }
+    header h1 { color: var(--cyan); font-size: 14px; margin: 0; text-shadow: var(--glow-sm) var(--cyan); }
+    #sp-status { color: #fa0; font-size: 11px; }
+    .btn { background: #111; color: var(--cyan); border: 1px solid var(--cyan); padding: 6px 14px; font-family: var(--font-mono); cursor: pointer; }
+    .btn:hover { box-shadow: var(--glow-sm) var(--cyan); }
+    #sp-boot { font-size: 14px; padding: 10px 20px; }
+    .hidden { display: none; }
+    #sp-app { display: flex; gap: 14px; padding: 14px; height: calc(100vh - 52px); }
+    #sp-left { flex: 1.4; display: flex; flex-direction: column; gap: 8px; min-width: 0; }
+    #sp-right { flex: 1; display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+    #sp-code { flex: 1; background: #080810; color: #0f4; border: 1px solid #234; font-family: var(--font-mono); font-size: 12px; padding: 8px; resize: none; }
+    .controls { display: flex; align-items: center; gap: 8px; }
+    #sp-lint { font-size: 11px; min-height: 15px; }
+    fieldset { border: 1px solid #234; padding: 8px 10px; }
+    legend { color: var(--cyan); font-size: 11px; }
+    .sp-sig { display: flex; align-items: center; gap: 8px; margin: 4px 0; }
+    .sp-sig label { width: 72px; color: #9ab; }
+    .sp-sig input { flex: 1; }
+    .sp-sig b { width: 44px; text-align: right; color: var(--green); }
+    #sp-palette-box { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+    #sp-filter { background: #111; color: var(--green); border: 1px solid #345; font-family: var(--font-mono); padding: 4px 6px; margin-bottom: 6px; }
+    #sp-palette { overflow-y: auto; display: flex; flex-wrap: wrap; gap: 4px 8px; align-content: flex-start; }
+    .sp-inst { color: #6cf; cursor: pointer; font-size: 11px; white-space: nowrap; }
+    .sp-inst:hover { color: var(--cyan); text-shadow: var(--glow-sm) var(--cyan); }
+    .hint { color: #678; font-size: 10px; }
+    a { color: #6cf; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>SONG PREVIEW</h1>
+    <button class="btn" id="sp-boot">▶ BOOT AUDIO</button>
+    <span id="sp-status"></span>
+  </header>
+
+  <div id="sp-app" class="hidden">
+    <div id="sp-left">
+      <div class="controls">
+        <button class="btn" id="sp-play">PLAY ▶</button>
+        <button class="btn" id="sp-stop">STOP ■</button>
+        <span class="hint">Author in <a href="https://strudel.cc" target="_blank" rel="noopener">strudel.cc</a> using the same <code>gus_*</code> instruments + signal names, then paste here to hear it in-engine.</span>
+      </div>
+      <textarea id="sp-code" spellcheck="false"></textarea>
+      <div id="sp-lint"></div>
+    </div>
+
+    <div id="sp-right">
+      <fieldset>
+        <legend>GAME SIGNALS (drive to hear reactivity)</legend>
+        <div id="sp-signals"></div>
+        <div class="hint">Reference in a song, e.g. <code>.lpf(threat.range(400,6000))</code>. Expandable via the signal registry.</div>
+      </fieldset>
+      <fieldset id="sp-palette-box">
+        <legend>INSTRUMENTS — <span id="sp-count">0</span> gus_* (click to copy)</legend>
+        <input id="sp-filter" type="text" placeholder="filter… (e.g. pad, bass, piano)">
+        <div id="sp-palette"></div>
+      </fieldset>
+    </div>
+  </div>
+
+  <script type="module">
+    import { initSongPreview } from "./js/ui/song-preview.js";
+    initSongPreview();
+  </script>
+</body>
+</html>

--- a/song-preview.html
+++ b/song-preview.html
@@ -76,6 +76,9 @@
     </div>
   </div>
 
+  <!-- AGPL-3.0 §13: source link (this tool loads the AGPL Strudel/superdough runtime). -->
+  <a id="source-link" href="https://github.com/lmorchard/starnet" target="_blank" rel="noopener">source</a>
+
   <script type="module">
     import { initSongPreview } from "./js/ui/song-preview.js";
     initSongPreview();

--- a/tests/signal-registry.test.js
+++ b/tests/signal-registry.test.js
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { SIGNAL_REGISTRY, signalNames, computeSignals } from "../js/audio/signal-registry.js";
+
+function stateWith({ owned = 0, total = 2, alert = "green", health = 1, deck = 1 } = {}) {
+  const nodes = {};
+  for (let i = 0; i < total; i++) nodes["n" + i] = { accessLevel: i < owned ? "owned" : "locked", visibility: "revealed" };
+  return {
+    nodes,
+    globalAlert: alert,
+    player: { health: { current: health, max: 1 }, deckIntegrity: { current: deck, max: 1 } },
+  };
+}
+
+test("signalNames lists the registered signals (progress + threat to start)", () => {
+  assert.deepEqual(signalNames().sort(), ["progress", "threat"]);
+});
+
+test("computeSignals derives progress and threat from state", () => {
+  const s = stateWith({ owned: 1, total: 2, alert: "green" });
+  const v = computeSignals(s);
+  assert.equal(v.progress, 0.5);
+  assert.equal(v.threat, 0);
+});
+
+test("threat tracks the alert ladder", () => {
+  assert.ok(Math.abs(computeSignals(stateWith({ alert: "red" })).threat - 2 / 3) < 1e-9);
+  assert.equal(computeSignals(stateWith({ alert: "trace" })).threat, 1);
+});
+
+test("computeSignals returns 0 for every signal when state is null", () => {
+  const v = computeSignals(null);
+  assert.deepEqual(v, { progress: 0, threat: 0 });
+});
+
+test("all computed values are clamped to 0..1", () => {
+  const v = computeSignals(stateWith({ owned: 2, total: 2, alert: "trace", health: 0, deck: 0 }));
+  for (const k of signalNames()) assert.ok(v[k] >= 0 && v[k] <= 1, `${k} in range`);
+});
+
+test("the registry is a plain name→derive map (expandable by one entry)", () => {
+  for (const [name, derive] of Object.entries(SIGNAL_REGISTRY)) {
+    assert.equal(typeof name, "string");
+    assert.equal(typeof derive, "function");
+  }
+});

--- a/tests/soundfont-naming.test.js
+++ b/tests/soundfont-naming.test.js
@@ -1,0 +1,26 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { sanitize } from "../js/audio/strudel/soundfont.js";
+
+test("preset names become distinct gus_* sound names (not gm_*)", () => {
+  assert.equal(sanitize("Warm Pad", 0), "gus_warm_pad");
+  assert.equal(sanitize("Tine Electric Piano", 1), "gus_tine_electric_piano");
+  assert.equal(sanitize("Synth Bass 2", 2), "gus_synth_bass_2");
+});
+
+test("non-alphanumerics collapse to single underscores, trimmed", () => {
+  assert.equal(sanitize("Honky-Tonk Piano!!", 0), "gus_honky_tonk_piano");
+  assert.equal(sanitize("  FM  E.Piano  ", 0), "gus_fm_e_piano");
+});
+
+test("blank/garbage names fall back to a stable per-index name", () => {
+  assert.equal(sanitize("", 7), "gus_preset_7");
+  assert.equal(sanitize("///", 3), "gus_preset_3");
+});
+
+test("names never collide with strudel.cc's gm_ namespace", () => {
+  for (const n of ["Electric Piano 2", "Pad 1 (new age)", "gm something"]) {
+    assert.ok(sanitize(n, 0).startsWith("gus_"), `${n} → gus_`);
+    assert.ok(!sanitize(n, 0).startsWith("gm_"));
+  }
+});


### PR DESCRIPTION
## Summary

Builds the **reactive Strudel song-playback engine + a permanent song preview tool** — part of the #254 audio arc, as its own branch (parallel to the parked Phase-1 PR #262). Lets a strudel.cc-authored song play in the game's runtime using the game's own instruments + game-state signals.

**Purely additive / safe:** the live game (`js/ui/main.js`) is untouched — the only change to `index.html` is an importmap entry. The new engine is used by `song-preview.html`; the game's shipped Tone audio is unaffected.

## What's included

- **Runtime** — vendored `@strudel/web@1.3.0` offline (`dist/strudel.js`), matching the strudel.cc dialect so real songs run via `evaluate()` with no shims (`$:`/`setcpm`/`arrange` all native).
- **Signal registry** (`js/audio/signal-registry.js`) + injection bridge (`js/audio/strudel/signal-bridge.js`): `progress`/`threat` exposed as live named Strudel signals a song references (`.lpf(threat.range(...))`), refreshed on `STATE_CHANGED`. Expandable by one registry entry.
- **Instruments** — vendored **GeneralUser GS** soundfont (clean license, `audio-content/soundfonts/`) registered as **287 distinct `gus_*` sounds** (deliberately NOT aliased to strudel.cc's `gm_*` — a separate, non-fungible set).
- **Preview tool** — `song-preview.html` + `js/ui/song-preview.js`: song editor, per-signal sliders (drive reactivity), filterable 287-instrument palette, and an **in-set linter** (flags sounds outside the kosher set so songs carry to the game).

## Notable fixes

- **STOP** must run `hush` *through the repl* (`evaluate("hush()")`) — the bare global doesn't clear `$:` patterns (that caused "won't stop" + replay stacking).
- **Firefox:** polyfill `AudioParam.cancelAndHoldAtTime` (sfumato's SF2 release needs it; Firefox lacks it) + schedule the soundfont note-off ourselves (superdough bails on soundfont handles).

## Verification

- Unit tests (test-first): signal registry, soundfont naming (1510 green, lint clean).
- Browser (Playwright, objective RMS): songs play with real `gus_*` instruments + drums; signals morph a playing song; STOP decays to silence; SFX one-shots are independent of songs.

## Follow-ups (filed)

- **#264** — transitions layer (fade in/out + snappier STOP + crossfade via orbits).
- **#265** — bidirectional authoring workflow (paste strudel.cc songs in unchanged + stub game signals in strudel.cc). Planned as the immediate next arc.
- Still to do (not in this PR): wiring song playback into the live game (`song-engine.js`); reconciling with the parked Phase-1 engine (#262, on 1.0.3 — this arc is on 1.3.0 and shares the strudel vendoring).

## Notes

- The 32MB `GeneralUser-GS.sf2` is committed (offline, per decision) with its permissive license alongside; the Pages deploy already runs `make bundle-vendor` (now builds `dist/strudel.js`).

Part of #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
