### PR TITLE
Hub bugbash: named networks reachable + fix hub menu crash (#261, #236)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -198,8 +198,10 @@ From the hub you:
    into the run; these become your hand. (Click a card, or `equip <#>`.)
 2. **Carry cash** — decide how much of your bank to bring along, e.g. to shop the
    darknet broker mid-run. (`carry <amount>`.)
-3. **Pick a target** — the hub offers a short list of targets at varying
-   difficulty. Selecting one launches the run. (`launch <id>`.)
+3. **Pick a target** — the hub offers a short list of **procedurally-generated
+   jobs** at varying difficulty (soft / standard / hard), plus a set of
+   **authored networks** (hand-crafted set-piece LANs). Selecting one launches the
+   run. (`targets` lists them, `launch <id>`.)
 
 From the hub you can also **discard disclosed exploits** (burned-out cards
 cluttering your inventory) and **visit the darknet broker** — opened from the

--- a/docs/dev-sessions/2026-07-01-1731-hub-bugbash/notes.md
+++ b/docs/dev-sessions/2026-07-01-1731-hub-bugbash/notes.md
@@ -1,0 +1,38 @@
+# Notes — Hub bugbash (#261, #236)
+
+Two independent hub fixes, TDD, one PR.
+
+## #236 — hub hamburger no longer throws
+
+`menuOpen`/`handCollapsed` live in per-run `state.ui`, so the toggles called `mutate()` which
+throws with no active run (the hub). Fix: module-level `_uiFallback` in `js/core/state/game.js`;
+each toggle branches on `getState()` — mutate `state.ui` in-run, flip the fallback at the hub.
+No change to the serialized-state shape or the round-trip test. New no-run tests in
+`tests/ui-state.test.js` (used `setActiveRun(null)` to simulate the hub).
+
+## #261 — named networks are authored hub jobs
+
+`hub.js launchTarget` always built procedural networks; authored named networks (incl. the Flow
+Subversion flows in Corporate Exchange) were only reachable via `?network=` / level-select.
+
+- `js/core/profile/targets.js`: `HubTarget` gains optional `network`; `generateTargets` appends one
+  authored target per `NAMED_NETWORKS` key (derived from the registry, so new networks auto-surface;
+  friendly labels via a small map). Procedural tiers keep `seed` + `spec`.
+- `js/ui/hub.js launchTarget`: branches — `network` → `NAMED_NETWORKS[network]()`, else
+  `buildGenerated({seed, spec})`. Same `startRun` downstream.
+- Registry (`data/networks/index.js`) stays the single source of truth.
+
+## Regression caught by the browser smoke (before shipping)
+
+Authored targets have **no `spec`**, but two symmetric readers assumed `t.spec.threat`:
+the `targets` console command and the `<starnet-hub>` GUI card (line 98). The GUI one would throw
+during Lit render and break the whole hub. Both now guard on `t.spec` and show "authored network"
+otherwise. (GUI/console symmetry — fixed together.)
+
+## Verification
+
+- `make check` green (1337 pass; +4 net new tests). `make census SEEDS=5` — no headless crash.
+- Headless-Chromium smoke: hub lists all 6 targets (3 procgen + 3 authored with correct `network`
+  keys); toggling the hamburger in the hub throws **0 errors**; `launch authored-corporate-exchange`
+  loaded a 15-node named graph. Only console 404 is the pre-existing `favicon.ico`.
+- MANUAL updated (hub target list now names procgen + authored jobs).

--- a/docs/dev-sessions/2026-07-01-1731-hub-bugbash/plan.md
+++ b/docs/dev-sessions/2026-07-01-1731-hub-bugbash/plan.md
@@ -1,0 +1,31 @@
+# Plan — Hub bugbash (#261, #236)
+
+TDD each. Both are independent; do #236 first (tiny), then #261.
+
+## Phase 1 — #236 run-independent menu/hand toggles
+
+1. **Test first** (`tests/ui-state.test.js`, new cases): with no active run,
+   `toggleMenuOpen()`/`toggleHandCollapsed()` do not throw, return the flipped value, and flip
+   back on a second call. In-run behavior + round-trip stay green.
+2. **Fix** `js/core/state/game.js`: module-level `_uiFallback = { menuOpen, handCollapsed }`;
+   each toggle branches on `getState()` — mutate `s.ui` when a run is active, else flip the
+   fallback. (Import `getState` from `./index.js`.)
+3. `make check`.
+
+## Phase 2 — #261 named networks as authored hub jobs
+
+1. **Test first** (`tests/hub-targets.test.js` or extend an existing hub test): `generateTargets`
+   includes one target per `NAMED_NETWORKS` key with a `network` field; a procedural tier has no
+   `network`. (Pure — no DOM.)
+2. **`js/core/profile/targets.js`:** add optional `network` to `HubTarget`; append authored
+   targets (label from a small name map or the network's meta). Keep procgen tiers unchanged.
+3. **`js/ui/hub.js` `launchTarget`:** if `target.network`, build via `NAMED_NETWORKS[target.network]()`
+   (import from `data/networks/index.js`); else `buildGenerated({seed, spec})` as today. Same
+   `startRun` downstream.
+4. `make check` + browser smoke (hub lists authored jobs; launching one loads the named graph;
+   hamburger opens in the hub without error).
+
+## Phase 3 — wrap
+
+- Update `MANUAL.md` if the hub target list is documented.
+- Session notes; squash; PR closing #261 + #236; Copilot review.

--- a/docs/dev-sessions/2026-07-01-1731-hub-bugbash/spec.md
+++ b/docs/dev-sessions/2026-07-01-1731-hub-bugbash/spec.md
@@ -29,12 +29,12 @@ there's no active run, so `toggleMenuOpen()`/`toggleHandCollapsed()` → `mutate
 **Decision:** make the two UI toggles **run-independent** via a module-level fallback — no change
 to the serialized-state shape or the existing round-trip test.
 
-**Approach (`js/core/state/game.js`):**
+**Approach (`js/core/state/game.js`) — as shipped:**
 - Module-level fallback `{ menuOpen, handCollapsed }`.
-- Each toggle: if an active run exists, mutate `state.ui` as today; otherwise flip the fallback.
-- Add read helpers (`isMenuOpen`/`isHandCollapsed`) that prefer run state, fall back to module
-  state, so the HUD reflects the right value in both contexts.
-- Use `getActiveRun()`-style guard (not `mutate`, which throws) to branch.
+- Each toggle branches on `getState()` (non-throwing, unlike `mutate`): with an active run, mutate
+  `state.ui` as today; otherwise flip the fallback. Both paths return the new value.
+- No read helpers needed — the HUD consumes the toggle's return value; nothing else reads
+  `state.ui.*` in production (only tests do, in-run).
 
 ## Non-goals
 

--- a/docs/dev-sessions/2026-07-01-1731-hub-bugbash/spec.md
+++ b/docs/dev-sessions/2026-07-01-1731-hub-bugbash/spec.md
@@ -1,0 +1,49 @@
+# Spec — Hub bugbash: named networks reachable + menu crash (#261, #236)
+
+Two small, independent hub fixes in one pass.
+
+## #261 — Named networks reachable from the hub
+
+**Problem:** authored named networks (`corporate-foothold`, `research-station`,
+`corporate-exchange` — the last carries the Flow Subversion flows) are only reachable via
+`?network=` deep-links or the level-select form. The hub (`js/ui/hub.js` `launchTarget`) always
+calls `buildGenerated(...)`, so authored/set-piece content is invisible in normal hub play.
+
+**Decision:** surface the named networks as their own **always-available "authored job" hub
+targets**, alongside the 3 procedural tiers (soft/standard/hard).
+
+**Approach:**
+- Extend `HubTarget` (`js/core/profile/targets.js`) with an optional `network` field (a
+  `NAMED_NETWORKS` key). Procedural tiers keep `spec` + `seed`; authored targets carry `network`.
+- `generateTargets` appends one target per named network (label from its meta / a friendly name).
+- `launchTarget` (`js/ui/hub.js`): if the target has a `network`, build via `NAMED_NETWORKS[name]()`
+  instead of `buildGenerated({seed, spec})`. Everything downstream (loadout, carry, startRun) is
+  unchanged.
+- Keep the registry as the single source of truth (`data/networks/index.js` `NAMED_NETWORKS`).
+
+## #236 — Hub hamburger menu throws `mutate requires an active run`
+
+**Problem:** `menuOpen`/`handCollapsed` live inside per-run `GameState` (`state.ui`). In the hub
+there's no active run, so `toggleMenuOpen()`/`toggleHandCollapsed()` → `mutate()` throws.
+
+**Decision:** make the two UI toggles **run-independent** via a module-level fallback — no change
+to the serialized-state shape or the existing round-trip test.
+
+**Approach (`js/core/state/game.js`):**
+- Module-level fallback `{ menuOpen, handCollapsed }`.
+- Each toggle: if an active run exists, mutate `state.ui` as today; otherwise flip the fallback.
+- Add read helpers (`isMenuOpen`/`isHandCollapsed`) that prefer run state, fall back to module
+  state, so the HUD reflects the right value in both contexts.
+- Use `getActiveRun()`-style guard (not `mutate`, which throws) to branch.
+
+## Non-goals
+
+- No hub UI redesign; authored targets reuse the existing target-card rendering.
+- Not folding named-network selection into procgen (a later Flow Subversion pillar item).
+
+## Verification
+
+- TDD: failing test first for each (hub-target launch path builds the named graph; toggles don't
+  throw with no active run and persist across a run boundary).
+- `make check` green; browser smoke: hub lists authored jobs + launches one; hub hamburger opens
+  without error.

--- a/js/core/profile/targets.js
+++ b/js/core/profile/targets.js
@@ -1,10 +1,14 @@
 // @ts-check
-// Hub target-list generation. v1: a small fixed set of difficulty tiers, with
-// seeds derived from the profile's hub-visit counter so the list is deterministic
-// for a given profile state and rotates as the player returns to the hub.
+// Hub target-list generation. Two kinds of target:
+//   1. Procedural tiers — a small fixed set of difficulty tiers, seeds derived from the profile's
+//      hub-visit counter so the list is deterministic per profile state and rotates on return.
+//   2. Authored jobs — one per hand-crafted named network (#261), always available so set-piece
+//      and Flow Subversion content is reachable from normal hub play (not just deep-links).
 //
-// This is deliberately minimal — the flat list is the seam where richer
-// navigation (a map / world hierarchy) will grow later.
+// This is deliberately minimal — the flat list is the seam where richer navigation (a map / world
+// hierarchy) will grow later.
+
+import { NAMED_NETWORKS } from "../../../data/networks/index.js";
 
 /** @typedef {import('../types.js').StarnetProfile} StarnetProfile */
 
@@ -12,25 +16,47 @@
  * @typedef {{
  *   id: string,
  *   label: string,
- *   seed: string,
- *   spec: { threat: string, wealth: string, complexity: string, depth: string },
+ *   seed?: string,
+ *   spec?: { threat: string, wealth: string, complexity: string, depth: string },
+ *   network?: string,
  * }} HubTarget
+ * A procedural target carries `seed` + `spec`; an authored target carries `network`
+ * (a NAMED_NETWORKS key). `launchTarget` in js/ui/hub.js branches on `network`.
  */
 
-/** @type {{ id: string, label: string, spec: HubTarget["spec"] }[]} */
+/** @type {{ id: string, label: string, spec: NonNullable<HubTarget["spec"]> }[]} */
 const TIERS = [
   { id: "soft",     label: "Soft target — residential edge", spec: { threat: "F", wealth: "D", complexity: "F", depth: "F" } },
   { id: "standard", label: "Standard job — corporate LAN",   spec: { threat: "C", wealth: "B", complexity: "C", depth: "C" } },
   { id: "hard",     label: "Hard mark — hardened vault",      spec: { threat: "A", wealth: "S", complexity: "B", depth: "B" } },
 ];
 
+// Friendly labels for the authored jobs; falls back to a title-cased key for any unmapped network.
+const AUTHORED_LABELS = {
+  "corporate-foothold": "Corporate Foothold — authored",
+  "research-station": "Research Station — authored",
+  "corporate-exchange": "Corporate Exchange — Flow Subversion",
+};
+
+const titleCase = (key) =>
+  key.split("-").map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+
+/** One always-available authored target per registered named network. */
+function authoredTargets() {
+  return Object.keys(NAMED_NETWORKS).map((network) => ({
+    id: `authored-${network}`,
+    label: AUTHORED_LABELS[network] ?? titleCase(network),
+    network,
+  }));
+}
+
 /**
- * Build the hub's target list. Seeds incorporate the profile's hub-visit counter
- * so each visit offers a fresh-but-deterministic set.
+ * Build the hub's target list: procedural tiers (seeded by hub-visit count) + authored jobs.
  * @param {StarnetProfile} profile
  * @returns {HubTarget[]}
  */
 export function generateTargets(profile) {
   const visit = profile._hubVisits ?? 0;
-  return TIERS.map((t) => ({ ...t, seed: `target-${visit}-${t.id}` }));
+  const procgen = TIERS.map((t) => ({ ...t, seed: `target-${visit}-${t.id}` }));
+  return [...procgen, ...authoredTargets()];
 }

--- a/js/core/profile/targets.test.js
+++ b/js/core/profile/targets.test.js
@@ -2,17 +2,34 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { generateTargets } from "./targets.js";
 import { createProfile } from "./index.js";
+import { NAMED_NETWORKS } from "../../../data/networks/index.js";
 
 describe("generateTargets", () => {
-  it("returns three well-formed targets", () => {
-    const targets = generateTargets(createProfile());
-    assert.equal(targets.length, 3);
-    for (const t of targets) {
+  it("returns the three procedural tiers, each well-formed", () => {
+    const procgen = generateTargets(createProfile()).filter((t) => !t.network);
+    assert.equal(procgen.length, 3);
+    for (const t of procgen) {
       assert.ok(typeof t.id === "string" && t.id.length > 0);
       assert.ok(typeof t.label === "string" && t.label.length > 0);
       assert.ok(typeof t.seed === "string" && t.seed.length > 0);
       assert.ok(t.spec && t.spec.threat && t.spec.wealth && t.spec.complexity && t.spec.depth);
     }
+  });
+
+  it("surfaces every named network as an authored target (#261)", () => {
+    const authored = generateTargets(createProfile()).filter((t) => t.network);
+    // one authored target per registered named network, each resolvable in the registry
+    assert.equal(authored.length, Object.keys(NAMED_NETWORKS).length);
+    for (const t of authored) {
+      assert.ok(typeof t.id === "string" && t.id.length > 0);
+      assert.ok(typeof t.label === "string" && t.label.length > 0);
+      assert.ok(t.network in NAMED_NETWORKS, `network "${t.network}" is registered`);
+    }
+    // every registered network is present exactly once
+    assert.deepEqual(
+      authored.map((t) => t.network).sort(),
+      Object.keys(NAMED_NETWORKS).sort(),
+    );
   });
 
   it("is deterministic for a given hub-visit count", () => {
@@ -21,12 +38,14 @@ describe("generateTargets", () => {
     assert.deepEqual(a, b);
   });
 
-  it("produces different seeds as the hub-visit count changes", () => {
-    const v0 = generateTargets({ ...createProfile(), _hubVisits: 0 });
-    const v1 = generateTargets({ ...createProfile(), _hubVisits: 1 });
-    assert.notDeepEqual(
-      v0.map((t) => t.seed),
-      v1.map((t) => t.seed),
-    );
+  it("produces different procedural seeds as the hub-visit count changes", () => {
+    const seeds = (v) => generateTargets({ ...createProfile(), _hubVisits: v })
+      .filter((t) => !t.network).map((t) => t.seed);
+    assert.notDeepEqual(seeds(0), seeds(1));
+  });
+
+  it("authored targets are stable across hub visits (not seed-rotated)", () => {
+    const authored = (v) => generateTargets({ ...createProfile(), _hubVisits: v }).filter((t) => t.network);
+    assert.deepEqual(authored(0), authored(3));
   });
 });

--- a/js/core/state/game.js
+++ b/js/core/state/game.js
@@ -1,7 +1,14 @@
 // @ts-check
 // Pure game-level state mutations. No event emission, no orchestration.
 
-import { mutate } from "./index.js";
+import { mutate, getState } from "./index.js";
+
+// Menu/hand are view chrome, not gameplay: the HUD hamburger + hand collapse are usable in the
+// overworld hub, where there is NO active run (so mutate() would throw — #236). When a run is
+// active the flags live in serialized run state (state.ui, round-tripped); with no run they fall
+// back to this module-level view state. The two scopes are independent by design — a run starts
+// with fresh state.ui, and the hub keeps its own toggle state between runs.
+const _uiFallback = { menuOpen: false, handCollapsed: false };
 
 /** Sets state.selectedNodeId (pass null to deselect). */
 export function setSelectedNode(nodeId) {
@@ -31,8 +38,9 @@ export function setCheating() {
   });
 }
 
-/** Toggle the HUD hamburger panel. @returns {boolean} new menuOpen */
+/** Toggle the HUD hamburger panel. Works in-run (state.ui) and at the hub (fallback). @returns {boolean} new menuOpen */
 export function toggleMenuOpen() {
+  if (!getState()) return (_uiFallback.menuOpen = !_uiFallback.menuOpen);
   let v;
   mutate((s) => {
     s.ui.menuOpen = !s.ui.menuOpen;
@@ -41,8 +49,9 @@ export function toggleMenuOpen() {
   return /** @type {boolean} */ (v);
 }
 
-/** Toggle the exploit-hand collapse. @returns {boolean} new handCollapsed */
+/** Toggle the exploit-hand collapse. Works in-run (state.ui) and at the hub (fallback). @returns {boolean} new handCollapsed */
 export function toggleHandCollapsed() {
+  if (!getState()) return (_uiFallback.handCollapsed = !_uiFallback.handCollapsed);
   let v;
   mutate((s) => {
     s.ui.handCollapsed = !s.ui.handCollapsed;

--- a/js/core/state/game.js
+++ b/js/core/state/game.js
@@ -3,11 +3,11 @@
 
 import { mutate, getState } from "./index.js";
 
-// Menu/hand are view chrome, not gameplay: the HUD hamburger + hand collapse are usable in the
-// overworld hub, where there is NO active run (so mutate() would throw — #236). When a run is
-// active the flags live in serialized run state (state.ui, round-tripped); with no run they fall
-// back to this module-level view state. The two scopes are independent by design — a run starts
-// with fresh state.ui, and the hub keeps its own toggle state between runs.
+// Menu/hand are view chrome, not gameplay: the HUD hamburger + hand collapse are usable at the
+// overworld hub. When a run is active the flags live in serialized run state (state.ui,
+// round-tripped). At the initial hub — before any run has been started this session — there is no
+// active run, so mutate() would throw (#236); the toggles fall back to this module-level view state
+// instead. The goal is simply that the toggles never throw regardless of run context.
 const _uiFallback = { menuOpen: false, handCollapsed: false };
 
 /** Sets state.selectedNodeId (pass null to deselect). */

--- a/js/ui/components/starnet-hub.js
+++ b/js/ui/components/starnet-hub.js
@@ -95,7 +95,7 @@ class StarnetHub extends StarnetElement {
           ${repeat(this.targets, (t) => t.id, (t) => html`
             <div class="hub-target" @click=${() => this._launch(t.id)}>
               <span class="hub-target-label">▸ ${t.label}</span>
-              <span class="hub-target-grade">threat ${t.spec.threat} · wealth ${t.spec.wealth}</span>
+              <span class="hub-target-grade">${t.spec ? html`threat ${t.spec.threat} · wealth ${t.spec.wealth}` : "authored network"}</span>
             </div>`)}
         </div>
       </div>`;

--- a/js/ui/hub-commands.js
+++ b/js/ui/hub-commands.js
@@ -57,7 +57,10 @@ registerCommand({
   execute() {
     const { targets } = getHub();
     log("AVAILABLE TARGETS:");
-    targets.forEach((t) => log(`  ${t.id}  —  ${t.label}  (threat ${t.spec.threat} / wealth ${t.spec.wealth})`));
+    targets.forEach((t) => {
+      const detail = t.spec ? `threat ${t.spec.threat} / wealth ${t.spec.wealth}` : "authored network";
+      log(`  ${t.id}  —  ${t.label}  (${detail})`);
+    });
     log("Use: launch <id>");
   },
 });

--- a/js/ui/hub.js
+++ b/js/ui/hub.js
@@ -11,6 +11,7 @@ import { buyFromStoreToProfile } from "../core/store-logic.js";
 import { getStoreCatalog } from "../core/exploits.js";
 import { startRun } from "./run-control.js";
 import { buildNetwork as buildGenerated } from "../../data/networks/generated.js";
+import { NAMED_NETWORKS } from "../../data/networks/index.js";
 import { emitEvent, E } from "../core/events.js";
 
 const MAX_LOADOUT = 5;
@@ -137,7 +138,15 @@ export function launchTarget(targetId) {
     withdrawAmount: selection.withdrawAmount,
   });
   if (!launchMeta) { log("[HUB] Insufficient bank for that carry amount.", "error"); return; }
-  const result = buildGenerated({ seed: target.seed, spec: target.spec });
+  // Authored jobs build a hand-crafted named network; procedural targets build from seed + spec (#261).
+  let result;
+  if (target.network) {
+    const build = NAMED_NETWORKS[target.network];
+    if (!build) { log(`[HUB] Unknown authored network: ${target.network}`, "error"); return; }
+    result = build();
+  } else {
+    result = buildGenerated({ seed: target.seed, spec: target.spec });
+  }
   const el = hubEl();
   if (el) el.open = false;
   log(`[HUB] Jacking into ${target.label}…`, "success");

--- a/tests/ui-state.test.js
+++ b/tests/ui-state.test.js
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import { createGateway, createRouter } from "../js/core/node-graph/node-factories.js";
 import { initGame, getState, serializeState, deserializeState } from "../js/core/state.js";
 import { toggleMenuOpen, toggleHandCollapsed } from "../js/core/state/game.js";
+import { setActiveRun } from "../js/core/run-context.js";
 
 function buildMinimalLAN() {
   return {
@@ -57,6 +58,24 @@ test("ui flags survive a JSON round-trip via serializeState", () => {
   const snapshot = JSON.parse(JSON.stringify(serializeState()));
   assert.equal(snapshot.ui.menuOpen, true);
   assert.equal(snapshot.ui.handCollapsed, false);
+});
+
+// #236 — the hub has no active run; the UI toggles must not require one.
+test("toggleMenuOpen works with no active run (hub) and does not throw", () => {
+  setActiveRun(null);   // simulate the overworld hub — no run in progress
+  assert.equal(getState(), null);
+  let open;
+  assert.doesNotThrow(() => { open = toggleMenuOpen(); });
+  assert.equal(open, true);
+  assert.equal(toggleMenuOpen(), false);   // flips back
+});
+
+test("toggleHandCollapsed works with no active run (hub) and does not throw", () => {
+  setActiveRun(null);
+  let collapsed;
+  assert.doesNotThrow(() => { collapsed = toggleHandCollapsed(); });
+  assert.equal(collapsed, true);
+  assert.equal(toggleHandCollapsed(), false);
 });
 
 test("loading a pre-ui save heals state.ui so the toggle setters don't crash", () => {


### PR DESCRIPTION
Two small, independent hub fixes. Closes #261, closes #236.

## #261 — named networks reachable from the hub
Authored named networks (`corporate-foothold`, `research-station`, `corporate-exchange` — the last carries the **Flow Subversion** flows) were only reachable via `?network=` deep-links or the level-select form; the hub always built procedural networks, so authored/set-piece content was invisible in normal play.

- `js/core/profile/targets.js`: `HubTarget` gains an optional `network` field; `generateTargets` appends **one authored target per `NAMED_NETWORKS` key** (derived from the registry, so new networks auto-surface; friendly labels via a small map). Procedural tiers keep `seed` + `spec`.
- `js/ui/hub.js launchTarget`: branches — `network` → `NAMED_NETWORKS[network]()`, else `buildGenerated({seed, spec})`. Same `startRun` downstream. Registry stays the single source of truth.
- The `targets` console command and the `<starnet-hub>` GUI card now guard on `t.spec` (authored targets have none) — the GUI one would otherwise throw during render. Fixed together (GUI/console symmetry).

## #236 — hub hamburger throws `mutate requires an active run`
`menuOpen`/`handCollapsed` live in per-run `state.ui`, so the toggles hit `mutate()` which throws with no active run (the hub). They now fall back to module-level view state when no run is active; **in-run behavior + the serialized round-trip are unchanged** (chose this over relocating the flags out of run state, to avoid touching the serialization contract).

## Verification
- `make check` green (**1337 pass**, +4 net new tests — TDD for both). `make census SEEDS=5` — no headless crash.
- Headless-Chromium smoke: hub lists all **6 targets** (3 procgen + 3 authored with correct `network` keys); toggling the hamburger in the hub throws **0 errors**; `launch authored-corporate-exchange` loaded a 15-node named graph. (The browser smoke caught the `t.spec` regression before shipping.)
- `MANUAL.md` updated (hub target list now names procgen + authored jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)