### PR TITLE
Strudel authoring: gus_* in the prebake (fonts:[] fix), completes #265

### DIFF
--- a/audio-content/strudel-prebake.js
+++ b/audio-content/strudel-prebake.js
@@ -13,6 +13,20 @@
 // the identical `gus_*`; js/audio/strudel/signal-bridge.js injects the same signals), so song files
 // carry no setup of their own — this prebake is the editor-side mirror of that contract.
 
+// ── 0. Firefox soundfont-release fix ──
+// Firefox does not implement AudioParam.cancelAndHoldAtTime, which the SF2 player calls on every
+// soundfont note-off. Without it note-offs throw in Firefox → gus_* voices never release (notes ring
+// forever, voices pile up). Polyfill it (hold-current-value) before anything plays. No-op in Chrome,
+// and no-op in the game (the engine's runtime installs the same shim). Mirrors runtime.js.
+if (typeof AudioParam !== 'undefined' && typeof AudioParam.prototype.cancelAndHoldAtTime !== 'function') {
+  AudioParam.prototype.cancelAndHoldAtTime = function (t) {
+    const held = this.value;
+    try { this.cancelScheduledValues(t); } catch (_) { /* ignore */ }
+    try { this.setValueAtTime(held, t); } catch (_) { /* ignore */ }
+    return this;
+  };
+}
+
 // ── 1. Instruments: load the game's vendored GeneralUser GS v2.0.3 + register the gus_* names ──
 // Loads Starnet's OWN vendored SF2 (raw.githubusercontent serves it CORS-enabled), so the sound set
 // is byte-identical to the game — no upstream drift. The naming (sanitize + dedup) and the note

--- a/audio-content/strudel-prebake.js
+++ b/audio-content/strudel-prebake.js
@@ -1,21 +1,48 @@
-// Starnet — strudel.cc PREBAKE
+// Starnet — strudel.cc PREBAKE  (one-paste authoring block)
 // =====================================================================================
-// Paste this into strudel.cc → Settings → "prebake" (the script that runs before every song). It
-// stubs the game's live signals so a Starnet song copied from the repo plays + reacts in the editor.
+// Paste this ONCE into strudel.cc → Settings → "prebake" (the script that runs before every
+// song). It sets up BOTH halves of the game's sound world so a Starnet song copied straight out
+// of the repo plays UNCHANGED in the editor:
 //
-// In the game these same names are injected by the engine (js/audio/strudel/signal-bridge.js), so
-// song files carry no setup of their own — this prebake is the editor-side mirror of that contract.
+//   1. Instruments — the game's `gus_*` GeneralUser GS presets (a DISTINCT set, not strudel's
+//      built-in `gm_*`; do not substitute).
+//   2. Signals — the live game variables `gameProgress` / `gameThreat`, stubbed here as sliders
+//      you drag to hear a song react.
 //
-// SOUNDS: songs that use the game's `gus_*` instruments won't sound in strudel.cc yet — registering
-// the soundfont from the prebake trips a strudel.cc Repl error (`i.fonts is undefined`). Author with
-// synth waveforms (sawtooth/square/triangle/…) + drum samples (bd/sd/hh/…) + the signals for now;
-// `gus_*` resolves in-game. Loading `gus_*` in the editor is tracked in #265. See
-// docs/strudel-authoring.md.
+// In the game these same names are provided by the engine (js/audio/strudel/soundfont.js registers
+// the identical `gus_*`; js/audio/strudel/signal-bridge.js injects the same signals), so song files
+// carry no setup of their own — this prebake is the editor-side mirror of that contract.
 
