### PR TITLE
Soundfont FX routing: return the voice node so effects apply (#290)

### DIFF
--- a/audio-content/strudel-prebake.js
+++ b/audio-content/strudel-prebake.js
@@ -45,12 +45,23 @@ async function registerSoundfont(url, prefix) {
     if (used.has(name)) { const base = name; let n = 2; while (used.has(name)) name = base + '_' + n++; }
     used.add(name);
     registerSound(name, (time, value) => {
+      // Route the voice into our own gain node and RETURN it so superdough applies its FX chain
+      // (gain/room/lpf/pan/…) — it only wires effects onto the returned node, and bails on none.
+      // sfumato's startPresetNote self-connects to ctx.destination, so proxy the ctx to redirect
+      // .destination to our tap node; superdough then handles note-off (ramps node.gain, calls stop).
       const ctx = getAudioContext();
       const note = value?.note ?? 'c3';
       const midi = typeof note === 'number' ? note : noteToMidi(note);
-      const stop = startPresetNote(ctx, preset, midi, time);
-      stop(time + (typeof value?.duration === 'number' ? value.duration : 0.5));
-      return { node: undefined, stop };
+      const out = ctx.createGain();
+      const proxied = new Proxy(ctx, {
+        get(target, prop) {
+          if (prop === 'destination') return out;
+          const v = target[prop];
+          return typeof v === 'function' ? v.bind(target) : v;
+        },
+      });
+      const stop = startPresetNote(proxied, preset, midi, time);
+      return { node: out, stop };
     }, { type: 'soundfont', prebake: false, fonts: [] });
   });
 }

--- a/js/audio/strudel/soundfont.js
+++ b/js/audio/strudel/soundfont.js
@@ -90,14 +90,23 @@ export async function loadGameSoundfont() {
           const ctx = window.getAudioContext();
           const note = value?.note ?? "c3";
           const midi = typeof note === "number" ? note : noteToMidi(note);
-          const stop = sfMod.startPresetNote(ctx, preset, midi, time);
-          // superdough bails early on a soundfont handle (node is undefined) and never schedules the
-          // note-off, so the voice would ring forever — schedule it ourselves from the hap duration
-          // (value.duration = hapDuration). This is what sfumato's own .soundfont() method does, and
-          // it makes hush()/stop actually silence the song (voices self-terminate; no new triggers).
-          const dur = typeof value?.duration === "number" ? value.duration : 0.5;
-          stop(time + dur);
-          return { node: undefined, stop };
+          // Route the voice into our own gain node and RETURN that node, so superdough can apply
+          // its FX chain (gain/room/lpf/pan/delay/…). superdough only wires effects onto the node a
+          // trigger returns and bails entirely when there's no node — which is why a soundfont that
+          // returns `node: undefined` plays raw (no effects) and trips "Failed to trigger sound".
+          // sfumato's startPresetNote self-connects to ctx.destination, so we proxy the context to
+          // redirect `.destination` to our tap node; superdough then handles note-off (it ramps
+          // node.gain to 0 and calls the returned stop() at release).
+          const out = ctx.createGain();
+          const proxied = new Proxy(ctx, {
+            get(target, prop) {
+              if (prop === "destination") return out;
+              const v = target[prop];
+              return typeof v === "function" ? v.bind(target) : v;
+            },
+          });
+          const stop = sfMod.startPresetNote(proxied, preset, midi, time);
+          return { node: out, stop };
         },
         { type: "soundfont", prebake: false },
       );

--- a/scripts/gen-prebake.js
+++ b/scripts/gen-prebake.js
@@ -119,12 +119,23 @@ async function registerSoundfont(url, prefix) {
     if (used.has(name)) { const base = name; let n = 2; while (used.has(name)) name = base + '_' + n++; }
     used.add(name);
     registerSound(name, (time, value) => {
+      // Route the voice into our own gain node and RETURN it so superdough applies its FX chain
+      // (gain/room/lpf/pan/…) — it only wires effects onto the returned node, and bails on none.
+      // sfumato's startPresetNote self-connects to ctx.destination, so proxy the ctx to redirect
+      // .destination to our tap node; superdough then handles note-off (ramps node.gain, calls stop).
       const ctx = getAudioContext();
       const note = value?.note ?? 'c3';
       const midi = typeof note === 'number' ? note : noteToMidi(note);
-      const stop = startPresetNote(ctx, preset, midi, time);
-      stop(time + (typeof value?.duration === 'number' ? value.duration : 0.5));
-      return { node: undefined, stop };
+      const out = ctx.createGain();
+      const proxied = new Proxy(ctx, {
+        get(target, prop) {
+          if (prop === 'destination') return out;
+          const v = target[prop];
+          return typeof v === 'function' ? v.bind(target) : v;
+        },
+      });
+      const stop = startPresetNote(proxied, preset, midi, time);
+      return { node: out, stop };
     }, { type: 'soundfont', prebake: false, fonts: [] });
   });
 }


### PR DESCRIPTION
Closes #290.

## Problem

Our soundfont `onTrigger` returned `{ node: undefined, stop }`. superdough only wires its FX chain onto the node a trigger returns and **bails before building the chain when there is none** (`superdough.mjs`: `if (!sourceNode) return;` right before `chain.connect(sourceNode)`). So `gain`/`room`/`lpf`/`pan`/`delay` silently no-oped on every soundfont sound — the note was audible only because sfumato self-connects the voice to `ctx.destination`. Affected `gus_` + all `msg_` sounds, **in-game and in the strudel.cc prebake** (shipped songs' effects on `gus_` parts werent applying either).

## Fix

Route the sfumato voice into our own gain node and **return that node**, so superdough inserts it into the FX chain and handles note-off (it ramps the node gain and calls the returned `stop()` at release — so we no longer schedule stop ourselves). sfumato's `startPresetNote` hardwires `ctx.destination`, so we proxy the context to redirect `.destination` to our tap node.

We keep sfumato doing the actual voice math (pitch/loops/envelope) — considered reimplementing a lean voice à la strudel's own `fontloader`, but that would duplicate sfumato's fiddliest correctness-critical code for a negligible per-note saving (one proxy + one gain node), so not worth the risk.

Applied to both `js/audio/strudel/soundfont.js` (in-game) and `scripts/gen-prebake.js` (prebake mirror); prebake regenerated. Likely also clears the "Failed to trigger sound after 10 attempts" warning (same missing-node path).

`make check` green (1378). **Needs an audible check**: re-paste the regenerated prebake into strudel.cc and confirm `room`/`gain` now shape the soundfont sounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)