### PR TITLE
Fix prebake: single-quote all string literals (strudel mini-notation)

### DIFF
--- a/audio-content/strudel-prebake.js
+++ b/audio-content/strudel-prebake.js
@@ -55,15 +55,17 @@ async function registerSoundfont(url, prefix) {
   });
 }
 
-await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/GeneralUser-GS.sf2', 'gus_'); // gus
-await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Pad.sf2', 'msgpad_'); // msgpad
-await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Lead.sf2', 'msglead_'); // msglead
-await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-FX.sf2', 'msgfx_'); // msgfx
-await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Bass.sf2', 'msgbass_'); // msgbass
-await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Keys.sf2', 'msgkeys_'); // msgkeys
-await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Organ.sf2', 'msgorg_'); // msgorg
-await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Guitar.sf2', 'msggtr_'); // msggtr
-await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Drums.sf2', 'msgdrum_'); // msgdrum
+await Promise.all([
+  registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/GeneralUser-GS.sf2', 'gus_'), // gus
+  registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Pad.sf2', 'msgpad_'), // msgpad
+  registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Lead.sf2', 'msglead_'), // msglead
+  registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-FX.sf2', 'msgfx_'), // msgfx
+  registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Bass.sf2', 'msgbass_'), // msgbass
+  registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Keys.sf2', 'msgkeys_'), // msgkeys
+  registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Organ.sf2', 'msgorg_'), // msgorg
+  registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Guitar.sf2', 'msggtr_'), // msggtr
+  registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Drums.sf2', 'msgdrum_'), // msgdrum
+]);
 
 // ── 2. Signals: stub gameProgress / gameThreat so reactive songs play + react while authoring ──
 // Keep this list in sync with js/audio/signal-registry.js (currently: gameProgress, gameThreat).

--- a/audio-content/strudel-prebake.js
+++ b/audio-content/strudel-prebake.js
@@ -55,15 +55,15 @@ async function registerSoundfont(url, prefix) {
   });
 }
 
-await registerSoundfont("https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/GeneralUser-GS.sf2", "gus_"); // gus
-await registerSoundfont("https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Pad.sf2", "msgpad_"); // msgpad
-await registerSoundfont("https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Lead.sf2", "msglead_"); // msglead
-await registerSoundfont("https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-FX.sf2", "msgfx_"); // msgfx
-await registerSoundfont("https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Bass.sf2", "msgbass_"); // msgbass
-await registerSoundfont("https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Keys.sf2", "msgkeys_"); // msgkeys
-await registerSoundfont("https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Organ.sf2", "msgorg_"); // msgorg
-await registerSoundfont("https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Guitar.sf2", "msggtr_"); // msggtr
-await registerSoundfont("https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Drums.sf2", "msgdrum_"); // msgdrum
+await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/GeneralUser-GS.sf2', 'gus_'); // gus
+await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Pad.sf2', 'msgpad_'); // msgpad
+await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Lead.sf2', 'msglead_'); // msglead
+await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-FX.sf2', 'msgfx_'); // msgfx
+await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Bass.sf2', 'msgbass_'); // msgbass
+await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Keys.sf2', 'msgkeys_'); // msgkeys
+await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Organ.sf2', 'msgorg_'); // msgorg
+await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Guitar.sf2', 'msggtr_'); // msggtr
+await registerSoundfont('https://raw.githubusercontent.com/lmorchard/starnet/main/audio-content/soundfonts/MuseScore-Drums.sf2', 'msgdrum_'); // msgdrum
 
 // ── 2. Signals: stub gameProgress / gameThreat so reactive songs play + react while authoring ──
 // Keep this list in sync with js/audio/signal-registry.js (currently: gameProgress, gameThreat).

--- a/scripts/gen-prebake.js
+++ b/scripts/gen-prebake.js
@@ -92,10 +92,16 @@ const sq = (s) => {
   return `'${s}'`;
 };
 