+// ── 1. Instruments: load the game's vendored GeneralUser GS v2.0.3 + register the gus_* names ──
+// Loads Starnet's OWN vendored SF2 (raw.githubusercontent serves it CORS-enabled), so the sound set
+// is byte-identical to the game — no upstream drift. The naming (sanitize + dedup) and the note
+// trigger MIRROR js/audio/strudel/soundfont.js exactly; keep them in sync if that file changes.
+// `fonts: []` is required so strudel.cc's soundfont UI can render the entry (it reads
+// options.fonts.length); our trigger closes over `preset`, so the array itself is unused for audio.
+await loadSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/GeneralUser-GS.sf2')
+  .then((sf) => {
+    const used = new Set();
+    sf.presets.forEach((preset, i) => {
+      const cleaned = String(preset.header?.name || '').toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+      let name = 'gus_' + (cleaned || 'preset_' + i);
+      if (used.has(name)) { const base = name; let n = 2; while (used.has(name)) name = base + '_' + n++; }
+      used.add(name);
+      registerSound(name, (time, value) => {
+        const ctx = getAudioContext();
+        const note = value?.note ?? 'c3';
+        const midi = typeof note === 'number' ? note : noteToMidi(note);
+        const stop = startPresetNote(ctx, preset, midi, time);
+        stop(time + (typeof value?.duration === 'number' ? value.duration : 0.5));
+        return { node: undefined, stop };
+      }, { type: 'soundfont', prebake: false, fonts: [] });
+    });
+  });
+
+// ── 2. Signals: stub gameProgress / gameThreat so reactive songs play + react while authoring ──
 // Keep this list in sync with js/audio/signal-registry.js (currently: gameProgress, gameThreat).
 // Assigned onto `window.` — NOT `let` (a let binding wouldn't be visible to the separately-evaluated
-// song, and bare assignment throws under strict mode). Default is sliders (draggable widgets); swap
-// to sweep or mouse below for hands-free / pointer control.
+// song, and bare assignment throws under strict mode). Default is sliders (draggable widgets);
+// swap to sweep or mouse below for hands-free / pointer control.
 
 // --- sliders (default): draggable widgets for deliberate values --------------------------------
 window.gameProgress = slider(0.5, 0, 1)

--- a/docs/strudel-authoring.md
+++ b/docs/strudel-authoring.md
@@ -2,33 +2,34 @@
 
 Starnet's music is **Strudel content** (the "wad" model). Compose a song in
 [strudel.cc](https://strudel.cc) using the game's sound set, then drop the file into the repo —
-it plays in-game **unchanged**. A song relies on two game-owned names — the `gus_*` instruments and
-the `gameProgress` / `gameThreat` signals — which resolve identically in the editor and the game.
-(Instruments in the editor are a known gap — see below.)
+it plays in-game **unchanged**. The two names a song relies on — the `gus_*` instruments and the
+`gameProgress` / `gameThreat` signals — resolve identically in the editor and the game.
 
 ## One-time setup: the prebake
 
 1. Open strudel.cc → **Settings** → the **prebake** script area (code that runs before every song).
 2. Paste the entire contents of [`audio-content/strudel-prebake.js`](../audio-content/strudel-prebake.js).
 
-That stubs the game signals as **sliders** you can drag while composing.
+That loads the game's `gus_*` instruments (GeneralUser GS v2.0.3, fetched from this repo so it's the
+exact same sound set) and stubs the game signals as **sliders** you can drag.
 
 ## Compose
 
