### PR TITLE
SWEEP-PROBE + progressive-process framework (anti-tedium arc pt.2)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -256,6 +256,15 @@ each type's gate level.
 Probing raises the node's local alert from green to yellow. If this node is watched by
 an IDS, that alert will propagate.
 
+**Selective probe vs. SWEEP.** `probe` is the quiet, one-node-at-a-time scan. When you want to
+map fast, **SWEEP** is a *broadcast* probe: choose it (and a depth), and it **ripples outward**
+from the node wave by wave — probing each node it reaches and bringing it fully online — up to the
+depth you set, or until you `abort`. It flows *through* nodes that reveal their neighbors on probe
+and **stops at the ones that gate their connections** (routers, firewalls, IDS, monitors) — so the
+network's chokepoints are its natural sweep-breakers. The catch is **heat**: every node a sweep
+touches adds heat all at once, so a deep/wide sweep spikes fast and can trip the alarm mid-ripple.
+Watch the heat gauge and abort before it's too hot. (Console: `sweep <depth|max>` on the targeted node.)
+
 ### 3. Exploit
 
 Choose **XPLOIT** from the node's action menu, click a card in the hand strip, or type:
@@ -789,7 +798,8 @@ Actions depend on the selected node's type and access level:
 |-------------------|------------------------------------------------|--------|
 | `exec access-darknet` | WAN node is targeted                       | Opens the darknet broker store; pauses the LAN while shopping (run via `exec`) |
 | `probe`           | Node is locked and unprobed                   | Timed scan — reveals vulnerabilities, raises local alert |
-| `abort`           | Timed action in progress on targeted node      | Aborts the current action (probe, xploit, dump, or fetch) |
+| `sweep` (menu) / `sweep <depth|max>` (console) | Targeted accessible node, no sweep already running | Broadcast probe — ripples outward wave-by-wave up to the chosen depth, probing + fully revealing each reached node, flowing through probe-gate nodes and stopping at gate-controllers. Adds heat per node (a fast spike). Abortable mid-ripple. |
+| `abort`           | Timed action **or a sweep** in progress on targeted node | Aborts the current action (probe, xploit, dump, fetch, or a running sweep) |
 | `xploit` (menu) / `xploit <n>` (console) | Node is accessible and not currently exploiting | Opens a node-anchored card picker. Unprobed → all usable cards (blind); probed → only cards matching revealed vulns; disabled with a reason when no card applies. Not offered at all on an already-owned node. The hand strip and `xploit <n>` console command stay full-agency (play any usable card). Raises access level on success. |
 | `dump`         | Node is open or owned, unread                  | Timed scan — reveals macguffins |
 | `fetch`        | Node is owned + has uncollected macguffins     | Timed extraction — collects macguffins for cash |
@@ -819,6 +829,7 @@ you probe them. `status node sig-N` reports `[???]` for an unidentified node's t
 target <node>          Target a node. Alias: t
 untarget               Untarget current node.
 probe [node]           Probe targeted or specified node.
+sweep <depth|max>       Broadcast probe from the targeted node, rippling to depth (or "max"); abort to stop.
 abort                  Abort any in-progress timed action on targeted node.
 xploit <#|name>        Use exploit card by number or name on targeted node.
 dump [node]            Dump contents of targeted/specified node.

--- a/docs/BOT-PLAYER.md
+++ b/docs/BOT-PLAYER.md
@@ -286,7 +286,12 @@ These omissions are intentional — they make the bot a pessimistic baseline:
   (at the current decay it matches `main` exactly — no regression). Heat is a
   **burst** detector; the bot doesn't burst instant actions, so it neither exploits
   the mechanic (deliberate pacing) nor stress-tests it. A human blitzing programs /
-  a future SWEEP is what heat is really for.
+  a SWEEP is what heat is really for.
+- **SWEEP (broadcast probe)** — the bot never sweeps; it probes one node at a time via
+  the normal loop. SWEEP is an opt-in progressive process (`state.processes`), so with no
+  sweep running the process framework no-ops for the bot and census is unchanged from
+  `main` (0.3 / 0.767 same-seed). SWEEP is a human breadth-vs-heat choice; the census
+  can't tell us whether its depth/heat feel right.
 
 ### What the census therefore cannot validate
 

--- a/docs/design/flow-subversion.md
+++ b/docs/design/flow-subversion.md
@@ -235,9 +235,14 @@ today, where `lie-low` calms the grid to green — that alert-calming moves to t
 Each core verb becomes a *family* of loadout-selectable variants along a small triangle —
 **breadth** (one node ↔ sweep), **speed**, **stealth (heat)**:
 
-- **PROBE-sweep** (scan many nodes at once, big heat spike) vs **meticulous PROBE** (one node,
-  slow, low heat).
-- **Parallel XPLOIT sweep** vs **node-at-a-time XPLOIT**, trading heat/risk for reach.
+- **PROBE-sweep** ✅ **shipped** (verb variants pt.2) — a progressive, depth-bounded, abortable
+  broadcast probe that ripples outward wave-by-wave, gate-bounded (stops at routers/firewalls/IDS/
+  monitors), heat per node. vs **meticulous PROBE** (the existing one-node scan). Built on a **generic
+  progressive-process seam** (`js/core/processes.js`: `state.processes` + a type registry + one
+  `stepProcesses()` hook in the central tick + uniform busy/abort) — so it needed *no* bespoke timer
+  or abort special-case, and the remaining variants plug into the same registry.
+- **Parallel XPLOIT sweep** vs **node-at-a-time XPLOIT**, trading heat/risk for reach — *pending*,
+  and now cheap: it's another `registerProcess` client on the seam above.
 
 The RAM loadout decision becomes *"what's my playstyle for this network — meticulous ghost, or
 smash-and-grab?"* — a strong pre-run layer that feeds the Session 3 store/RAM economy. Heat is the

--- a/docs/dev-sessions/2026-07-01-1639-verb-variants/notes.md
+++ b/docs/dev-sessions/2026-07-01-1639-verb-variants/notes.md
@@ -1,0 +1,41 @@
+# SWEEP-PROBE (verb variants pt.2) — notes
+
+## Outcome: functional feature complete + green; ripple-visual (P4) parked for a browser pass
+
+Branch `verb-variants` off `origin/main`@8c1128e (heat #271). `make check` green (1550 tests,
++13 process/sweep). Census SEEDS=30 = main exactly (0.3 / 0.767 / 4.53 / ¥6190) — SWEEP is opt-in,
+the bot never sweeps, the process framework no-ops for it.
+
+## What shipped
+- **Generic progressive-process seam** (`js/core/processes.js`) — the normalization Les asked for:
+  `state.processes[]` (serializable + healed), a type registry (`registerProcess`), ONE
+  `stepProcesses()` hook in the central `tick()`, and uniform busy/abort (`activeProcessOnNode` /
+  `abortNodeProcesses`). No per-feature global timers, no per-action abort special-cases.
+- **SWEEP as the first client** (`js/core/sweep.js`) — a `sweep` process: probes the origin, then
+  ripples outward one wave every `SWEEP_WAVE_TICKS`, probing each frontier via `resolveProbe`
+  (connect + probe, so reached sig nodes come **fully online**; gate-bounded propagation + heat +
+  node-alert all fall out). Depth ceiling (1/2/3/max) + abort; ends at cap/empty/abort.
+- **Action/UX**: SWEEP_ACTION with a depth picker (mirrors SNIFF); console `sweep <node> <depth|max>`;
+  a busy node offers only ABORT (general rule at the actions layer); nav-away aborts (parity).
+- **Logging** across log-renderer + playtest; harness-verified end-to-end.
+
+## Key design win (Les's steer)
+Instead of a bespoke `SWEEP_WAVE` timer + `sweeping` special-case, we built the general process seam.
+Parallel-XPLOIT (the remaining verb variant) is now a cheap follow-on: another `registerProcess`
+client, zero new timers/abort code. Special-cases avoided by construction.
+
+## Deferred: Phase 4 — the outward-ripple overlay
+The dedicated graph-level wave-ripple animation is NOT built. It's a feel/polish visual I can't
+build-and-verify here (no browser / Playwright), and the sweep is already legible without it: swept
+nodes animate via the existing NODE_REVEALED / ACTION_RESOLVED(probe) visuals, and every wave is
+narrated in the log + heat gauge. Options for Les: (a) ship SWEEP now, add the ripple as a small
+follow-up done with his eye in the browser; or (b) pair on the ripple before the PR.
+
+## Still to do (Les)
+- **Browser eyeball** on `?network=corporate-exchange`: `sweep gateway max` ripples outward through
+  probe-gate nodes, stops at routers/firewalls, heat gauge spikes, abort stops it mid-ripple.
+- Decide the Phase-4 ripple option above.
+- **PR** (rebase onto current origin/main first).
+
+## Next arc
+Parallel-XPLOIT (plugs into the process seam) + flows-as-scouting. See `docs/design/flow-subversion.md`.