-const fontCalls = SOUNDFONTS.map((entry) => {
-  if (!entry.host) throw new Error(`[gen-prebake] manifest entry '${entry.prefix}' has no host URL`);
-  return `await registerSoundfont(${sq(entry.host)}, ${sq(entry.prefix)}); // ${labelOf(entry.prefix)}`;
-}).join("\n");
+// Load all fonts CONCURRENTLY (Promise.all) rather than one await at a time — the full palette is
+// ~9 fonts / >100MB, and serial loading leaves a long window where a song can trigger a sound
+// before its font is registered (strudel then retries + warns "Failed to trigger sound").
+const fontCalls =
+  "await Promise.all([\n" +
+  SOUNDFONTS.map((entry) => {
+    if (!entry.host) throw new Error(`[gen-prebake] manifest entry '${entry.prefix}' has no host URL`);
+    return `  registerSoundfont(${sq(entry.host)}, ${sq(entry.prefix)}), // ${labelOf(entry.prefix)}`;
+  }).join("\n") +
+  "\n]);";
 
 const INSTRUMENTS = `\
 // ── 1. Instruments: register every font's presets under its prefix ──

--- a/scripts/gen-prebake.js
+++ b/scripts/gen-prebake.js
@@ -81,9 +81,20 @@ window.gameThreat   = slider(0.5, 0, 1)
 /** Terse font label for the inline comment on each call, e.g. "msgpad_" → "msgpad". */
 const labelOf = (prefix) => prefix.replace(/_$/, "");
 
+// IMPORTANT: emit SINGLE-quoted string literals. strudel.cc's transpiler rewrites DOUBLE-quoted
+// strings into mini-notation patterns — a URL like "https://…/x.sf2" would then be parsed as
+// mini-notation and crash on the "/". Single-quoted strings pass through as plain JS. (JSON.stringify
+// would emit double quotes, so we hand-wrap in single quotes and reject any value that couldn't be.)
+const sq = (s) => {
+  if (/['\\\n]/.test(s)) {
+    throw new Error(`[gen-prebake] value unsafe for a single-quoted literal (has quote/backslash/newline): ${JSON.stringify(s)}`);
+  }
+  return `'${s}'`;
+};
+
 const fontCalls = SOUNDFONTS.map((entry) => {
   if (!entry.host) throw new Error(`[gen-prebake] manifest entry '${entry.prefix}' has no host URL`);
-  return `await registerSoundfont(${JSON.stringify(entry.host)}, ${JSON.stringify(entry.prefix)}); // ${labelOf(entry.prefix)}`;
+  return `await registerSoundfont(${sq(entry.host)}, ${sq(entry.prefix)}); // ${labelOf(entry.prefix)}`;
 }).join("\n");
 
 const INSTRUMENTS = `\

--- a/tests/strudel-prebake.test.js
+++ b/tests/strudel-prebake.test.js
@@ -1,0 +1,24 @@
+// @ts-check
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+// strudel.cc's transpiler rewrites DOUBLE-quoted string literals into mini-notation patterns. A
+// double-quoted URL like "https://…/x.sf2" is therefore parsed as mini-notation and crashes on the
+// "/" ([mini] parse error). The generated prebake (audio-content/strudel-prebake.js) MUST use
+// single-quoted string literals only. Plain `node --check` can't catch this — it's valid JS; the
+// breakage is strudel-transpiler-specific. This guard encodes the invariant: any line containing a
+// double-quote must be a `//` comment (prose), never code.
+test("generated prebake has no double-quoted string literals in code (strudel treats them as mini-notation)", () => {
+  const src = readFileSync("audio-content/strudel-prebake.js", "utf8");
+  const offenders = src
+    .split("\n")
+    .map((line, i) => ({ line, n: i + 1 }))
+    .filter(({ line }) => line.includes('"') && !line.trim().startsWith("//"));
+  assert.equal(
+    offenders.length,
+    0,
+    "prebake must use single-quoted strings (strudel parses double-quoted strings as mini-notation):\n" +
+      offenders.map((o) => `  L${o.n}: ${o.line.trim()}`).join("\n"),
+  );
+});


### PR DESCRIPTION
Follow-up to #283.

## Problem

strudel.cc's transpiler rewrites **double-quoted** string literals into mini-notation patterns; single-quoted strings pass through as plain JS. The generated prebake (from the DRY refactor) emitted string args via `JSON.stringify` → double quotes. Two symptoms:

- Double-quoted **URL** → strudel parses `"https://…/x.sf2"` as mini-notation → `[mini] parse error … "/" found`.
- Double-quoted **prefix** → `"gus_"` becomes a mini-notation *pattern object*, so `prefix + presetName` stringifies to `[object Object]…` → instrument names like `[object_object]12_string_guitar`.

`node --check` can't catch either — it's valid JS; the breakage is strudel-transpiler-specific.

## Fix

`scripts/gen-prebake.js` now emits **single-quoted** string literals (a `sq()` helper that rejects any value containing a quote/backslash/newline), and the prebake is regenerated. Both the URL and the prefix are single-quoted.

Adds `tests/strudel-prebake.test.js` — guards that the generated prebake has **no double-quoted string literals in code** (any line with a `"` must be a `//` comment). Verified it flags all 9 offending lines in the current merged prebake and passes on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)