### PR TITLE
Fix incomplete rollback in slot-filler wire-failure path (#164)

### DIFF
--- a/docs/dev-sessions/2026-07-01-2318-slot-filler-rollback/notes.md
+++ b/docs/dev-sessions/2026-07-01-2318-slot-filler-rollback/notes.md
@@ -1,0 +1,35 @@
+# Notes — Fix incomplete rollback in slot-filler wire-failure path (#164)
+
+## The bug
+
+In `js/core/network/slot-filler.js` `fillSlot`, the orphan-prevention fallback (parent has no free
+outbound port) popped the just-placed piece from `pieces` and refunded the budget, but left two
+earlier side effects in place:
+
+- `usedPieceIds.add(chosen.id)` — the discarded piece kept counting against diversity, so a later
+  slot trying the same id got a 0.33× penalty for a piece that was never placed.
+- `placed.set(slot.id, piece)` — the slot stayed mapped to a piece no longer in `pieces`.
+
+## Fix
+
+On the rollback branch, also `usedPieceIds.delete(chosen.id)` and `placed.delete(slot.id)`.
+
+## Reproduction (TDD, honest observable)
+
+`placed`/`usedPieceIds` are internal to `fillSkeleton`. The observable invariant of the
+stale-mapping half is: **every piece referenced by `placed` is present in `pieces`.** Surfaced
+`placed` on the `fillSkeleton` return (a justified test seam) and added a seed-sweep test at a dense
+spec (S/S/S/S) in `tests/network-gen.test.js`.
+
+Confirmed reproducible before fixing via a scratch sweep (300 seeds × 4 dense specs):
+**1196 / 1200** configs violated the invariant pre-fix, **0 / 1200** post-fix — so the invariant
+measures exactly this bug. The committed test fails on seed 1 alone without the fix.
+
+## Verification
+
+- `make check` green (1338 pass; +1 new test). No test-consumed snapshot changed — the
+  `tests/fixtures/network-gen-*.json` files are orphaned reference dumps (no test loads them; only
+  the ICE snapshot test reads `fixtures/`), so there was nothing to re-baseline.
+- `make census SEEDS=50` (default grades), branch vs main (c48b3dc): successRate 0.24 = 0.24,
+  traceFiredRate 0.80 = 0.80, avgNodesOwned 3.68 = 3.68, avgCash 5391 vs 5393. No difficulty
+  regression — the only delta is a ~2¥ cash blip from corrected piece selection on affected seeds.

--- a/js/core/network/slot-filler.js
+++ b/js/core/network/slot-filler.js
@@ -64,7 +64,7 @@ import { walkSlots } from "./tree-utils.js";
  * @param {number} [opts.budgetOverride] - override computed budget
  * @param {boolean} [opts.skipScatterPlacement] - return scatter obligations without placing them
  * @param {boolean} [opts.skipSubBiomeSlots] - skip slots that have subBiomeId (for backbone-only filling)
- * @returns {{ pieces: PlacedPiece[], crossEdges: [string, string][], ok: boolean, scatterObligations?: ScatterObligation[] }}
+ * @returns {{ pieces: PlacedPiece[], crossEdges: [string, string][], ok: boolean, scatterObligations?: ScatterObligation[], placed?: Map<string, PlacedPiece> }}
  */
 export function fillSkeleton(skeleton, biome, spec, rng, opts = {}) {
   const budgetRemaining = opts.budgetOverride ?? costBudget(spec);
@@ -95,15 +95,17 @@ export function fillSkeleton(skeleton, biome, spec, rng, opts = {}) {
     usedPieceIds, scatterObligations, piecePalette, preAssigned, skipSubBiome,
   };
   const ok = fillSlot(skeleton, null, fillContext);
-  if (!ok) return { pieces, crossEdges, ok: false };
+  if (!ok) return { pieces, crossEdges, ok: false, placed };
 
   // Pass 2: place scattered nodes (unless caller wants to handle them)
   if (!skipScatter && scatterObligations.length > 0) {
     const scatterOk = placeScatteredNodes(scatterObligations, pieces, skeleton, crossEdges, placed);
-    if (!scatterOk) return { pieces, crossEdges, ok: false };
+    if (!scatterOk) return { pieces, crossEdges, ok: false, placed };
   }
 
-  return { pieces, crossEdges, ok, scatterObligations: skipScatter ? scatterObligations : [] };
+  // `placed` is surfaced (slotId → placed piece) so callers/tests can assert the slot→piece map
+  // stays consistent with `pieces` (see the wire-failure rollback path in fillSlot).
+  return { pieces, crossEdges, ok, scatterObligations: skipScatter ? scatterObligations : [], placed };
 }
 
 /**
@@ -218,9 +220,14 @@ function fillSlot(slot, parentPiece, ctx) {
     if (parentOutPort) {
       crossEdges.push([parentOutPort, piece.inboundNodeId]);
     } else {
-      // Can't wire — remove piece to prevent orphan. Refund budget.
+      // Can't wire — remove piece to prevent orphan. Refund budget + undo ALL side effects from
+      // steps 6–7 so the discarded piece leaves no trace: pop it, refund, drop the diversity mark
+      // (else a later slot is wrongly penalized for a piece that was never placed) and the stale
+      // slot→piece mapping (else `placed` points at a piece absent from the network). (#164)
       pieces.pop();
       state.budget += gradeToNumber(chosen.cost ?? "F");
+      usedPieceIds.delete(chosen.id);
+      placed.delete(slot.id);
       // Also remove any scatter obligation for this piece
       const oblIdx = scatterObligations.findIndex(o => o.prefix === prefix);
       if (oblIdx !== -1) scatterObligations.splice(oblIdx, 1);

--- a/tests/network-gen.test.js
+++ b/tests/network-gen.test.js
@@ -340,6 +340,30 @@ describe("Slot-filler: multi-port consumption", () => {
   });
 });
 
+describe("Slot-filler: wire-failure rollback (#164)", () => {
+  // When the orphan-prevention fallback fires (parent has no free outbound port), the just-placed
+  // piece is popped from `pieces`. The rollback must ALSO drop its slot→piece entry in `placed` and
+  // its diversity mark in `usedPieceIds` — otherwise `placed` points at a piece absent from the
+  // network and a later slot is wrongly penalized. Observable invariant: every piece referenced by
+  // `placed` is present in `pieces`. Dense specs trigger the fallback constantly, so a small seed
+  // sweep is a strong reproduction (pre-fix this failed on ~all seeds).
+  const DENSE = { threat: "S", wealth: "S", complexity: "S", depth: "S" };
+
+  it("never leaves a slot mapped to a piece absent from the network", () => {
+    for (let seed = 1; seed <= 60; seed++) {
+      const skeleton = generateSkeleton(DENSE, CORPORATE_BIOME, makeRng(seed));
+      const { pieces, placed } = fillSkeleton(skeleton, CORPORATE_BIOME, DENSE, makeRng(seed));
+      const pieceSet = new Set(pieces);
+      for (const [slotId, piece] of placed) {
+        assert.ok(
+          pieceSet.has(piece),
+          `seed ${seed}: slot ${slotId} maps to piece ${piece.pieceDef?.id} that is not in the network`,
+        );
+      }
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Phase 4: Hierarchical skeleton generation
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #164.

## Bug
In `js/core/network/slot-filler.js` `fillSlot`, the orphan-prevention fallback (parent has no free outbound port) popped the just-placed piece from `pieces` and refunded the budget, but left two earlier side effects in place:
- `usedPieceIds.add(chosen.id)` — the discarded piece kept counting against diversity, so a later slot retrying the same id got a 0.33× penalty for a piece that was never placed.
- `placed.set(slot.id, piece)` — the slot stayed mapped to a piece no longer in `pieces`.

## Fix
On the rollback branch, also `usedPieceIds.delete(chosen.id)` and `placed.delete(slot.id)`.

## Reproduction (TDD)
`placed`/`usedPieceIds` are internal to `fillSkeleton`. The observable invariant of the stale-mapping half is **every piece referenced by `placed` is present in `pieces`** — surfaced `placed` on the `fillSkeleton` return (a small test seam) and added a dense-spec seed-sweep test in `tests/network-gen.test.js`. A scratch sweep (300 seeds × 4 dense specs) showed **1196/1200** configs violated the invariant pre-fix, **0/1200** after — so the test measures exactly this bug (it fails on seed 1 alone without the fix).

## Verification
- `make check` green (**1338 pass**, +1 test).
- No test-consumed snapshot changed — the `tests/fixtures/network-gen-*.json` files are orphaned reference dumps (no test loads them), so there was nothing to re-baseline.
- `make census SEEDS=50` (default grades) branch vs main (`c48b3dc`): successRate 0.24 = 0.24, traceFiredRate 0.80 = 0.80, avgNodesOwned 3.68 = 3.68, avgCash 5391 vs 5393. **No difficulty regression** — the only delta is a ~2¥ cash blip from corrected piece selection on rollback-affected seeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)