-- **Instruments:** plain synth waveforms (`sawtooth`/`square`/`triangle`/…) and drum samples
-  (`bd`/`sd`/`hh`/…) — strudel.cc has these natively. The game's `gus_*` presets are **not yet
-  loadable in the editor** (see the known limitation below); they resolve in-game.
+- **Instruments:** the game's `.s("gus_warm_pad")` etc. (`gus_*`), and/or plain synth waveforms
+  (`sawtooth`/`square`/`triangle`/…) and drum samples (`bd`/`sd`/`hh`/…).
 - **React to game state:** reference the signals directly —
   `.lpf(gameThreat.range(400, 6000))`, `.gain(gameProgress.range(0, 0.8))`, etc.
 - **Hear it react:** drag the `gameProgress` / `gameThreat` sliders. (Prefer hands-free? Swap the
   prebake's slider lines for the commented `sine`-sweep or `mousex/mousey` alternatives.)
 
+> `gus_*` is a **distinct** set from strudel.cc's built-in `gm_*` (a different soundfont) — do not
+> substitute, or the sound won't carry to the game.
+
 ## Check it carries to the game
 
 Open [`preview/music.html`](../preview/music.html) (the game's preview harness), paste your song, and
-**PLAY**. Unlike strudel.cc, the preview harness loads the full `gus_*` set, so this is where you
-confirm a `gus_*`-using song actually sounds right, and the in-set **linter** flags any sound name
-not in the kosher set (so paste-parity holds).
+**PLAY**. It runs through the game's own runtime + `gus_*` + signal sliders, and the in-set **linter**
+flags any sound name not in the kosher set (so paste-parity holds).
 
 ## Add it to the game
 
@@ -38,45 +39,6 @@ not in the kosher set (so paste-parity holds).
 
 It then joins the run rotation and appears in the preview picker.
 
-## Known limitation: `gus_*` instruments in the editor
-
-Loading the game's GeneralUser GS set into strudel.cc from the prebake is **not working yet**. The
-prelude below registers the `gus_*` names correctly (verified: it produces the same 287 names as the
-game), but running it in strudel.cc's prebake trips a Repl render error — `can't access property
-"length", i.fonts is undefined` — apparently because the manual `registerSound(..., {type:'soundfont'})`
-path leaves strudel.cc's soundfont UI in a state it can't render. Tracked in #265.
-
-Until that's resolved: author with synth waveforms + drums + the signals in strudel.cc, and use
-`preview/music.html` (which loads `gus_*`) to audition anything that uses the game presets.
-
-<details>
-<summary>Experimental gus_* prelude (currently errors in strudel.cc)</summary>
-
-```js
-// Loads Starnet's vendored GeneralUser GS v2.0.3 and registers the gus_* names, mirroring
-// js/audio/strudel/soundfont.js. Produces names identical to the game — but currently trips
-// a strudel.cc Repl error (i.fonts undefined). See #265.
-await loadSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/GeneralUser-GS.sf2')
-  .then((sf) => {
-    const used = new Set();
-    sf.presets.forEach((preset, i) => {
-      const cleaned = String(preset.header?.name || '').toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
-      let name = 'gus_' + (cleaned || 'preset_' + i);
-      if (used.has(name)) { const base = name; let n = 2; while (used.has(name)) name = base + '_' + n++; }
-      used.add(name);
-      registerSound(name, (time, value) => {
-        const ctx = getAudioContext();
-        const note = value?.note ?? 'c3';
-        const midi = typeof note === 'number' ? note : noteToMidi(note);
-        const stop = startPresetNote(ctx, preset, midi, time);
-        stop(time + (typeof value?.duration === 'number' ? value.duration : 0.5));
-        return { node: undefined, stop };
-      }, { type: 'soundfont', prebake: false });
-    });
-  });
-```
-</details>
-
 ## Notes
 
 - **Song files carry no setup** — no soundfont load, no signal stubs. The prebake (editor) and the
@@ -84,5 +46,7 @@ await loadSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/au
 - The prebake's signal list must stay in sync with
   [`js/audio/signal-registry.js`](../js/audio/signal-registry.js) (currently: `gameProgress`,
   `gameThreat`). Add a game signal there → add the matching stub in the prebake.
-- `gus_*` is a **distinct** set from strudel.cc's built-in `gm_*` (a different soundfont) — do not
-  substitute.
+- The `gus_*` registration in the prebake mirrors `js/audio/strudel/soundfont.js`; if that changes
+  (naming, note trigger), update the prebake to match. The `fonts: []` option on the prebake's
+  `registerSound` is required only for strudel.cc's soundfont UI (it reads `options.fonts.length`);
+  the game runtime has no such UI and doesn't need it.


### PR DESCRIPTION
Completes the bidirectional Strudel authoring workflow (#265): the strudel.cc prebake now sets up
**both** halves of the game sound world — the `gus_*` instruments and the `gameProgress` /
`gameThreat` signals — so a song composed in strudel.cc plays + reacts, and carries into the game
unchanged.

## The fix

Loading `gus_*` from the prebake was crashing strudel.cc's Repl (`can't access property "length",
i.fonts is undefined`). Root cause, from the `@strudel/soundfonts` source: the editor's soundfont UI
reads `options.fonts.length` on registered soundfont sounds. Strudel's built-in GM path always passes
a `fonts` array (`fontloader.mjs`); our `registerSound(..., { type: 'soundfont' })` omitted it (as
does the *commented-out* per-preset path in `sfumato.mjs`). Adding **`fonts: []`** satisfies the UI
without affecting audio — our trigger closes over the `preset`, and superdough reads `fonts` from the
trigger, not the options.

## What ships

- `audio-content/strudel-prebake.js` — one paste-block that loads the game's vendored GeneralUser GS
  v2.0.3 (registering `gus_*`, mirroring `js/audio/strudel/soundfont.js`) and stubs the signals as
  sliders.
- `docs/strudel-authoring.md` — the compose-in-strudel.cc → paste-into-repo workflow.

## Verification

- `gus_*` load + play confirmed in strudel.cc (the `fonts: []` fix).
- `gus_*` naming parity proven earlier — 287 names identical to the game.
- Signal idiom (`window.* = slider(...)`) confirmed earlier.

Closes #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
