### PR TITLE
Nav-cancel handler derives its action set from TIMED_ACTIONS (#225)

### DIFF
--- a/docs/dev-sessions/2026-07-01-2332-navcancel-derive/notes.md
+++ b/docs/dev-sessions/2026-07-01-2332-navcancel-derive/notes.md
@@ -1,0 +1,44 @@
+# Notes — Nav-cancel handler derives from TIMED_ACTIONS (#225)
+
+## What
+
+The navigation-cancel handler (`initNavigationCancelHandler` in `js/core/node-graph/game-ctx.js`)
+hand-enumerated all six abortable timed actions in a six-branch `if (attrs.probing) … if
+(attrs.exploiting) …` block. That was the last hand-enumeration site after #170 centralized the
+`_ta_` attribute names — a multi-site authoring trap: add a seventh abortable action and jack-out /
+navigation would silently leave its timer running. Replaced it with a loop over the registry.
+
+## Change
+
+- `js/core/node-graph/timed-actions.js`: added `ABORTABLE_TIMED_ACTIONS` (the `abortable` subset)
+  and an optional `clearOnCancel: string[]` field on `TimedActionDef` — set to `["activeExploitId"]`
+  on the `xploit` entry (the one action with extra cancel cleanup). `ABORTABLE_FLAGS` now derives
+  from `ABORTABLE_TIMED_ACTIONS` (unchanged value).
+- `js/core/node-graph/game-ctx.js`: the handler now loops `ABORTABLE_TIMED_ACTIONS`, resetting
+  `activeAttr`/progress/duration, nulling any `clearOnCancel` attrs, and emitting one `cancel`
+  `ACTION_FEEDBACK` per active action.
+
+## Two wrinkles the issue flagged
+
+1. **`action → A.*` feedback constant.** Turned out to be a non-issue: the `A.*` action-id
+   constants are *equal to* the registry `action` ids (`A.PROBE === "probe"`, etc.), so emitting
+   `def.action` produces byte-identical payloads. No mapping needed.
+2. **XPLOIT clears `activeExploitId`.** Handled via the new registry `clearOnCancel` field, so the
+   loop stays generic and the registry is the home for that last per-action fact.
+
+`reboot` stays excluded — it's `abortable: false` (involuntary), which is exactly why the loop is
+over `ABORTABLE_TIMED_ACTIONS`, not all of `TIMED_ACTIONS`.
+
+## Verification (no behavior change)
+
+- New `tests/nav-cancel.test.js` derives its cases from `ABORTABLE_TIMED_ACTIONS`, so it covers the
+  whole abortable set (and any future 7th action — the drift this refactor prevents): each in-progress
+  action resets attr/progress/duration + `clearOnCancel`, fires exactly one `cancel` feedback with the
+  right action id; an idle navigate fires none. Written as a characterization test — passed against the
+  original six-branch handler *and* the refactor, proving identical behavior.
+- `make check` green (1345 pass). `make census SEEDS=10` — no headless crash.
+
+## Groundwork for #187
+
+This is the surface #187 (make most node actions timed) touches; clearing the hand-enumeration trap
+now means #187 can add actions to the registry and get nav-cancel for free.

--- a/js/core/node-graph/game-ctx.js
+++ b/js/core/node-graph/game-ctx.js
@@ -37,7 +37,7 @@ import { getState } from "../state.js";
 import { setNodeProbed, setNodeAlertState, setNodeRead, collectMacguffins, setNodeLooted, incrementMineAttempts, setMineExhausted } from "../state/node.js";
 import { setLastDisturbedNode } from "../state/ice.js";
 import { launchExploit } from "../combat.js";
-import { getTimedActionAttrNames } from "./timed-actions.js";
+import { getTimedActionAttrNames, ABORTABLE_TIMED_ACTIONS } from "./timed-actions.js";
 
 /** Convenience: `_ta_<action>_progress` for the given timed action. */
 const progressAttr = (action) => getTimedActionAttrNames(action).progressAttr;
@@ -386,47 +386,23 @@ export function initNavigationCancelHandler() {
   const graph = s.nodeGraph;
   if (!graph) return;
 
+  // Derive the abortable set from the TIMED_ACTIONS registry (#225) rather than hand-enumerating
+  // each action — adding a new abortable timed action now cancels correctly with no edit here.
+  // The registry `action` id is exactly the ACTION_FEEDBACK action constant (A.PROBE === "probe",
+  // etc.), so emitting `def.action` matches the former per-branch A.* payloads byte-for-byte.
   for (const nodeId of graph.getNodeIds()) {
     const attrs = graph.getNodeState(nodeId);
-    // Reset duration along with progress on every cancel: the timed-action operator only
-    // re-emits "start" when both are 0, so a stale duration would leave a restarted action's
-    // overlay/log un-armed. (XPLOIT already cleared its ctx-set duration below.)
-    if (attrs.probing) {
-      graph.setNodeAttr(nodeId, "probing", false);
-      graph.setNodeAttr(nodeId, progressAttr("probe"), 0);
-      graph.setNodeAttr(nodeId, durationAttr("probe"), 0);
-      emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.PROBE, phase: "cancel", progress: 0 });
-    }
-    if (attrs.exploiting) {
-      graph.setNodeAttr(nodeId, "exploiting", false);
-      graph.setNodeAttr(nodeId, progressAttr("xploit"), 0);
-      graph.setNodeAttr(nodeId, durationAttr("xploit"), 0);
-      graph.setNodeAttr(nodeId, "activeExploitId", null);
-      emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.XPLOIT, phase: "cancel", progress: 0 });
-    }
-    if (attrs.reading) {
-      graph.setNodeAttr(nodeId, "reading", false);
-      graph.setNodeAttr(nodeId, progressAttr("dump"), 0);
-      graph.setNodeAttr(nodeId, durationAttr("dump"), 0);
-      emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.DUMP, phase: "cancel", progress: 0 });
-    }
-    if (attrs.looting) {
-      graph.setNodeAttr(nodeId, "looting", false);
-      graph.setNodeAttr(nodeId, progressAttr("fetch"), 0);
-      graph.setNodeAttr(nodeId, durationAttr("fetch"), 0);
-      emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.FETCH, phase: "cancel", progress: 0 });
-    }
-    if (attrs.mining) {
-      graph.setNodeAttr(nodeId, "mining", false);
-      graph.setNodeAttr(nodeId, progressAttr("mine"), 0);
-      graph.setNodeAttr(nodeId, durationAttr("mine"), 0);
-      emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.MINE, phase: "cancel", progress: 0 });
-    }
-    if (attrs.lyingLow) {
-      graph.setNodeAttr(nodeId, "lyingLow", false);
-      graph.setNodeAttr(nodeId, progressAttr("lie-low"), 0);
-      graph.setNodeAttr(nodeId, durationAttr("lie-low"), 0);
-      emitEvent(E.ACTION_FEEDBACK, { nodeId, action: A.LIE_LOW, phase: "cancel", progress: 0 });
+    for (const def of ABORTABLE_TIMED_ACTIONS) {
+      if (!attrs[def.activeAttr]) continue;
+      // Reset duration along with progress on every cancel: the timed-action operator only
+      // re-emits "start" when both are 0, so a stale duration would leave a restarted action's
+      // overlay/log un-armed.
+      graph.setNodeAttr(nodeId, def.activeAttr, false);
+      graph.setNodeAttr(nodeId, progressAttr(def.action), 0);
+      graph.setNodeAttr(nodeId, durationAttr(def.action), 0);
+      // Extra per-action cleanup (e.g. xploit's activeExploitId), centralized in the registry.
+      for (const attr of def.clearOnCancel ?? []) graph.setNodeAttr(nodeId, attr, null);
+      emitEvent(E.ACTION_FEEDBACK, { nodeId, action: def.action, phase: "cancel", progress: 0 });
     }
   }
   });

