### PR TITLE
Strudel song switching: engine-aware music command (closes #272)

### DIFF
--- a/js/audio/music-commands.js
+++ b/js/audio/music-commands.js
@@ -2,22 +2,70 @@
 // Console commands for music control. Registered from the audio (browser) layer so
 // core/headless never imports audio. Mirrors the hamburger-menu music controls for
 // GUI/console symmetry. Imported once from js/ui/main.js.
+//
+// Engine-aware: on/off go through setMusicEnabled (which emits MUSIC_CHANGED and so drives BOTH the
+// Tone renderer and the Strudel engine). Song selection (list/set/next/random/status) routes to the
+// active engine — the Tone scores (audio-renderer.js) or the Strudel song manifest + MUSIC_SONG_SELECT.
 import { registerCommand } from "../core/console-commands/index.js";
-import { emitEvent, E } from "../core/events.js";
+import { emitEvent, on, E } from "../core/events.js";
 import {
   isMusicEnabled, getNowPlayingName, isRunMusicLive, setMusicEnabled,
   listScoreNames, setScoreByName, randomScore,
 } from "./audio-renderer.js";
+import { getAudioEngine } from "./engine-select.js";
+import { SONG_MANIFEST, resolveSongQuery, songAlias } from "./strudel/songs/index.js";
 
 function log(text, type = "meta") { emitEvent(E.LOG_ENTRY, { text, type }); }
 
 const SUBCOMMANDS = ["status", "on", "off", "list", "next", "random", "set"];
-/** Short single-word alias per score (its last word), e.g. "Corporate — Neon" → "neon". */
-const aliases = () => listScoreNames().map((n) => (n.split(/\s+/).pop() || "").toLowerCase());
+const isStrudel = () => getAudioEngine() === "strudel";
+
+// Track what the Strudel engine is playing (it reports via MUSIC_SONG_CHANGED); the Tone engine
+// answers getNowPlayingName() directly.
+let _strudelNow = null;
+on(E.MUSIC_SONG_CHANGED, ({ name }) => { _strudelNow = name; });
+
+// ---- engine-aware song helpers ----------------------------------------------------------------
+/** @returns {string[]} display names of the selectable songs/scores for the active engine. */
+function songNames() {
+  return isStrudel() ? SONG_MANIFEST.map((e) => e.name) : listScoreNames();
+}
+/** @returns {string[]} last-word aliases for tab-completion. */
+function aliases() {
+  return isStrudel()
+    ? SONG_MANIFEST.map(songAlias)
+    : listScoreNames().map((n) => (n.split(/\s+/).pop() || "").toLowerCase());
+}
+/** What's playing now (engine-aware). @returns {string|null} */
+function nowPlaying() {
+  return isStrudel() ? _strudelNow : getNowPlayingName();
+}
+/** Switch to a random song (engine-aware, avoiding the current one where possible). @returns {string|null} name */
+function selectRandom() {
+  if (isStrudel()) {
+    const pool = SONG_MANIFEST.filter((e) => e.name !== _strudelNow);
+    const list = pool.length ? pool : SONG_MANIFEST;
+    const entry = list[Math.floor(Math.random() * list.length)];
+    if (!entry) return null;
+    emitEvent(E.MUSIC_SONG_SELECT, { songId: entry.id });
+    return entry.name;
+  }
+  return randomScore();
+}
+/** Switch to a song matching `query` (engine-aware). @returns {string|null} name */
+function selectByQuery(query) {
+  if (isStrudel()) {
+    const entry = resolveSongQuery(query);
+    if (!entry) return null;
+    emitEvent(E.MUSIC_SONG_SELECT, { songId: entry.id });
+    return entry.name;
+  }
+  return setScoreByName(query);
+}
 
 function showStatus() {
   if (!isMusicEnabled()) { log("[MUSIC] off"); return; }
-  const now = getNowPlayingName();
+  const now = nowPlaying();
   log(now ? `[MUSIC] playing: ${now}` : "[MUSIC] on (idle — click in to start)");
 }
 
@@ -25,7 +73,7 @@ registerCommand({
   verb: "music",
   complete(args, partial) {
     const p = partial.toLowerCase();
-    // first token: subcommands + score aliases; after `set`: score aliases only
+    // first token: subcommands + song aliases; after `set`: song aliases only
     const pool = args.length === 0 ? [...SUBCOMMANDS, ...aliases()]
       : (args[0] === "set" ? aliases() : []);
     const matches = pool.filter((s) => s.startsWith(p));
@@ -37,22 +85,23 @@ registerCommand({
     if (sub === "on")  { setMusicEnabled(true);  showStatus(); return; }
     if (sub === "off") { setMusicEnabled(false); log("[MUSIC] off"); return; }
     if (sub === "list") {
-      log("[MUSIC] scores:");
-      listScoreNames().forEach((n, i) => log(`  [${i + 1}] ${n}`));
+      log("[MUSIC] songs:");
+      songNames().forEach((n, i) => log(`  [${i + 1}] ${n}`));
       return;
     }
-    const pending = isRunMusicLive() ? "" : " (applies to your next run)";
+    // Strudel selection applies immediately; Tone scores apply to the next run unless one is live.
+    const pending = isStrudel() ? "" : (isRunMusicLive() ? "" : " (applies to your next run)");
     if (sub === "next" || sub === "random") {
-      const name = randomScore();
+      const name = selectRandom();
       if (name) log(`[MUSIC] switched to: ${name}${pending}`);
-      else log("[MUSIC] no scores available", "error");
+      else log("[MUSIC] no songs available", "error");
       return;
     }
     // `music set <name>` or the shorthand `music <name>`
     const query = (sub === "set" ? args.slice(1) : args).join(" ");
     if (!query) { log("Usage: music [status | on | off | list | next | set <name> | <name>]", "error"); return; }
-    const name = setScoreByName(query);
-    if (name) log(`[MUSIC] score: ${name}${pending}`);
-    else log(`[MUSIC] no score matching "${query}" — try: music list`, "error");
+    const name = selectByQuery(query);
+    if (name) log(`[MUSIC] song: ${name}${pending}`);
+    else log(`[MUSIC] no song matching "${query}" — try: music list`, "error");
   },
 });

--- a/js/audio/strudel/index.js
+++ b/js/audio/strudel/index.js
@@ -8,7 +8,8 @@
 // Pref/event ownership stays in the Tone renderer modules: setMusicEnabled/setSfxEnabled still write
 // localStorage + emit MUSIC_CHANGED/SFX_CHANGED even when Tone isn't running, so the HUD buttons +
 // music/sfx commands keep working — this engine just listens.
-import { on, E } from "../../core/events.js";
+import { on, emitEvent, E } from "../../core/events.js";
+import { getState } from "../../core/state.js";
 import { bootStrudel } from "./runtime.js";
 import { loadGameSoundfont } from "./soundfont.js";
 import { installGameSignals } from "./signal-bridge.js";
@@ -57,21 +58,35 @@ function wire(rt, songs = []) {
 
   const hubSong = songs.find((s) => s.id === HUB_ID) || null;
   const runSongs = songs.filter((s) => s.id !== HUB_ID);
+  const pickRunSong = () => runSongs[Math.floor(Math.random() * runSongs.length)] || runSongs[0] || hubSong;
+  let override = null;                    // explicit `music set/next` selection (song id); overrides the run/hub pick
 
   // ---- Music (reactive songs) — play via the repl; stop via repl hush (clears $: patterns) ------
-  const play = (song) => { if (song) { try { rt.evaluate(song.code); } catch (e) { console.warn("[strudel] song eval failed:", e); } } };
+  const play = (song) => {
+    if (!song) return;
+    try { rt.evaluate(song.code); emitEvent(E.MUSIC_SONG_CHANGED, { id: song.id, name: song.name }); }
+    catch (e) { console.warn("[strudel] song eval failed:", e); }
+  };
   const stop = () => { try { rt.evaluate("hush()"); } catch (_) {} };
-  const desired = () => (runActive ? runSong : hubSong);
+  const byId = (id) => songs.find((s) => s.id === id) || null;
+  const desired = () => (override && byId(override)) || (runActive ? runSong : hubSong);
   const refresh = () => { if (musicEnabled) play(desired()); else stop(); };
 
-  refresh();                             // hub song at boot (if enabled)
+  // Boot-race guard: if a run is already live by the time the engine booted (the RUN_STARTED
+  // handler below wasn't registered yet when it fired), reflect that so we play a run song, not hub.
+  if (getState()) { runActive = true; runSong = pickRunSong(); }
+  refresh();                             // hub or run song at boot (if enabled)
+
   on(E.RUN_STARTED, () => {
-    runActive = true;                                     // random run score (like the Tone engine)
-    runSong = runSongs[Math.floor(Math.random() * runSongs.length)] || runSongs[0] || hubSong;
+    runActive = true;                    // random run score (like the Tone engine); clears any manual pick
+    override = null;
+    runSong = pickRunSong();
     refresh();
   });
-  on(E.RUN_ENDED, () => { runActive = false; refresh(); });
+  on(E.RUN_ENDED, () => { runActive = false; override = null; refresh(); });
   on(E.MUSIC_CHANGED, ({ enabled }) => { musicEnabled = !!enabled; refresh(); });
+  // `music set/next/random` (console) → switch immediately (persists until the next run).
+  on(E.MUSIC_SONG_SELECT, ({ songId }) => { override = songId; refresh(); });
 
   // ---- One-shot SFX -----------------------------------------------------------------------------
   const sfx = createSfx(rt);

--- a/js/audio/strudel/songs/index.js
+++ b/js/audio/strudel/songs/index.js
@@ -20,6 +20,25 @@ export const SONG_MANIFEST = [
   { id: "corporate-noir",  name: "Corporate — Noir",   file: "corporate-noir.strudel" },
 ];
 
+/** Last-word alias for a song, e.g. "Corporate — Neon" → "neon", "Hub Ambient" → "ambient". */
+export function songAlias(entry) {
+  return (entry.name.split(/\s+/).pop() || "").toLowerCase();
+}
+
+/**
+ * Resolve a query to a manifest entry: exact id, exact name, last-word alias, or loose name-contains
+ * (case-insensitive), in that priority. Pure — safe to import anywhere. @returns {SongEntry|null}
+ */
+export function resolveSongQuery(query) {
+  const q = String(query || "").trim().toLowerCase();
+  if (!q) return null;
+  return SONG_MANIFEST.find((e) => e.id.toLowerCase() === q)
+      || SONG_MANIFEST.find((e) => e.name.toLowerCase() === q)
+      || SONG_MANIFEST.find((e) => songAlias(e) === q)
+      || SONG_MANIFEST.find((e) => e.name.toLowerCase().includes(q))
+      || null;
+}
+
 /** Fetch one song's code. @param {SongEntry} entry @returns {Promise<string>} */
 export async function fetchSongCode(entry) {
   const res = await fetch(new URL(entry.file, BASE));

--- a/js/core/events.js
+++ b/js/core/events.js
@@ -84,4 +84,7 @@ export const E = Object.freeze({
   // Audio (music on/off changed — keeps HUD + console in sync)
   MUSIC_CHANGED:        "audio:music-changed",
   SFX_CHANGED:          "audio:sfx-changed",
+  // Strudel song selection: request (command → engine) + report (engine → console/UI)
+  MUSIC_SONG_SELECT:    "audio:music-song-select",
+  MUSIC_SONG_CHANGED:   "audio:music-song-changed",
 });

--- a/tests/strudel-song-select.test.js
+++ b/tests/strudel-song-select.test.js
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { SONG_MANIFEST, resolveSongQuery, songAlias } from "../js/audio/strudel/songs/index.js";
+
+test("songAlias is the lowercased last word of the display name", () => {
+  assert.equal(songAlias({ name: "Corporate — Neon" }), "neon");
+  assert.equal(songAlias({ name: "Hub Ambient" }), "ambient");
+});
+
+test("resolveSongQuery matches by exact id", () => {
+  assert.equal(resolveSongQuery("corporate-neon")?.id, "corporate-neon");
+  assert.equal(resolveSongQuery("hub")?.id, "hub");
+});
+
+test("resolveSongQuery matches by exact display name (case-insensitive)", () => {
+  assert.equal(resolveSongQuery("Corporate — Neon")?.id, "corporate-neon");
+  assert.equal(resolveSongQuery("corporate — neon")?.id, "corporate-neon");
+});
+
+test("resolveSongQuery matches by last-word alias", () => {
+  assert.equal(resolveSongQuery("neon")?.id, "corporate-neon");
+  assert.equal(resolveSongQuery("NEON")?.id, "corporate-neon");
+  assert.equal(resolveSongQuery("ambient")?.id, "hub");
+});
+
+test("resolveSongQuery falls back to a loose name-contains match", () => {
+  // "corporate" isn't an id/name/alias, but every corporate song's name contains it → first wins.
+  const r = resolveSongQuery("corporate");
+  assert.ok(r && r.id.startsWith("corporate-"));
+});
+
+test("resolveSongQuery returns null for empty or unknown queries", () => {
+  assert.equal(resolveSongQuery(""), null);
+  assert.equal(resolveSongQuery("   "), null);
+  assert.equal(resolveSongQuery("no-such-song"), null);
+  assert.equal(resolveSongQuery(undefined), null);
+});
+
+test("every manifest entry resolves by its own id, name, and alias", () => {
+  for (const e of SONG_MANIFEST) {
+    assert.equal(resolveSongQuery(e.id)?.id, e.id, `id ${e.id}`);
+    assert.equal(resolveSongQuery(e.name)?.id, e.id, `name ${e.name}`);
+    // alias may collide across entries (e.g. duplicate last words); assert it resolves to *some* entry
+    assert.ok(resolveSongQuery(songAlias(e)), `alias ${songAlias(e)}`);
+  }
+});


### PR DESCRIPTION
Under the Strudel engine you can now change songs from the `music` command — previously `list` /
`set` / `next` / `random` only drove the Tone scores, so Strudel playback was random-only.

## What's here

- **Engine-aware `music` command** — `list` / `set` / `next` / `random` / `status` route to the active
  engine: Tone scores (`audio-renderer.js`) or the Strudel song manifest. `on` / `off` already worked
  cross-engine via `MUSIC_CHANGED`.
- **Strudel song control in the engine** — a `music set/next/random` selection emits
  `MUSIC_SONG_SELECT`; the engine switches **immediately** (persists until the next run) and reports
  the current song via `MUSIC_SONG_CHANGED` (drives `music status`).
- **Song resolution** (`resolveSongQuery`) — matches by id, display name, last-word alias, or loose
  name-contains; unit-tested.
- **Boot-race fix** (the edge noted in #272): if a run is already live when the engine finishes
  booting, it now plays a run song instead of the hub ambient.

## Verification

- In-game (Strudel): `music set neon` / `set glitch`, the `music <alias>` shorthand, and `music next`
  all switch the playing song; an unknown query is rejected; zero console errors.
- `make check` green (1532 tests, +7 for `resolveSongQuery`).

Closes #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
