### PR TITLE
Default the audio engine to Strudel

### DIFF
--- a/js/audio/engine-select.js
+++ b/js/audio/engine-select.js
@@ -1,16 +1,16 @@
 // @ts-check
 // Audio engine selection — a client preference (NOT game state; audio is never serialized).
-// Chooses between the legacy Tone.js engine (default) and the Strudel + superdough engine.
-// Read once at boot by js/ui/main.js; switching requires a page reload to take effect.
+// Chooses between the Strudel + superdough engine (default) and the legacy Tone.js engine (opt-in,
+// pending removal — #267). Read once at boot by js/ui/main.js; switching requires a page reload.
 
 /** @type {readonly ["tone", "strudel"]} */
 export const AUDIO_ENGINES = ["tone", "strudel"];
 
 const ENGINE_PREF_KEY = "starnet:audio-engine";
-const DEFAULT_ENGINE = "tone";
+const DEFAULT_ENGINE = "strudel";
 
 /**
- * @returns {"tone"|"strudel"} the selected audio engine, defaulting to "tone".
+ * @returns {"tone"|"strudel"} the selected audio engine, defaulting to "strudel".
  */
 export function getAudioEngine() {
   try {

--- a/js/audio/strudel/index.js
+++ b/js/audio/strudel/index.js
@@ -4,7 +4,7 @@
 // 1.3.0 base from #266 (runtime + signal registry/bridge + GeneralUser GS soundfont) + the song
 // model (evaluate strudel-song content), replacing #262's bespoke score interpreter.
 //
-// Browser-only. Tone-default users never load this (main.js dynamic-imports it only when selected).
+// Browser-only. This is the default engine (main.js dynamic-imports it); opt-in Tone users don't load it.
 // Pref/event ownership stays in the Tone renderer modules: setMusicEnabled/setSfxEnabled still write
 // localStorage + emit MUSIC_CHANGED/SFX_CHANGED even when Tone isn't running, so the HUD buttons +
 // music/sfx commands keep working — this engine just listens.

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -73,8 +73,8 @@ function init() {
   initConsole();
   initResizers();  // apply saved layout + wire the resize splitters
   initVisualRenderer();  // must subscribe before initGame fires STATE_CHANGED
-  // Audio engine select (boot-time; switching requires a reload). Tone is the default; the Strudel
-  // engine is lazy-imported so Tone users never download its runtime bundle.
+  // Audio engine select (boot-time; switching requires a reload). Strudel is the default; the legacy
+  // Tone engine loads only when explicitly selected, so default users never download its bundle.
   let audioEngine = null;   // exposed as window.starnet.audio (Tone engine, or null under Strudel)
   if (getAudioEngine() === "strudel") {
     import("../audio/strudel/index.js").then((m) => m.initStrudelEngine());

--- a/tests/audio-engine-select.test.js
+++ b/tests/audio-engine-select.test.js
@@ -22,9 +22,9 @@ test("AUDIO_ENGINES lists tone and strudel", () => {
   assert.deepEqual([...AUDIO_ENGINES].sort(), ["strudel", "tone"]);
 });
 
-test("defaults to tone when unset", () => {
+test("defaults to strudel when unset", () => {
   installStorage();
-  assert.equal(getAudioEngine(), "tone");
+  assert.equal(getAudioEngine(), "strudel");
 });
 
 test("setAudioEngine persists the choice and returns it", () => {
@@ -35,16 +35,16 @@ test("setAudioEngine persists the choice and returns it", () => {
 
 test("setAudioEngine rejects an unknown engine and leaves the pref unchanged", () => {
   installStorage();
-  setAudioEngine("strudel");
+  setAudioEngine("tone");   // set the NON-default so the assertion is distinguishable from the default
   assert.equal(setAudioEngine("bogus"), null);
-  assert.equal(getAudioEngine(), "strudel");
+  assert.equal(getAudioEngine(), "tone");
 });
 
-test("getAudioEngine falls back to tone when storage throws", () => {
+test("getAudioEngine falls back to strudel (the default) when storage throws", () => {
   globalThis.localStorage = {
     getItem() { throw new Error("blocked"); },
     setItem() { throw new Error("blocked"); },
   };
-  assert.equal(getAudioEngine(), "tone");
-  assert.equal(setAudioEngine("strudel"), "strudel"); // returns the value even if persist fails
+  assert.equal(getAudioEngine(), "strudel");
+  assert.equal(setAudioEngine("tone"), "tone"); // returns the value even if persist fails
 });


### PR DESCRIPTION
Makes **Strudel the default audio engine**. New/unset players now boot the Strudel + superdough
engine (songs + SFX + drones); the legacy Tone engine stays selectable via `audio engine tone` but is
opt-in and only loaded when explicitly selected, pending removal in the #267 cleanup.

Minimal by design — flip + fix what breaks; the Tone code teardown and doc reconciliation
(audio-direction.md, MANUAL.md, CLAUDE.md "What's Shipped") are the #267 follow-up.

- `DEFAULT_ENGINE`: `tone` → `strudel`; engine-select / main / strudel-index comments updated.
- `audio-engine-select` tests updated to the new default (the reject-unknown test now sets the
  non-default value so it stays distinguishable from the default).

Verified in-game: with no engine pref, boot loads Strudel and never loads Tone; `make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