--- a/js/core/node-graph/timed-actions.js
+++ b/js/core/node-graph/timed-actions.js
@@ -13,15 +13,18 @@
 
 /**
  * @typedef {Object} TimedActionDef
- * @property {string} action      timed-action id (drives the _ta_<action>_* attr names)
- * @property {string} activeAttr  boolean "in progress" attribute (mapped explicitly — irregular)
- * @property {boolean} abortable  whether ABORT can cancel it (reboot is involuntary, so no)
+ * @property {string} action        timed-action id (drives the _ta_<action>_* attr names)
+ * @property {string} activeAttr    boolean "in progress" attribute (mapped explicitly — irregular)
+ * @property {boolean} abortable    whether ABORT can cancel it (reboot is involuntary, so no)
+ * @property {string[]} [clearOnCancel] extra node attributes to null out when the action is cancelled
+ *   (nav-cancel / jack-out). Beyond the standard activeAttr/progress/duration reset — e.g. xploit's
+ *   `activeExploitId`. Centralized here so the nav-cancel handler stays a generic loop (#225).
  */
 
 /** @type {TimedActionDef[]} */
 export const TIMED_ACTIONS = [
   { action: "probe",   activeAttr: "probing",    abortable: true },
-  { action: "xploit",  activeAttr: "exploiting", abortable: true },
+  { action: "xploit",  activeAttr: "exploiting", abortable: true, clearOnCancel: ["activeExploitId"] },
   { action: "dump",    activeAttr: "reading",    abortable: true },
   { action: "fetch",   activeAttr: "looting",    abortable: true },
   { action: "mine",    activeAttr: "mining",     abortable: true },
@@ -30,11 +33,19 @@ export const TIMED_ACTIONS = [
 ];
 
 /**
+ * The ABORTABLE timed actions — the set the nav-cancel / jack-out handler resets. reboot is
+ * excluded (involuntary). The nav-cancel handler (game-ctx.js) iterates this instead of
+ * hand-enumerating each action.
+ * @type {TimedActionDef[]}
+ */
+export const ABORTABLE_TIMED_ACTIONS = TIMED_ACTIONS.filter((t) => t.abortable);
+
+/**
  * activeAttr flags for the ABORTABLE timed actions. ABORT shows when any is true;
  * NOT_BUSY (action-templates.js) requires all of them — plus `rebooting` — false.
  * @type {string[]}
  */
-export const ABORTABLE_FLAGS = TIMED_ACTIONS.filter((t) => t.abortable).map((t) => t.activeAttr);
+export const ABORTABLE_FLAGS = ABORTABLE_TIMED_ACTIONS.map((t) => t.activeAttr);
 
 /**
  * The standard attribute names for a timed action, derived from its id. Operators

--- a/tests/nav-cancel.test.js
+++ b/tests/nav-cancel.test.js
@@ -1,0 +1,76 @@
+// @ts-check
+// Nav-cancel handler (#225): on PLAYER_NAVIGATED, every in-progress ABORTABLE timed action is
+// cancelled — its activeAttr/progress/duration reset and exactly one "cancel" ACTION_FEEDBACK
+// fired. This is derived from the TIMED_ACTIONS registry (the single source of truth), so it
+// covers whatever abortable set is registered — including any future 7th action, which is exactly
+// the multi-site drift this handler's refactor prevents.
+
+import { test, before } from "node:test";
+import assert from "node:assert/strict";
+
+import { createGateway, createRouter } from "../js/core/node-graph/node-factories.js";
+import { initGame, getState } from "../js/core/state.js";
+import { emitEvent, on, off, E, clearHandlers } from "../js/core/events.js";
+import { initNavigationCancelHandler } from "../js/core/node-graph/game-ctx.js";
+import { ABORTABLE_TIMED_ACTIONS, getTimedActionAttrNames } from "../js/core/node-graph/timed-actions.js";
+
+function buildMinimalLAN() {
+  return {
+    graphDef: {
+      nodes: [
+        createGateway("gateway", { attributes: { visibility: "accessible" } }),
+        createRouter("router-a"),
+      ],
+      edges: [["gateway", "router-a"]],
+      triggers: [],
+    },
+    meta: { startNode: "gateway", startCash: 0, moneyCost: "F" },
+  };
+}
+
+// Guarantee exactly one nav-cancel handler is registered (game-ctx registers one at module load;
+// clear + re-register so the "exactly one cancel feedback" assertion is not confounded).
+before(() => { clearHandlers(); initNavigationCancelHandler(); });
+
+for (const def of ABORTABLE_TIMED_ACTIONS) {
+  test(`PLAYER_NAVIGATED cancels an in-progress "${def.action}"`, () => {
+    initGame(() => buildMinimalLAN(), `nav-${def.action}`);
+    const graph = getState().nodeGraph;
+    const nodeId = "router-a";
+    const { progressAttr, durationAttr } = getTimedActionAttrNames(def.action);
+
+    // Put the action in progress.
+    graph.setNodeAttr(nodeId, def.activeAttr, true);
+    graph.setNodeAttr(nodeId, progressAttr, 5);
+    graph.setNodeAttr(nodeId, durationAttr, 10);
+    for (const attr of def.clearOnCancel ?? []) graph.setNodeAttr(nodeId, attr, "sentinel");
+
+    const cancels = [];
+    const h = (p) => { if (p?.phase === "cancel") cancels.push(p); };
+    on(E.ACTION_FEEDBACK, h);
+    emitEvent(E.PLAYER_NAVIGATED, {});
+    off(E.ACTION_FEEDBACK, h);
+
+    const attrs = graph.getNodeState(nodeId);
+    assert.equal(attrs[def.activeAttr], false, "activeAttr reset");
+    assert.equal(attrs[progressAttr], 0, "progress reset");
+    assert.equal(attrs[durationAttr], 0, "duration reset");
+    for (const attr of def.clearOnCancel ?? []) {
+      assert.equal(attrs[attr], null, `${attr} cleared on cancel`);
+    }
+
+    assert.equal(cancels.length, 1, "exactly one cancel feedback");
+    assert.equal(cancels[0].nodeId, nodeId);
+    assert.equal(cancels[0].action, def.action, "feedback action id matches the registry");
+  });
+}
+
+test("PLAYER_NAVIGATED with no action in progress fires no cancel feedback", () => {
+  initGame(() => buildMinimalLAN(), "nav-idle");
+  const cancels = [];
+  const h = (p) => { if (p?.phase === "cancel") cancels.push(p); };
+  on(E.ACTION_FEEDBACK, h);
+  emitEvent(E.PLAYER_NAVIGATED, {});
+  off(E.ACTION_FEEDBACK, h);
+  assert.equal(cancels.length, 0);
+});


### PR DESCRIPTION
Closes #225.

## What
The navigation-cancel handler (`initNavigationCancelHandler` in `game-ctx.js`) hand-enumerated all six abortable timed actions in a six-branch `if (attrs.probing) … if (attrs.exploiting) …` block. That was the **last hand-enumeration site** after #170 centralized the `_ta_` attribute names — and a multi-site trap: add a seventh abortable action and jack-out / navigation would silently leave its timer running. Now it loops the registry.

## Change
- `timed-actions.js`: add `ABORTABLE_TIMED_ACTIONS` (the abortable subset) and an optional `clearOnCancel: string[]` field on `TimedActionDef`, set to `["activeExploitId"]` on the `xploit` entry. `ABORTABLE_FLAGS` derives from it (value unchanged).
- `game-ctx.js`: the handler loops `ABORTABLE_TIMED_ACTIONS`, resetting `activeAttr`/progress/duration, nulling any `clearOnCancel` attrs, and emitting one `cancel` `ACTION_FEEDBACK` per active action.

## The two wrinkles the issue flagged
1. **`action → A.*` feedback constant** — non-issue: the `A.*` action-id constants *equal* the registry `action` ids (`A.PROBE === "probe"`, …), so emitting `def.action` is byte-identical to the former per-branch payloads.
2. **XPLOIT clears `activeExploitId`** — handled by the new registry `clearOnCancel` field, keeping the loop generic and the registry the home for that last per-action fact.

`reboot` stays excluded (it is `abortable: false` — involuntary), which is why the loop is over `ABORTABLE_TIMED_ACTIONS`, not all of `TIMED_ACTIONS`.

## Verification — no behavior change
- New `tests/nav-cancel.test.js` derives its cases from `ABORTABLE_TIMED_ACTIONS`, so it covers the whole abortable set (and any future 7th action — the drift this refactor prevents): each in-progress action resets attr/progress/duration + `clearOnCancel`, fires exactly one `cancel` feedback with the right action id; an idle navigate fires none. **Written as a characterization test — it passed against the original six-branch handler *and* the refactor**, proving identical behavior.
- `make check` green (**1345 pass**). `make census SEEDS=10` — no headless crash.

## Groundwork for #187
This is the surface #187 (make most node actions timed) touches — clearing the hand-enumeration trap now means #187 can add actions to the registry and get nav-cancel for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)