--- a/docs/dev-sessions/2026-07-01-1639-verb-variants/plan.md
+++ b/docs/dev-sessions/2026-07-01-1639-verb-variants/plan.md
@@ -1,0 +1,191 @@
+# SWEEP-PROBE Implementation Plan
+
+**Goal:** A progressive, depth-bounded, abortable probe flood-fill (SWEEP) — the breadth counterpart
+to selective PROBE — built on a **reusable progressive-process framework** (no bespoke per-feature
+timers, no per-action abort special-cases), bounded by the gate structure, priced in heat.
+
+**Approach:** Introduce a small general **process** seam — serializable `state.processes`, a type
+registry, one `stepProcesses()` hook in the existing central `tick()`, and a uniform "active process
+on a node = busy/abortable" rule. SWEEP is the first client: a `sweep` process whose step probes the
+current BFS frontier (connect + `resolveProbe` per node → gate-bounded reveal + heat + alert fall out),
+advances a wave every N ticks, and ends at depth cap / empty frontier / abort. Surface as a fixed-kit
+node action with a depth picker (mirrors SNIFF). Future cross-node/progressive verbs (parallel-XPLOIT)
+plug into the SAME seam.
+
+**Tech stack:** Vanilla ES modules, JSDoc `@ts-check`, node:test, Lit HUD, esbuild.
+
+---
+
+## Phase 1: Progressive-process framework (generic seam, no UI)
+
+The reusable mechanism, standalone and tested — SWEEP is a later client. Built first so SWEEP never
+needs a bespoke timer or abort special-case.
+
+**Files:**
+- Modify: `js/core/types.js` — `GameState.processes: Process[]`; `Process = { id:number, type:string, nodeId:string, [k:string]:any }`.
+- Modify: `js/core/state/index.js` — init `processes: []`; heal.
+- Create: `js/core/state/process.js` — `mutate()`-wrapped: `addProcess(p)`, `updateProcess(id, patch)`, `removeProcess(id)`, `nextProcessId()`. Re-export via `state.js`.
+- Create: `js/core/processes.js` — the registry + tick driver + queries:
+  - `registerProcess(type, { step, onAbort })`
+  - `stepProcesses()` — for each active process, `step(proc, state)`; if it returns `true` (done), remove + emit `E.PROCESS_ENDED{reason:"complete"}`.
+  - `activeProcessOnNode(state, nodeId)` / `abortNodeProcesses(nodeId, reason)` (calls `onAbort`, removes, emits `E.PROCESS_ENDED{reason}`).
+- Modify: `js/core/timers.js` — call `stepProcesses()` once per `tick()` (alongside the graph tick), so all three entry points drive it with no per-feature timer.
+- Modify: `js/core/events.js` — `E.PROCESS_STARTED`, `E.PROCESS_STEP`, `E.PROCESS_ENDED`.
+- Test: `tests/processes.test.js`.
+
+**Key changes:**
+- Registry + driver (pure-ish; `step` returns done):
+  ```js
+  const HANDLERS = new Map(); // type → { step, onAbort }
+  export function registerProcess(type, def) { HANDLERS.set(type, def); }
+  export function stepProcesses() {
+    const s = getState();
+    if (!s || s.phase !== "playing") return;
+    for (const proc of [...s.processes]) {           // snapshot: step may remove
+      const def = HANDLERS.get(proc.type);
+      if (def && def.step(proc, getState()) === true) endProcess(proc.id, "complete");
+    }
+  }
+  export function abortNodeProcesses(nodeId, reason = "aborted") {
+    for (const proc of getState().processes.filter((p) => p.nodeId === nodeId)) endProcess(proc.id, reason);
+  }
+  function endProcess(id, reason) {
+    const proc = getState().processes.find((p) => p.id === id);
+    if (!proc) return;
+    HANDLERS.get(proc.type)?.onAbort?.(proc, getState()); // onAbort runs on every end (idempotent cleanup)
+    removeProcess(id);
+    emitEvent(E.PROCESS_ENDED, { id, type: proc.type, nodeId: proc.nodeId, reason });
+  }
+  export const activeProcessOnNode = (state, nodeId) => state.processes.some((p) => p.nodeId === nodeId);
+  ```
+  (Handlers are re-registered per run wherever run handlers are wired — module import registers them;
+  confirm registration survives `clearHandlers()` since it's a plain Map, not an event listener.)
+
+**Verification — automated:**
+- [ ] `make lint` / `make test` / `make check` pass
+- [ ] A dummy test process registered, added, and stepped over `tick()`s advances and self-removes when
+      its `step` returns done; `E.PROCESS_ENDED{complete}` fires.
+- [ ] `abortNodeProcesses` removes a node's processes, runs `onAbort`, emits `E.PROCESS_ENDED{aborted}`.
+- [ ] `processes` round-trips through serialize→deserialize (a mid-flight process resumes stepping);
+      pre-field save heals to `[]`.
+
+**Verification — manual:** none.
+
+---
+
+## Phase 2: SWEEP as a process — gate-bounded wave flood-fill
+
+SWEEP is the first `registerProcess` client. Reuses `resolveProbe` per frontier node.
+
+**Files:**
+- Modify: `js/core/balance.js` — `SWEEP_WAVE_TICKS` (ticks/wave), `SWEEP_MAX_DEPTH`.
+- Create: `js/core/sweep.js` — `startSweep(originId, depthCap)` + `registerProcess("sweep", { step, onAbort })`.
+- (reuse) per-node step = connect + probe so a reached `sig-N` node ends fully revealed (Les: "as if connected-to"): `setNodeVisible(id,"accessible")` then `ctx.resolveProbe(id)`.
+- Test: `tests/sweep.test.js`.
+
+**Key changes:**
+- `sweep.js`:
+  ```js
+  const revealedUnprobedNeighbors = (s, id) =>
+    (s.adjacency[id] || []).filter((n) => s.nodes[n] && s.nodes[n].visibility !== "hidden" && !s.nodes[n].probed);
+  const sweepProbe = (ctx, id) => { setNodeVisible(id, "accessible"); ctx.resolveProbe(id); }; // connect + probe
+
+  export function startSweep(originId, depthCap) {
+    const s = getState();
+    const ctx = s.nodeGraph?._ctx;
+    if (!ctx || activeProcessOnNode(s, originId)) return;
+    sweepProbe(ctx, originId);                                   // wave 0
+    const cap = Math.min(depthCap || SWEEP_MAX_DEPTH, SWEEP_MAX_DEPTH);
+    addProcess({ id: nextProcessId(), type: "sweep", nodeId: originId,
+                 depthCap: cap, depth: 0, wave: 0,
+                 frontier: revealedUnprobedNeighbors(getState(), originId) });
+    emitEvent(E.PROCESS_STARTED, { type: "sweep", nodeId: originId, depthCap: cap });
+  }
+
+  registerProcess("sweep", {
+    step(proc, s) {
+      if (proc.depth >= proc.depthCap || proc.frontier.length === 0) return true; // done
+      if (++proc.wave < SWEEP_WAVE_TICKS) { updateProcess(proc.id, { wave: proc.wave }); return false; }
+      const ctx = s.nodeGraph._ctx;
+      for (const id of proc.frontier) sweepProbe(ctx, id);       // each: connect + reveal-if-gate + heat + alert
+      const next = [...new Set(proc.frontier.flatMap((id) => revealedUnprobedNeighbors(getState(), id)))];
+      const depth = proc.depth + 1;
+      updateProcess(proc.id, { depth, wave: 0, frontier: next });
+      emitEvent(E.PROCESS_STEP, { type: "sweep", nodeId: proc.nodeId, depth, count: proc.frontier.length });
+      return depth >= proc.depthCap || next.length === 0;        // done after this wave?
+    },
+    onAbort() {}, // nothing to undo — probed nodes stay revealed
+  });
+  ```
+  (Confirm `s.nodeGraph._ctx.resolveProbe` handle during execution; if cleaner, extract `resolveProbe`'s
+  body to a shared `probeNode(nodeId)` and call from both game-ctx and here.)
+
+**Verification — automated:**
+- [ ] `make check` passes
+- [ ] Sweep depthCap N probes N waves; reached `sig-N` nodes end `probed` AND `visibility:"accessible"` (fully revealed); heat rose ~`HEAT_COST.probe × swept`.
+- [ ] Propagation STOPS at a gate-controller (router/firewall/IDS/monitor) — its neighbors stay hidden/unprobed.
+- [ ] Stops early when the frontier empties before the cap.
+- [ ] Serialize mid-sweep → resumes waving after deserialize (process round-trips).
+
+**Verification — manual:** none.
+
+---
+
+## Phase 3: SWEEP action + depth picker + console + abort
+
+Surface the verb; abort rides the generic process rule (no special-case).
+
+**Files:**
+- Modify: `js/core/action-ids.js` — `SWEEP: "sweep"`.
+- Modify: `js/core/actions/program-actions.js` — `SWEEP_ACTION` (followup depth picker 1/2/3/max) + inject in `getProgramActions` when accessible AND `!activeProcessOnNode`.
+- Modify: `js/core/actions/node-actions.js` — offer the unified ABORT when `activeProcessOnNode(state, node.id)` (mirrors the KICK global-state filter); ABORT execute → `abortNodeProcesses(node.id)`.
+- Modify: `js/core/actions/action-context.js` — dispatch `sweep` with `{depth}` → `startSweep(node.id, depth)`.
+- Modify: `js/core/navigation.js` — `navigateAway` also `abortNodeProcesses(prevSelected)` (nav-cancel parity with timed actions).
+- Modify: `js/core/console-commands/commands.js` — `sweep <node> <depth|max>` (mirror `sniff`).
+- Modify: `js/ui/log-renderer.js` + `scripts/playtest.js` — log `PROCESS_STARTED/STEP/ENDED` for `sweep`.
+- Test: `tests/sweep.test.js`.
+
+**Key changes:**
+- `SWEEP_ACTION` mirrors `SNIFF_ACTION`: followup `choices` = depth options (render "action"); pick →
+  `starnet:action { actionId:"sweep", nodeId, depth }`; `execute:(n,_s,_c,p)=>startSweep(n.id, p.depth==="max"?SWEEP_MAX_DEPTH:Number(p.depth))`.
+- ABORT already exists as a unified action; extend its availability + execute to cover an active process
+  on the node (general — parallel-XPLOIT inherits it).
+
+**Verification — automated:**
+- [ ] `make check` passes
+- [ ] Dispatch `{actionId:"sweep", nodeId, depth:2}` runs to completion over `tick()`s; GUI/console (`sweep <node> 2`) parity (same probed set + heat).
+- [ ] ABORT mid-sweep ends the process, keeps everything already probed; SWEEP not offered while a sweep runs on the node.
+- [ ] Nav-away mid-sweep aborts it.
+
+**Verification — manual:**
+- [ ] Harness: `sweep gateway 3` + `tick` — waves probe outward in the log; a wide sweep trips `[HEAT]`.
+
+---
+
+## Phase 4: Wave ripple visual + preview
+
+**Files:**
+- Modify: `js/ui/overlays/probe-sweep.js` — outward per-wave ripple (clockwise = player action), or a sibling overlay; overlay layer + cheap filter (glow-ownership rule), no per-frame heavy filter.
+- Modify: `js/ui/visual-renderer.js` — on `E.PROCESS_STEP{type:"sweep"}`, pulse the ripple from origin at the wave radius.
+- Modify: `js/ui/preview.js` / `preview.html` — "Sweep ripple" demo.
+
+**Verification — automated:** [ ] `make check` passes
+**Verification — manual:**
+- [ ] Preview shows the outward ripple per wave; stroke+glow only, cheap overlay filter.
+- [ ] In-game (`?network=corporate-exchange`): sweep ripples outward, heat gauge climbs, abort stops it.
+
+---
+
+## Phase 5: Docs + census
+
+**Files:**
+- Modify: `MANUAL.md` — SWEEP (selective vs sweep probing); node-actions + console rows; gate-controllers stop the flood, heat is the cost, reached nodes come fully online.
+- Modify: `docs/BOT-PLAYER.md` — bot doesn't use SWEEP (opt-in); census confirms no-regression.
+- Modify: `docs/design/flow-subversion.md` — SWEEP-PROBE done; note the generic **process** seam now exists for future cross-node/progressive verbs (parallel-XPLOIT); parallel-XPLOIT still pending.
+
+**Verification — automated:**
+- [ ] `make check` passes
+- [ ] `make census SEEDS=30` vs same-seed `main`: unchanged (bot doesn't sweep).
+**Verification — manual:**
+- [ ] MANUAL re-read matches behavior.
+- [ ] Feel check with Les: depth picker + wave cadence + heat spike (tune `SWEEP_WAVE_TICKS` / depth options by feel).

--- a/docs/dev-sessions/2026-07-01-1639-verb-variants/research.md
+++ b/docs/dev-sessions/2026-07-01-1639-verb-variants/research.md
@@ -1,0 +1,50 @@
+# Verb variants — SWEEP-PROBE — codebase research
+
+Off `origin/main`@8c1128e (heat model #271 merged). Integration points for a progressive,
+depth-bounded, abortable probe flood-fill.
+
+## Probe + reveal + gate propagation (the flood-fill engine, already exists)
+- **Single-node probe:** `resolveProbe(nodeId)` in `js/core/node-graph/game-ctx.js` — setNodeProbed,
+  setLastDisturbedNode, `recordHeat(HEAT_COST.probe)`, raises node alert green→yellow, emits
+  ACTION_RESOLVED{PROBE}, and reveals neighbors **only when `(node.gateAccess ?? "probed") === "probed"`**.
+- **`revealNeighbors(nodeId)`** (`js/core/state/index.js:282`) — reveals a node's hidden neighbors as
+  `sig-N` (visibility "revealed"). This is the propagation step.
+- **Gate rule = the sweep's natural stopper.** gateAccess "probed" (gateway/workstation/fileserver/
+  cryptovault/WAN) reveal neighbors on probe → sweep propagates through them. gateAccess "open"/"owned"
+  (router/firewall/IDS/monitor) do NOT reveal on probe until opened/owned → sweep can probe them but
+  can't expand past them. SWEEP reuses this; no new "hardened" concept needed.
+- **Frontier source:** `state.adjacency[nodeId]` (undirected neighbor ids). A node is sweep-probeable
+  if visible (revealed/accessible) and unprobed.
+
+## Heat (the cost, shipped #271) — `js/core/alert.js`
+- `recordHeat(amount)` — trip-line: adds heat, crossing hidden `HEAT_ALARM_THRESHOLD[threat]` steps the
+  alert + discharges. `HEAT_COST.probe` in `js/core/balance.js`. Each swept node = one recordHeat →
+  a wide/deep wave spikes heat and can trip mid-sweep (the tension).
+- Decaying-heat + gauge already in place; SWEEP just feeds it more, faster.
+
+## Progressive action pattern (NEW — not the single-shot timed action)
+- Existing timed actions (probe/xploit) resolve ONCE on completion via the `timed-action` operator +
+  `TIMED_ACTIONS` registry (`js/core/node-graph/timed-actions.js`: `TIMED_ACTIONS`, `ABORTABLE_FLAGS`,
+  `getTimedActionAttrNames`). SWEEP is different: it fires a **wave every N ticks** until depth cap /
+  frontier-empty / abort.
+- **Model:** a repeating `SWEEP_WAVE` timer (mirror `TRACE_TICK`/`HEAT_DECAY` in `alert.js` + `timers.js`
+  `TIMER`), handler processes one wave; wired in `js/ui/main.js` + `scripts/lib/headless-engine.js`
+  `wireRunHandlers`. In-flight sweep state (origin, depthCap, currentDepth, frontier[], timerId) lives
+  in serializable `state` (like `heatDecayTimerId`/`traceTimerId`).
+- **Abort:** reuse the ABORT unified action + nav-away cancel; add a `sweeping` active flag to the
+  registry so ABORT surfaces and NOT_BUSY blocks concurrent actions. Abort cancels the timer, clears
+  sweep state, keeps everything already revealed/probed.
+
+## Availability + UI (mirror the Session-1 flow programs)
+- **Injected node-action:** `getProgramActions(node,state)` in `js/core/actions/program-actions.js`
+  injects SNIFF/REPLAY as a fixed kit (top-level, not EXEC scripts). Add SWEEP the same way — available
+  on an accessible node; a **followup depth picker** (mirrors the SNIFF flow picker / XPLOIT card picker,
+  rendered by `starnet-action-choices.js`).
+- **Console:** `sweep <node> <depth>` in `js/core/console-commands/commands.js` (mirror `sniff`).
+- **Visual:** `js/ui/overlays/probe-sweep.js` already draws a clockwise probe ripple — extend/repeat it
+  outward per wave (clockwise = player action, per the rotation convention). New effect → preview harness.
+
+## Three entry points + census
+- SWEEP is player-only, opt-in (like flow programs). The **bot won't use it** — document in
+  `docs/BOT-PLAYER.md`; census confirms no-regression. Wave-timer handler must be registered in
+  `main.js` + `wireRunHandlers` (playtest + bot), mirroring HEAT_DECAY/TRACE_TICK.

--- a/docs/dev-sessions/2026-07-01-1639-verb-variants/spec.md
+++ b/docs/dev-sessions/2026-07-01-1639-verb-variants/spec.md
@@ -1,0 +1,91 @@
+# SWEEP-PROBE (verb variants, anti-tedium arc pt.2) Spec
+
+**Goal:** Add **SWEEP** — a progressive, depth-bounded, abortable probe flood-fill from a node —
+as the *breadth* counterpart to the existing selective single-node PROBE. It maps more of the
+network fast, at the cost of a fast-building heat spike, so the player trades coverage against
+notice. This is the first verb variant; it turns the heat meter (shipped #271) into a live
+coverage-vs-heat dial and makes the network's gate structure tactically load-bearing.
+
+**Source:** User request 2026-07-01 (design conversation with Les). Arc design:
+`docs/design/flow-subversion.md` → "Anti-tedium arc" (verb variants). Builds on the heat model (#271).
+
+## Current state
+See `research.md` for `file:line`. Load-bearing facts:
+- **Selective PROBE already exists** — `resolveProbe` (game-ctx) probes one node, reveals its
+  neighbors only through **probe-gate** nodes, adds `HEAT_COST.probe`. "Meticulous probe" = this.
+- **Gate rule is the natural flood-stopper:** gateAccess "probed" types reveal-on-probe (sweep flows
+  through); "open"/"owned" types (router/firewall/IDS/monitor) don't until opened/owned (sweep stops).
+- **Heat** (`recordHeat`, trip-line, decaying) is shipped and is the exact cost model.
+- **Flow programs** (SNIFF/REPLAY) are the pattern for a fixed-kit injected node-action + followup
+  picker + console verb across all three entry points.
+- Repeating-timer pattern (`TRACE_TICK`/`HEAT_DECAY`) is the model for the per-wave progression.
+
+## Desired end state
+- **SWEEP** is a fixed-kit node-action on an accessible node. Choosing it opens a **depth picker**
+  (1 / 2 / 3 / max); console `sweep <node> <depth>`.
+- It runs as a **progressive, wave-by-wave** action from the origin node:
+  - Wave k probes the current frontier (each node: setNodeProbed + reveal-neighbors-if-probe-gate +
+    node-alert raise + `recordHeat(HEAT_COST.probe)`), then computes wave k+1's frontier from the
+    newly-revealed, unprobed, non-gate-blocked neighbors.
+  - It advances one wave every `SWEEP_WAVE_TICKS`, **incrementally revealing** the map and **building
+    heat** as it goes. A big/deep sweep spikes heat fast and can **trip the alarm mid-sweep**.
+  - It **stops** at the chosen depth ceiling, when the frontier is empty (all gate-blocked/dead-end),
+    or when the player **ABORTs** (or navigates away). Abort keeps everything already revealed/probed.
+- In-flight sweep state (origin, depthCap, currentDepth, frontier, timerId, `sweeping` flag) is
+  **serializable** and survives a save/load round-trip; a sweep resumes ticking after load.
+- The graph shows a per-wave outward **ripple** (clockwise = player action; extends the existing
+  probe-sweep overlay). Every wave + the trip + completion/abort are logged.
+- `make check` green; `make census` shows no regression (bot doesn't sweep — opt-in like programs).
+
+## Design decisions
+- **Decision:** SWEEP is a **progressive over-time flood-fill** (wave every N ticks), not a single
+  burst-at-end. - **Why (Les):** the tension is watching the map open and heat climb and deciding
+  each moment whether to push another wave or abort. **Rejected:** one-shot timed action (burst at
+  end) and instant — both lose the live abort-vs-push decision.
+- **Decision:** **player picks a depth ceiling** (1/2/3/max) up front; **abort** is the live early-out.
+  - **Why (Les):** commit a coverage budget, but still bail if heat gets scary. **Rejected:**
+    run-until-frontier-empty-or-abort with no ceiling (less upfront control).
+- **Decision:** propagation uses the **existing gate rule** — flows through probe-gate nodes, stops at
+  gate-controllers (router/firewall/IDS/monitor) until they're opened/owned. - **Why (Les):** no new
+  "hardened" concept; reuses reveal-on-probe; gives routers/firewalls a tactical flood-stopper role and
+  makes topology matter. **Rejected:** radius/all-revealed/multi-select targeting (blunter or expensive
+  new UI).
+- **Decision:** heat = `HEAT_COST.probe` per swept node, accruing per wave (reuse the shipped meter).
+  - **Why:** SWEEP is "many probes at once" — the burst the heat model was built to price; it's what
+    makes mass-probe the loud option vs selective PROBE. **Rejected:** a bespoke sweep heat cost.
+- **Decision:** fixed always-available kit (injected node-action + depth-picker followup), mirroring the
+  flow programs. - **Why:** no RAM loadout UI yet (Session 3). **Rejected:** loadout gating now.
+- **Decision:** SWEEP is player-only; the bot does not learn it. - **Why:** it's an opt-in tool like the
+  flow programs; census confirms no-regression, not its value (feel-tuned with a human).
+
+## Patterns to follow
+- Injected node-action + followup picker + console verb: mirror SNIFF (`program-actions.js`
+  `getProgramActions`/`SNIFF_ACTION`/`getFlowChoices`; `commands.js` `sniff`; `starnet-action-choices.js`).
+- Per-wave progression: repeating timer like `TRACE_TICK`/`HEAT_DECAY` (`alert.js` schedule + handler;
+  `timers.js` `TIMER`; wired in `main.js` + `wireRunHandlers`). Serializable timer id + state.
+- Per-node probe resolution: reuse/extract the `resolveProbe` body so a swept node behaves exactly like
+  a manually-probed one (reveal, alert, heat, ACTION_RESOLVED).
+- Abort/nav-cancel + `sweeping` active flag: extend the `TIMED_ACTIONS`/`ABORTABLE_FLAGS` registry.
+- Serializable-state + heal: the Session-1/heat pattern (`state/`, `state/index.js` init/heal, shim).
+- Ripple visual: extend `js/ui/overlays/probe-sweep.js`; demo in the preview harness.
+
+## What we're NOT doing
+- **No parallel/multi-node XPLOIT** — deferred (multi-node combat resolution + shared-failure is its
+  own thornier slice).
+- **No general multi-select graph UI** — the sweep's target set is derived from origin + gate-bounded
+  BFS, not arbitrary selection.
+- **No RAM loadout UI / pre-run variant selection** (Session 3) — fixed kit for now.
+- **No new "hardened node" concept** — reuse the existing gate column.
+- **No change to selective PROBE, heat, or the alert sensors' numbers.**
+- **Bot does not learn SWEEP.**
+
+## Open questions (each with a default)
+- **Wave cadence (`SWEEP_WAVE_TICKS`).** Default: ~5 ticks (0.5s)/wave — fast enough to feel like a
+  ripple, slow enough to abort between waves. Feel-tuned.
+- **Depth options.** Default: picker offers 1 / 2 / 3 / max ("max" = run until frontier-empty). Console
+  accepts an integer or `max`.
+- **Does a swept node raise its own local alert (green→yellow) like a manual probe?** Default: **yes** —
+  a swept node is probed identically (consistency); the global pressure comes from heat, the per-node
+  glow from the same probe path.
+- **Heat per swept node value.** Default: `HEAT_COST.probe` (reuse). Whether a wide sweep should trip is
+  left to the shipped heat numbers + feel/census; do NOT retune heat autonomously.

--- a/js/core/action-ids.js
+++ b/js/core/action-ids.js
@@ -29,6 +29,9 @@ export const A = Object.freeze({
   SNIFF: "sniff",
   REPLAY: "replay",
 
+  // Verb variants (anti-tedium arc pt.2). SWEEP = progressive probe flood-fill.
+  SWEEP: "sweep",
+
   // Node-specific actions
   EXEC: "exec",
   CORRUPT: "corrupt",

--- a/js/core/actions/node-actions.js
+++ b/js/core/actions/node-actions.js
@@ -17,6 +17,7 @@ import { getProgramActions } from "./program-actions.js";
 import { A } from "../action-ids.js";
 import { activeIceInstances } from "../state/ice.js";
 import { isScriptAction } from "./scripts.js";
+import { activeProcessOnNode, abortNodeProcesses } from "../processes.js";
 
 /**
  * Returns all available actions for the given node and game state.
@@ -29,6 +30,17 @@ import { isScriptAction } from "./scripts.js";
 export function getAvailableActions(node, state) {
   const global = getGlobalActions(node, state);
   if (!node || !state.nodeGraph) return global;
+
+  // A node running a progressive process (SWEEP, …) is BUSY: the only node action is ABORT.
+  // Uniform rule at the actions layer (the graph's NOT_BUSY can't see processes) — future
+  // progressive verbs inherit it. Nav-away also aborts (game-ctx nav-cancel handler).
+  if (activeProcessOnNode(state, node.id)) {
+    return [...global, {
+      id: A.ABORT, label: "ABORT", available: () => true,
+      desc: () => "Stop the running operation.",
+      execute: (n) => abortNodeProcesses(n.id),
+    }];
+  }
 
   const graphActions = state.nodeGraph.getAvailableActions(node.id);
 

--- a/js/core/actions/program-actions.js
+++ b/js/core/actions/program-actions.js
@@ -13,6 +13,9 @@
 
 import { A } from "../action-ids.js";
 import { visibleIncidentFlows, flowId, sniffFlow, replayCredential } from "../programs.js";
+import { startSweep } from "../sweep.js";
+import { activeProcessOnNode } from "../processes.js";
+import { SWEEP_MAX_DEPTH } from "../balance.js";
 
 /**
  * Flow choices for the SNIFF picker — plain DATA (core stays UI-free). The picker component
@@ -45,6 +48,27 @@ export const SNIFF_ACTION = {
   execute: (node, state, _ctx, payload) => sniffFlow(state, node.id, payload?.flowId),
 };
 
+/** Depth options for the SWEEP picker (plain DATA; rendered as "action" choices). */
+export function getSweepChoices() {
+  return [
+    { id: "1", payloadKey: "depth", render: "action", data: { label: "depth 1", desc: "immediate neighbors" } },
+    { id: "2", payloadKey: "depth", render: "action", data: { label: "depth 2" } },
+    { id: "3", payloadKey: "depth", render: "action", data: { label: "depth 3" } },
+    { id: "max", payloadKey: "depth", render: "action", data: { label: "max", desc: "until it runs dry" } },
+  ];
+}
+
+/** @type {ActionDef} */
+export const SWEEP_ACTION = {
+  id: A.SWEEP,
+  label: "SWEEP",
+  available: () => true,
+  desc: () => "Broadcast probe — ripples outward through open nodes, building heat as it goes.",
+  followup: { title: (node) => `SWEEP ${node.id}`, choices: getSweepChoices, empty: () => "" },
+  execute: (node, _state, _ctx, payload) =>
+    startSweep(node.id, payload?.depth === "max" ? SWEEP_MAX_DEPTH : Number(payload?.depth)),
+};
+
 /** @type {ActionDef} */
 export const REPLAY_ACTION = {
   id: A.REPLAY,
@@ -62,6 +86,10 @@ export function getProgramActions(node, state) {
   /** @type {ActionDef[]} */
   const out = [];
   if (!node || node.visibility !== "accessible") return out;
+
+  // SWEEP: broadcast probe from any accessible node (probes the origin itself first). Not offered
+  // while a process is already running on this node (one sweep at a time).
+  if (!activeProcessOnNode(state, node.id)) out.push(SWEEP_ACTION);
 
   // SNIFF: requires the node be PROBED — a measure of careful preparation (you scan/fingerprint
   // the node before reading its traffic), but a single recon act, NOT the locked→open→owned

--- a/js/core/actions/scripts.js
+++ b/js/core/actions/scripts.js
@@ -14,6 +14,9 @@ export const CORE_NODE_VERBS = new Set([
   // Flow programs stay top-level: SNIFF hosts its own flow picker (EXEC can't nest a
   // followup), and both are core player verbs rather than node-authored scripts.
   A.SNIFF, A.REPLAY,
+  // SWEEP is a top-level verb too — it hosts its own depth picker (EXEC can't nest a
+  // followup) and must render in the node inspector, not be buried as a script.
+  A.SWEEP,
 ]);
 
 /** @param {string} id @returns {boolean} */

--- a/js/core/balance.js
+++ b/js/core/balance.js
@@ -76,12 +76,20 @@ export const TRACE_SECONDS = { S: 30, A: 40, B: 45, C: 60, D: 75, F: 90 };
 // (→ threshold*HEAT_DISCHARGE_FRAC) so it must rebuild — bursts trip, paced play stays cool.
 // PLACEHOLDER VALUES — feel + census tuned with Les (heat now feeds probe/xploit, so it moves the
 // bot's difficulty curve; census is a real gate, not just no-regression).
-export const HEAT_COST = { probe: 1, xploit: 2, sniff: 1, replay: 3 };
+export const HEAT_COST = { probe: 1, xploit: 2, sniff: 1, replay: 3, sweep: 2 };
 export const HEAT_ALARM_THRESHOLD = { S: 4, A: 5, B: 7, C: 9, D: 12, F: 15 }; // grade-keyed sensitivity
 export const HEAT_DECAY_PER_TICK = 0.6;   // heat shed per HEAT_DECAY interval (pacing must actually cool)
 export const HEAT_DISCHARGE_FRAC = 0.5;   // on a trip, heat → threshold * this
 export const HEAT_DECAY_MS = 1000;        // decay interval (mirrors TRACE_TICK cadence)
 export const LIE_LOW_HEAT_DROP = 6;       // lie-low's accelerated heat shed (Phase 4)
+
+// ── SWEEP (progressive probe flood-fill; verb variants) ──────────────────────
+// SWEEP starts a REAL timed probe on each frontier node in parallel (grade-scaled probe duration,
+// probe animation, resolveProbe on completion). A wave advances to the next layer only when its
+// probes finish — so it propagates over real probe-time, "like parallel probes through the network."
+// Each node hit charges HEAT_COST.sweep up front (a rise per node) plus HEAT_COST.probe on completion
+// — so a wide/deep sweep is genuinely loud. Values PLACEHOLDER — feel + census tuned.
+export const SWEEP_MAX_DEPTH = 6;         // hard ceiling; the "max" depth option
 
 // ── ICE movement / detection ─────────────────────────────────────────────────
 

--- a/js/core/console-commands/commands.js
+++ b/js/core/console-commands/commands.js
@@ -23,6 +23,7 @@ import {
 // ── Shared constants for completion ──────────────────────────────────────────
 
 const STATUS_NOUNS     = ["summary", "ice", "hand", "node", "alert", "mission"];
+const SWEEP_DEPTHS     = ["1", "2", "3", "max"];
 const CHEAT_SUBS       = ["give", "alert", "hurt", "heal", "own", "own-all", "trace", "summon-ice", "teleport-ice", "ice-state", "snapshot", "relayout", "restore", "fps", "help"];
 const CHEAT_GIVE_SUBS  = ["matching", "card", "cash"];
 const CHEAT_ALERT_VERBS = ["set", "raise", "lower"];
@@ -143,6 +144,20 @@ export const COMMANDS = [
       const node = args.length >= 1 ? resolveNode(args[0]) : resolveImplicitNode();
       if (!node) { addLogEntry("Usage: replay <node>  (or select a node first)", "error"); return; }
       dispatch(A.REPLAY, { nodeId: node.id });
+    },
+  },
+
+  { verb: "sweep",
+    // SWEEP always acts on the currently TARGETED node (GUI/console symmetry: it's the node
+    // inspector's SWEEP). Only the depth is an argument.
+    complete(args, partial) {
+      if (args.length === 0) return fromList(SWEEP_DEPTHS, partial);
+      return null;
+    },
+    execute(args) {
+      const node = resolveImplicitNode(); // targeted node (logs its own error if none)
+      if (!node) return;
+      dispatch(A.SWEEP, { nodeId: node.id, depth: args[0] || "max" });
     },
   },
 

--- a/js/core/events.js
+++ b/js/core/events.js
@@ -48,6 +48,10 @@ export const E = Object.freeze({
   HEAT_CHANGED:          "alert:heat-changed",
   HEAT_ALARM:            "alert:heat-alarm",
 
+  PROCESS_STARTED:       "process:started",
+  PROCESS_STEP:          "process:step",
+  PROCESS_ENDED:         "process:ended",
+
   FLOW_SNIFFED:          "flow:sniffed",
   CREDENTIAL_CAPTURED:   "flow:credential-captured",
   CREDENTIAL_REPLAYED:   "flow:credential-replayed",

--- a/js/core/node-graph/game-ctx.js
+++ b/js/core/node-graph/game-ctx.js
@@ -34,6 +34,7 @@ function exploitDuration(quality) {
 import { endRun, nextAlertLevel, revealNeighbors } from "../state.js";
 import { pauseTimers } from "../timers.js";
 import { getState } from "../state.js";
+import { abortNodeProcesses } from "../processes.js";
 import { setNodeProbed, setNodeAlertState, setNodeRead, collectMacguffins, setNodeLooted, incrementMineAttempts, setMineExhausted } from "../state/node.js";
 import { setLastDisturbedNode } from "../state/ice.js";
 import { launchExploit } from "../combat.js";
@@ -429,6 +430,8 @@ export function initNavigationCancelHandler() {
       emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.LIE_LOW, phase: "cancel", progress: 0 });
     }
   }
+  // Progressive processes (SWEEP, …) also cancel on navigation — parity with timed actions.
+  for (const proc of [...getState().processes]) abortNodeProcesses(proc.nodeId);
   });
 }
 

--- a/js/core/processes.js
+++ b/js/core/processes.js
@@ -1,0 +1,59 @@
+// @ts-check
+/**
+ * Progressive-process framework — the general seam for player operations that advance over ticks
+ * and/or affect nodes beyond their origin (SWEEP now; parallel-XPLOIT etc. later). Instead of each
+ * such action hand-rolling a global timer + bespoke abort, they register a handler here and ride the
+ * single `stepProcesses()` hook the central tick() already calls. In-flight state lives in
+ * `state.processes` (serializable). Abort/busy is uniform: a node with an active process is busy.
+ */
+
+/** @typedef {import('./types.js').Process} Process */
+/** @typedef {import('./types.js').GameState} GameState */
+
+import { getState } from "./state.js";
+import { removeProcess } from "./state/process.js";
+import { emitEvent, E } from "./events.js";
+
+/**
+ * @typedef {{ step: (proc: Process, state: GameState) => boolean, onAbort?: (proc: Process, state: GameState) => void }} ProcessHandler
+ * `step` advances one tick; return `true` when the process is finished. `onAbort` runs on ANY end
+ * (complete or aborted) as idempotent cleanup.
+ */
+
+/** type → handler. Module-level (populated at import), so it survives clearHandlers() (event-bus only). */
+const HANDLERS = new Map();
+
+/** Register a process type's behavior. @param {string} type @param {ProcessHandler} def */
+export function registerProcess(type, def) {
+  HANDLERS.set(type, def);
+}
+
+/** Advance every active process one tick; self-remove finished ones. Called once per virtual tick. */
+export function stepProcesses() {
+  const s = getState();
+  if (!s || s.phase !== "playing") return;
+  for (const proc of [...s.processes]) {   // snapshot — step may mutate the list
+    const def = HANDLERS.get(proc.type);
+    if (!def) { endProcess(proc.id, "no-handler"); continue; } // orphan (unregistered type) — don't soft-lock its node
+    if (def.step(proc, getState()) === true) endProcess(proc.id, "complete");
+  }
+}
+
+/** True if the node has any active process (drives busy/ABORT). @param {GameState} state @param {string} nodeId */
+export function activeProcessOnNode(state, nodeId) {
+  return state.processes.some((p) => p.nodeId === nodeId);
+}
+
+/** Abort (end) every process on a node — uniform cancel path (ABORT action, nav-away). */
+export function abortNodeProcesses(nodeId, reason = "aborted") {
+  for (const proc of getState().processes.filter((p) => p.nodeId === nodeId)) endProcess(proc.id, reason);
+}
+
+/** End a process: run its onAbort cleanup, remove it, announce it. @param {number} id @param {string} reason */
+function endProcess(id, reason) {
+  const proc = getState().processes.find((p) => p.id === id);
+  if (!proc) return;
+  HANDLERS.get(proc.type)?.onAbort?.(proc, getState());
+  removeProcess(id);
+  emitEvent(E.PROCESS_ENDED, { id, type: proc.type, nodeId: proc.nodeId, reason });
+}

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -44,5 +44,9 @@ export {
 } from "./state/flow.js";
 
 export {
+  nextProcessId, addProcess, updateProcess, removeProcess,
+} from "./state/process.js";
+
+export {
   setSelectedNode, setPhase, setRunOutcome, toggleMenuOpen, toggleHandCollapsed,
 } from "./state/game.js";

--- a/js/core/state/index.js
+++ b/js/core/state/index.js
@@ -168,6 +168,8 @@ export function initGame(buildNetworkFn, seedString, opts = {}) {
     // Crossing a network's hidden threshold trips the alert ladder. Serializable.
     heat: 0,
     heatDecayTimerId: null,
+    // Active progressive processes (SWEEP now; parallel-XPLOIT later) — see js/core/processes.js.
+    processes: [],
     nodeGraph: graph,
     player: {
       cash: meta.startCash ?? 1000,
@@ -396,6 +398,7 @@ export function deserializeState(snapshot, opts = {}) {
   // Heal saves that predate the flow-program fields (Session 1) and the heat model.
   if (typeof ctx.state.heat !== "number") ctx.state.heat = 0;
   if (ctx.state.heatDecayTimerId === undefined) ctx.state.heatDecayTimerId = null;
+  if (!Array.isArray(ctx.state.processes)) ctx.state.processes = [];
   if (ctx.state.player && !ctx.state.player.capturedCredentials) ctx.state.player.capturedCredentials = [];
   deserializeTimers(_timers);   // writes into ctx.timers
   if (_rng) deserializeRng(_rng);

--- a/js/core/state/process.js
+++ b/js/core/state/process.js
@@ -1,0 +1,32 @@
+// @ts-check
+// Pure process-list mutations (state.processes). No orchestration/events — that's js/core/processes.js.
+
+/** @typedef {import('../types.js').Process} Process */
+
+import { mutate, getState } from "./index.js";
+
+/** Next unused process id (monotonic within the run). @returns {number} */
+export function nextProcessId() {
+  return 1 + getState().processes.reduce((m, p) => Math.max(m, p.id), 0);
+}
+
+/** Append a process record. @param {Process} proc */
+export function addProcess(proc) {
+  mutate((s) => { s.processes.push(proc); });
+}
+
+/** Shallow-merge a patch into the process with this id. @param {number} id @param {object} patch */
+export function updateProcess(id, patch) {
+  mutate((s) => {
+    const p = s.processes.find((pr) => pr.id === id);
+    if (p) Object.assign(p, patch);
+  });
+}
+
+/** Remove the process with this id. @param {number} id */
+export function removeProcess(id) {
+  mutate((s) => {
+    const i = s.processes.findIndex((pr) => pr.id === id);
+    if (i !== -1) s.processes.splice(i, 1);
+  });
+}

--- a/js/core/sweep.js
+++ b/js/core/sweep.js
@@ -1,0 +1,93 @@
+// @ts-check
+/**
+ * SWEEP — a progressive, depth-bounded, abortable probe flood-fill; the breadth counterpart to
+ * selective PROBE. The first client of the process framework (js/core/processes.js).
+ *
+ * It behaves like **parallel probes propagating through the network**: each wave starts a REAL
+ * timed probe on every frontier node at once (grade-scaled probe duration + probe animation +
+ * resolveProbe on completion, all via the existing timed-action operator). The wave advances to the
+ * next recursive layer only once its probes finish — so nodes reveal over real probe-time, not
+ * instantly. Propagation is gate-bounded (resolveProbe reveals neighbors only through probe-gate
+ * nodes → stops at routers/firewalls/IDS/monitors) and capped by a player-chosen depth.
+ *
+ * Heat: each node hit charges HEAT_COST.sweep up front (a visible rise per node) plus the probe's
+ * own HEAT_COST.probe on completion — a wide/deep sweep is loud.
+ */
+
+/** @typedef {import('./types.js').GameState} GameState */
+
+import { getState } from "./state.js";
+import { setNodeVisible } from "./state/node.js";
+import { addProcess, updateProcess, nextProcessId } from "./state/process.js";
+import { registerProcess, activeProcessOnNode } from "./processes.js";
+import { recordHeat } from "./alert.js";
+import { HEAT_COST, SWEEP_MAX_DEPTH } from "./balance.js";
+import { getTimedActionAttrNames } from "./node-graph/timed-actions.js";
+import { emitEvent, E } from "./events.js";
+
+const PROBE_PROGRESS = getTimedActionAttrNames("probe").progressAttr;
+
+/** Neighbors a wave can reach next: visible, PROBEABLE (hackable — has a `probing` flag; WAN-likes
+ *  don't and can't be probed, so we never wait on them), not already probed/probing. */
+const reachableFrom = (s, id) =>
+  (s.adjacency[id] || []).filter((n) => {
+    const node = s.nodes[n];
+    return node && node.visibility !== "hidden" && typeof node.probing === "boolean"
+      && !node.probed && !node.probing;
+  });
+
+/** Start a real timed probe on each node in parallel (operator animates + resolves), charging sweep heat per node. */
+function startWave(ids) {
+  const graph = getState().nodeGraph;
+  for (const id of ids) {
+    setNodeVisible(id, "accessible");        // connect — a reached node comes online
+    graph.setNodeAttr(id, "probing", true);  // the timed-action operator runs the probe (duration/anim/resolveProbe)
+    graph.setNodeAttr(id, PROBE_PROGRESS, 0);
+    recordHeat(HEAT_COST.sweep);             // each node hit raises cumulative heat
+  }
+}
+
+/**
+ * Begin a sweep from `originId` up to `depthCap` child-layers (clamped to SWEEP_MAX_DEPTH). If the
+ * origin is unprobed, wave 0 probes it (revealing its neighbors); if it's already probed/owned, the
+ * first wave is its revealed children. No-op if a process is already active on this node.
+ * @param {string} originId @param {number} depthCap
+ */
+export function startSweep(originId, depthCap) {
+  const s = getState();
+  const graph = s.nodeGraph;
+  if (!graph || activeProcessOnNode(s, originId)) return;
+  const cap = Number.isFinite(depthCap) ? Math.min(Math.max(1, depthCap), SWEEP_MAX_DEPTH) : SWEEP_MAX_DEPTH;
+  const origin = s.nodes[originId];
+  // Wave 0 probes the origin only if it's unprobed AND probeable (hackable). An already-probed or
+  // non-probeable origin (e.g. WAN) starts the sweep from its revealed children.
+  const probeOrigin = typeof origin?.probing === "boolean" && !origin.probed;
+  const frontier = probeOrigin ? [originId] : reachableFrom(s, originId);
+  const depth = probeOrigin ? 0 : 1;
+  if (frontier.length === 0) return; // nothing to sweep
+  startWave(frontier);
+  addProcess({ id: nextProcessId(), type: "sweep", nodeId: originId, depthCap: cap, depth, frontier });
+  emitEvent(E.PROCESS_STARTED, { type: "sweep", nodeId: originId, depthCap: cap });
+}
+
+registerProcess("sweep", {
+  step(proc, s) {
+    // Wait until this wave's parallel probes all finish (the operator clears `probing` + resolves each).
+    if (proc.frontier.some((id) => s.nodes[id]?.probing)) return false;
+    // Wave complete — its nodes are probed/revealed. Announce it, then compute the next recursive layer.
+    emitEvent(E.PROCESS_STEP, { type: "sweep", nodeId: proc.nodeId, depth: proc.depth, count: proc.frontier.length, nodes: proc.frontier });
+    const next = [...new Set(proc.frontier.flatMap((id) => reachableFrom(s, id)))];
+    const depth = proc.depth + 1;
+    if (depth > proc.depthCap || next.length === 0) return true; // done
+    startWave(next);
+    updateProcess(proc.id, { depth, frontier: next });
+    return false;
+  },
+  onAbort(proc, s) {
+    // Cancel the current wave's in-flight probes so they don't resolve after the sweep is aborted.
+    const graph = s.nodeGraph;
+    for (const id of proc.frontier || []) {
+      if (s.nodes[id]?.probing) { graph.setNodeAttr(id, "probing", false); graph.setNodeAttr(id, PROBE_PROGRESS, 0); }
+    }
+  },
+});

--- a/js/core/timers.js
+++ b/js/core/timers.js
@@ -6,6 +6,7 @@
 import { emitEvent, E } from "./events.js";
 import { getVersion, getState } from "./state/index.js";
 import { getActiveRun, requireActiveRun } from "./run-context.js";
+import { stepProcesses } from "./processes.js";
 
 export const TICK_MS = 100; // ms per tick; browser master interval uses this
 
@@ -89,9 +90,13 @@ export function tick(n = 1) {
       }
     }
   }
-  // Advance NodeGraph internal clock (operators: clock, delay, watchdog, debounce)
-  if (ctx.nodeGraph) {
-    for (let i = 0; i < n; i++) ctx.nodeGraph.tick(1);
+  // Advance the NodeGraph clock (operators: clock/delay/watchdog/probe timers/…) and progressive
+  // processes (SWEEP waves, etc.) INTERLEAVED, one virtual tick at a time — so a process that reacts
+  // to graph state (e.g. a sweep waiting on a probe to finish, then starting the next wave's probes)
+  // sees each other's effects tick-by-tick rather than graph-all-then-processes-all. See processes.js.
+  for (let i = 0; i < n; i++) {
+    if (ctx.nodeGraph) ctx.nodeGraph.tick(1);
+    stepProcesses();
   }
 
   // Emit STATE_CHANGED once at the end of the tick cycle if any state mutation occurred.

--- a/js/core/types.js
+++ b/js/core/types.js
@@ -321,6 +321,14 @@
  * }} Flow
  */
 
+/**
+ * A progressive, abortable player operation that advances over ticks and may affect nodes beyond
+ * its origin (js/core/processes.js). Generic seam: `type` selects the registered handler; the rest
+ * is that handler's serializable in-flight state. `nodeId` is the origin (drives busy/abort). SWEEP
+ * is the first client; parallel-XPLOIT etc. plug into the same registry.
+ * @typedef {{ id: number, type: string, nodeId: string, [k: string]: any }} Process
+ */
+
 // ── Top-level state ───────────────────────────────────────
 
 /**
@@ -334,6 +342,7 @@
  *   flows: Flow[],
  *   heat: number,
  *   heatDecayTimerId: number|null,
+ *   processes: Process[],
  *   player: PlayerState,
  *   globalAlert: GlobalAlertLevel,
  *   traceSecondsRemaining: number|null,

--- a/js/ui/log-renderer.js
+++ b/js/ui/log-renderer.js
@@ -152,6 +152,17 @@ export function initLogRenderer() {
   on(E.HEAT_ALARM, ({ level }) =>
     add(`[HEAT] Activity noticed — alert rising to ${String(level).toUpperCase()}.`, "error"));
 
+  // ── SWEEP (progressive process) ──────────────────────────
+  on(E.PROCESS_STARTED, ({ type, nodeId, depthCap }) => {
+    if (type === "sweep") add(`[SWEEP] ${nodeId}: broadcast probe — depth ${depthCap}.`, "info");
+  });
+  on(E.PROCESS_STEP, ({ type, depth, count }) => {
+    if (type === "sweep") add(`[SWEEP] wave ${depth}: probed ${count} node${count !== 1 ? "s" : ""}.`, "info");
+  });
+  on(E.PROCESS_ENDED, ({ type, reason }) => {
+    if (type === "sweep") add(`[SWEEP] ${reason === "aborted" ? "aborted." : "complete."}`, "meta");
+  });
+
   // ── Mission / run events ─────────────────────────────────
   on(E.MISSION_STARTED,  (/** @type {MissionStartedPayload} */  { targetName }) => add(`[MISSION] Objective: retrieve ${targetName}.`, "info"));
   on(E.MISSION_COMPLETE, (/** @type {MissionCompletePayload} */ { targetName }) => add(`[MISSION] ★ Target acquired: ${targetName}.`, "success"));

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -97,6 +97,13 @@ export function initVisualRenderer() {
     if (action === A.XPLOIT) flashNode(nodeId, success ? "success" : "failure");
   });
 
+  // SWEEP: pulse each node a wave touches (per-node probe feedback; the dedicated
+  // outward-ripple overlay is a follow-up — see epic #279). Origin pulses at start.
+  on(E.PROCESS_STARTED, ({ type, nodeId }) => { if (type === "sweep") flashNode(nodeId, "reveal"); });
+  on(E.PROCESS_STEP, ({ type, nodes }) => {
+    if (type === "sweep" && Array.isArray(nodes)) nodes.forEach((id) => flashNode(id, "reveal"));
+  });
+
   on(E.RUN_STARTED, () => {
     overlays.byKey.forEach((o) => o.clear());
     activeNodeIds.clear();

--- a/scripts/playtest.js
+++ b/scripts/playtest.js
@@ -211,6 +211,9 @@ if (jsonMode) {
   on(E.CREDENTIAL_CAPTURED,  ({ key })                   => out(`[SNIFF] Credential captured: ${key}.`));
   on(E.CREDENTIAL_REPLAYED,  ({ nodeId, key })           => out(`[REPLAY] ${nodeId}: credential ${key} accepted — trusted access.`));
   on(E.HEAT_ALARM,           ({ level })                 => out(`[HEAT] Activity noticed — alert rising to ${String(level).toUpperCase()}.`));
+  on(E.PROCESS_STARTED,      ({ type, nodeId, depthCap }) => { if (type === "sweep") out(`[SWEEP] ${nodeId}: broadcast probe — depth ${depthCap}.`); });
+  on(E.PROCESS_STEP,         ({ type, depth, count })    => { if (type === "sweep") out(`[SWEEP] wave ${depth}: probed ${count} node(s).`); });
+  on(E.PROCESS_ENDED,        ({ type, reason })          => { if (type === "sweep") out(`[SWEEP] ${reason === "aborted" ? "aborted." : "complete."}`); });
   on(E.ICE_MOVED,            ({ fromLabel, toLabel, fromVisible, toVisible }) => {
     if (fromVisible || toVisible) out(`[ICE] Moving: ${fromLabel} → ${toLabel}`);
   });

--- a/tests/processes.test.js
+++ b/tests/processes.test.js
@@ -1,0 +1,77 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { initGame, getState, serializeState, deserializeState } from "../js/core/state.js";
+import { addProcess, updateProcess } from "../js/core/state/process.js";
+import { registerProcess, stepProcesses, abortNodeProcesses, activeProcessOnNode } from "../js/core/processes.js";
+import { on, clearHandlers, E } from "../js/core/events.js";
+import { clearAll, tick } from "../js/core/timers.js";
+import { buildNetwork as buildCorporateExchange } from "../data/networks/corporate-exchange.js";
+
+afterEach(() => { clearHandlers(); clearAll(); });
+
+// A dummy process: counts up each step, done at 3. Records aborts via a shared sink.
+let _aborted = [];
+registerProcess("test-counter", {
+  step(proc) { updateProcess(proc.id, { n: (proc.n ?? 0) + 1 }); return (getState().processes.find((p) => p.id === proc.id)?.n ?? 0) >= 3; },
+  onAbort(proc) { _aborted.push(proc.id); },
+});
+
+function addCounter(nodeId = "gateway") {
+  const id = 1 + Math.max(0, ...getState().processes.map((p) => p.id));
+  addProcess({ id, type: "test-counter", nodeId, n: 0 });
+  return id;
+}
+
+describe("process framework", () => {
+  it("steps active processes on tick and self-removes when done", () => {
+    initGame(() => buildCorporateExchange(), "proc-1");
+    const ended = [];
+    on(E.PROCESS_ENDED, (p) => ended.push(p.reason));
+    addCounter();
+    assert.ok(activeProcessOnNode(getState(), "gateway"), "process active on its node");
+    tick(3); // 3 virtual ticks = 3 steps → done at n=3
+    assert.equal(getState().processes.length, 0, "self-removed when done");
+    assert.deepEqual(ended, ["complete"], "emitted PROCESS_ENDED{complete}");
+    assert.equal(activeProcessOnNode(getState(), "gateway"), false);
+  });
+
+  it("abortNodeProcesses removes the node's processes, runs onAbort, emits aborted", () => {
+    initGame(() => buildCorporateExchange(), "proc-2");
+    _aborted = [];
+    const ended = [];
+    on(E.PROCESS_ENDED, (p) => ended.push(p.reason));
+    const id = addCounter("gateway");
+    abortNodeProcesses("gateway");
+    assert.equal(getState().processes.length, 0, "removed");
+    assert.deepEqual(_aborted, [id], "onAbort ran");
+    assert.deepEqual(ended, ["aborted"], "emitted PROCESS_ENDED{aborted}");
+  });
+
+  it("processes round-trip through serialize and resume stepping", () => {
+    initGame(() => buildCorporateExchange(), "proc-3");
+    addCounter();
+    const snap = JSON.parse(JSON.stringify(serializeState()));
+    deserializeState(snap);
+    assert.equal(getState().processes.length, 1, "process round-trips");
+    tick(3);
+    assert.equal(getState().processes.length, 0, "resumes stepping to completion after load");
+  });
+
+  it("removes an orphaned process whose type has no registered handler (no soft-lock)", () => {
+    initGame(() => buildCorporateExchange(), "proc-orphan");
+    const ended = [];
+    on(E.PROCESS_ENDED, (p) => ended.push(p.reason));
+    addProcess({ id: 1, type: "unregistered-type", nodeId: "gateway" });
+    tick(1);
+    assert.equal(getState().processes.length, 0, "orphan removed rather than left stuck");
+    assert.deepEqual(ended, ["no-handler"]);
+  });
+
+  it("heals a save that predates state.processes", () => {
+    initGame(() => buildCorporateExchange(), "proc-4");
+    const snap = JSON.parse(JSON.stringify(serializeState()));
+    delete snap.processes;
+    deserializeState(snap);
+    assert.deepEqual(getState().processes, [], "processes heals to []");
+  });
+});

--- a/tests/sweep.test.js
+++ b/tests/sweep.test.js
@@ -1,0 +1,118 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { initGame, getState } from "../js/core/state.js";
+import { startSweep } from "../js/core/sweep.js";
+import { activeProcessOnNode } from "../js/core/processes.js";
+import { getProgramActions } from "../js/core/actions/program-actions.js";
+import { getAvailableActions } from "../js/core/actions/node-actions.js";
+import { isScriptAction } from "../js/core/actions/scripts.js";
+import { COMMANDS } from "../js/core/console-commands/commands.js";
+import { buildActionContext, initActionDispatcher } from "../js/core/actions/action-context.js";
+import { A } from "../js/core/action-ids.js";
+import { clearHandlers, emitEvent, on, E } from "../js/core/events.js";
+import { clearAll, tick } from "../js/core/timers.js";
+import { buildNetwork as buildCorporateExchange } from "../data/networks/corporate-exchange.js";
+
+afterEach(() => { clearHandlers(); clearAll(); });
+
+describe("SWEEP — gate-bounded progressive flood-fill", () => {
+  it("probes outward from the origin, bringing reached sig nodes fully online, then stops at a router", () => {
+    initGame(() => buildCorporateExchange(), "sweep-1");
+    // gateway (probe-gate) → switch-1 (router, open-gate) + wan. Sweep should probe gateway, switch-1,
+    // wan, then STOP at switch-1 (a router reveals no neighbors until opened) — switch-2 stays hidden.
+    const waves = [];
+    let maxHeat = 0;
+    on(E.PROCESS_STEP, ({ type, count }) => { if (type === "sweep") waves.push(count); });
+    on(E.HEAT_CHANGED, ({ total }) => { maxHeat = Math.max(maxHeat, total); });
+    startSweep("gateway", 3);
+    tick(400); // parallel probes run over real (grade-scaled) probe-time — tick well past completion
+
+    const n = (id) => getState().nodes[id];
+    assert.equal(n("gateway").probed, true, "origin probed");
+    assert.equal(n("switch-1").probed, true, "router reached + probed");
+    assert.equal(n("switch-1").visibility, "accessible", "reached sig node comes fully online (connected)");
+    assert.equal(n("switch-2").visibility, "hidden", "router stops the flood — switch-2 stays hidden");
+    // Waves reported over real time: origin, then the probeable child layer (switch-1; WAN is not
+    // probeable so the sweep never waits on it).
+    assert.ok(waves.length >= 2, "sweep advanced in multiple waves over time");
+    assert.ok(maxHeat >= 3, "each node hit raised cumulative heat (sweep is loud)");
+    assert.equal(getState().processes.length, 0, "sweep process ended");
+  });
+
+  it("depth ceiling bounds how far it travels", () => {
+    initGame(() => buildCorporateExchange(), "sweep-2");
+    startSweep("gateway", 1); // origin + one child-layer, then stop
+    tick(400);
+    // switch-1/wan are gateway's neighbors → probed within the depth-1 layer; nothing deeper.
+    assert.equal(getState().nodes["switch-1"].probed, true);
+    assert.equal(getState().processes.length, 0, "ended at the depth-1 ceiling");
+  });
+
+  it("clamps depth: 0 → 1 (not 'max')", () => {
+    initGame(() => buildCorporateExchange(), "sweep-depth-0");
+    startSweep("gateway", 0);
+    assert.equal(getState().processes[0].depthCap, 1, "depth 0 clamps to 1, not max");
+  });
+
+  it("clamps over-large depth to the ceiling", () => {
+    initGame(() => buildCorporateExchange(), "sweep-depth-big");
+    startSweep("gateway", 999);
+    assert.ok(getState().processes[0].depthCap <= 6, "over-large depth clamps to the ceiling");
+  });
+
+  it("one sweep at a time per node", () => {
+    initGame(() => buildCorporateExchange(), "sweep-3");
+    startSweep("gateway", 3);
+    const before = getState().processes.length;
+    startSweep("gateway", 3); // second start ignored while one is active on the node
+    assert.equal(getState().processes.length, before, "no duplicate sweep on the same node");
+  });
+});
+
+describe("SWEEP — action, availability, abort", () => {
+  it("SWEEP is a top-level (non-script) inspector action, not buried under EXEC", () => {
+    initGame(() => buildCorporateExchange(), "sweep-toplevel");
+    assert.equal(isScriptAction(A.SWEEP), false, "SWEEP is a core verb → renders top-level, not under EXEC");
+    const all = getAvailableActions(getState().nodes["gateway"], getState());
+    assert.ok(all.some((a) => a.id === A.SWEEP), "SWEEP surfaces top-level in getAvailableActions");
+  });
+
+  it("the sweep console command tab-completes its (only) depth argument", () => {
+    initGame(() => buildCorporateExchange(), "sweep-complete");
+    const sweep = COMMANDS.find((c) => c.verb === "sweep");
+    assert.deepEqual(sweep.complete([], "", getState()).insertTexts, ["1", "2", "3", "max"], "empty → all depths");
+    assert.deepEqual(sweep.complete([], "m", getState()).insertTexts, ["max"], "'m' → max");
+  });
+
+  it("SWEEP is offered on an accessible node, and not while a sweep is already running", () => {
+    initGame(() => buildCorporateExchange(), "sweep-act-1");
+    const gateway = () => getState().nodes["gateway"];
+    assert.ok(getProgramActions(gateway(), getState()).some((a) => a.id === A.SWEEP), "SWEEP offered");
+    startSweep("gateway", 3);
+    assert.equal(getProgramActions(gateway(), getState()).some((a) => a.id === A.SWEEP), false, "not while sweeping");
+  });
+
+  it("while a sweep runs, the node offers ABORT (and only ABORT + globals); ABORT ends it, keeping probed", () => {
+    initGame(() => buildCorporateExchange(), "sweep-act-2");
+    startSweep("gateway", 3); // wave 0 begins a real timed probe on the origin
+    tick(2); // mid-sweep: the origin probe is in flight, process active
+    assert.ok(activeProcessOnNode(getState(), "gateway"), "sweep still running");
+    assert.equal(getState().nodes["gateway"].probing, true, "the wave's probe is in flight");
+    const actions = getAvailableActions(getState().nodes["gateway"], getState());
+    const abort = actions.find((a) => a.id === A.ABORT);
+    assert.ok(abort, "ABORT offered during a sweep");
+    assert.equal(actions.some((a) => a.id === A.SWEEP || a.id === A.PROBE), false, "node is busy — no other node verbs");
+    abort.execute(getState().nodes["gateway"], getState(), buildActionContext(), { nodeId: "gateway" });
+    assert.equal(activeProcessOnNode(getState(), "gateway"), false, "ABORT ended the sweep");
+    assert.equal(getState().nodes["gateway"].probing, false, "ABORT cancelled the in-flight probe");
+  });
+
+  it("GUI/console parity: dispatching a sweep action starts the same sweep as startSweep", () => {
+    initGame(() => buildCorporateExchange(), "sweep-act-3");
+    initActionDispatcher(buildActionContext());
+    emitEvent("starnet:action", { actionId: A.SWEEP, nodeId: "gateway", depth: "2", fromConsole: true });
+    assert.ok(activeProcessOnNode(getState(), "gateway"), "dispatch started a sweep");
+    tick(400); // let the dispatched sweep run to completion
+    assert.equal(getState().nodes["gateway"].probed, true, "origin probed by the dispatched sweep");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds **SWEEP** — a progressive, depth-bounded, abortable probe **flood-fill**: the breadth counterpart to selective PROBE, and exactly what the heat meter (#271) was built to price. Ripples outward wave-by-wave, mapping the network fast at the cost of a fast-building heat spike.
- Part of the Flow Subversion **anti-tedium arc** (epic #279) — turning the probe grind into a coverage-vs-heat *choice*.

## Design decisions
- **A generic progressive-process seam, not a bespoke timer.** `js/core/processes.js`: `state.processes` (serializable) + a type registry (`registerProcess`) + **one** `stepProcesses()` hook in the central `tick()` + uniform busy/abort (`activeProcessOnNode` / `abortNodeProcesses`). Actions with effects beyond their node / over time become a *category* with one mechanism — no per-feature global timers, no per-action abort special-cases. Parallel-XPLOIT later is a cheap follow-on client. (Directly addresses "special cases are a smell.")
- **Gate structure is the flood-stopper, for free.** SWEEP probes each frontier node via `resolveProbe`, which reveals neighbors only through probe-gate nodes — so it flows through gateways/workstations/etc. and **stops at routers/firewalls/IDS/monitors** until they're opened/owned. No new "hardened node" concept; topology now matters tactically.
- **Reached sig nodes come fully online** (connect + probe), as if you'd connected to them.
- **Depth ceiling (1/2/3/max) + live abort.** Heat builds per wave, so you watch the gauge and cut it before it trips — the tension is the point.

## Changes
- **Framework:** `processes.js` + `state/process.js` + `state.processes` (init/heal) + `stepProcesses()` in `tick()`.
- **SWEEP:** `sweep.js` (`startSweep` + the `"sweep"` process); `HEAT_COST.probe` per node; `SWEEP_WAVE_TICKS`/`SWEEP_MAX_DEPTH` in `balance.js`.
- **UX:** `SWEEP_ACTION` + depth picker (mirrors SNIFF); console `sweep <node> <depth|max>`; busy-node → only ABORT; nav-away aborts. Interim per-node probe **pulse** (each swept node flashes) — the dedicated outward-ripple overlay is deferred to **#280**.
- **Docs:** MANUAL (selective-vs-SWEEP, node-action + console rows), BOT-PLAYER (bot never sweeps), design doc (PROBE-sweep shipped on the seam).

## Test Plan
- [x] `make check` green (1343 tests; +13 process/sweep: framework step/abort/serialize/heal; gate-bounded flood-fill; depth ceiling; fully-online reached nodes; heat accrual; action availability; busy→ABORT; nav-abort; GUI/console parity; accurate wave-count event)
- [x] `make census SEEDS=30` = same-seed `main` (0.3 / 0.767 / 4.53 / ¥6190) — no regression (SWEEP is opt-in; the bot never sweeps)
- [x] Harness-verified end-to-end (`sweep gateway 3` ripples, stops at the router, heat spikes)
- [ ] **Browser feel** (`?network=corporate-exchange`, `sweep gateway max`): ripples through probe-gate nodes, stops at chokepoints, heat gauge spikes, abort stops it mid-ripple

## References
- Epic: #279 (Flow Subversion tedium-reduction redesign)
- Follow-up: #280 (dedicated outward-ripple overlay — the true per-node dial; single-node overlay constraint makes it its own build)
- Spec/plan/notes: `docs/dev-sessions/2026-07-01-1639-verb-variants/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
