### PR TITLE
Strudel authoring: signals prebake + workflow doc (advances #265)

### DIFF
--- a/audio-content/strudel-prebake.js
+++ b/audio-content/strudel-prebake.js
@@ -1,21 +1,46 @@
-// Starnet — strudel.cc PREBAKE
+// Starnet — strudel.cc PREBAKE  (one-paste authoring block)
 // =====================================================================================
-// Paste this into strudel.cc → Settings → "prebake" (the script that runs before every
-// song). It defines the game's live signals so a Starnet song copied straight out of the
-// repo plays UNCHANGED in the editor.
+// Paste this ONCE into strudel.cc → Settings → "prebake" (the script that runs before every
+// song). It sets up BOTH halves of the game's sound world so a Starnet song copied straight out
+// of the repo plays UNCHANGED in the editor:
 //
-// In the game these same names are injected live by the engine
-// (js/audio/strudel/signal-bridge.js, from js/audio/signal-registry.js), so the song files
-// themselves never carry any stub — this prebake is the editor-side half of that contract.
-// Keep the signal list here in sync with signal-registry.js (currently: gameProgress, gameThreat).
+//   1. Instruments — the game's `gus_*` GeneralUser GS presets (a DISTINCT set, not strudel's
+//      built-in `gm_*`; do not substitute).
+//   2. Signals — the live game variables `gameProgress` / `gameThreat`, stubbed here as sliders
+//      you drag to hear a song react.
 //
-//   gameProgress = fraction of the LAN owned            (0..1)
-//   gameThreat   = alert ladder + injury pressure        (0..1)
-//
-// Pick ONE driver per signal below. Default is sliders (verified working in strudel.cc: they render
-// as draggable widgets you steer while the song plays). Assigned onto `window.` — NOT `let` (a `let`
-// binding wouldn't be visible to the separately-evaluated song, and bare assignment throws under
-// strict mode). Swap to sweep or mouse for hands-free / pointer control.
+// In the game these same names are provided by the engine (js/audio/strudel/soundfont.js registers
+// the identical `gus_*`; js/audio/strudel/signal-bridge.js injects the same signals), so song files
+// carry no setup of their own — this prebake is the editor-side mirror of that contract.
+
+// ── 1. Instruments: load the game's vendored GeneralUser GS v2.0.3 + register the gus_* names ──
+// Loads Starnet's OWN vendored SF2 (raw.githubusercontent serves it CORS-enabled), so the sound set
+// is byte-identical to the game — no upstream drift. The naming (sanitize + dedup) and the note
+// trigger MIRROR js/audio/strudel/soundfont.js exactly; keep them in sync if that file changes.
+await loadSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/GeneralUser-GS.sf2')
+  .then((sf) => {
+    const used = new Set();
+    sf.presets.forEach((preset, i) => {
+      const cleaned = String(preset.header?.name || '').toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+      let name = 'gus_' + (cleaned || 'preset_' + i);
+      if (used.has(name)) { const base = name; let n = 2; while (used.has(name)) name = base + '_' + n++; }
+      used.add(name);
+      registerSound(name, (time, value) => {
+        const ctx = getAudioContext();
+        const note = value?.note ?? 'c3';
+        const midi = typeof note === 'number' ? note : noteToMidi(note);
+        const stop = startPresetNote(ctx, preset, midi, time);
+        stop(time + (typeof value?.duration === 'number' ? value.duration : 0.5));
+        return { node: undefined, stop };
+      }, { type: 'soundfont', prebake: false });
+    });
+  });
+
+// ── 2. Signals: stub gameProgress / gameThreat so reactive songs play + react while authoring ──
+// Keep this list in sync with js/audio/signal-registry.js (currently: gameProgress, gameThreat).
+// Assigned onto `window.` — NOT `let` (a let binding wouldn't be visible to the separately-evaluated
+// song, and bare assignment throws under strict mode). Default is sliders (draggable widgets);
+// swap to sweep or mouse below for hands-free / pointer control.
 
 // --- sliders (default): draggable widgets for deliberate values --------------------------------
 window.gameProgress = slider(0.5, 0, 1)

--- a/audio-content/strudel-prebake.js
+++ b/audio-content/strudel-prebake.js
@@ -1,46 +1,21 @@
-// Starnet — strudel.cc PREBAKE  (one-paste authoring block)
+// Starnet — strudel.cc PREBAKE
 // =====================================================================================
-// Paste this ONCE into strudel.cc → Settings → "prebake" (the script that runs before every
-// song). It sets up BOTH halves of the game's sound world so a Starnet song copied straight out
-// of the repo plays UNCHANGED in the editor:
+// Paste this into strudel.cc → Settings → "prebake" (the script that runs before every song). It
+// stubs the game's live signals so a Starnet song copied from the repo plays + reacts in the editor.
 //
-//   1. Instruments — the game's `gus_*` GeneralUser GS presets (a DISTINCT set, not strudel's
-//      built-in `gm_*`; do not substitute).
-//   2. Signals — the live game variables `gameProgress` / `gameThreat`, stubbed here as sliders
-//      you drag to hear a song react.
+// In the game these same names are injected by the engine (js/audio/strudel/signal-bridge.js), so
+// song files carry no setup of their own — this prebake is the editor-side mirror of that contract.
 //
-// In the game these same names are provided by the engine (js/audio/strudel/soundfont.js registers
-// the identical `gus_*`; js/audio/strudel/signal-bridge.js injects the same signals), so song files
-// carry no setup of their own — this prebake is the editor-side mirror of that contract.
+// SOUNDS: songs that use the game's `gus_*` instruments won't sound in strudel.cc yet — registering
+// the soundfont from the prebake trips a strudel.cc Repl error (`i.fonts is undefined`). Author with
+// synth waveforms (sawtooth/square/triangle/…) + drum samples (bd/sd/hh/…) + the signals for now;
+// `gus_*` resolves in-game. Loading `gus_*` in the editor is tracked in #265. See
+// docs/strudel-authoring.md.
 
-// ── 1. Instruments: load the game's vendored GeneralUser GS v2.0.3 + register the gus_* names ──
-// Loads Starnet's OWN vendored SF2 (raw.githubusercontent serves it CORS-enabled), so the sound set
-// is byte-identical to the game — no upstream drift. The naming (sanitize + dedup) and the note
-// trigger MIRROR js/audio/strudel/soundfont.js exactly; keep them in sync if that file changes.
-await loadSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/GeneralUser-GS.sf2')
-  .then((sf) => {
-    const used = new Set();
-    sf.presets.forEach((preset, i) => {
-      const cleaned = String(preset.header?.name || '').toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
-      let name = 'gus_' + (cleaned || 'preset_' + i);
-      if (used.has(name)) { const base = name; let n = 2; while (used.has(name)) name = base + '_' + n++; }
-      used.add(name);
-      registerSound(name, (time, value) => {
-        const ctx = getAudioContext();
-        const note = value?.note ?? 'c3';
-        const midi = typeof note === 'number' ? note : noteToMidi(note);
-        const stop = startPresetNote(ctx, preset, midi, time);
-        stop(time + (typeof value?.duration === 'number' ? value.duration : 0.5));
-        return { node: undefined, stop };
-      }, { type: 'soundfont', prebake: false });
-    });
-  });
-
-// ── 2. Signals: stub gameProgress / gameThreat so reactive songs play + react while authoring ──
 // Keep this list in sync with js/audio/signal-registry.js (currently: gameProgress, gameThreat).
 // Assigned onto `window.` — NOT `let` (a let binding wouldn't be visible to the separately-evaluated
-// song, and bare assignment throws under strict mode). Default is sliders (draggable widgets);
-// swap to sweep or mouse below for hands-free / pointer control.
+// song, and bare assignment throws under strict mode). Default is sliders (draggable widgets); swap
+// to sweep or mouse below for hands-free / pointer control.
 
 // --- sliders (default): draggable widgets for deliberate values --------------------------------
 window.gameProgress = slider(0.5, 0, 1)

--- a/docs/strudel-authoring.md
+++ b/docs/strudel-authoring.md
@@ -1,0 +1,50 @@
+# Authoring Starnet songs in strudel.cc
+
+Starnet's music is **Strudel content** (the "wad" model). Compose a song in
+[strudel.cc](https://strudel.cc) using the game's sound set, then drop the file into the repo —
+it plays in-game **unchanged**. The two names a song relies on — the `gus_*` instruments and the
+`gameProgress` / `gameThreat` signals — resolve identically in the editor and in the game.
+
+## One-time setup: the prebake
+
+1. Open strudel.cc → **Settings** → the **prebake** script area (code that runs before every song).
+2. Paste the entire contents of [`audio-content/strudel-prebake.js`](../audio-content/strudel-prebake.js).
+
+That loads the game's `gus_*` instruments (GeneralUser GS v2.0.3, fetched from this repo so it's the
+exact same sound set) and stubs the game signals as **sliders** you can drag.
+
+## Compose
+
+- **Instruments:** the game's `.s("gus_warm_pad")` etc. (`gus_*`), and/or plain synth waveforms
+  (`sawtooth`/`square`/`triangle`/…) and drum samples (`bd`/`sd`/`hh`/…).
+- **React to game state:** reference the signals directly —
+  `.lpf(gameThreat.range(400, 6000))`, `.gain(gameProgress.range(0, 0.8))`, etc.
+- **Hear it react:** drag the `gameProgress` / `gameThreat` sliders. (Prefer hands-free? Swap the
+  prebake's slider lines for the commented `sine`-sweep or `mousex/mousey` alternatives.)
+
+> `gus_*` is a **distinct** set from strudel.cc's built-in `gm_*` (a different soundfont) — do not
+> substitute, or the sound won't carry to the game.
+
+## Check it carries to the game
+
+Open [`preview/music.html`](../preview/music.html) (the game's preview harness), paste your song, and
+**PLAY**. It runs through the game's own runtime + `gus_*` + signal sliders, and the in-set **linter**
+flags any sound name not in the kosher set (so paste-parity holds).
+
+## Add it to the game
+
+1. Save the song as `audio-content/songs/<id>.strudel`.
+2. Add a manifest entry in `js/audio/strudel/songs/index.js` (`SONG_MANIFEST`:
+   `{ id, name, file }`).
+
+It then joins the run rotation and appears in the preview picker.
+
+## Notes
+
+- **Song files carry no setup** — no soundfont load, no signal stubs. The prebake (editor) and the
+  engine (game) provide those. Keep songs as pure patterns so they stay portable both ways.
+- The prebake's signal list must stay in sync with
+  [`js/audio/signal-registry.js`](../js/audio/signal-registry.js) (currently: `gameProgress`,
+  `gameThreat`). Add a game signal there → add the matching stub in the prebake.
+- The `gus_*` registration in the prebake mirrors `js/audio/strudel/soundfont.js`; if that changes
+  (naming, note trigger), update the prebake to match.

--- a/docs/strudel-authoring.md
+++ b/docs/strudel-authoring.md
@@ -2,34 +2,33 @@
 
 Starnet's music is **Strudel content** (the "wad" model). Compose a song in
 [strudel.cc](https://strudel.cc) using the game's sound set, then drop the file into the repo —
-it plays in-game **unchanged**. The two names a song relies on — the `gus_*` instruments and the
-`gameProgress` / `gameThreat` signals — resolve identically in the editor and in the game.
+it plays in-game **unchanged**. A song relies on two game-owned names — the `gus_*` instruments and
+the `gameProgress` / `gameThreat` signals — which resolve identically in the editor and the game.
+(Instruments in the editor are a known gap — see below.)
 
 ## One-time setup: the prebake
 
 1. Open strudel.cc → **Settings** → the **prebake** script area (code that runs before every song).
 2. Paste the entire contents of [`audio-content/strudel-prebake.js`](../audio-content/strudel-prebake.js).
 
-That loads the game's `gus_*` instruments (GeneralUser GS v2.0.3, fetched from this repo so it's the
-exact same sound set) and stubs the game signals as **sliders** you can drag.
+That stubs the game signals as **sliders** you can drag while composing.
 
 ## Compose
 
-- **Instruments:** the game's `.s("gus_warm_pad")` etc. (`gus_*`), and/or plain synth waveforms
-  (`sawtooth`/`square`/`triangle`/…) and drum samples (`bd`/`sd`/`hh`/…).
+- **Instruments:** plain synth waveforms (`sawtooth`/`square`/`triangle`/…) and drum samples
+  (`bd`/`sd`/`hh`/…) — strudel.cc has these natively. The game's `gus_*` presets are **not yet
+  loadable in the editor** (see the known limitation below); they resolve in-game.
 - **React to game state:** reference the signals directly —
   `.lpf(gameThreat.range(400, 6000))`, `.gain(gameProgress.range(0, 0.8))`, etc.
 - **Hear it react:** drag the `gameProgress` / `gameThreat` sliders. (Prefer hands-free? Swap the
   prebake's slider lines for the commented `sine`-sweep or `mousex/mousey` alternatives.)
 
-> `gus_*` is a **distinct** set from strudel.cc's built-in `gm_*` (a different soundfont) — do not
-> substitute, or the sound won't carry to the game.
-
 ## Check it carries to the game
 
 Open [`preview/music.html`](../preview/music.html) (the game's preview harness), paste your song, and
-**PLAY**. It runs through the game's own runtime + `gus_*` + signal sliders, and the in-set **linter**
-flags any sound name not in the kosher set (so paste-parity holds).
+**PLAY**. Unlike strudel.cc, the preview harness loads the full `gus_*` set, so this is where you
+confirm a `gus_*`-using song actually sounds right, and the in-set **linter** flags any sound name
+not in the kosher set (so paste-parity holds).
 
 ## Add it to the game
 
@@ -39,6 +38,45 @@ flags any sound name not in the kosher set (so paste-parity holds).
 
 It then joins the run rotation and appears in the preview picker.
 
+## Known limitation: `gus_*` instruments in the editor
+
+Loading the game's GeneralUser GS set into strudel.cc from the prebake is **not working yet**. The
+prelude below registers the `gus_*` names correctly (verified: it produces the same 287 names as the
+game), but running it in strudel.cc's prebake trips a Repl render error — `can't access property
+"length", i.fonts is undefined` — apparently because the manual `registerSound(..., {type:'soundfont'})`
+path leaves strudel.cc's soundfont UI in a state it can't render. Tracked in #265.
+
+Until that's resolved: author with synth waveforms + drums + the signals in strudel.cc, and use
+`preview/music.html` (which loads `gus_*`) to audition anything that uses the game presets.
+
+<details>
+<summary>Experimental gus_* prelude (currently errors in strudel.cc)</summary>
+
+```js
+// Loads Starnet's vendored GeneralUser GS v2.0.3 and registers the gus_* names, mirroring
+// js/audio/strudel/soundfont.js. Produces names identical to the game — but currently trips
+// a strudel.cc Repl error (i.fonts undefined). See #265.
+await loadSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/GeneralUser-GS.sf2')
+  .then((sf) => {
+    const used = new Set();
+    sf.presets.forEach((preset, i) => {
+      const cleaned = String(preset.header?.name || '').toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+      let name = 'gus_' + (cleaned || 'preset_' + i);
+      if (used.has(name)) { const base = name; let n = 2; while (used.has(name)) name = base + '_' + n++; }
+      used.add(name);
+      registerSound(name, (time, value) => {
+        const ctx = getAudioContext();
+        const note = value?.note ?? 'c3';
+        const midi = typeof note === 'number' ? note : noteToMidi(note);
+        const stop = startPresetNote(ctx, preset, midi, time);
+        stop(time + (typeof value?.duration === 'number' ? value.duration : 0.5));
+        return { node: undefined, stop };
+      }, { type: 'soundfont', prebake: false });
+    });
+  });
+```
+</details>
+
 ## Notes
 
 - **Song files carry no setup** — no soundfont load, no signal stubs. The prebake (editor) and the
@@ -46,5 +84,5 @@ It then joins the run rotation and appears in the preview picker.
 - The prebake's signal list must stay in sync with
   [`js/audio/signal-registry.js`](../js/audio/signal-registry.js) (currently: `gameProgress`,
   `gameThreat`). Add a game signal there → add the matching stub in the prebake.
-- The `gus_*` registration in the prebake mirrors `js/audio/strudel/soundfont.js`; if that changes
-  (naming, note trigger), update the prebake to match.
+- `gus_*` is a **distinct** set from strudel.cc's built-in `gm_*` (a different soundfont) — do not
+  substitute.


### PR DESCRIPTION
Advances the bidirectional authoring workflow (#265): compose a song in strudel.cc against the game's
signals, paste it into the repo, and it plays in-game unchanged.

## What ships (working)

- **Signals prebake** (`audio-content/strudel-prebake.js`) — paste into strudel.cc → Settings →
  prebake to stub `gameProgress` / `gameThreat` as sliders (verified idiom: `window.* = slider(...)`),
  with sweep / mouse as commented alternatives.
- **Workflow doc** (`docs/strudel-authoring.md`) — prebake setup → compose against synth/drums +
  signals → lint via `preview/music.html` → add to the manifest.
- **SF2 hosting decision** (for the instruments piece): Starnet's own vendored SF2 via
  `raw.githubusercontent.com/lmorchard/starnet/...` — exact file, CORS-fetchable.

## Known gap — `gus_*` instruments in the editor (stays open in #265)

Loading the game's GeneralUser GS set into strudel.cc from the prebake **doesn't work yet**: the
prelude registers the right names (**proven — 287 names identical to the game**), but running it in
strudel.cc's prebake trips a Repl render error (`can't access property "length", i.fonts is
undefined`) — the manual `registerSound(..., {type:'soundfont'})` path leaves strudel.cc's soundfont
UI unrenderable. The prelude is preserved as a documented experiment in `docs/strudel-authoring.md`;
for now, author with synth waveforms + drums + signals in the editor and audition `gus_*` songs via
`preview/music.html`.

## Verification

- Signals prebake idiom confirmed working in strudel.cc (earlier).
- `gus_*` naming parity proven (287 identical names) — the blocker is strudel.cc registration, not naming.
- `make check` green.

Advances #265 (signals authoring + workflow + hosting decision); the `gus_*`-in-editor piece remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
