### PR TITLE
Timed actions Phase 1: declarable timing + generic legible feedback (#187)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -810,7 +810,7 @@ Actions depend on the selected node's type and access level:
 | `mine`         | Node is owned and not exhausted                | Timed data-mining — rolls a yield chance for one exploit card targeting the node's own vuln classes; yield decays per attempt; disappears when the node is exhausted |
 | `sniff`        | Probed node with a visible flow touching it    | Opens a flow picker (only flows to already-revealed nodes). Reads a flow (decrypts an encrypted one; captures a credential token from a credential flow). Adds heat. Needs the node probed first — not available on an unprobed node. |
 | `replay`       | Finesse-locked node you hold its trusted credential for | Replays the captured credential → node jumps to owned (reveals what it gated). Adds heat. |
-| `exec <script>` | An open/owned node exposes node scripts       | Lists/runs the node's scripts (corrupt, spoof, unlock-vault, cancel-trace, access-darknet, …) |
+| `exec <script>` | An open/owned node exposes node scripts       | Lists/runs the node's scripts (corrupt, spoof, unlock-vault, cancel-trace, access-darknet, …). Set-piece/puzzle scripts run as timed actions by default (brief, ~2s, with the generic-process animation) unless they're a UI/exit action like cancel-trace, access-darknet, or disconnect |
 | `corrupt`      | IDS node is open or owned                      | Timed subversion — severs event forwarding to security monitor once complete; grade-scaled duration (run via `exec`) |
 | `scrub-logs`   | Security-monitor, open or owned                | Wipes that monitor's accumulated alerts, eases the global alert one level (below trace; run via `exec`) |
 | `lie-low`      | WAN node, uses remaining this run              | Timed wait that sheds **heat** (does not lower the alert ladder); limited per run (run via `exec`) |
@@ -921,11 +921,12 @@ cards escalate by rarity (common → uncommon → rare); a big-value loot haul g
 a small one; and **revealing nodes is a "discovery rush"** — a single reveal is a bright blip, but
 unlocking a cluster of neighbors cascades into a quick rising run.
 
-Every **timed action** (probe, xploit, dump, fetch, mine, lie-low, reboot, corrupt) also gets its own
-**sustained drone** that plays while the action is in progress and evolves as it advances —
-echoing the action's on-graph animation (a scanning pulse for probe, a grinding tighten for xploit,
-a lock-on beat that settles for mine, and so on). The drone stops when the action completes or is
-cancelled, and the usual one-shot fires at the end.
+Every **timed action** (probe, xploit, dump, fetch, mine, lie-low, reboot, corrupt, and — by
+default — set-piece/EXEC scripts) also gets its own **sustained drone** that plays while the
+action is in progress and evolves as it advances — echoing the action's on-graph animation (a
+scanning pulse for probe, a grinding tighten for xploit, a lock-on beat that settles for mine,
+a neutral pulse for a generic set-piece script, and so on). The drone stops when the action
+completes or is cancelled, and the usual one-shot fires at the end.
 
 SFX are **independent of the music** — they have their own on/off and run on their own audio bus,
 so you can have effects with the music off, and they play in the hub as well as in a run.

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -649,8 +649,10 @@ If you can open and then **corrupt** an IDS node:
 > exec corrupt
 ```
 
-Event forwarding from that IDS to its connected security monitor is severed — that monitor
-goes dark and stops climbing the alert ladder, no matter how many exploits you fail. (A LAN
+This is a **timed action** — subverting the IDS takes a few seconds, longer on a higher-grade
+IDS, and can be aborted mid-run. Once it completes, event forwarding from that IDS to its
+connected security monitor is severed — that monitor goes dark and stops climbing the alert
+ladder, no matter how many exploits you fail. (A LAN
 with more than one IDS/monitor pair needs each IDS corrupted to fully go dark.) This is often
 worth the detour, especially on an ICE-less LAN where the grid is your only clock.
 
@@ -801,7 +803,7 @@ Actions depend on the selected node's type and access level:
 | `exec access-darknet` | WAN node is targeted                       | Opens the darknet broker store; pauses the LAN while shopping (run via `exec`) |
 | `probe`           | Node is locked and unprobed                   | Timed scan — reveals vulnerabilities, raises local alert |
 | `sweep` (menu) / `sweep <depth|max>` (console) | Targeted accessible node, no sweep already running | Broadcast probe — ripples outward wave-by-wave up to the chosen depth, probing + fully revealing each reached node, flowing through probe-gate nodes and stopping at gate-controllers. Adds heat per node (a fast spike). Abortable mid-ripple. |
-| `abort`           | Timed action **or a sweep** in progress on targeted node | Aborts the current action (probe, xploit, dump, fetch, or a running sweep) |
+| `abort`           | Timed action **or a sweep** in progress on targeted node | Aborts the current action (probe, xploit, dump, fetch, corrupt, or a running sweep) |
 | `xploit` (menu) / `xploit <n>` (console) | Node is accessible and not currently exploiting | Opens a node-anchored card picker. Unprobed → all usable cards (blind); probed → only cards matching revealed vulns; disabled with a reason when no card applies. Not offered at all on an already-owned node. The hand strip and `xploit <n>` console command stay full-agency (play any usable card). Raises access level on success. |
 | `dump`         | Node is open or owned, unread                  | Timed scan — reveals macguffins |
 | `fetch`        | Node is owned + has uncollected macguffins     | Timed extraction — collects macguffins for cash |
@@ -809,7 +811,7 @@ Actions depend on the selected node's type and access level:
 | `sniff`        | Probed node with a visible flow touching it    | Opens a flow picker (only flows to already-revealed nodes). Reads a flow (decrypts an encrypted one; captures a credential token from a credential flow). Adds heat. Needs the node probed first — not available on an unprobed node. |
 | `replay`       | Finesse-locked node you hold its trusted credential for | Replays the captured credential → node jumps to owned (reveals what it gated). Adds heat. |
 | `exec <script>` | An open/owned node exposes node scripts       | Lists/runs the node's scripts (corrupt, spoof, unlock-vault, cancel-trace, access-darknet, …) |
-| `corrupt`      | IDS node is open or owned                      | Severs event forwarding to security monitor (run via `exec`) |
+| `corrupt`      | IDS node is open or owned                      | Timed subversion — severs event forwarding to security monitor once complete; grade-scaled duration (run via `exec`) |
 | `scrub-logs`   | Security-monitor, open or owned                | Wipes that monitor's accumulated alerts, eases the global alert one level (below trace; run via `exec`) |
 | `lie-low`      | WAN node, uses remaining this run              | Timed wait that sheds **heat** (does not lower the alert ladder); limited per run (run via `exec`) |
 | `spoof`        | Security-monitor node, open or owned           | Recalibrates security monitor (run via `exec`) |
@@ -919,7 +921,7 @@ cards escalate by rarity (common → uncommon → rare); a big-value loot haul g
 a small one; and **revealing nodes is a "discovery rush"** — a single reveal is a bright blip, but
 unlocking a cluster of neighbors cascades into a quick rising run.
 
-Every **timed action** (probe, xploit, dump, fetch, mine, lie-low, reboot) also gets its own
+Every **timed action** (probe, xploit, dump, fetch, mine, lie-low, reboot, corrupt) also gets its own
 **sustained drone** that plays while the action is in progress and evolves as it advances —
 echoing the action's on-graph animation (a scanning pulse for probe, a grinding tighten for xploit,
 a lock-on beat that settles for mine, and so on). The drone stops when the action completes or is

--- a/data/biomes/corporate-pieces/scattered.js
+++ b/data/biomes/corporate-pieces/scattered.js
@@ -65,6 +65,7 @@ function makeScatteredLock(n, cost) {
           {
             id: "scan-lock",
             label: "Scan Lock",
+            instant: true,   // status readout, not in-world work — stays instant (#187)
             requires: [
               /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
             ],
@@ -188,6 +189,7 @@ function makeScatteredKeyVault(n, cost) {
           {
             id: "scan-vault",
             label: "Scan Vault",
+            instant: true,   // status readout, not in-world work — stays instant (#187)
             requires: [
               /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
             ],
@@ -285,6 +287,7 @@ function makeScatteredEncryptedVault(n, cost) {
           {
             id: "scan-vault",
             label: "Scan Vault",
+            instant: true,   // status readout, not in-world work — stays instant (#187)
             requires: [
               /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
             ],

--- a/data/biomes/corporate-pieces/scattered.js
+++ b/data/biomes/corporate-pieces/scattered.js
@@ -91,7 +91,14 @@ function makeScatteredLock(n, cost) {
               // (owned + locks-opened>=n) are monotonic and never revert, so without
               // this the action stays available forever and farms cash on every click.
               /** @type {const} */ ({ type: "node-attr", attr: "cracked", eq: false }),
+              // One-at-a-time gate (#187 Phase 5): structural check, same as the core
+              // verbs' NOT_BUSY — blocks re-triggering while the crack is already in flight.
+              /** @type {const} */ ({ type: "no-active-timed-action" }),
             ],
+            // Timed (#187 Phase 5): flat feel-draft duration — turns the instant payout
+            // into a legible crack rather than a silent dud. Synthesis rewrites `effects`
+            // below into the timed-action operator's onComplete.
+            timed: { duration: 20 },
             effects: [
               /** @type {const} */ ({ effect: "ctx-call", method: "giveReward", args: [1500] }),
               /** @type {const} */ ({ effect: "set-attr", attr: "cracked", value: true }),
@@ -245,7 +252,14 @@ function makeScatteredEncryptedVault(n, cost) {
           requires: [
             /** @type {const} */ ({ type: "node-attr", attr: "accessLevel", eq: "owned" }),
             /** @type {const} */ ({ type: "node-attr", attr: "keyExtracted", eq: false }),
+            // One-at-a-time gate (#187 Phase 5): structural check, same as the core
+            // verbs' NOT_BUSY — blocks re-triggering while the extraction is in flight.
+            /** @type {const} */ ({ type: "no-active-timed-action" }),
           ],
+          // Timed (#187 Phase 5): flat feel-draft duration — turns the instant extraction
+          // into a legible process rather than a silent dud. Synthesis rewrites `effects`
+          // below into the timed-action operator's onComplete.
+          timed: { duration: 20 },
           effects: [
             /** @type {const} */ ({ effect: "set-attr", attr: "keyExtracted", value: true }),
             /** @type {const} */ ({ effect: "quality-delta", name: "decryption-keys", delta: 1 }),

--- a/data/biomes/corporate-pieces/scattered.js
+++ b/data/biomes/corporate-pieces/scattered.js
@@ -95,10 +95,10 @@ function makeScatteredLock(n, cost) {
               // verbs' NOT_BUSY — blocks re-triggering while the crack is already in flight.
               /** @type {const} */ ({ type: "no-active-timed-action" }),
             ],
-            // Timed (#187 Phase 5): flat feel-draft duration — turns the instant payout
-            // into a legible crack rather than a silent dud. Synthesis rewrites `effects`
-            // below into the timed-action operator's onComplete.
-            timed: { duration: 20 },
+            // Timed (#187 default-flip): crack-vault is a script action, so it's
+            // synthesized as timed by default (DEFAULT_SCRIPT_ACTION_DURATION, same 20-tick
+            // feel-draft value this explicit block used to spell out) — turning the instant
+            // payout into a legible crack rather than a silent dud, with no annotation needed.
             effects: [
               /** @type {const} */ ({ effect: "ctx-call", method: "giveReward", args: [1500] }),
               /** @type {const} */ ({ effect: "set-attr", attr: "cracked", value: true }),
@@ -256,10 +256,10 @@ function makeScatteredEncryptedVault(n, cost) {
             // verbs' NOT_BUSY — blocks re-triggering while the extraction is in flight.
             /** @type {const} */ ({ type: "no-active-timed-action" }),
           ],
-          // Timed (#187 Phase 5): flat feel-draft duration — turns the instant extraction
-          // into a legible process rather than a silent dud. Synthesis rewrites `effects`
-          // below into the timed-action operator's onComplete.
-          timed: { duration: 20 },
+          // Timed (#187 default-flip): extract-key is a script action, so it's synthesized
+          // as timed by default (DEFAULT_SCRIPT_ACTION_DURATION, same 20-tick feel-draft
+          // value this explicit block used to spell out) — turning the instant extraction
+          // into a legible process rather than a silent dud, with no annotation needed.
           effects: [
             /** @type {const} */ ({ effect: "set-attr", attr: "keyExtracted", value: true }),
             /** @type {const} */ ({ effect: "quality-delta", name: "decryption-keys", delta: 1 }),

--- a/docs/BOT-PLAYER.md
+++ b/docs/BOT-PLAYER.md
@@ -292,6 +292,14 @@ These omissions are intentional — they make the bot a pessimistic baseline:
   sweep running the process framework no-ops for the bot and census is unchanged from
   `main` (0.3 / 0.767 same-seed). SWEEP is a human breadth-vs-heat choice; the census
   can't tell us whether its depth/heat feel right.
+- **Timed set-piece verbs (`crack-vault`/`extract-key`)** — now timed (#187), but the bot
+  keeps them in `INSTANT_ACTIONS` (they resolve their reward via `onComplete`, never emit
+  `ACTION_RESOLVED`, so `tickUntilResolved` would spin the tick budget for nothing). The bot
+  proposes each once and the ~20-tick arm resolves passively in the background as the loop
+  advances. Residual: if a run ends (trace/jack-out) before the arm completes, the one-shot
+  reward is silently lost — acceptable for the greedy baseline (census is byte-identical to
+  base), but a human sees the timed action + reward. `corrupt`, by contrast, IS in the bot's
+  `TIMED_ACTIONS` set (it emits `ACTION_RESOLVED`), so the bot waits for it correctly.
 
 ### What the census therefore cannot validate
 

--- a/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/generic-overlay-lab.html
+++ b/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/generic-overlay-lab.html
@@ -1,0 +1,150 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Generic process overlay — feel lab (#187 Phase 4a)</title>
+<style>
+  :root { --cyan:#00e5ff; --green:#39ff14; --mag:#ff00aa; }
+  html,body { margin:0; height:100%; background:#0a0a0f; color:#8fe; font:13px/1.5 ui-monospace,Menlo,monospace; }
+  .wrap { display:flex; height:100%; }
+  #stage { flex:1; display:grid; place-items:center; }
+  canvas { background:radial-gradient(circle at 50% 45%, #0d0d16, #06060a 70%); }
+  #panel { width:320px; padding:16px 18px; background:#0c0c12; border-left:1px solid #1c2233; overflow:auto; }
+  h1 { font-size:13px; color:var(--cyan); letter-spacing:.08em; margin:0 0 4px; }
+  .sub { color:#5a6b82; margin:0 0 16px; font-size:11px; }
+  .row { margin:0 0 12px; }
+  label { display:flex; justify-content:space-between; color:#9fb3c9; font-size:11px; letter-spacing:.04em; }
+  label b { color:var(--cyan); font-weight:600; }
+  input[type=range] { width:100%; accent-color:var(--cyan); }
+  select, button { background:#11151f; color:#cfe; border:1px solid #263042; border-radius:4px; padding:6px 8px; font:inherit; }
+  button { cursor:pointer; }
+  .styles { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:14px; }
+  .styles button.active { border-color:var(--cyan); color:var(--cyan); box-shadow:0 0 8px #00e5ff55; }
+  fieldset { border:1px solid #1c2233; border-radius:6px; margin:0 0 14px; padding:10px 12px; }
+  legend { color:#5a6b82; font-size:10px; letter-spacing:.1em; text-transform:uppercase; }
+  .dump { white-space:pre; color:#5a6b82; font-size:10px; background:#08080d; border:1px solid #1c2233; border-radius:4px; padding:8px; margin-top:6px; max-height:150px; overflow:auto; }
+  .hint { color:#5a6b82; font-size:10px; margin-top:2px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div id="stage"><canvas id="cv" width="520" height="520"></canvas></div>
+  <div id="panel">
+    <h1>GENERIC PROCESS OVERLAY</h1>
+    <p class="sub">#187 Phase 4a — throwaway feel lab. Drive it; I'll tune params from what you describe, then lock + port. Clockwise = player action.</p>
+
+    <div class="styles" id="styles"></div>
+
+    <fieldset><legend>Progress</legend>
+      <div class="row"><label>progress <b id="vprogress">0.00</b></label><input type="range" id="progress" min="0" max="1" step="0.001" value="0"></div>
+      <div class="row"><button id="play">▶ auto-run (3s loop)</button> <button id="jitter">⟳ re-arm</button></div>
+    </fieldset>
+
+    <fieldset><legend>Geometry</legend>
+      <div class="row"><label>radius <b id="vradius">54</b></label><input type="range" id="radius" min="24" max="120" step="1" value="54"></div>
+      <div class="row"><label>segments / ticks <b id="vsides">12</b></label><input type="range" id="sides" min="3" max="48" step="1" value="12"></div>
+      <div class="row"><label>stroke width <b id="vstroke">2.0</b></label><input type="range" id="stroke" min="0.5" max="6" step="0.1" value="2"></div>
+      <div class="row"><label>gap between segments <b id="vgap">0.18</b></label><input type="range" id="gap" min="0" max="0.5" step="0.01" value="0.18"></div>
+      <div class="row"><label>idle spin (deg/s) <b id="vspin">8</b></label><input type="range" id="spin" min="-90" max="90" step="1" value="8"></div>
+    </fieldset>
+
+    <fieldset><legend>Phosphene</legend>
+      <div class="row"><label>hue <b id="vhue">141</b></label><input type="range" id="hue" min="0" max="360" step="1" value="141"></div>
+      <div class="row"><label>glow blur <b id="vglow">10</b></label><input type="range" id="glow" min="0" max="30" step="1" value="10"></div>
+      <div class="row"><label>unlit dimness <b id="vdim">0.10</b></label><input type="range" id="dim" min="0" max="0.6" step="0.01" value="0.10"></div>
+      <div class="row"><label>leading-edge pulse <b id="vpulse">0.5</b></label><input type="range" id="pulse" min="0" max="1" step="0.01" value="0.5"></div>
+    </fieldset>
+
+    <button id="copy">⧉ copy current params</button>
+    <div class="dump" id="dump"></div>
+    <p class="hint">Node glyph in the center is just context (a stroked hexagon). Tell me: shape, density, speed, glow, color, and which STYLE reads best as "a process is running here."</p>
+  </div>
+</div>
+<script>
+const cv = document.getElementById('cv'), ctx = cv.getContext('2d');
+const P = {}; // params
+const ids = ['progress','radius','sides','stroke','gap','spin','hue','glow','dim','pulse'];
+ids.forEach(id => {
+  const el = document.getElementById(id);
+  P[id] = parseFloat(el.value);
+  el.addEventListener('input', () => { P[id] = parseFloat(el.value); document.getElementById('v'+id).textContent = fmt(id, P[id]); updateDump(); });
+  document.getElementById('v'+id).textContent = fmt(id, P[id]);
+});
+function fmt(id,v){ return (id==='progress'||id==='gap'||id==='dim'||id==='pulse'||id==='stroke') ? v.toFixed(2) : String(v|0); }
+
+const STYLES = ['segmented-ring','converging-brackets','sweep-ticks','aperture-blades'];
+let style = STYLES[0];
+const sc = document.getElementById('styles');
+STYLES.forEach(s => { const b=document.createElement('button'); b.textContent=s; b.onclick=()=>{style=s; [...sc.children].forEach(c=>c.classList.toggle('active',c===b)); updateDump();}; sc.appendChild(b); if(s===style) b.classList.add('active'); });
+
+// auto-run
+let playing=false, t0=0;
+document.getElementById('play').onclick = e => { playing=!playing; t0=performance.now(); e.target.textContent = playing?'⏸ pause':'▶ auto-run (3s loop)'; };
+document.getElementById('jitter').onclick = () => { document.getElementById('progress').value=0; P.progress=0; playing=true; t0=performance.now(); };
+document.getElementById('copy').onclick = () => navigator.clipboard?.writeText(dumpText());
+
+function dumpText(){ return 'style: '+style+'\n'+ids.filter(i=>i!=='progress').map(i=>'  '+i+': '+P[i]).join('\n'); }
+function updateDump(){ document.getElementById('dump').textContent = dumpText(); }
+updateDump();
+
+const TAU = Math.PI*2;
+function stroke(hueShift=0, alpha=1, w=P.stroke){ ctx.strokeStyle=`hsla(${(P.hue+hueShift)%360},100%,60%,${alpha})`; ctx.lineWidth=w; ctx.shadowBlur=P.glow; ctx.shadowColor=`hsla(${P.hue},100%,60%,${Math.min(1,alpha)})`; }
+
+function nodeGlyph(cx,cy){ // stroked hexagon for context
+  ctx.beginPath();
+  for(let i=0;i<6;i++){ const a=-Math.PI/2 + i*TAU/6; const x=cx+16*Math.cos(a), y=cy+16*Math.sin(a); i?ctx.lineTo(x,y):ctx.moveTo(x,y);} ctx.closePath();
+  stroke(0,0.85,1.5); ctx.stroke();
+}
+
+function draw(now){
+  ctx.clearRect(0,0,cv.width,cv.height);
+  const cx=cv.width/2, cy=cv.height/2;
+  if(playing){ const p=((now-t0)%3000)/3000; P.progress=p; const el=document.getElementById('progress'); el.value=p; document.getElementById('vprogress').textContent=p.toFixed(2); }
+  const spin = (P.spin*Math.PI/180)*(now/1000); // CW idle rotation
+  const N=P.sides|0, R=P.radius, prog=P.progress;
+  const lit = prog*N; // fractional lit segments (CW)
+  const pulse = 1 + P.pulse*0.5*Math.sin(now/120); // leading-edge shimmer
+
+  ctx.save(); ctx.translate(cx,cy);
+  if(style==='segmented-ring'){
+    const seg = TAU/N, half = seg*(1-P.gap)/2;
+    for(let i=0;i<N;i++){
+      const a = -Math.PI/2 + i*seg + spin; // start at top, go CW
+      const on = i < Math.floor(lit), lead = i===Math.floor(lit);
+      ctx.beginPath(); ctx.arc(0,0,R, a-half, a+half); // short arc = "edge" (acceptable curve at segment scale)
+      stroke(on? -20: 0, on?1:(lead?0.9*pulse:P.dim), on?P.stroke:P.stroke*0.85); ctx.stroke();
+    }
+  } else if(style==='converging-brackets'){
+    // 4 corner brackets marching inward with progress
+    const inset = R*(1 - 0.5*prog), armLen=R*0.5, corners=[[1,1],[-1,1],[-1,-1],[1,-1]];
+    ctx.save(); ctx.rotate(spin*0.3);
+    corners.forEach(([sx,sy])=>{ const x=sx*inset,y=sy*inset;
+      ctx.beginPath(); ctx.moveTo(x-sx*armLen,y); ctx.lineTo(x,y); ctx.lineTo(x,y-sy*armLen);
+      stroke(0, 0.55 + 0.45*prog, P.stroke); ctx.stroke(); }); ctx.restore();
+    // progress ring of ticks behind
+    for(let i=0;i<N;i++){ const a=-Math.PI/2+i*TAU/N+spin; const on=i<lit; const r1=R*0.9, r2=R*(on?1.06:1.0);
+      ctx.beginPath(); ctx.moveTo(r1*Math.cos(a),r1*Math.sin(a)); ctx.lineTo(r2*Math.cos(a),r2*Math.sin(a));
+      stroke(on?-20:0, on?1:P.dim, P.stroke*0.8); ctx.stroke(); }
+  } else if(style==='sweep-ticks'){
+    const sweepA = -Math.PI/2 + prog*TAU; // CW sweep line
+    for(let i=0;i<N;i++){ const a=-Math.PI/2+i*TAU/N; const passed=(a-(-Math.PI/2)+TAU)%TAU <= prog*TAU;
+      const r1=R*0.82, r2=R*(passed?1.0:0.92);
+      ctx.beginPath(); ctx.moveTo(r1*Math.cos(a),r1*Math.sin(a)); ctx.lineTo(r2*Math.cos(a),r2*Math.sin(a));
+      stroke(passed?-20:0, passed?1:P.dim, P.stroke); ctx.stroke(); }
+    ctx.beginPath(); ctx.moveTo(0,0); ctx.lineTo(R*Math.cos(sweepA),R*Math.sin(sweepA));
+    stroke(30, pulse, P.stroke*1.1); ctx.stroke();
+  } else if(style==='aperture-blades'){
+    const blades=N, close=prog; // blades rotate CW + close with progress
+    for(let i=0;i<blades;i++){ const a=i*TAU/blades+spin; const inner=R*(1-0.65*close);
+      const x1=R*Math.cos(a), y1=R*Math.sin(a); const x2=inner*Math.cos(a+0.5), y2=inner*Math.sin(a+0.5);
+      ctx.beginPath(); ctx.moveTo(x1,y1); ctx.lineTo(x2,y2);
+      stroke(-15*close, 0.5+0.5*prog, P.stroke); ctx.stroke(); }
+  }
+  ctx.restore();
+  nodeGlyph(cx,cy);
+  requestAnimationFrame(draw);
+}
+requestAnimationFrame(draw);
+</script>
+</body>
+</html>

--- a/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/notes.md
+++ b/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/notes.md
@@ -44,3 +44,21 @@ string literals inside the conditional branch).
 Not touched (correctly out of scope for Phase 1): `isNodeBusy`, `NOT_BUSY`/ABORT wiring, feedback
 resolution, overlay/drone default, and the `corrupt`/`crack-vault`/`extract-key` proof slice — all later
 phases per `plan.md`.
+
+## Phase 4a — generic-overlay feel loop (with Les)
+
+Feel lab: `tmp/generic-overlay-lab.html` (throwaway, gitignored) — a slider-driven Canvas harness with
+four candidate treatments. **Chosen for the generic default: `segmented-ring`** — a stroked polygon ring
+whose segments light up clockwise as progress fills. Locked feel: idle spin ~8°/s, unlit dimness ~0.10,
+hue **141** (green), radius 54, 12 segments, stroke 2.0, segment gap 0.18, glow blur 10, leading-edge
+pulse 0.5. (Confirm final spin/dim with Les before porting.)
+
+**Future palette candidates (Les — keep for the bespoke-feedback arc; see spec "future palette" + #288):**
+the three unchosen lab styles are worth reusing as bespoke overlays assigned across ranges of actions:
+- **`converging-brackets`** — four corner brackets marching inward + a progress tick-ring. Reads as
+  "locking on / tightening" — good for exploit-like or vault-crack actions.
+- **`sweep-ticks`** — a clockwise sweep line lighting a tick ring as it passes. Reads as "scanning" —
+  good for scan/probe-family set-piece actions.
+- **`aperture-blades`** — blades rotating CW and closing with progress. Reads as "opening/sealing" —
+  good for unlock/extract/gate actions.
+The lab code preserves the exact geometry of all four if we rebuild it for that arc.

--- a/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/notes.md
+++ b/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/notes.md
@@ -62,3 +62,77 @@ the three unchosen lab styles are worth reusing as bespoke overlays assigned acr
 - **`aperture-blades`** — blades rotating CW and closing with progress. Reads as "opening/sealing" —
   good for unlock/extract/gate actions.
 The lab code preserves the exact geometry of all four if we rebuild it for that arc.
+
+## Phase 5 — Proof slice: `corrupt` + `crack-vault` + `extract-key` go timed (#187)
+
+Converted the three actions named in `plan.md`'s proof slice from instant to timed, proving the
+full Phase 1-4 chain (declarable `timed` → synthesis → arm/tick/complete, unified abortable
+busy/abort, generic default overlay/drone/cue) against real gameplay verbs instead of a synthetic
+fixture.
+
+**`corrupt` (core verb, trait-supplied):** `RECONFIGURE_ACTION` in `js/core/node-graph/action-templates.js`
+gained `timed: { durationTable: { S:30, A:25, B:20, C:15, D:12, F:8 } }` and `...NOT_BUSY` in
+`requires`. No hand-moved effects — synthesis rewrites `effects` (`forwardingEnabled=false` +
+`reconfigureNode`) into `onComplete` automatically. Since `RECONFIGURE_ACTION` is shared by
+reference across every `detectable`-trait node, this is the first *real* exercise of the Phase-1
+new-object-per-node synthesis (previously only proven via a synthetic test fixture) — a dedicated
+test constructs a two-IDS bare NodeGraph and asserts each node got its own synthesized operator
+object (`notEqual`) and arms independently.
+
+**`crack-vault` / `extract-key` (set-piece verbs):** inline `ActionDef`s in
+`data/biomes/corporate-pieces/scattered.js` (on the scattered-vault and scattered-encrypted-vault
+set-pieces) each gained `timed: { duration: 20 }` (flat, feel-draft ~2s) plus a
+`{ type: "no-active-timed-action" }` structural busy-gate in `requires` (one-at-a-time, matching
+the core verbs' `NOT_BUSY` intent — these files don't import `action-templates.js`'s local
+`NOT_BUSY` const, so the bare structural condition was used directly rather than adding a new
+export). Neither declares an inline `feedback` override, so both fall through the layered
+resolution straight to `DEFAULT_PROFILE` (`generic-process` overlay / `generic` drone /
+`process.done` cue) — the intended "kill the dud" outcome.
+
+**Bot compatibility (`scripts/bot/execute.js`):** moved `A.CORRUPT` from `INSTANT_ACTIONS` to
+`TIMED_ACTIONS` — it emits `ACTION_RESOLVED` on completion (`reconfigureNode`), same shape as
+probe/dump/fetch/reboot/mine, so `tickUntilResolved` can wait for it correctly. **Left
+`crack-vault`/`extract-key` in `INSTANT_ACTIONS` deliberately** — they only call
+`giveReward`/`set-attr`/`log` via `onComplete`, never `ACTION_RESOLVED`, so `tickUntilResolved`
+would never see them resolve and would spin to the full tick budget (500) for nothing. They're
+one-shot puzzle actions the bot proposes at most once per node (`puzzleStrategy`'s `completed`
+set survives regardless of instant/timed dispatch), and `loop.js`'s
+`totalTicks += result.ticksUsed || 1` guarantees the game clock keeps advancing at least one tick
+per bot cycle either way, so the 20-tick arm resolves naturally in the background over the
+following cycles without the bot blocking on it. Verified via `make census SEEDS=50` — no
+observable regression (see below).
+
+**Existing tests updated for the new timing (behavior legitimately changed, not broken):**
+`js/core/node-graph/node-factories.test.js` (corrupt), `js/core/network/set-pieces.test.js`
+(crack-vault reward test, crack-vault one-shot test, decrypt-loot-requires-all-keys test — each
+needed a `graph.tick(...)` inserted after the dispatch), and `tests/integration.test.js` (the two
+EXEC/corrupt tests). One pre-existing corrupt-adjacent test (`"corrupting the IDS severs the
+chain"`, `idsRelayChain` set-piece) did NOT need updating — it exercises a *different*,
+hand-authored inline `corrupt` ActionDef defined directly on that specific set-piece node
+(`data/biomes/corporate-pieces/defense.js`), not `RECONFIGURE_ACTION`; out of scope, left alone.
+
+**New test suite:** `tests/timed-proof-slice.test.js` (16 tests) — dispatch-doesn't-complete-instantly,
+tick-to-completion (asserting the observable consequence: `forwardingEnabled`/cash/`keyExtracted`/
+quality, not an intermediate flag), the durationTable branch's exact tick count (grade C → 15
+progress ticks + 1 resolve tick = 16 total — the brief's "previously untested" carry-forward),
+mid-action ABORT and `PLAYER_NAVIGATED` cancellation (no effect fires, ticking further doesn't
+resurrect it), the two-IDS shared-synthesis check, and legibility (`resolveFeedback` resolves all
+three converted actions to `DEFAULT_PROFILE`, confirming no central profile entry and thus the
+generic overlay/drone/cue instead of a silent dud).
+
+**MANUAL.md updated:** `corrupt` row + "Subverting the IDS" section note it's now timed
+(grade-scaled, abortable); the `abort` row and the timed-action list in the SFX section both add
+`corrupt`. `crack-vault`/`extract-key` aren't individually documented in the manual (no prior
+entries existed for these set-piece-specific verb ids — they're covered generically as
+puzzle-payout mechanics), so nothing needed changing there.
+
+**Test result:** `make check` green — 1436 passing (1420 baseline + 16 new), 0 failures. `tsc`
+lint clean.
+
+**Census (this branch, `make census SEEDS=50`, default grades C/B/C/C):**
+`successRate: 0.20`, `traceFiredRate: 0.88`, `avgTicksElapsed: 603.78`, `avgNodesOwned: 3.44`,
+`avgCash: 4949.2`. Not compared against a `main` run in this session (per the task brief, the
+controller/Les will diff against a same-seed `main` census) — no retuning performed regardless of
+how the numbers land; `corrupt` going timed does change IDS-subversion pacing (grade C IDS now
+takes ~1.6s of grid exposure before the corrupt lands, vs. instant before), so some shift in
+`traceFiredRate` relative to `main` would be expected and is not itself a bug.

--- a/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/notes.md
+++ b/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/notes.md
@@ -1,0 +1,46 @@
+# Timed Actions — Session Notes
+
+## Phase 1 — Declarable `timed` → operator synthesis (#187)
+
+Implemented per `plan.md` Phase 1, TDD (`tests/timed-synthesis.test.js` written and watched fail
+before implementation).
+
+**Files:**
+- `js/core/node-graph/types.js` — added `ActionDef.timed` (`TimedActionSpec`: `duration?`,
+  `durationTable?`, `abortable?` — `abortable` typed now, wiring deferred to Phase 2), `ActionDef.feedback`
+  (`ActionFeedbackSpec`, reserved for Phase 3, unread by Phase 1), and `ActionDef._timedSynthesized`.
+- `js/core/node-graph/timed-actions.js` — added `timedActiveAttr(actionId)` (`_ta_active_<id>`).
+  Additive; `TIMED_ACTIONS`/`ABORTABLE_FLAGS` untouched.
+- `js/core/node-graph/timed-synthesis.js` (new) — `synthesizeTimedActions(node)`.
+- `js/core/node-graph/runtime.js` — calls `synthesizeTimedActions(n)` right after `resolveTraits(raw)`
+  in the constructor's per-node loop, before the node is stored — covers both trait-supplied and inline
+  actions.
+- `tests/timed-synthesis.test.js` (new) — 3 tests: operator+arm-effects shape at construction,
+  idempotency, and dispatch→tick→completion behavior.
+
+**Deviation from the plan's reference sketch (worth flagging):** the sketch mutates `action.effects`
+and pushes onto `node.operators` in place. Trait-supplied `ActionDef` objects are shared by reference
+across every node composing that trait (`traits.js`'s `actionMap.set(action.id, action)` copies the
+reference, not the object — confirmed by reading `resolveTraits`). In-place mutation plus the
+`_timedSynthesized` guard would mean the *first* node to synthesize a shared trait action "steals" the
+operator: later nodes see `_timedSynthesized` already `true` on the shared object and skip, silently
+missing their own operator. `synthesizeTimedActions` instead returns a **new** action object per node
+(via `.map()`) and rebuilds `node.operators` via spread rather than `.push()`, so nothing shared is
+mutated. Added a dedicated idempotency test that constructs two graphs from the same node-def object
+to lock this in. This only matters once a *trait* declares a `timed` action (no built-in trait does
+yet — Phase 5 converts `corrupt`, which is trait-supplied via `RECONFIGURE_ACTION`, so this would have
+surfaced there if left unfixed).
+
+**Also confirmed against the real operator (not the sketch):** a flat `duration` is seeded directly by
+the arm effects, so the operator's grade-table "first tick sets duration" branch is bypassed entirely —
+completion lands at exactly `tick(duration)`, not `tick(duration + 1)`. The plan's sketch commentary said
+`tick(6)` for a `duration:5` case; verified via the test that `tick(5)` is correct and used that.
+
+**Test result:** `make check` green — 1363 passing (1360 baseline + 3 new), 0 failures. `tsc` lint clean
+(needed one adjustment: extracting the arm-effects array into a `/** @type {Effect[]} */`-annotated
+`const` built with `.push()` rather than array-literal `...` spread, so TS doesn't widen the `effect`
+string literals inside the conditional branch).
+
+Not touched (correctly out of scope for Phase 1): `isNodeBusy`, `NOT_BUSY`/ABORT wiring, feedback
+resolution, overlay/drone default, and the `corrupt`/`crack-vault`/`extract-key` proof slice — all later
+phases per `plan.md`.

--- a/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/plan.md
+++ b/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/plan.md
@@ -172,8 +172,13 @@ generality; it renames nothing.
   resolve). Keep `overlayDescriptorForAction` working via `resolveFeedback(action).overlay`.
 - Modify `js/ui/overlays/dispatch.js` — resolve `action → resolveFeedback → profile.overlay → element`;
   no element (unmapped/not-yet-built) → early return (safe, like `reboot`).
-- Modify the Strudel drone player (`js/audio/strudel/index.js`) — resolve `profile.drone` (fallback to
-  the generic drone id) instead of `resolveDrone(action)`; resolve `profile.completionCue` on complete.
+- Modify the Strudel drone player (`js/audio/strudel/index.js`) — resolve the drone as
+  `inline ?? central ?? resolveDrone(action) ?? DEFAULT.drone`, and the completion cue as
+  `inline ?? central ?? <existing cue map> ?? DEFAULT.completionCue`. **The existing `resolveDrone`/cue
+  maps stay as a fallback layer** so every core verb keeps its bespoke drone with zero enumeration and
+  zero regression; `DEFAULT` only applies to actions the legacy maps don't know (the set-piece duds).
+  (So `ACTION_FEEDBACK_PROFILES` need only list *overlay* overrides for core verbs — their audio is
+  preserved by the resolveDrone fallback, not by re-listing drone ids here.)
 - Test: `tests/feedback-profiles.test.js` (pure resolution) + assert the operator's `start` payload
   carries `feedback`.
 

--- a/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/plan.md
+++ b/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/plan.md
@@ -1,0 +1,295 @@
+# Timed Actions Phase 1 — Implementation Plan
+
+> **For agentic workers:** implement task-by-task; TDD (failing test → minimal code → green → commit).
+> Phase 4a is a **human-in-the-loop feel loop with Les** — NOT autonomous. Everything else is
+> autonomous-friendly.
+
+**Goal:** Make timing declarable per-action (`ActionDef.timed`) so core verbs *and* inline set-piece
+actions share one path, unify busy/abort, add an action→feedback mapping with a generic default so no
+timed action is a silent dud, and prove it on `corrupt` + `extract-key` + `crack-vault`.
+
+**Architecture:** `timed` on an ActionDef synthesizes — at node construction — the *same*
+`timed-action` operator the runtime already ticks (activeAttr generated, `onComplete` = the action's
+effects, effects rewritten to the arm pattern). Busy/abort unifies into `isNodeBusy = active timed
+operator OR activeProcessOnNode` (additively — the #282 process contract is untouched). A feedback
+profile `{overlay,drone,completionCue}` resolves inline → central → default, riding the existing
+`ACTION_FEEDBACK` payload; the generic default overlay/drone is prototyped with Les then ported.
+
+**Tech stack:** Vanilla ES modules, JSDoc `@ts-check`, node:test, Lit HUD + SVG overlays, Strudel
+audio, esbuild.
+
+## Global constraints (copied from spec)
+
+- **Additive only on shared surfaces.** Do NOT alter the `processes.js` contract (`state.processes`,
+  `activeProcessOnNode`, `abortNodeProcesses`, `PROCESS_*`). Do NOT rename/relocate `timed-actions.js`
+  / `ABORTABLE_FLAGS` / `TIMED_ACTION_FLAGS`. Any surface rename → ping the #286 session; the dissolve
+  is deferred to #288.
+- **One runtime engine.** `timed` generates the existing operator config shape — no second execution path.
+- **No behavior change** for the existing core verbs, SWEEP, heat, or the alert sensors' numbers.
+- Seed every `initGame()` in tests. `make check` green per phase; `make census` (same-seed vs main)
+  after `corrupt` goes timed.
+
+---
+
+## Phase 1 — Declarable `timed` → operator synthesis (engine)
+
+Make an inline/trait action carrying `timed` become a real timed action at construction. No feedback yet.
+
+**Files:**
+- Modify `js/core/node-graph/types.js` — add the `timed` typedef to `ActionDef`.
+- Create `js/core/node-graph/timed-synthesis.js` — `synthesizeTimedActions(node)`: for each action with
+  `timed`, push a synthesized `timed-action` operator and rewrite the action's `effects` to the arm pattern.
+- Modify `js/core/node-graph/runtime.js` (~line 62-68, after `resolveTraits`) — call
+  `synthesizeTimedActions(node)` on every constructed node.
+- Modify `js/core/node-graph/timed-actions.js` — export `timedActiveAttr(actionId)` helper
+  (`_ta_active_<id>`) used by synthesis + the busy query. (Additive; does not touch `ABORTABLE_FLAGS`.)
+- Test: `tests/timed-synthesis.test.js`.
+
+**Interfaces produced:**
+- `ActionDef.timed?: { duration?: number, durationTable?: Record<Grade,number>, abortable?: boolean }`
+- `synthesizeTimedActions(node): void` (mutates the constructed node in place)
+- `timedActiveAttr(actionId): string`
+
+**Key changes:**
+```js
+// timed-synthesis.js
+import { getTimedActionAttrNames, timedActiveAttr } from "./timed-actions.js";
+
+/** Turn each action.timed into a real timed-action operator + arm-pattern effects. Idempotent. */
+export function synthesizeTimedActions(node) {
+  for (const action of node.actions ?? []) {
+    if (!action.timed || action._timedSynthesized) continue;
+    const activeAttr = timedActiveAttr(action.id);              // "_ta_active_<id>"
+    const { progressAttr } = getTimedActionAttrNames(action.id);
+    node.operators = node.operators ?? [];
+    node.operators.push({
+      name: "timed-action",
+      action: action.id,
+      activeAttr,
+      ...(action.timed.durationTable ? { durationTable: action.timed.durationTable } : {}),
+      ...(action.timed.duration != null ? { durationAttr: getTimedActionAttrNames(action.id).durationAttr } : {}),
+      onComplete: action.effects,                               // original effects fire on completion
+      _abortable: action.timed.abortable !== false,             // default true
+    });
+    // If a flat `duration` was given (no table), seed it as the initial duration attr.
+    action.effects = [
+      { effect: "set-attr", attr: activeAttr, value: true },
+      { effect: "set-attr", attr: progressAttr, value: 0 },
+      ...(action.timed.duration != null
+        ? [{ effect: "set-attr", attr: getTimedActionAttrNames(action.id).durationAttr, value: action.timed.duration }]
+        : []),
+    ];
+    action._timedSynthesized = true;
+  }
+}
+```
+```js
+// timed-actions.js (append)
+/** Generated "in progress" flag for a declared timed action (distinct from the core verbs' irregular flags). */
+export function timedActiveAttr(actionId) { return `_ta_active_${actionId}`; }
+```
+
+**Steps (TDD):**
+1. Write `tests/timed-synthesis.test.js`: build a node from a def with one inline action
+   `{ id:"test-act", timed:{ duration:5 }, effects:[{effect:"set-attr", attr:"done", value:true}] }`.
+   Assert after construction: the node has a `timed-action` operator with `action:"test-act"`,
+   `activeAttr:"_ta_active_test-act"`, `onComplete` deep-equals the original effects; and the action's
+   own `effects` are the arm pattern (sets active flag + progress 0 + duration 5).
+2. Run → FAIL (module missing).
+3. Implement `timedActiveAttr` + `synthesizeTimedActions`; wire the call in `runtime.js` after `resolveTraits`.
+4. Run → PASS.
+5. Add an integration case (in the same file or `tests/integration.test.js`): dispatch the action via
+   `graph.executeAction` → assert `done` is NOT set immediately (only the arm flag is), then
+   `tick(6)` → assert `done === true` and the active flag cleared, and exactly one `ACTION_FEEDBACK`
+   `complete` fired for `test-act`. Run → PASS.
+6. `make check`. Commit: `feat: declarable ActionDef.timed synthesizes a timed-action operator (#187)`.
+
+---
+
+## Phase 2 — Unified `isNodeBusy` (additive)
+
+One notion of "busy" spanning the operator and process runtimes; ABORT + nav-cancel cancel both.
+
+**Files:**
+- Modify `js/core/node-graph/runtime.js` — `isNodeBusy(nodeId)` method: `getActiveTimedAction(nodeId) != null`.
+- Create/append `js/core/node-graph/conditions.js` — a `no-active-timed-action` condition type
+  (passes when the node has no active timed operator). Used by `NOT_BUSY`.
+- Modify `js/core/node-graph/action-templates.js` — `NOT_BUSY` gains the `no-active-timed-action`
+  condition (kept alongside the existing `ABORTABLE_FLAGS` spread — additive, covers synthesized flags);
+  `ABORT` shows when a timed operator OR a process is active.
+- Modify `js/core/node-graph/game-ctx.js` — the nav-cancel handler + `abortTimedAction` generalize to
+  cancel *any* active timed operator on the node (via `getActiveTimedAction`) and still call
+  `abortNodeProcesses` (already present, #282). Keep the existing enumerated reset path working.
+- Test: `tests/timed-busy.test.js`.
+
+**Interfaces produced:**
+- `graph.isNodeBusy(nodeId): boolean` — true if any timed-action operator is active on the node.
+- condition `{ type: "no-active-timed-action" }`.
+
+**Key changes:**
+```js
+// runtime.js
+isNodeBusy(nodeId) { return this.getActiveTimedAction(nodeId) != null; }
+```
+```js
+// action's requires (action-templates.js NOT_BUSY) — additive: enumerated flags + the general query
+const NOT_BUSY = [
+  ...ABORTABLE_FLAGS.map((attr) => ({ type: "not", condition: { type: "node-attr", attr, eq: true } })),
+  { type: "node-attr", attr: "rebooting", eq: false },
+  { type: "no-active-timed-action" },   // covers synthesized set-piece timed actions too
+];
+```
+Note the process side of busy already lives in `getAvailableActions` (`activeProcessOnNode`, #282) and
+stays as-is; ABORT/nav-cancel already call `abortNodeProcesses`. This phase only *adds* the timed-operator
+generality; it renames nothing.
+
+**Steps (TDD):**
+1. Write `tests/timed-busy.test.js`: a node with a synthesized timed action in progress → a second
+   startable action's `requires` fails (node busy); ABORT is available; firing ABORT clears the active
+   flag + progress. Also: a node with an active *process* (stub one into `state.processes`) → busy too.
+2. Run → FAIL.
+3. Implement `isNodeBusy` + the `no-active-timed-action` condition + wire into `NOT_BUSY`/`ABORT`;
+   generalize nav-cancel/`abortTimedAction` to the `getActiveTimedAction` scan.
+4. Run → PASS.
+5. Regression: existing `tests/nav-cancel.test.js` + integration still green (core verbs unaffected).
+6. `make check`. Commit: `feat: unify busy/abort across timed operators + processes (isNodeBusy) (#187)`.
+
+---
+
+## Phase 3 — Feedback mapping + resolution (plumbing; default may render nothing until Phase 4)
+
+**Files:**
+- Create `js/ui/feedback-profiles.js` — `ACTION_FEEDBACK_PROFILES` (central: core-verb entries),
+  `DEFAULT_PROFILE = { overlay: "generic-process", drone: "generic", completionCue: "process.done" }`,
+  and `resolveFeedback(actionId, inline)` doing field-level `inline ?? central ?? default`.
+- Modify `js/core/node-graph/operators.js` — the `timed-action` operator's `start` `ACTION_FEEDBACK`
+  payload includes the action's inline `feedback` (available on the operator config; thread it through
+  synthesis). (Additive payload field; existing consumers ignore unknown fields.)
+- Modify `js/core/node-graph/timed-synthesis.js` — copy `action.feedback` onto the synthesized operator
+  config so the operator can emit it.
+- Modify `js/ui/overlays/registry.js` — overlays keyed by **name**; add `descriptorForName(name)`.
+  Add central entries mapping the core verbs' actions → their existing overlay names (so lookups still
+  resolve). Keep `overlayDescriptorForAction` working via `resolveFeedback(action).overlay`.
+- Modify `js/ui/overlays/dispatch.js` — resolve `action → resolveFeedback → profile.overlay → element`;
+  no element (unmapped/not-yet-built) → early return (safe, like `reboot`).
+- Modify the Strudel drone player (`js/audio/strudel/index.js`) — resolve `profile.drone` (fallback to
+  the generic drone id) instead of `resolveDrone(action)`; resolve `profile.completionCue` on complete.
+- Test: `tests/feedback-profiles.test.js` (pure resolution) + assert the operator's `start` payload
+  carries `feedback`.
+
+**Interfaces produced:**
+- `resolveFeedback(actionId, inline?): { overlay?, drone?, completionCue? }`
+- `ActionDef.feedback?: { overlay?: string, drone?: string, completionCue?: string }` (typedef in types.js)
+
+**Key changes:**
+```js
+// feedback-profiles.js
+export const DEFAULT_PROFILE = { overlay: "generic-process", drone: "generic", completionCue: "process.done" };
+export const ACTION_FEEDBACK_PROFILES = {
+  probe: { overlay: "probe-sweep" }, xploit: { overlay: "exploit-brackets" },
+  dump: { overlay: "read-sectors" }, fetch: { overlay: "loot-rings" },
+  mine: { overlay: "mine-scan" }, "lie-low": { overlay: "lie-low-clock" },
+  // (drone/cue omitted → inherit default; core drones already keyed by action id — see note)
+};
+export function resolveFeedback(actionId, inline = {}) {
+  const c = ACTION_FEEDBACK_PROFILES[actionId] ?? {};
+  const pick = (k) => inline[k] ?? c[k] ?? DEFAULT_PROFILE[k];
+  return { overlay: pick("overlay"), drone: pick("drone"), completionCue: pick("completionCue") };
+}
+```
+
+**Steps (TDD):**
+1. Write `tests/feedback-profiles.test.js`: field-level layering — inline wins; central fills; default
+   fills the rest; a core verb (`probe`) resolves to `"probe-sweep"`; an unmapped verb resolves overlay
+   to `"generic-process"`.
+2. Run → FAIL. Implement `feedback-profiles.js`. Run → PASS.
+3. Thread `feedback` through synthesis → operator config → `ACTION_FEEDBACK` start payload; add a test
+   asserting the payload carries the inline `feedback`. Repoint `dispatch.js` + registry to name-keyed
+   resolution; repoint the Strudel drone/cue to `profile.drone`/`profile.completionCue`.
+4. Regression: core-verb overlays still dispatch (probe shows probe-sweep). `make check`.
+5. Commit: `feat: action→feedback profile mapping with layered default resolution (#187)`.
+
+> Between Phase 3 and 4, an unmapped action resolves overlay `"generic-process"` which isn't registered
+> yet → `dispatch.js` early-returns (no overlay), exactly like `reboot` today. Safe interim state.
+
+---
+
+## Phase 4 — Generic default overlay + drone (FEEL — prototype-first)
+
+### 4a. Interactive feel loop (human-in-the-loop with Les — NOT autonomous)
+- Build a throwaway slider-driven Canvas lab in `tmp/` (per the interactive-lab pattern): a node glyph
+  + a `progress` slider (0→1) driving the candidate generic overlay (stroked, angular, clockwise,
+  phosphene glow). Iterate geometry/feel live with Les until locked. Simultaneously audition the
+  generic drone + completion cue (via `preview/sfx.html` or a lab hook).
+- **Output:** locked geometry constants + drone/cue spec. Do NOT proceed to 4b until Les signs off.
+
+### 4b. Port (autonomous, TDD)
+**Files:**
+- Create `js/ui/overlays/generic-process.js` — the overlay custom element (`sync/clear/reposition`),
+  geometry from a pure module `js/ui/generic-process-glyph.js` (testable, consumed by overlay + preview).
+- Modify `js/ui/overlays/index.js` — import + register; add the `"generic-process"` descriptor (driver
+  `action-feedback`, keyed for the default).
+- Modify `js/ui/overlays/registry.js` — register the `"generic-process"` name.
+- Modify `preview.html` / `js/ui/preview.js` — a demo node + progress control for the generic overlay
+  (per the "new visual effects go in the preview harness" rule).
+- Modify Strudel audio (`js/audio/strudel/data/drones.js` + `data/cues.js`) — add the `generic` drone
+  spec + `process.done` completion cue, so `DEFAULT_PROFILE` resolves to real audio.
+- Test: `tests/generic-process-glyph.test.js` (pure geometry: N segments lit at progress p; CW order).
+
+**Steps:**
+1. Write `tests/generic-process-glyph.test.js` for the pure geometry (locked constants from 4a). FAIL.
+2. Implement `generic-process-glyph.js`. PASS.
+3. Build the overlay element consuming the glyph; register + descriptor + preview demo; add drone/cue.
+4. `make check`. Commit: `feat: generic default process overlay + drone/cue (#187)`.
+
+---
+
+## Phase 5 — Proof slice (convert three actions)
+
+**Files:**
+- Modify `js/core/node-graph/action-templates.js` — `RECONFIGURE_ACTION` (`corrupt`): add
+  `timed: { durationTable: { S:30,A:25,B:20,C:15,D:12,F:8 } }` (feel-draft), and **move** the
+  `set-attr forwardingEnabled=false` from `effects` into what becomes `onComplete` (i.e. leave it in
+  `effects`; synthesis moves effects → onComplete). Confirm `...NOT_BUSY` is in its `requires` (add it).
+- Modify `data/biomes/corporate-pieces/scattered.js` — `crack-vault` + `extract-key` (find their defs):
+  add `timed: { duration: 20 }` (feel-draft). No `feedback` → inherit the generic default.
+- Test: `tests/timed-proof-slice.test.js` + `tests/integration.test.js` additions.
+
+**Steps (TDD):**
+1. `corrupt`: test that dispatching it does NOT flip `forwardingEnabled` immediately; after `tick`(to
+   completion) `forwardingEnabled === false` and `ACTION_RESOLVED`/`reconfigureNode` fired once; ABORT
+   mid-action leaves `forwardingEnabled` unchanged (true). FAIL → add `timed` + NOT_BUSY → PASS.
+2. `crack-vault`: test that reward is NOT granted instantly; after completion `giveReward` + `cracked`
+   fire once; nav-away mid-action cancels (no reward). FAIL → add `timed` → PASS.
+3. `extract-key`: analogous timed + cancel test.
+4. Assert each converted action's `start` `ACTION_FEEDBACK` resolves overlay `"generic-process"` (set-piece)
+   / its central entry (corrupt has none → generic) — i.e. they're legible, not duds.
+5. `make check`.
+6. `make census SEEDS=50` (default grades) vs `main` — `corrupt` now timed changes IDS-subversion
+   timing; confirm successRate/traceFiredRate not materially regressed. Record numbers in `notes.md`.
+7. Commit: `feat: convert corrupt + crack-vault + extract-key to timed actions (#187)`.
+
+---
+
+## Phase 6 — Verify, docs, PR
+
+- Browser smoke (headless Chromium): the three converted actions show the generic overlay + drone +
+  completion cue, are abortable (ABORT + navigate-away), and honor one-at-a-time against both a timed
+  action and an active process (start a SWEEP, confirm the node is busy). Zero new console errors.
+- Update `MANUAL.md` (actions that are now timed; note the generic "process running" feedback), and the
+  session `notes.md` (decisions, census numbers, the #286/#288 coordination).
+- `make check` green, `make bundle-vendor` clean, `make census` recorded.
+- Squash-ready branch; open PR to `main` closing the Phase-1 portion of #187 (note Phase 2 breadth +
+  #288 convergence remain). Request Copilot review.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** declarable `timed` (P1), unified busy/abort (P2), feedback mapping + default (P3),
+  generic overlay/drone prototype→port (P4), proof slice corrupt+extract-key+crack-vault (P5),
+  testing + census + docs (P5/P6). All spec sections mapped.
+- **Additivity:** P2/P3 explicitly keep `ABORTABLE_FLAGS` + the `processes.js` contract intact (#286).
+- **Feel gate:** P4a is the only non-autonomous task — flagged for a live loop with Les.
+- **Verify P5.4 assumption during execution:** confirm `extract-key`/`crack-vault` exact file+shape in
+  `data/biomes/corporate-pieces/scattered.js` before editing (labels/ids confirmed present).

--- a/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/spec.md
+++ b/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/spec.md
@@ -95,9 +95,19 @@ isNodeBusy(state, node) = (node has any active timed-action operator) OR activeP
 - **Nav-cancel** (game-ctx) uses the same unified query + abort path.
 
 "Active timed-action operator on a node" is answered by the existing `getActiveTimedAction(nodeId)`;
-generalizing to *any* active operator retires the `ABORTABLE_FLAGS` enumeration for declared actions
-(a new condition type, e.g. `no-active-timed-action`, backs `NOT_BUSY`). This is the concrete
-down-payment toward #288 — one notion of "busy," not the current hand-bridged two.
+a new condition type (e.g. `no-active-timed-action`) backs `NOT_BUSY`, so declared set-piece actions
+(with generated activeAttrs, not in the enumeration) are covered without registry edits. This is the
+concrete down-payment toward #288 — one notion of "busy," not the current hand-bridged two.
+
+**Coordination with #286 (reactive substrate / cascade) — Phase 1 is additive on both surfaces:**
+- The **`processes.js` contract is untouched.** `isNodeBusy` *composes* `activeProcessOnNode` (calls
+  it); `state.processes`, `activeProcessOnNode`, `abortNodeProcesses`, and the `PROCESS_*` events are
+  unchanged. #286's SWEEP reimplementation (new `cascade` operator, slimmed process `step`) depends
+  on that contract — we do not alter it.
+- **No rename/relocate of the operator-side registry** (`timed-actions.js`, `ABORTABLE_FLAGS` /
+  `TIMED_ACTION_FLAGS`) in Phase 1. The generalized busy query is *added alongside* the existing
+  enumeration, not a replacement. If a rename becomes necessary, ping the #286 session first. The
+  actual framework dissolve/convergence (and retiring the enumeration) is deferred to **#288**.
 
 ### 3. Feedback mapping + generic default
 

--- a/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/spec.md
+++ b/docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/spec.md
@@ -1,0 +1,170 @@
+# Spec — Timed actions, Phase 1: declarable timing + generic legible feedback (#187)
+
+## Goal & intent
+
+Two intents, from the design conversation with Les:
+
+1. **Nearly every player action should be a time-bound, abortable process** — an *exposure /
+   commitment window*. While it runs you're committed and exposed (ICE closing in, the trace/heat
+   climbing) and can bail with ABORT / navigating away. This turns "click to resolve" into "commit,
+   watch, disengage" — the evasion tension the loop wants.
+2. **Every timed action must be a *legible* event** — something the player can see and hear, not
+   just a console log line. Today ~13 authored set-piece actions ("Extract Key", "Crack Vault", …)
+   are duds: no overlay, no drone, one log line. That's the real gap.
+
+**North-star (tracked in #288, not resolved here):** collapse special-cased "core" verbs into one
+"action-owns-its-process" model so behavior lives on the authoring surfaces, not in hand-wired
+exceptions.
+
+## Scope
+
+**Phase 1 (this spec):** the foundation + generic legibility + a proof slice.
+- Make timing **declarable per action** (`ActionDef.timed`), so both core trait-verbs and inline
+  set-piece actions use one path.
+- **Unify busy/abort** into a single `isNodeBusy` across the operator and process (#282) runtimes.
+- An **action → feedback mapping** (`{overlay, drone, completionCue}`) with inline → central →
+  default resolution, and a **generic default** overlay + drone + completion cue so nothing is a
+  silent dud.
+- **Prove end-to-end** by converting three actions: `corrupt` (core) + `extract-key`, `crack-vault`
+  (set-piece).
+
+**Phase 2 (follow-up, stays under #187):** breadth — convert the remaining instant verbs (kick-short,
+scrub-logs, sniff, replay) + the rest of the ~13 set-piece actions; finalize instant exceptions;
+per-action durations; `make census` tuning + feel pass.
+
+**Deferred (own issues):** full operator↔process runtime convergence + core-verb migration onto
+`timed` → **#288**. Bespoke per-action visual/audio palette (assigned across ranges of actions) →
+future arc.
+
+## Current state (origin: `main` @ #282)
+
+- **Single-node timed actions** run on the node-graph **`timed-action` operator**
+  (`js/core/node-graph/operators.js`): progress in node attrs (`_ta_<action>_*`), emits
+  `ACTION_FEEDBACK` (start/progress/complete), which drives overlays (`js/ui/overlays/`) + Strudel
+  action drones. Core verbs (probe/xploit/dump/fetch/mine/lie-low/reboot) get their operator config
+  hand-wired on a **trait** (`traits.js`); the start-action `effects` merely arm it
+  (`set-attr activeAttr=true` + zero progress). Registry: `TIMED_ACTIONS` / `ABORTABLE_FLAGS`
+  (`timed-actions.js`); `NOT_BUSY` (action-templates.js) enforces one-at-a-time; ABORT + nav-cancel
+  (game-ctx.js, generalized in #225) cancel.
+- **Multi-node / over-time orchestration** runs on **`js/core/processes.js`** (#282): `state.processes`
+  + `registerProcess`/`stepProcesses` (central tick), `PROCESS_*` events. SWEEP is the first client
+  and *composes* the operator. Busy/abort via `activeProcessOnNode` / `abortNodeProcesses`, bridged
+  by hand into `getAvailableActions` (ABORT affordance) and the nav-cancel handler.
+- **Set-piece actions** are inline `{id,label,requires,effects}` on set-piece node defs
+  (`data/biomes/corporate-pieces/*.js`), surfaced under the synthetic **EXEC** menu (`isScriptAction`
+  = any non-core verb). They run **instantly** — the EXEC path applies their `effects` synchronously.
+  ~13 exist today (Scan Lock, Crack Vault, Extract Token/Key, Unlock/Decrypt Vault, Activate,
+  Corrupt IDS, Muffle Sensor, Neutralize Tamper Relay, Spoof Sensor, Disarm Latch, Subvert Relay).
+- **Instant-but-keep:** cancel-trace (panic button), access-darknet (UI transition), disconnect,
+  abort, target/untarget/jackout.
+
+## Design
+
+### 1. Declarable timing — `ActionDef.timed`
+
+An `ActionDef` gains an optional block:
+
+```js
+{ id: "extract-key", label: "Extract Key",
+  timed: { durationTable: { S:40, A:35, B:30, C:25, D:20, F:12 } /* or */ duration: 20,
+           abortable: true /* default */ },
+  effects: [ /* the original instant effects — become onComplete */ ] }
+```
+
+At **node construction**, for any action carrying `timed`, the builder synthesizes the *same*
+`timed-action` operator config the runtime already has (activeAttr derived from the action id,
+duration from the block, `onComplete` = the action's `effects`) and rewrites the action's own
+`effects` to the arm pattern (`set-attr activeAttr=true` + zero progress). **One runtime engine, one
+config shape** — `timed` generates the config the operator already consumes; it is not a second
+execution path. Core verbs are a drop-in for this later (migration deferred to #288).
+
+The activeAttr naming for declared actions is generated + collision-safe (e.g. `_ta_active_<id>`),
+so arbitrary set-piece verbs never need registry edits.
+
+### 2. Unified busy / abort — `isNodeBusy`
+
+Replace the enumerated operator flag-list *and* the parallel process check with one predicate:
+
+```
+isNodeBusy(state, node) = (node has any active timed-action operator) OR activeProcessOnNode(state, node)
+```
+
+- `NOT_BUSY` (the one-at-a-time guard spread into startable actions) uses `isNodeBusy`.
+- **ABORT** shows when `isNodeBusy`, and its single execute path cancels **both** an active operator
+  (reset activeAttr/progress/duration + `clearOnCancel`) and any active process (`abortNodeProcesses`).
+- **Nav-cancel** (game-ctx) uses the same unified query + abort path.
+
+"Active timed-action operator on a node" is answered by the existing `getActiveTimedAction(nodeId)`;
+generalizing to *any* active operator retires the `ABORTABLE_FLAGS` enumeration for declared actions
+(a new condition type, e.g. `no-active-timed-action`, backs `NOT_BUSY`). This is the concrete
+down-payment toward #288 — one notion of "busy," not the current hand-bridged two.
+
+### 3. Feedback mapping + generic default
+
+A **feedback profile** = `{ overlay, drone, completionCue }` (all optional name strings). Resolution
+is **field-level, layered**:
+
+```
+inline ActionDef.feedback.<field>  ??  ACTION_FEEDBACK_PROFILES[actionId].<field>  ??  DEFAULT_PROFILE.<field>
+```
+
+- **Inline** on the ActionDef is the set-piece authoring surface (feedback authored where the puzzle
+  is composed).
+- **Central** `ACTION_FEEDBACK_PROFILES` holds the core-verb mappings (probe→"probe-sweep", …, so
+  they are unchanged) and is where the future palette assigns feedback across ranges of actions.
+- **Default** profile is the generic overlay + drone + cue.
+
+Wiring stays decoupled from action defs: the timed-action operator includes the action's inline
+`feedback` on the `ACTION_FEEDBACK` `start` payload; the browser resolves central + default. Then:
+- **Overlay:** the overlay registry becomes *name → element* (today *action → element*); the
+  dispatcher does action → profile.overlay → element, falling back to the generic default. Core
+  verbs get central entries → zero behavior change.
+- **Audio:** the Strudel drone player resolves `profile.drone` (default = generic drone) instead of
+  `resolveDrone(action)`; completion resolves `profile.completionCue`.
+
+### 4. The generic default feedback (feel — prototype-driven)
+
+The one piece a spec can't pin down. Built like the waveforms: a throwaway **slider-driven Canvas
+lab in `tmp/`**, iterated live with Les, then the locked values ported into a real overlay module +
+tests.
+
+- **Visual:** a stroked, angular, node-anchored progress indicator (retro-vector: strokes not fills;
+  clockwise = player agency; phosphene glow via the cheap overlay bloom). Generic — legible as "a
+  process is running here, this far along," deliberately distinct from the bespoke core sweeps.
+- **Audio:** a generic sustained, progress-driven action drone (existing Strudel drone idiom) + a
+  completion one-shot cue. Auditioned by ear against the visual.
+
+### 5. Proof slice
+
+- **`corrupt`** (core, currently instant) → `timed`. Proves a core verb on the declarable path and
+  the "effect resolves on completion" move: its `set-attr forwardingEnabled=false` shifts into
+  `onComplete`, giving IDS subversion a real exposure window (the issue's called-out natural fit).
+- **`extract-key`, `crack-vault`** (set-piece) → inline `timed` + default `feedback`. Proves inline
+  authoring, the EXEC path running timed, and duds → legible.
+
+## Testing
+
+- **Unit:** `timed` → synthesized operator config matches the hand-wired shape; `isNodeBusy`
+  unification (a node with any active operator *or* process blocks new actions + shows ABORT);
+  feedback resolution is field-level layered (inline → central → default).
+- **Integration:** dispatch a `timed` set-piece action → does *not* resolve instantly → ticks →
+  `onComplete` fires the original effects exactly once; ABORT and PLAYER_NAVIGATED both cancel it and
+  reset progress; `ACTION_FEEDBACK` carries the resolved overlay/drone/cue names (default when
+  unmapped).
+- **No-regression:** existing core verbs unchanged (same durations, same bespoke overlays via central
+  entries); SWEEP + the process framework still work (busy/abort still cancels a sweep).
+- **Balance:** `make census` after `corrupt` goes timed (changes IDS-subversion timing), same-seed vs
+  main.
+
+## Non-goals
+
+- Phase 2 breadth / remaining actions (stays under #187).
+- Operator↔process runtime convergence + core-verb migration onto `timed` (#288).
+- Bespoke per-action visuals/audio (future palette arc).
+- Any change to SWEEP, heat, or the alert sensors' numbers.
+
+## Verification gates
+
+`make check` green; `make census` no regression (same-seed vs main); browser smoke (the three
+converted actions show the generic overlay + drone + completion cue, are abortable, and honor
+one-at-a-time against both operator and process busy); preview-harness demo for the generic overlay.

--- a/js/audio/strudel/data/cues.js
+++ b/js/audio/strudel/data/cues.js
@@ -6,7 +6,14 @@
 // which @strudel/web 1.3.0 drops as "in the past" (see sfx.js); the rest of each object is the
 // superdough value (note/s/cutoff/envelope/gain/room/resonance). Phase-1 event coverage per
 // issue #254; other routed events degrade to no cue (extend in a follow-up).
+//
+// #187 Phase 3: `resolveActionCue` resolves the *timed-action completion* cue id — a distinct,
+// new concept from `resolveCue` above (which maps whole game EVENT TYPES like NODE_REVEALED or
+// ACTION_RESOLVED to a cue, not per-action-id timed-action completions). There is no legacy
+// per-action completion-cue map to fall back to, so the chain is just inline → central
+// (ACTION_FEEDBACK_PROFILES) → DEFAULT_PROFILE.completionCue.
 import { E } from "../../../core/events.js";
+import { ACTION_FEEDBACK_PROFILES, DEFAULT_PROFILE } from "../../../ui/feedback-profiles.js";
 
 export const CUES = {
   // node discovery — short bright blip
@@ -41,4 +48,19 @@ export function resolveCue(type, payload) {
     case E.ALERT_TRACE_STARTED: return CUES["trace.start"];
     default: return null;
   }
+}
+
+/**
+ * Resolve the completion-cue id for a timed action's ACTION_FEEDBACK "complete" phase (#187
+ * Phase 3): inline (the "start" payload's `feedback.completionCue`) → central
+ * (ACTION_FEEDBACK_PROFILES[actionId].completionCue) → DEFAULT_PROFILE.completionCue. The
+ * DEFAULT id ("process.done") isn't backed by a real CUES entry until Phase 4 — sfx.playCue()
+ * already no-ops on an unregistered id (see sfx.js `play()`), so this degrades silently.
+ * @param {string} actionId
+ * @param {{ completionCue?: string }} [inline]
+ * @returns {string}
+ */
+export function resolveActionCue(actionId, inline = {}) {
+  const central = ACTION_FEEDBACK_PROFILES[actionId] ?? {};
+  return inline?.completionCue ?? central.completionCue ?? DEFAULT_PROFILE.completionCue;
 }

--- a/js/audio/strudel/data/cues.js
+++ b/js/audio/strudel/data/cues.js
@@ -29,6 +29,10 @@ export const CUES = {
   "ice.detected":{ note: "d3", s: "square",   cutoff: 1200, attack: 0.001, decay: 0.18, sustain: 0,   release: 0.1,  gain: 0.5,  _dur: 0.2 },
   // trace started — low ominous square
   "trace.start": { note: "e2", s: "square",   cutoff: 600,  attack: 0.001, decay: 0.4,  sustain: 0,   release: 0.3,  gain: 0.6,  _dur: 0.5 },
+  // process.done — DEFAULT_PROFILE.completionCue fallback (#187 Phase 4b): short, soft blip for
+  // any timed action with no bespoke completion cue. A feel-DRAFT default (the Phase 4a session
+  // tuned the *visual* generic overlay with Les, not audio) — tunable later via preview/sfx.html.
+  "process.done": { note: "e5", s: "sine",    cutoff: 2200, attack: 0.002, decay: 0.12, sustain: 0,   release: 0.1,  gain: 0.35, _dur: 0.15 },
 };
 
 /**
@@ -53,9 +57,9 @@ export function resolveCue(type, payload) {
 /**
  * Resolve the completion-cue id for a timed action's ACTION_FEEDBACK "complete" phase (#187
  * Phase 3): inline (the "start" payload's `feedback.completionCue`) → central
- * (ACTION_FEEDBACK_PROFILES[actionId].completionCue) → DEFAULT_PROFILE.completionCue. The
- * DEFAULT id ("process.done") isn't backed by a real CUES entry until Phase 4 — sfx.playCue()
- * already no-ops on an unregistered id (see sfx.js `play()`), so this degrades silently.
+ * (ACTION_FEEDBACK_PROFILES[actionId].completionCue) → DEFAULT_PROFILE.completionCue. As of
+ * #187 Phase 4b, CUES["process.done"] is a real (feel-DRAFT) spec, so the DEFAULT fallback plays
+ * real audio instead of degrading silently.
  * @param {string} actionId
  * @param {{ completionCue?: string }} [inline]
  * @returns {string}

--- a/js/audio/strudel/data/drones.js
+++ b/js/audio/strudel/data/drones.js
@@ -4,6 +4,11 @@
 // ACTION_FEEDBACK `action` string. `loop:true` ignores progress (reboot — a system state, not a
 // player sweep). Ported from the retired Tone drone specs (removed in #267); same character.
 //
+// #187 Phase 3: `resolveActionDrone` layers inline → central (ACTION_FEEDBACK_PROFILES) →
+// resolveDrone(action) (this file's legacy per-action lookup, kept as-is) → DEFAULT_PROFILE.drone.
+// resolveDrone() stays untouched and is NOT re-enumerated centrally — every core verb keeps its
+// bespoke drone via that existing fallback, with zero regression risk.
+//
 // Spec shape (interpreted in drones.js): {
 //   source: "sawtooth"|"sine"|"square"|"triangle"|"noise"|"fm"|"dual",
 //   note, osc?, harmonicity?/modIndex? (fm), type? (noise),
@@ -11,6 +16,8 @@
 //   lfo?: { rate, depth, target:"amp"|"cutoff" },  fade?, volume? (dB), loop?
 // }
 // {from,to} values sweep with progress; amp-LFO and progress-gain are mutually exclusive.
+
+import { ACTION_FEEDBACK_PROFILES, DEFAULT_PROFILE } from "../../../ui/feedback-profiles.js";
 
 export const DRONES = {
   // probe — radar sweep: thin scanning pulse, filter brightens as the ring fills.
@@ -45,4 +52,20 @@ export const DRONE_IDS = Object.freeze(Object.keys(DRONES));
  */
 export function resolveDrone(action) {
   return action && Object.prototype.hasOwnProperty.call(DRONES, action) ? action : null;
+}
+
+/**
+ * Resolve the drone id for an ACTION_FEEDBACK "start" event (#187 Phase 3): inline (the payload's
+ * `feedback.drone`) → central (ACTION_FEEDBACK_PROFILES[actionId].drone) → resolveDrone(actionId)
+ * (the legacy per-action lookup above, preserving every core verb's bespoke drone) →
+ * DEFAULT_PROFILE.drone (not backed by a real spec until Phase 4 — DRONES["generic"] is
+ * undefined, and createDroneVoice() already no-ops on an undefined spec, so this degrades
+ * silently, same as an unknown id does today).
+ * @param {string} actionId
+ * @param {{ drone?: string }} [inline]
+ * @returns {string}
+ */
+export function resolveActionDrone(actionId, inline = {}) {
+  const central = ACTION_FEEDBACK_PROFILES[actionId] ?? {};
+  return inline?.drone ?? central.drone ?? resolveDrone(actionId) ?? DEFAULT_PROFILE.drone;
 }

--- a/js/audio/strudel/data/drones.js
+++ b/js/audio/strudel/data/drones.js
@@ -41,6 +41,11 @@ export const DRONES = {
   // reboot — offline pulse: adversarial slow-pulsing sour drone, loops (no progress sweep).
   reboot:   { source: "sawtooth", note: "C2", detune: -25, cutoff: 520, q: 5,
               lfo: { rate: 0.5, depth: 0.5, target: "amp" }, volume: -19, fade: 0.35, loop: true },
+  // generic — DEFAULT_PROFILE.drone fallback (#187 Phase 4b): neutral, soft, sustained hum for any
+  // timed action with no bespoke drone. A feel-DRAFT default (the Phase 4a session tuned the
+  // *visual* generic overlay with Les, not audio) — tunable later via preview/sfx.html.
+  generic:  { source: "sine", note: "F2", cutoff: { from: 500, to: 900 }, q: 1.5,
+              lfo: { rate: 4, depth: 0.2, target: "amp" }, volume: -24, fade: 0.18 },
 };
 
 export const DRONE_IDS = Object.freeze(Object.keys(DRONES));
@@ -58,9 +63,8 @@ export function resolveDrone(action) {
  * Resolve the drone id for an ACTION_FEEDBACK "start" event (#187 Phase 3): inline (the payload's
  * `feedback.drone`) → central (ACTION_FEEDBACK_PROFILES[actionId].drone) → resolveDrone(actionId)
  * (the legacy per-action lookup above, preserving every core verb's bespoke drone) →
- * DEFAULT_PROFILE.drone (not backed by a real spec until Phase 4 — DRONES["generic"] is
- * undefined, and createDroneVoice() already no-ops on an undefined spec, so this degrades
- * silently, same as an unknown id does today).
+ * DEFAULT_PROFILE.drone. As of #187 Phase 4b, DRONES["generic"] is a real (feel-DRAFT) spec, so
+ * the DEFAULT fallback resolves to real audio instead of degrading silently.
  * @param {string} actionId
  * @param {{ drone?: string }} [inline]
  * @returns {string}

--- a/js/audio/strudel/index.js
+++ b/js/audio/strudel/index.js
@@ -13,9 +13,9 @@ import { bootStrudel } from "./runtime.js";
 import { loadGameSoundfont } from "./soundfont.js";
 import { installGameSignals } from "./signal-bridge.js";
 import { createSfx } from "./sfx.js";
-import { resolveCue } from "./data/cues.js";
+import { resolveCue, resolveActionCue } from "./data/cues.js";
 import { createDroneVoice } from "./drones.js";
-import { DRONES, resolveDrone } from "./data/drones.js";
+import { DRONES, resolveActionDrone } from "./data/drones.js";
 import { loadSongs, HUB_ID } from "./songs/index.js";
 import { isMusicEnabled, isSfxEnabled } from "../audio-prefs.js";
 
@@ -98,22 +98,34 @@ function wire(rt, songs = []) {
   }
 
   // ---- Action drones (sustained, progress-driven; raw Web Audio) --------------------------------
+  // #187 Phase 3: drone + completion-cue ids resolve via resolveActionDrone/resolveActionCue
+  // (inline payload.feedback → central ACTION_FEEDBACK_PROFILES → the legacy resolveDrone()
+  // fallback for drones / DEFAULT_PROFILE otherwise) — see js/audio/strudel/data/drones.js and
+  // data/cues.js. `feedback` only rides the "start" payload (operators.js), so the resolved
+  // completion cue is remembered per in-flight action for playback at "complete".
   const drones = new Map();
-  const stopAllDrones = () => { for (const d of drones.values()) d.stop(); drones.clear(); };
+  const pendingCues = new Map();
+  const stopAllDrones = () => { for (const d of drones.values()) d.stop(); drones.clear(); pendingCues.clear(); };
   on(E.ACTION_FEEDBACK, (payload) => {
     if (!sfx.isEnabled()) return;
-    const { nodeId, action, phase, progress } = payload || {};
+    const { nodeId, action, phase, progress, feedback } = payload || {};
     const key = `${nodeId}:${action}`;
     if (phase === "start") {
-      if (drones.has(key)) return;
-      const id = resolveDrone(action);
-      if (!id) return;
-      drones.set(key, createDroneVoice(rt.ctx, DRONES[id]));
+      if (!drones.has(key)) {
+        const id = resolveActionDrone(action, feedback);
+        if (id) drones.set(key, createDroneVoice(rt.ctx, DRONES[id]));
+      }
+      pendingCues.set(key, resolveActionCue(action, feedback));
     } else if (phase === "progress") {
       drones.get(key)?.setProgress(progress ?? 0);
     } else if (phase === "complete" || phase === "cancel") {
       drones.get(key)?.stop();
       drones.delete(key);
+      if (phase === "complete") {
+        const cueId = pendingCues.get(key);
+        if (cueId) sfx.playCue(cueId);
+      }
+      pendingCues.delete(key);
     }
   });
   on(E.RUN_ENDED, stopAllDrones);

--- a/js/core/network/set-pieces.test.js
+++ b/js/core/network/set-pieces.test.js
@@ -204,6 +204,7 @@ describe("instantiate: two instances have independent IDs", () => {
     graph.executeAction("v1/switch-a", "activate");
     graph.executeAction("v1/switch-b", "activate");
     graph.executeAction("v1/switch-c", "activate");
+    graph.tick(20); // activate is timed-by-default (#187 default-flip) — let it complete
 
     assert.ok(ctx.calls.revealNode?.length > 0);
     assert.deepEqual(ctx.calls.revealNode[0], ["v1/vault"]);
@@ -251,6 +252,7 @@ describe("ids-relay-chain: alert forwarding and subversion", () => {
     assert.ok(available.map((a) => a.id).includes("corrupt"));
 
     graph.executeAction("east/ids", "corrupt");
+    graph.tick(20); // corrupt is timed-by-default (#187 default-flip) — let it complete
     assert.equal(graph.getNodeState("east/ids").forwardingEnabled, false);
   });
 
@@ -261,6 +263,7 @@ describe("ids-relay-chain: alert forwarding and subversion", () => {
 
     graph._nodes.get("east/ids").attributes.accessLevel = "owned";
     graph.executeAction("east/ids", "corrupt");
+    graph.tick(20); // corrupt is timed-by-default (#187 default-flip) — let it complete
 
     graph.sendMessage("east/ids", createMessage({ type: "alert", origin: "probe-node", payload: {} }));
     assert.equal(graph.getNodeState("east/monitor").alerted, false);
@@ -281,6 +284,7 @@ describe("combination-lock: all three switches must activate", () => {
 
     graph.executeAction("v1/switch-a", "activate");
     graph.executeAction("v1/switch-b", "activate");
+    graph.tick(20); // activate is timed-by-default (#187 default-flip) — let it complete
     assert.equal(ctx.calls.giveReward, undefined);
     assert.equal(ctx.calls.revealNode, undefined);
   });
@@ -296,6 +300,7 @@ describe("combination-lock: all three switches must activate", () => {
     graph.executeAction("v1/switch-a", "activate");
     graph.executeAction("v1/switch-b", "activate");
     graph.executeAction("v1/switch-c", "activate");
+    graph.tick(20); // activate is timed-by-default (#187 default-flip) — let it complete
 
     assert.equal(graph.getNodeState("v1/vault").concealed, false);
     assert.ok(ctx.calls.revealNode?.length > 0);
@@ -315,6 +320,7 @@ describe("combination-lock: all three switches must activate", () => {
     graph.executeAction("v1/switch-a", "activate");
     graph.executeAction("v1/switch-b", "activate");
     graph.executeAction("v1/switch-c", "activate");
+    graph.tick(20); // activate is timed-by-default (#187 default-flip) — let it complete
 
     // Vault is opened but not yet owned — crack-vault unavailable
     let available = graph.getAvailableActions("v1/vault").map(a => a.id);
@@ -326,6 +332,7 @@ describe("combination-lock: all three switches must activate", () => {
     assert.ok(available.includes("crack-vault"));
 
     graph.executeAction("v1/vault", "crack-vault");
+    graph.tick(20); // crack-vault is timed-by-default (#187 default-flip) — let it complete
     assert.equal(ctx.calls.giveReward?.length, 1);
     assert.deepEqual(ctx.calls.giveReward[0], [1500]);
 
@@ -379,9 +386,11 @@ describe("switch-arrangement: quality-delta reveals hidden subnet", () => {
 
     graph.executeAction("seg1/panel-alpha", "align");
     graph.executeAction("seg1/panel-beta", "align");
+    graph.tick(20); // align is timed-by-default (#187 default-flip) — let it complete
     assert.equal(ctx.calls.revealNode, undefined);
 
     graph.executeAction("seg1/panel-gamma", "align");
+    graph.tick(20); // align is timed-by-default (#187 default-flip) — let it complete
     assert.ok(ctx.calls.revealNode?.length > 0);
     assert.deepEqual(ctx.calls.revealNode[0], ["seg1/hidden-subnet"]);
   });
@@ -393,6 +402,7 @@ describe("switch-arrangement: quality-delta reveals hidden subnet", () => {
 
     graph._nodes.get("seg1/panel-alpha").attributes.accessLevel = "owned";
     graph.executeAction("seg1/panel-alpha", "align");
+    graph.tick(20); // align is timed-by-default (#187 default-flip) — let it complete
 
     // Second align should fail — requires aligned:false but it's now true
     assert.throws(() => graph.executeAction("seg1/panel-alpha", "align"));
@@ -420,12 +430,14 @@ describe("multi-key-vault: requires two tokens before looting", () => {
 
     graph.executeAction("mk1/key-server-1", "extract-token");
     graph.executeAction("mk1/key-server-2", "extract-token");
+    graph.tick(20); // extract-token is timed-by-default (#187 default-flip) — let it complete
     assert.equal(graph.getQuality("mk1/auth-tokens"), 2);
 
     const available = graph.getAvailableActions("mk1/vault-node").map((a) => a.id);
     assert.ok(available.includes("unlock-vault"));
 
     graph.executeAction("mk1/vault-node", "unlock-vault");
+    graph.tick(20); // unlock-vault is timed-by-default (#187 default-flip) — let it complete
     assert.equal(ctx.calls.giveReward?.length, 1);
     assert.deepEqual(ctx.calls.giveReward[0], [5000]);
   });
@@ -526,12 +538,14 @@ describe("encrypted-vault: key expiry forces timing pressure", () => {
     // Fire clock, extract key, then claim the vault bonus
     graph.tick(120);
     graph.executeAction("ev1/key-gen", "extract-key");
+    graph.tick(20); // extract-key is timed-by-default (#187 default-flip) — let it complete
     assert.equal(graph.getQuality("ev1/decryption-key"), 1);
 
     const available = graph.getAvailableActions("ev1/vault").map((a) => a.id);
     assert.ok(available.includes("fetch-vault"));
 
     graph.executeAction("ev1/vault", "fetch-vault");
+    graph.tick(20); // fetch-vault is timed-by-default (#187 default-flip) — let it complete
     assert.equal(ctx.calls.giveReward?.length, 1);
     assert.deepEqual(ctx.calls.giveReward[0], [3000]);
     assert.equal(graph.getQuality("ev1/decryption-key"), 0);
@@ -577,6 +591,7 @@ describe("encrypted-vault: key expiry forces timing pressure", () => {
     // First clock cycle: extract the key
     graph.tick(120);
     graph.executeAction("ev1/key-gen", "extract-key");
+    graph.tick(20); // extract-key is timed-by-default (#187 default-flip) — let it complete
     assert.equal(graph.getQuality("ev1/decryption-key"), 1);
 
     // Don't loot — let next clock cycle fire and expire the key
@@ -611,10 +626,12 @@ describe("cascade-shutdown: subvert all relays before watchdog expires", () => {
     for (const r of ["cs1/relay-a", "cs1/relay-b", "cs1/relay-c"]) {
       graph._nodes.get(r).attributes.accessLevel = "owned";
     }
-    // Subvert all 3 without advancing time
+    // Subvert all 3 (subvert is timed-by-default — #187 default-flip — so let them complete
+    // before checking the puzzle-complete trigger)
     graph.executeAction("cs1/relay-a", "subvert");
     graph.executeAction("cs1/relay-b", "subvert");
     graph.executeAction("cs1/relay-c", "subvert");
+    graph.tick(20);
 
     assert.equal(ctx.calls.giveReward?.length, 1);
     assert.deepEqual(ctx.calls.giveReward[0], [2000]);
@@ -631,6 +648,7 @@ describe("cascade-shutdown: subvert all relays before watchdog expires", () => {
     // subvert-ping directly to watchdog (bypassing relay-a's own operators),
     // which resets the watchdog timer. Need 5 more ticks for it to expire (grade D).
     graph.executeAction("cs1/relay-a", "subvert");
+    graph.tick(20); // subvert is timed-by-default (#187 default-flip) — completing emits the ping that arms the watchdog
     graph.tick(5); // watchdog period elapses without further messages (grade D)
 
     assert.equal(ctx.calls.startTrace?.length, 1);
@@ -655,7 +673,8 @@ describe("cascade-shutdown: watchdog stays dormant until the player engages", ()
     const graph = new NodeGraph(inst, ctx);
 
     graph._nodes.get("cs1/relay-a").attributes.accessLevel = "owned";
-    graph.executeAction("cs1/relay-a", "subvert"); // arms the watchdog
+    graph.executeAction("cs1/relay-a", "subvert"); // arms the watchdog once it completes
+    graph.tick(20); // subvert is timed-by-default (#187 default-flip) — completing emits the arming ping
     graph.tick(6); // the now-armed watchdog expires (grade D period 5)
 
     assert.equal(ctx.calls.startTrace?.length, 1);
@@ -672,6 +691,7 @@ describe("cascade-shutdown: watchdog stays dormant until the player engages", ()
     graph.executeAction("cs1/relay-a", "subvert");
     graph.executeAction("cs1/relay-b", "subvert");
     graph.executeAction("cs1/relay-c", "subvert");
+    graph.tick(20); // subvert is timed-by-default (#187 default-flip) — let all three complete
 
     assert.equal(ctx.calls.giveReward?.length, 1);
 
@@ -830,6 +850,7 @@ describe("tamper-detect: corrupting IDS without neutralizing relay triggers trac
     // Give player ownership so corrupt is available
     graph._nodes.get("td1/ids").attributes.accessLevel = "owned";
     graph.executeAction("td1/ids", "corrupt");
+    graph.tick(20); // corrupt is timed-by-default (#187 default-flip) — let it complete
 
     assert.equal(graph.getNodeState("td1/tamper-flag").triggered, true);
     assert.equal(ctx.calls.startTrace?.length, 1);
@@ -852,11 +873,13 @@ describe("tamper-detect: corrupting IDS without neutralizing relay triggers trac
     // Own and neutralize the tamper relay first
     graph._nodes.get("td1/tamper-relay").attributes.accessLevel = "owned";
     graph.executeAction("td1/tamper-relay", "neutralize");
+    graph.tick(20); // neutralize is timed-by-default (#187 default-flip) — let it complete
     assert.equal(graph.getNodeState("td1/tamper-relay").forwardingEnabled, false);
 
     // Now corrupt the IDS safely
     graph._nodes.get("td1/ids").attributes.accessLevel = "owned";
     graph.executeAction("td1/ids", "corrupt");
+    graph.tick(20); // corrupt is timed-by-default (#187 default-flip) — let it complete
 
     assert.equal(graph.getNodeState("td1/tamper-flag").triggered, false);
     assert.equal(ctx.calls.startTrace, undefined);
@@ -921,10 +944,12 @@ describe("scatteredLock3: quality communication in NodeGraph", () => {
     // Activate 2 — vault should NOT reveal
     graph.executeAction("sl/switch-a", "activate");
     graph.executeAction("sl/switch-b", "activate");
+    graph.tick(20); // activate is timed-by-default (#187 default-flip) — let it complete
     assert.equal(ctx.calls.revealNode, undefined);
 
     // Activate 3rd — vault reveals
     graph.executeAction("sl/switch-c", "activate");
+    graph.tick(20); // activate is timed-by-default (#187 default-flip) — let it complete
     assert.ok(ctx.calls.revealNode?.length > 0);
     assert.deepEqual(ctx.calls.revealNode[0], ["sl/vault"]);
     assert.equal(graph.getNodeState("sl/vault").concealed, false);
@@ -939,12 +964,15 @@ describe("scatteredLock3: scan-lock action reports progress", () => {
 
     graph._nodes.get("sl/gate").attributes.accessLevel = "owned";
     graph.executeAction("sl/gate", "scan-lock");
+    graph.tick(20); // scan-lock is timed-by-default (#187 default-flip) — let it complete
     assert.ok(ctx.calls.log?.some(args => args[0] === "Combination lock: 0/3 switches activated"));
 
     // Activate one switch
     graph._nodes.get("sl/switch-a").attributes.accessLevel = "owned";
     graph.executeAction("sl/switch-a", "activate");
+    graph.tick(20); // activate is timed-by-default (#187 default-flip) — let it complete
     graph.executeAction("sl/gate", "scan-lock");
+    graph.tick(20); // scan-lock is timed-by-default (#187 default-flip) — let it complete
     assert.ok(ctx.calls.log?.some(args => args[0] === "Combination lock: 1/3 switches activated"));
   });
 });
@@ -961,6 +989,7 @@ describe("scatteredLock3: crack-vault requires all switches + owned", () => {
     graph.executeAction("sl/switch-a", "activate");
     graph.executeAction("sl/switch-b", "activate");
     graph.executeAction("sl/switch-c", "activate");
+    graph.tick(20); // activate is timed-by-default (#187 default-flip) — let it complete
 
     // Vault not owned — crack-vault unavailable
     let available = graph.getAvailableActions("sl/vault").map(a => a.id);
@@ -972,7 +1001,7 @@ describe("scatteredLock3: crack-vault requires all switches + owned", () => {
     assert.ok(available.includes("crack-vault"));
 
     graph.executeAction("sl/vault", "crack-vault");
-    graph.tick(20); // crack-vault is timed (#187 Phase 5) — flat duration:20
+    graph.tick(20); // crack-vault is timed by default (#187 default-flip) — same 20-tick duration
     assert.equal(ctx.calls.giveReward?.length, 1);
     assert.deepEqual(ctx.calls.giveReward[0], [1500]);
   });
@@ -988,9 +1017,10 @@ describe("scatteredLock3: crack-vault requires all switches + owned", () => {
     graph.executeAction("sl/switch-a", "activate");
     graph.executeAction("sl/switch-b", "activate");
     graph.executeAction("sl/switch-c", "activate");
+    graph.tick(20); // activate is timed-by-default (#187 default-flip) — let it complete
     graph._nodes.get("sl/vault").attributes.accessLevel = "owned";
 
-    // First crack pays out (timed — #187 Phase 5 — flat duration:20).
+    // First crack pays out (timed by default — #187 default-flip — 20-tick duration).
     graph.executeAction("sl/vault", "crack-vault");
     graph.tick(20);
     assert.equal(ctx.calls.giveReward?.length, 1);
@@ -1032,10 +1062,11 @@ describe("scatteredKeyVault: quality communication", () => {
     const inst = instantiate(scatteredKeyVault2, "kv");
     const graph = new NodeGraph(inst, ctx);
 
-    // Own and extract from both keys
+    // Own and extract from both keys (extract-token is timed-by-default — #187 default-flip)
     for (const ks of ["kv/key-server-1", "kv/key-server-2"]) {
       graph._nodes.get(ks).attributes.accessLevel = "owned";
       graph.executeAction(ks, "extract-token");
+      graph.tick(20);
     }
 
     // Own vault and unlock
@@ -1044,6 +1075,7 @@ describe("scatteredKeyVault: quality communication", () => {
     assert.ok(available.includes("unlock-vault"));
 
     graph.executeAction("kv/vault-node", "unlock-vault");
+    graph.tick(20); // unlock-vault is timed-by-default (#187 default-flip) — let it complete
     assert.equal(ctx.calls.giveReward?.length, 1);
     assert.deepEqual(ctx.calls.giveReward[0], [5000]);
   });
@@ -1055,6 +1087,7 @@ describe("scatteredKeyVault: quality communication", () => {
 
     graph._nodes.get("kv/vault-node").attributes.accessLevel = "owned";
     graph.executeAction("kv/vault-node", "scan-vault");
+    graph.tick(20); // scan-vault is timed-by-default (#187 default-flip) — let it complete
     assert.ok(ctx.calls.log?.some(args => args[0] === "Key vault: 0/3 tokens collected"));
   });
 });
@@ -1084,6 +1117,7 @@ describe("scatteredEncryptedVault: quality communication", () => {
     // Own vault and decrypt
     graph._nodes.get("ev/vault").attributes.accessLevel = "owned";
     graph.executeAction("ev/vault", "decrypt-loot");
+    graph.tick(20); // decrypt-loot is timed-by-default (#187 default-flip) — let it complete
     assert.equal(ctx.calls.giveReward?.length, 1);
     assert.deepEqual(ctx.calls.giveReward[0], [3000]);
   });
@@ -1095,6 +1129,7 @@ describe("scatteredEncryptedVault: quality communication", () => {
 
     graph._nodes.get("ev/vault").attributes.accessLevel = "owned";
     graph.executeAction("ev/vault", "scan-vault");
+    graph.tick(20); // scan-vault is timed-by-default (#187 default-flip) — let it complete
     assert.ok(ctx.calls.log?.some(args => args[0] === "Encrypted vault: 0/3 keys collected"));
   });
 });

--- a/js/core/network/set-pieces.test.js
+++ b/js/core/network/set-pieces.test.js
@@ -972,6 +972,7 @@ describe("scatteredLock3: crack-vault requires all switches + owned", () => {
     assert.ok(available.includes("crack-vault"));
 
     graph.executeAction("sl/vault", "crack-vault");
+    graph.tick(20); // crack-vault is timed (#187 Phase 5) — flat duration:20
     assert.equal(ctx.calls.giveReward?.length, 1);
     assert.deepEqual(ctx.calls.giveReward[0], [1500]);
   });
@@ -989,8 +990,9 @@ describe("scatteredLock3: crack-vault requires all switches + owned", () => {
     graph.executeAction("sl/switch-c", "activate");
     graph._nodes.get("sl/vault").attributes.accessLevel = "owned";
 
-    // First crack pays out.
+    // First crack pays out (timed — #187 Phase 5 — flat duration:20).
     graph.executeAction("sl/vault", "crack-vault");
+    graph.tick(20);
     assert.equal(ctx.calls.giveReward?.length, 1);
 
     // The vault is now spent: crack-vault is no longer offered, so the player
@@ -1072,10 +1074,11 @@ describe("scatteredEncryptedVault: quality communication", () => {
     const inst = instantiate(scatteredEncryptedVault2, "ev");
     const graph = new NodeGraph(inst, ctx);
 
-    // Own and extract from both key-gens
+    // Own and extract from both key-gens (extract-key is timed — #187 Phase 5 — flat duration:20)
     for (const kg of ["ev/key-gen-1", "ev/key-gen-2"]) {
       graph._nodes.get(kg).attributes.accessLevel = "owned";
       graph.executeAction(kg, "extract-key");
+      graph.tick(20);
     }
 
     // Own vault and decrypt

--- a/js/core/node-graph/action-templates.js
+++ b/js/core/node-graph/action-templates.js
@@ -227,7 +227,13 @@ const RECONFIGURE_ACTION = {
       ],
     },
     { type: "node-attr", attr: "forwardingEnabled", eq: true },
+    ...NOT_BUSY,
   ],
+  // Timed (#187 Phase 5): subverting an IDS takes time, grade-scaled — a higher-grade
+  // IDS resists longer. Feel-draft numbers. Synthesis (timed-synthesis.js) rewrites these
+  // `effects` into the timed-action operator's `onComplete`, so forwardingEnabled only
+  // flips (and reconfigureNode only fires) once the subversion completes, not at dispatch.
+  timed: { durationTable: { S: 30, A: 25, B: 20, C: 15, D: 12, F: 8 } },
   effects: [
     { effect: "set-attr", attr: "forwardingEnabled", value: false },
     { effect: "ctx-call", method: "reconfigureNode", args: ["$nodeId"] },

--- a/js/core/node-graph/action-templates.js
+++ b/js/core/node-graph/action-templates.js
@@ -21,9 +21,12 @@ import { ABORTABLE_FLAGS, getTimedActionAttrNames } from "./timed-actions.js";
 // ── Shared action templates ──────────────────────────────────
 
 // activeAttr flags for the player-initiated, abortable timed actions, sourced
-// from the TIMED_ACTIONS registry (timed-actions.js): ABORT shows when any is
-// true, and NOT_BUSY (below) requires all of them false. Add new timed actions
-// to the registry, not here.
+// from the TIMED_ACTIONS registry (timed-actions.js): NOT_BUSY (below) requires
+// all of them false. ABORT no longer reads this list directly — it uses the
+// structural `active-abortable-timed-action` condition instead (#187 Phase 2
+// review fix) — but NOT_BUSY still needs the enumerated flags (a busy node is
+// busy whether or not the thing making it busy is abortable). Add new timed
+// actions to the registry, not here.
 const TIMED_ACTION_FLAGS = ABORTABLE_FLAGS;
 
 // A node may run at most ONE timed action at a time. Every startable action
@@ -63,27 +66,22 @@ const PROBE_ACTION = {
 };
 
 // Abort: unified cancel for any timed action. The execution is generic
-// (queries timed-action operators at runtime); the requires list shows it
-// whenever any abortable timed action is in flight (see TIMED_ACTION_FLAGS),
-// OR a synthesized timed action is active (structural check, #187 Phase 2 —
-// covers a dynamically-named activeAttr the enumerated flags can't list).
-// The #282 process-framework busy case (SWEEP, …) is handled separately, one
-// layer up in node-actions.js — it swaps in its own ABORT before this template
-// is ever consulted, so it isn't duplicated here.
+// (queries timed-action operators at runtime); the requires list is the single
+// structural `active-abortable-timed-action` check (#187 Phase 2 review fix) —
+// it covers both the enumerated core verbs (probe, xploit, …) and a synthesized
+// timed action (dynamically-named activeAttr) alike, while EXCLUDING an action
+// marked non-abortable (reboot — involuntary, ABORT must not offer to cancel it).
+// This replaced a broader `not(no-active-timed-action)` check that didn't
+// distinguish abortable from non-abortable, which let ABORT wrongly show during
+// a reboot. The #282 process-framework busy case (SWEEP, …) is handled
+// separately, one layer up in node-actions.js — it swaps in its own ABORT
+// before this template is ever consulted, so it isn't duplicated here.
 /** @type {ActionDef} */
 const ABORT_ACTION = {
   id: A.ABORT,
   label: "ABORT",
   desc: "Cancel the current timed action.",
-  requires: [
-    {
-      type: "any-of",
-      conditions: [
-        ...TIMED_ACTION_FLAGS.map((attr) => /** @type {Condition} */ ({ type: "node-attr", attr, eq: true })),
-        { type: "not", condition: { type: "no-active-timed-action" } },
-      ],
-    },
-  ],
+  requires: [{ type: "active-abortable-timed-action" }],
   effects: [
     { effect: "ctx-call", method: "abortTimedAction", args: ["$nodeId"] },
   ],

--- a/js/core/node-graph/action-templates.js
+++ b/js/core/node-graph/action-templates.js
@@ -245,6 +245,10 @@ const CANCEL_TRACE_ACTION = {
   id: A.CANCEL_TRACE,
   label: "CANCEL TRACE",
   desc: "Abort trace countdown.",
+  // Instant (#187 default-flip opt-out): the panic button. Racing the trace countdown
+  // while the game keeps the player waiting on this action to complete would be pure
+  // frustration, not in-world timed work.
+  instant: true,
   requires: [
     { type: "node-attr", attr: "accessLevel", eq: "owned" },
   ],
@@ -258,6 +262,9 @@ const ACCESS_DARKNET_ACTION = {
   id: A.ACCESS_DARKNET,
   label: "ACCESS DARKNET",
   desc: "Access the darknet broker to purchase exploit cards.",
+  // Instant (#187 default-flip opt-out): a UI transition (opens the store modal), not
+  // in-world timed work.
+  instant: true,
   requires: [],
   effects: [
     { effect: "ctx-call", method: "openDarknetsStore", args: [] },
@@ -269,6 +276,9 @@ const DISCONNECT_ACTION = {
   id: A.DISCONNECT,
   label: "DISCONNECT",
   desc: "Sever the uplink — jack out and end the run.",
+  // Instant (#187 default-flip opt-out): jacking out ends the run immediately — an exit
+  // action, not in-world timed work.
+  instant: true,
   requires: [],
   effects: [
     { effect: "ctx-call", method: "jackOut", args: [] },

--- a/js/core/node-graph/action-templates.js
+++ b/js/core/node-graph/action-templates.js
@@ -36,9 +36,15 @@ const TIMED_ACTION_FLAGS = ABORTABLE_FLAGS;
 // rather than `eq false`: some flags (e.g. reading/looting) aren't defined on
 // non-lootable node types, and undefined must read as idle, not busy.
 /** @type {import('./types.js').Condition[]} */
-const NOT_BUSY = [...TIMED_ACTION_FLAGS, "rebooting"].map(
-  (attr) => ({ type: "not", condition: { type: "node-attr", attr, eq: true } })
-);
+const NOT_BUSY = [
+  ...[...TIMED_ACTION_FLAGS, "rebooting"].map(
+    (attr) => /** @type {Condition} */ ({ type: "not", condition: { type: "node-attr", attr, eq: true } })
+  ),
+  // Structural check (#187 Phase 2), additive alongside the enumerated flags above:
+  // catches a busy *synthesized* timed action (declarative ActionDef.timed), whose
+  // activeAttr is minted per-action-id and so can't be named in TIMED_ACTION_FLAGS.
+  { type: "no-active-timed-action" },
+];
 
 /** @type {ActionDef} */
 const PROBE_ACTION = {
@@ -58,7 +64,12 @@ const PROBE_ACTION = {
 
 // Abort: unified cancel for any timed action. The execution is generic
 // (queries timed-action operators at runtime); the requires list shows it
-// whenever any abortable timed action is in flight (see TIMED_ACTION_FLAGS).
+// whenever any abortable timed action is in flight (see TIMED_ACTION_FLAGS),
+// OR a synthesized timed action is active (structural check, #187 Phase 2 —
+// covers a dynamically-named activeAttr the enumerated flags can't list).
+// The #282 process-framework busy case (SWEEP, …) is handled separately, one
+// layer up in node-actions.js — it swaps in its own ABORT before this template
+// is ever consulted, so it isn't duplicated here.
 /** @type {ActionDef} */
 const ABORT_ACTION = {
   id: A.ABORT,
@@ -67,7 +78,10 @@ const ABORT_ACTION = {
   requires: [
     {
       type: "any-of",
-      conditions: TIMED_ACTION_FLAGS.map((attr) => ({ type: "node-attr", attr, eq: true })),
+      conditions: [
+        ...TIMED_ACTION_FLAGS.map((attr) => /** @type {Condition} */ ({ type: "node-attr", attr, eq: true })),
+        { type: "not", condition: { type: "no-active-timed-action" } },
+      ],
     },
   ],
   effects: [

--- a/js/core/node-graph/actions.js
+++ b/js/core/node-graph/actions.js
@@ -7,6 +7,7 @@ import { applyEffect } from "./effects.js";
  * @typedef {Object} ActionAccessors
  * @property {(nodeId: string, attr: string) => any} getNodeAttr
  * @property {(name: string) => number} getQuality
+ * @property {(nodeId: string) => boolean} isNodeBusy
  */
 
 /**

--- a/js/core/node-graph/actions.js
+++ b/js/core/node-graph/actions.js
@@ -8,6 +8,7 @@ import { applyEffect } from "./effects.js";
  * @property {(nodeId: string, attr: string) => any} getNodeAttr
  * @property {(name: string) => number} getQuality
  * @property {(nodeId: string) => boolean} isNodeBusy
+ * @property {(nodeId: string) => boolean} hasActiveAbortableTimedAction
  */
 
 /**

--- a/js/core/node-graph/conditions.js
+++ b/js/core/node-graph/conditions.js
@@ -5,10 +5,10 @@
  * Evaluate a condition against the current state.
  *
  * @param {Condition} condition
- * @param {{ getNodeAttr: (nodeId: string, attr: string) => any, getQuality: (name: string) => number }} accessors
+ * @param {{ getNodeAttr: (nodeId: string, attr: string) => any, getQuality: (name: string) => number, isNodeBusy: (nodeId: string) => boolean }} accessors
  * @returns {boolean}
  */
-export function evaluateCondition(condition, { getNodeAttr, getQuality }) {
+export function evaluateCondition(condition, { getNodeAttr, getQuality, isNodeBusy }) {
   switch (condition.type) {
     case "node-attr":
       return getNodeAttr(condition.nodeId ?? "", condition.attr) === condition.eq;
@@ -21,16 +21,27 @@ export function evaluateCondition(condition, { getNodeAttr, getQuality }) {
 
     case "all-of":
       return condition.conditions.every((c) =>
-        evaluateCondition(c, { getNodeAttr, getQuality })
+        evaluateCondition(c, { getNodeAttr, getQuality, isNodeBusy })
       );
 
     case "any-of":
       return condition.conditions.some((c) =>
-        evaluateCondition(c, { getNodeAttr, getQuality })
+        evaluateCondition(c, { getNodeAttr, getQuality, isNodeBusy })
       );
 
     case "not":
-      return !evaluateCondition(condition.condition, { getNodeAttr, getQuality });
+      return !evaluateCondition(condition.condition, { getNodeAttr, getQuality, isNodeBusy });
+
+    // Structural check (#187 Phase 2): passes when the node has NO active
+    // timed-action operator — covers both the hand-wired core verbs (probe,
+    // xploit, …) AND a synthesized `timed` action (ActionDef.timed), which
+    // mints a dynamically-named activeAttr that a static node-attr condition
+    // can't name in advance. Unifies with the #282 process framework's busy
+    // check (activeProcessOnNode), which is enforced separately at the
+    // getAvailableActions layer (node-actions.js) since a condition here has
+    // no access to game state, only this node's graph-runtime data.
+    case "no-active-timed-action":
+      return !isNodeBusy(condition.nodeId ?? "");
 
     case "quality-from-attr": {
       // Read quality name from a node attribute, then check the quality value.
@@ -51,14 +62,19 @@ export function evaluateCondition(condition, { getNodeAttr, getQuality }) {
 /**
  * Pre-fill a missing `nodeId` on a condition tree so self-targeting conditions
  * resolve against the owning node. Recurses through all-of/any-of/not and fills
- * the two node-bearing condition types (node-attr, quality-from-attr).
+ * the node-bearing condition types (node-attr, quality-from-attr, no-active-timed-action).
  *
  * @param {Condition} condition
  * @param {string} nodeId
  * @returns {Condition}
  */
 export function fillConditionNodeId(condition, nodeId) {
-  if ((condition.type === "node-attr" || condition.type === "quality-from-attr") && !condition.nodeId) {
+  if (
+    (condition.type === "node-attr" ||
+      condition.type === "quality-from-attr" ||
+      condition.type === "no-active-timed-action") &&
+    !condition.nodeId
+  ) {
     return { ...condition, nodeId };
   }
   if (condition.type === "all-of" || condition.type === "any-of") {

--- a/js/core/node-graph/conditions.js
+++ b/js/core/node-graph/conditions.js
@@ -5,10 +5,11 @@
  * Evaluate a condition against the current state.
  *
  * @param {Condition} condition
- * @param {{ getNodeAttr: (nodeId: string, attr: string) => any, getQuality: (name: string) => number, isNodeBusy: (nodeId: string) => boolean }} accessors
+ * @param {{ getNodeAttr: (nodeId: string, attr: string) => any, getQuality: (name: string) => number, isNodeBusy: (nodeId: string) => boolean, hasActiveAbortableTimedAction: (nodeId: string) => boolean }} accessors
  * @returns {boolean}
  */
-export function evaluateCondition(condition, { getNodeAttr, getQuality, isNodeBusy }) {
+export function evaluateCondition(condition, { getNodeAttr, getQuality, isNodeBusy, hasActiveAbortableTimedAction }) {
+  const accessors = { getNodeAttr, getQuality, isNodeBusy, hasActiveAbortableTimedAction };
   switch (condition.type) {
     case "node-attr":
       return getNodeAttr(condition.nodeId ?? "", condition.attr) === condition.eq;
@@ -20,17 +21,13 @@ export function evaluateCondition(condition, { getNodeAttr, getQuality, isNodeBu
       return getQuality(condition.name) === condition.value;
 
     case "all-of":
-      return condition.conditions.every((c) =>
-        evaluateCondition(c, { getNodeAttr, getQuality, isNodeBusy })
-      );
+      return condition.conditions.every((c) => evaluateCondition(c, accessors));
 
     case "any-of":
-      return condition.conditions.some((c) =>
-        evaluateCondition(c, { getNodeAttr, getQuality, isNodeBusy })
-      );
+      return condition.conditions.some((c) => evaluateCondition(c, accessors));
 
     case "not":
-      return !evaluateCondition(condition.condition, { getNodeAttr, getQuality, isNodeBusy });
+      return !evaluateCondition(condition.condition, accessors);
 
     // Structural check (#187 Phase 2): passes when the node has NO active
     // timed-action operator — covers both the hand-wired core verbs (probe,
@@ -42,6 +39,15 @@ export function evaluateCondition(condition, { getNodeAttr, getQuality, isNodeBu
     // no access to game state, only this node's graph-runtime data.
     case "no-active-timed-action":
       return !isNodeBusy(condition.nodeId ?? "");
+
+    // Structural check (review fix, #187 Phase 2): passes when the node HAS an
+    // active timed-action that ABORT is allowed to cancel. Narrower than
+    // `no-active-timed-action` — it excludes an action marked non-abortable
+    // (reboot is the only one today: it's involuntary, so ABORT must not offer
+    // to cancel it) while still catching synthesized `timed` actions the same
+    // way the broader check does. Drives ABORT_ACTION.requires.
+    case "active-abortable-timed-action":
+      return hasActiveAbortableTimedAction(condition.nodeId ?? "");
 
     case "quality-from-attr": {
       // Read quality name from a node attribute, then check the quality value.
@@ -62,7 +68,8 @@ export function evaluateCondition(condition, { getNodeAttr, getQuality, isNodeBu
 /**
  * Pre-fill a missing `nodeId` on a condition tree so self-targeting conditions
  * resolve against the owning node. Recurses through all-of/any-of/not and fills
- * the node-bearing condition types (node-attr, quality-from-attr, no-active-timed-action).
+ * the node-bearing condition types (node-attr, quality-from-attr,
+ * no-active-timed-action, active-abortable-timed-action).
  *
  * @param {Condition} condition
  * @param {string} nodeId
@@ -72,7 +79,8 @@ export function fillConditionNodeId(condition, nodeId) {
   if (
     (condition.type === "node-attr" ||
       condition.type === "quality-from-attr" ||
-      condition.type === "no-active-timed-action") &&
+      condition.type === "no-active-timed-action" ||
+      condition.type === "active-abortable-timed-action") &&
     !condition.nodeId
   ) {
     return { ...condition, nodeId };

--- a/js/core/node-graph/conditions.test.js
+++ b/js/core/node-graph/conditions.test.js
@@ -8,9 +8,12 @@ const attrs = {
 };
 const qualities = { tokens: 5, panels: 2 };
 
+const busy = { "node-A": true, "node-B": false };
+
 const accessors = {
   getNodeAttr: (nodeId, attr) => attrs[nodeId]?.[attr],
   getQuality: (name) => qualities[name] ?? 0,
+  isNodeBusy: (nodeId) => busy[nodeId] ?? false,
 };
 
 describe("evaluateCondition: node-attr", () => {
@@ -104,6 +107,28 @@ describe("evaluateCondition: not", () => {
   });
 });
 
+describe("evaluateCondition: no-active-timed-action (#187 Phase 2)", () => {
+  it("returns false when the node is busy", () => {
+    assert.equal(evaluateCondition({ type: "no-active-timed-action", nodeId: "node-A" }, accessors), false);
+  });
+
+  it("returns true when the node is idle", () => {
+    assert.equal(evaluateCondition({ type: "no-active-timed-action", nodeId: "node-B" }, accessors), true);
+  });
+
+  it("composes through not/any-of (the ABORT-style structural check)", () => {
+    assert.equal(evaluateCondition({
+      type: "not",
+      condition: { type: "no-active-timed-action", nodeId: "node-A" },
+    }, accessors), true, "not(no-active-timed-action) is true when busy");
+
+    assert.equal(evaluateCondition({
+      type: "any-of",
+      conditions: [{ type: "not", condition: { type: "no-active-timed-action", nodeId: "node-B" } }],
+    }, accessors), false, "not(no-active-timed-action) is false when idle");
+  });
+});
+
 describe("evaluateCondition: unknown type", () => {
   it("throws for unknown condition type", () => {
     assert.throws(() => evaluateCondition(/** @type {any} */ ({ type: "bogus" }), accessors));
@@ -118,6 +143,11 @@ describe("fillConditionNodeId", () => {
 
   it("fills a missing nodeId on a quality-from-attr condition", () => {
     const filled = fillConditionNodeId({ type: "quality-from-attr", attr: "tokenName", gte: 1 }, "self");
+    assert.equal(filled.nodeId, "self");
+  });
+
+  it("fills a missing nodeId on a no-active-timed-action condition", () => {
+    const filled = fillConditionNodeId({ type: "no-active-timed-action" }, "self");
     assert.equal(filled.nodeId, "self");
   });
 

--- a/js/core/node-graph/game-ctx.js
+++ b/js/core/node-graph/game-ctx.js
@@ -128,8 +128,12 @@ export function buildGameCtx(opts = {}) {
     abortTimedAction: (nodeId) => {
       // Unified abort — query the node's timed-action operators to find whichever
       // one is active, then clear it generically. No hardcoded action list.
+      // getActiveAbortableTimedAction (not getActiveTimedAction) is deliberate
+      // (#187 Phase 2 review fix): defense in depth so this is a no-op on a
+      // non-abortable active action (reboot) even if invoked outside the normal
+      // ABORT_ACTION.requires gate, which already excludes it.
       if (!ctx._graph) return;
-      const active = ctx._graph.getActiveTimedAction(nodeId);
+      const active = ctx._graph.getActiveAbortableTimedAction(nodeId);
       if (!active) return;
 
       // Exploit is special — has extra attributes (activeExploitId) beyond the

--- a/js/core/node-graph/game-ctx.js
+++ b/js/core/node-graph/game-ctx.js
@@ -38,7 +38,7 @@ import { abortNodeProcesses } from "../processes.js";
 import { setNodeProbed, setNodeAlertState, setNodeRead, collectMacguffins, setNodeLooted, incrementMineAttempts, setMineExhausted } from "../state/node.js";
 import { setLastDisturbedNode } from "../state/ice.js";
 import { launchExploit } from "../combat.js";
-import { getTimedActionAttrNames, ABORTABLE_TIMED_ACTIONS } from "./timed-actions.js";
+import { getTimedActionAttrNames, ABORTABLE_TIMED_ACTIONS, TIMED_ACTIONS } from "./timed-actions.js";
 
 /** Convenience: `_ta_<action>_progress` for the given timed action. */
 const progressAttr = (action) => getTimedActionAttrNames(action).progressAttr;
@@ -404,6 +404,20 @@ export function initNavigationCancelHandler() {
       // Extra per-action cleanup (e.g. xploit's activeExploitId), centralized in the registry.
       for (const attr of def.clearOnCancel ?? []) graph.setNodeAttr(nodeId, attr, null);
       emitEvent(E.ACTION_FEEDBACK, { nodeId, action: def.action, phase: "cancel", progress: 0 });
+    }
+
+    // Generalized fallback (#187 Phase 2): a synthesized timed action (declarative
+    // ActionDef.timed) isn't in the TIMED_ACTIONS registry, so the enumerated loop
+    // above can't see it by name. getActiveTimedAction finds it structurally (any
+    // active timed-action operator) instead — cancel it the same way. Skip anything
+    // already IN the registry: the loop above either already reset it (abortable),
+    // or it's intentionally excluded (reboot — involuntary, ABORT can't touch it).
+    const active = graph.getActiveTimedAction(nodeId);
+    if (active && !TIMED_ACTIONS.some((t) => t.action === active.action)) {
+      graph.setNodeAttr(nodeId, active.activeAttr, false);
+      graph.setNodeAttr(nodeId, active.progressAttr, 0);
+      graph.setNodeAttr(nodeId, active.durationAttr, 0);
+      emitEvent(E.ACTION_FEEDBACK, { nodeId, action: active.action, phase: "cancel", progress: 0 });
     }
   }
   // Progressive processes (SWEEP, …) also cancel on navigation — parity with timed actions.

--- a/js/core/node-graph/node-factories.test.js
+++ b/js/core/node-graph/node-factories.test.js
@@ -301,13 +301,18 @@ describe("action execution", () => {
     assert.equal(graph.getNodeState("gw").probing, true);
   });
 
-  it("corrupt action sets forwardingEnabled false and calls ctx", () => {
+  it("corrupt action sets forwardingEnabled false and calls ctx (timed — #187 Phase 5)", () => {
     const ctx = mockCtx();
     const ids = createIDS("ids-1", {
       attributes: { visibility: "accessible", accessLevel: "owned" },
     });
     const graph = new NodeGraph({ nodes: [ids], edges: [] }, ctx);
     graph.executeAction("ids-1", "corrupt");
+    // Dispatch only arms it — forwardingEnabled/reconfigureNode resolve on completion.
+    assert.equal(graph.getNodeState("ids-1").forwardingEnabled, true);
+    assert.equal(ctx.calls.reconfigureNode, undefined);
+
+    graph.tick(16); // grade C: 1 tick to resolve duration from the table + 15 progress ticks
     assert.equal(graph.getNodeState("ids-1").forwardingEnabled, false);
     assert.equal(ctx.calls.reconfigureNode?.length, 1);
     assert.deepEqual(ctx.calls.reconfigureNode[0], ["ids-1"]);

--- a/js/core/node-graph/operators.js
+++ b/js/core/node-graph/operators.js
@@ -382,6 +382,11 @@ registerOperator("tally", (config, _attrs, message, _ctx) => {
  *     Phase 3, threaded from ActionDef.feedback by timed-synthesis.js); echoed onto the "start"
  *     ACTION_FEEDBACK payload for overlay dispatch + the Strudel audio module to layer over the
  *     central/DEFAULT profile (js/ui/feedback-profiles.js)
+ *   emitStartOnArm?: boolean — set only by timed-synthesis.js for a flat `duration` (no
+ *     durationTable): that path seeds `duration` at arm time, bypassing the grade-table
+ *     first-tick branch below (the only other place "start" is emitted), so this flag makes
+ *     the first counting tick emit "start" instead (#187 review fix — flat actions were
+ *     never emitting "start", so their overlay never mounted)
  */
 registerOperator("timed-action", (config, attrs, message, _ctx) => {
   if (!message || message.type !== "tick") return {};
@@ -433,6 +438,26 @@ registerOperator("timed-action", (config, attrs, message, _ctx) => {
   // Duration not yet set (waiting for ctx to set it, e.g. exploit)
   if (duration === 0) return {};
 
+  // Flat-duration synthesized actions (timed-synthesis.js) seed `duration` directly at arm
+  // time, bypassing the grade-table branch above — the only place that otherwise emits
+  // "start". So this, the first counting tick, is where a flat action's "start" belongs.
+  // Scoped via `emitStartOnArm` (set only for the flat-duration synthesis path) so
+  // durationTable actions (already started above) and ctx-set actions like xploit/reboot
+  // (started from game-ctx.js) never double-fire. Prepended to whichever events array this
+  // tick returns below — progress still increments in the same tick, so completion timing
+  // (tick(duration), not duration+1) is unchanged.
+  /** @type {{type: string, payload: object}[]} */
+  const startEvents = [];
+  if (progress === 0 && config.emitStartOnArm) {
+    startEvents.push({
+      type: "action-feedback",
+      payload: {
+        nodeId: attrs.label, action, phase: "start", progress: 0, durationTicks: duration,
+        ...(config.feedback ? { feedback: config.feedback } : {}),
+      },
+    });
+  }
+
   const newProgress = progress + 1;
 
   // Check progress milestone effects (e.g. exploit noise every 10%)
@@ -463,7 +488,7 @@ registerOperator("timed-action", (config, attrs, message, _ctx) => {
   if (newProgress >= duration) {
     // Completed — fire onComplete effects via ctx-call events
     /** @type {{type: string, payload: object}[]} */
-    const events = [{
+    const events = [...startEvents, {
       type: "action-feedback",
       payload: { nodeId: attrs.label, action, phase: "complete", progress: 1.0 },
     }];
@@ -490,7 +515,7 @@ registerOperator("timed-action", (config, attrs, message, _ctx) => {
   return {
     attributes: { [progressAttr]: newProgress },
     outgoing,
-    events: [{
+    events: [...startEvents, {
       type: "action-feedback",
       payload: { nodeId: attrs.label, action, phase: "progress", progress: newProgress / duration },
     }],

--- a/js/core/node-graph/operators.js
+++ b/js/core/node-graph/operators.js
@@ -378,6 +378,10 @@ registerOperator("tally", (config, _attrs, message, _ctx) => {
  *   onComplete?: Effect[] — effects to fire on completion (stored as data, executed by ctx)
  *   onProgressInterval?: number — fraction (0-1) at which to fire onProgressEffects
  *   onProgressEffects?: Effect[] — effects to fire at progress milestones (e.g. exploit noise)
+ *   feedback?: { overlay?, drone?, completionCue? } — inline feedback-profile override (#187
+ *     Phase 3, threaded from ActionDef.feedback by timed-synthesis.js); echoed onto the "start"
+ *     ACTION_FEEDBACK payload for overlay dispatch + the Strudel audio module to layer over the
+ *     central/DEFAULT profile (js/ui/feedback-profiles.js)
  */
 registerOperator("timed-action", (config, attrs, message, _ctx) => {
   if (!message || message.type !== "tick") return {};
@@ -415,7 +419,13 @@ registerOperator("timed-action", (config, attrs, message, _ctx) => {
       },
       events: [{
         type: "action-feedback",
-        payload: { nodeId: attrs.label, action, phase: "start", progress: 0, durationTicks: gradeDuration },
+        payload: {
+          nodeId: attrs.label, action, phase: "start", progress: 0, durationTicks: gradeDuration,
+          // Inline feedback-profile override (#187 Phase 3), if the ActionDef declared one —
+          // consumed by overlay dispatch + the Strudel audio module's layered resolution.
+          // Additive field; existing consumers ignore it.
+          ...(config.feedback ? { feedback: config.feedback } : {}),
+        },
       }],
     };
   }

--- a/js/core/node-graph/runtime.js
+++ b/js/core/node-graph/runtime.js
@@ -240,6 +240,21 @@ export class NodeGraph {
   }
 
   /**
+   * True if the node has any active timed-action operator (#187 Phase 2) — the
+   * structural "is this node busy?" check that spans both the hand-wired core
+   * verbs and any synthesized `timed` action, without needing to know its
+   * (dynamically-named) activeAttr in advance. Does NOT know about the #282
+   * process framework (`state.processes`) — that's a separate busy source
+   * layered on top at the getAvailableActions level (node-actions.js), since
+   * this graph has no access to game state.
+   * @param {string} nodeId
+   * @returns {boolean}
+   */
+  isNodeBusy(nodeId) {
+    return this.getActiveTimedAction(nodeId) != null;
+  }
+
+  /**
    * Return a node's full data: id, type, and all attributes.
    * Useful for populating game state objects.
    * @param {string} nodeId
@@ -405,12 +420,16 @@ export class NodeGraph {
 
   /**
    * Build state accessor object for conditions and trigger evaluation.
-   * @returns {{ getNodeAttr: (nodeId: string, attr: string) => any, getQuality: (name: string) => number }}
+   * @returns {{ getNodeAttr: (nodeId: string, attr: string) => any, getQuality: (name: string) => number, isNodeBusy: (nodeId: string) => boolean }}
    */
   _stateAccessors() {
     return {
       getNodeAttr: (nodeId, attr) => this._nodes.get(nodeId)?.attributes[attr],
       getQuality: (name) => this._qualities.get(name),
+      // Guard against an unknown nodeId rather than throwing (matches the other
+      // accessors here, which read via optional chaining) — isNodeBusy() itself
+      // throws for a missing node, like the rest of the public API (getNodeState, …).
+      isNodeBusy: (nodeId) => (this._nodes.has(nodeId) ? this.isNodeBusy(nodeId) : false),
     };
   }
 

--- a/js/core/node-graph/runtime.js
+++ b/js/core/node-graph/runtime.js
@@ -15,8 +15,26 @@ import { fillConditionNodeId } from "./conditions.js";
 import { applyEffect } from "./effects.js";
 import { nullCtx } from "./ctx.js";
 import { resolveTraits } from "./traits.js";
-import { getTimedActionAttrNames } from "./timed-actions.js";
+import { getTimedActionAttrNames, TIMED_ACTIONS } from "./timed-actions.js";
 import { synthesizeTimedActions } from "./timed-synthesis.js";
+
+/**
+ * True if a `timed-action` operator's action can be cancelled by ABORT. Hand-wired
+ * core verbs look themselves up in the TIMED_ACTIONS registry (reboot is the only
+ * `abortable: false` entry there); a synthesized action (declarative ActionDef.timed,
+ * not registered in TIMED_ACTIONS) instead carries its own `_abortable` flag on the
+ * operator config (set by timed-synthesis.js from `ActionDef.timed.abortable`),
+ * defaulting to abortable when unset — matching the pre-#187-Phase-2 behavior for
+ * synthesized actions and for any other hand-authored `timed-action` operator that
+ * doesn't opt out (e.g. the `volatile` trait).
+ * @param {{ action?: string, _abortable?: boolean }} op
+ * @returns {boolean}
+ */
+function isOperatorAbortable(op) {
+  const def = TIMED_ACTIONS.find((t) => t.action === op.action);
+  if (def) return def.abortable;
+  return op._abortable !== false;
+}
 
 // Re-exported so callers can reach the timed-action attr-name helper via runtime.
 export { getTimedActionAttrNames } from "./timed-actions.js";
@@ -216,17 +234,20 @@ export class NodeGraph {
   }
 
   /**
-   * Find the active timed-action on a node, if any.
-   * Scans timed-action operators and returns the first whose activeAttr is true.
+   * Scan a node's operators for the first active `timed-action`, optionally
+   * restricted to abortable ones. Shared by getActiveTimedAction and
+   * getActiveAbortableTimedAction.
    * @param {string} nodeId
+   * @param {{ abortableOnly?: boolean }} [opts]
    * @returns {{ action: string, activeAttr: string, progressAttr: string, durationAttr: string } | null}
    */
-  getActiveTimedAction(nodeId) {
+  _findActiveTimedAction(nodeId, { abortableOnly = false } = {}) {
     const node = this._requireNode(nodeId);
     for (const op of node.operators) {
       if (op.name !== "timed-action") continue;
       const activeAttr = op.activeAttr;
       if (!activeAttr || !node.attributes[activeAttr]) continue;
+      if (abortableOnly && !isOperatorAbortable(op)) continue;
       const action = op.action ?? "unknown";
       const names = getTimedActionAttrNames(action);
       return {
@@ -237,6 +258,40 @@ export class NodeGraph {
       };
     }
     return null;
+  }
+
+  /**
+   * Find the active timed-action on a node, if any (including a non-abortable one,
+   * e.g. reboot). Scans timed-action operators and returns the first whose
+   * activeAttr is true.
+   * @param {string} nodeId
+   * @returns {{ action: string, activeAttr: string, progressAttr: string, durationAttr: string } | null}
+   */
+  getActiveTimedAction(nodeId) {
+    return this._findActiveTimedAction(nodeId);
+  }
+
+  /**
+   * Find the active timed-action on a node, if any, EXCLUDING one marked
+   * non-abortable (e.g. reboot — involuntary, ABORT can't cancel it). Backs the
+   * `active-abortable-timed-action` condition that scopes ABORT's visibility
+   * (review fix, #187 Phase 2) — distinct from getActiveTimedAction/isNodeBusy,
+   * which intentionally still count a non-abortable action as "busy" (a rebooting
+   * node still can't start something new).
+   * @param {string} nodeId
+   * @returns {{ action: string, activeAttr: string, progressAttr: string, durationAttr: string } | null}
+   */
+  getActiveAbortableTimedAction(nodeId) {
+    return this._findActiveTimedAction(nodeId, { abortableOnly: true });
+  }
+
+  /**
+   * True if the node has an active timed-action that ABORT is allowed to cancel.
+   * @param {string} nodeId
+   * @returns {boolean}
+   */
+  hasActiveAbortableTimedAction(nodeId) {
+    return this.getActiveAbortableTimedAction(nodeId) != null;
   }
 
   /**
@@ -420,7 +475,7 @@ export class NodeGraph {
 
   /**
    * Build state accessor object for conditions and trigger evaluation.
-   * @returns {{ getNodeAttr: (nodeId: string, attr: string) => any, getQuality: (name: string) => number, isNodeBusy: (nodeId: string) => boolean }}
+   * @returns {{ getNodeAttr: (nodeId: string, attr: string) => any, getQuality: (name: string) => number, isNodeBusy: (nodeId: string) => boolean, hasActiveAbortableTimedAction: (nodeId: string) => boolean }}
    */
   _stateAccessors() {
     return {
@@ -430,6 +485,8 @@ export class NodeGraph {
       // accessors here, which read via optional chaining) — isNodeBusy() itself
       // throws for a missing node, like the rest of the public API (getNodeState, …).
       isNodeBusy: (nodeId) => (this._nodes.has(nodeId) ? this.isNodeBusy(nodeId) : false),
+      hasActiveAbortableTimedAction: (nodeId) =>
+        this._nodes.has(nodeId) ? this.hasActiveAbortableTimedAction(nodeId) : false,
     };
   }
 

--- a/js/core/node-graph/runtime.js
+++ b/js/core/node-graph/runtime.js
@@ -16,6 +16,7 @@ import { applyEffect } from "./effects.js";
 import { nullCtx } from "./ctx.js";
 import { resolveTraits } from "./traits.js";
 import { getTimedActionAttrNames } from "./timed-actions.js";
+import { synthesizeTimedActions } from "./timed-synthesis.js";
 
 // Re-exported so callers can reach the timed-action attr-name helper via runtime.
 export { getTimedActionAttrNames } from "./timed-actions.js";
@@ -60,6 +61,10 @@ export class NodeGraph {
     const allTriggers = [...triggers];
     for (const raw of nodes) {
       const n = resolveTraits(raw);
+      // Declarable `timed` actions (#187, Phase 1) synthesize their timed-action operator
+      // + arm effects here, once per constructed node — covers both trait-supplied and
+      // inline actions, since both have passed through resolveTraits by this point.
+      synthesizeTimedActions(n);
       this._nodes.set(n.id, {
         id: n.id,
         type: n.type,

--- a/js/core/node-graph/runtime.test.js
+++ b/js/core/node-graph/runtime.test.js
@@ -363,6 +363,7 @@ describe("player action execute — full pipeline", () => {
     }, ctx);
 
     graph.executeAction("switch", "flip-route");
+    graph.tick(20); // flip-route is a script action, timed-by-default (#187 default-flip)
 
     assert.equal(graph.getQuality("routing-panels-aligned"), 1);
     assert.equal(ctx.calls.giveReward?.length, 1);

--- a/js/core/node-graph/timed-actions.js
+++ b/js/core/node-graph/timed-actions.js
@@ -62,3 +62,17 @@ export function getTimedActionAttrNames(action) {
     durationAttr: `_ta_${action}_duration`,
   };
 }
+
+/**
+ * The active-flag attribute name for a *synthesized* timed action (#187, Phase 1):
+ * an ActionDef's declarative `timed` block doesn't hand-pick an irregular activeAttr
+ * name the way the seven hand-wired TIMED_ACTIONS entries do (`probing`, `exploiting`,
+ * etc.) — it mints one deterministically from the action id instead. Not registered in
+ * TIMED_ACTIONS: synthesized actions aren't part of the nav-cancel/ABORT flow this
+ * registry drives (that wiring is a later phase).
+ * @param {string} actionId
+ * @returns {string}
+ */
+export function timedActiveAttr(actionId) {
+  return `_ta_active_${actionId}`;
+}

--- a/js/core/node-graph/timed-actions.js
+++ b/js/core/node-graph/timed-actions.js
@@ -68,8 +68,10 @@ export function getTimedActionAttrNames(action) {
  * an ActionDef's declarative `timed` block doesn't hand-pick an irregular activeAttr
  * name the way the seven hand-wired TIMED_ACTIONS entries do (`probing`, `exploiting`,
  * etc.) — it mints one deterministically from the action id instead. Not registered in
- * TIMED_ACTIONS: synthesized actions aren't part of the nav-cancel/ABORT flow this
- * registry drives (that wiring is a later phase).
+ * TIMED_ACTIONS (it has no fixed activeAttr to enumerate), but a synthesized abortable
+ * action DOES participate in NOT_BUSY/ABORT/nav-cancel — those checks find it
+ * structurally instead, via NodeGraph#getActiveTimedAction /
+ * #getActiveAbortableTimedAction, rather than by name (#187 Phase 2).
  * @param {string} actionId
  * @returns {string}
  */

--- a/js/core/node-graph/timed-synthesis.js
+++ b/js/core/node-graph/timed-synthesis.js
@@ -31,12 +31,31 @@
  * more than one NodeGraph construction. The `_timedSynthesized` guard on the *new*
  * object then only has to protect against re-running synthesis on an
  * already-synthesized node (idempotency), not against cross-node sharing.
+ *
+ * Timed-by-default flip (#187 default-flip): declaring `timed:{}` on every set-piece/
+ * script action doesn't scale — it's easy to forget (exactly what happened to the
+ * `puzzles.js` multiKeyVault `extract-key`, which never got a `timed` block and so
+ * never animated, unlike its `scattered.js` sibling). So a script action (per
+ * `isScriptAction()`, i.e. not a core deck verb) is synthesized into a timed action
+ * EVEN WITHOUT an explicit `timed` block, using `DEFAULT_SCRIPT_ACTION_DURATION` — unless
+ * it opts out via `instant: true`, or the node already carries a hand-wired
+ * `timed-action` operator for that action id (e.g. the `darknet` trait's `lie-low`,
+ * wired directly via `LIE_LOW_OPERATOR` rather than through `ActionDef.timed`). A
+ * default-timed action is just "explicit `timed`" with a default duration — it reuses
+ * the exact same synthesis path below.
  */
 
 /** @typedef {import('./runtime.js').NodeState} NodeState */
 /** @typedef {import('./types.js').NodeDef} NodeDef */
+/** @typedef {import('./types.js').TimedActionSpec} TimedActionSpec */
 
 import { getTimedActionAttrNames, timedActiveAttr } from "./timed-actions.js";
+import { isScriptAction } from "../actions/scripts.js";
+
+// Flat duration (ticks) applied to a script action synthesized as timed-by-default (no
+// explicit `timed` block). ~2s at the standard 100ms tick — a feel-draft placeholder,
+// same value the Phase-5 hand-conversions (extract-key/crack-vault) used explicitly.
+export const DEFAULT_SCRIPT_ACTION_DURATION = 20;
 
 /**
  * @param {NodeState | NodeDef} node - the node object under construction; mutated in place
@@ -47,8 +66,24 @@ export function synthesizeTimedActions(node) {
 
   let operators = node.operators ?? [];
 
+  // Action ids that already have a hand-wired `timed-action` operator (e.g. `lie-low` via
+  // the `darknet` trait's LIE_LOW_OPERATOR) — the default-timed path must not double-wire
+  // these. Snapshotted once, before this pass adds any operators of its own.
+  const alreadyTimed = new Set(
+    operators.filter((o) => o.name === "timed-action").map((o) => o.action)
+  );
+
   const actions = node.actions.map((action) => {
-    if (!action.timed || action._timedSynthesized) return action;
+    if (action._timedSynthesized) return action;
+
+    /** @type {TimedActionSpec | undefined} */
+    let timedSpec = action.timed;
+    if (!timedSpec) {
+      // Timed-by-default: a script action with no explicit `timed` block still gets
+      // synthesized, unless it opts out (`instant`) or is already timed some other way.
+      if (!isScriptAction(action.id) || action.instant || alreadyTimed.has(action.id)) return action;
+      timedSpec = { duration: DEFAULT_SCRIPT_ACTION_DURATION };
+    }
 
     const activeAttr = timedActiveAttr(action.id);
     const { progressAttr, durationAttr } = getTimedActionAttrNames(action.id);
@@ -59,14 +94,14 @@ export function synthesizeTimedActions(node) {
         name: "timed-action",
         action: action.id,
         activeAttr,
-        ...(action.timed.durationTable ? { durationTable: action.timed.durationTable } : {}),
+        ...(timedSpec.durationTable ? { durationTable: timedSpec.durationTable } : {}),
         // Flat-duration actions seed `duration` directly via the arm effects below, which
         // bypasses the operator's grade-table first-tick branch (progress===0 && duration===0)
         // — that branch is the ONLY place the operator emits a "start" ACTION_FEEDBACK, so
         // without this flag a flat-duration action never starts its overlay animation
         // (manual-smoke bug, #187 review fix). Not set for durationTable actions — that branch
         // already emits "start" and must not double-fire.
-        ...(action.timed.duration != null && !action.timed.durationTable ? { emitStartOnArm: true } : {}),
+        ...(timedSpec.duration != null && !timedSpec.durationTable ? { emitStartOnArm: true } : {}),
         // Inline feedback-profile override (#187 Phase 3), carried through to the "start"
         // ACTION_FEEDBACK payload by the timed-action operator (operators.js). Additive —
         // absent unless the ActionDef declares `feedback`.
@@ -75,7 +110,7 @@ export function synthesizeTimedActions(node) {
         // Wired through for the ABORT/nav-cancel structural checks (review fix,
         // #187 Phase 2): defaults to abortable unless the ActionDef explicitly
         // opts out via `timed.abortable: false`.
-        _abortable: action.timed.abortable !== false,
+        _abortable: timedSpec.abortable !== false,
       },
     ];
 
@@ -84,8 +119,8 @@ export function synthesizeTimedActions(node) {
       { effect: "set-attr", attr: activeAttr, value: true },
       { effect: "set-attr", attr: progressAttr, value: 0 },
     ];
-    if (action.timed.duration != null) {
-      armEffects.push({ effect: "set-attr", attr: durationAttr, value: action.timed.duration });
+    if (timedSpec.duration != null) {
+      armEffects.push({ effect: "set-attr", attr: durationAttr, value: timedSpec.duration });
     }
 
     return { ...action, _timedSynthesized: true, effects: armEffects };

--- a/js/core/node-graph/timed-synthesis.js
+++ b/js/core/node-graph/timed-synthesis.js
@@ -60,6 +60,10 @@ export function synthesizeTimedActions(node) {
         action: action.id,
         activeAttr,
         ...(action.timed.durationTable ? { durationTable: action.timed.durationTable } : {}),
+        // Inline feedback-profile override (#187 Phase 3), carried through to the "start"
+        // ACTION_FEEDBACK payload by the timed-action operator (operators.js). Additive —
+        // absent unless the ActionDef declares `feedback`.
+        ...(action.feedback ? { feedback: action.feedback } : {}),
         onComplete: action.effects,
         // Wired through for the ABORT/nav-cancel structural checks (review fix,
         // #187 Phase 2): defaults to abortable unless the ActionDef explicitly

--- a/js/core/node-graph/timed-synthesis.js
+++ b/js/core/node-graph/timed-synthesis.js
@@ -60,6 +60,13 @@ export function synthesizeTimedActions(node) {
         action: action.id,
         activeAttr,
         ...(action.timed.durationTable ? { durationTable: action.timed.durationTable } : {}),
+        // Flat-duration actions seed `duration` directly via the arm effects below, which
+        // bypasses the operator's grade-table first-tick branch (progress===0 && duration===0)
+        // — that branch is the ONLY place the operator emits a "start" ACTION_FEEDBACK, so
+        // without this flag a flat-duration action never starts its overlay animation
+        // (manual-smoke bug, #187 review fix). Not set for durationTable actions — that branch
+        // already emits "start" and must not double-fire.
+        ...(action.timed.duration != null && !action.timed.durationTable ? { emitStartOnArm: true } : {}),
         // Inline feedback-profile override (#187 Phase 3), carried through to the "start"
         // ACTION_FEEDBACK payload by the timed-action operator (operators.js). Additive —
         // absent unless the ActionDef declares `feedback`.

--- a/js/core/node-graph/timed-synthesis.js
+++ b/js/core/node-graph/timed-synthesis.js
@@ -1,0 +1,81 @@
+// @ts-check
+/**
+ * Phase 1 (#187): declarable `timed` block → operator synthesis.
+ *
+ * Today, an action that needs to run over time hand-authors both a `timed-action`
+ * operator (operators.js) *and* rewrites its own `effects` to the "arm" pattern — see
+ * the `encrypted` trait's `dump` action override in traits.js. `synthesizeTimedActions`
+ * generalizes that: an ActionDef may declare `timed: { duration?, durationTable?,
+ * abortable? }` instead, and this function — called once per constructed node from
+ * NodeGraph's constructor (runtime.js) — does the rewrite for it:
+ *
+ *   1. Synthesizes a `timed-action` operator wired to the action's *original* `effects`
+ *      as `onComplete`.
+ *   2. Replaces the action's own `effects` with the arm pattern: set the active flag,
+ *      zero progress, and — only for a flat `duration` — seed the duration attribute
+ *      directly (mirroring how xploit/reboot seed duration via ctx rather than a grade
+ *      table, so the timed-action operator's grade-table branch is bypassed). A
+ *      `durationTable` is left for the operator itself to resolve on the first armed
+ *      tick, same as the hand-authored probe/dump/fetch/mine operators.
+ *
+ * One runtime engine: this produces the exact operator config shape operators.js
+ * already knows how to run. No second execution path.
+ *
+ * ActionDef objects can be shared by reference across every node that composes a given
+ * trait (traits.js resolves `actionMap.set(action.id, action)` from the trait's own
+ * action list — the same object, not a copy). Mutating that shared object in place
+ * would let the first node to synthesize it silently "steal" the timed-action operator
+ * from every other node using the same trait. So each synthesized action becomes a new
+ * object (map, don't mutate) and each node's `operators` array is rebuilt via spread
+ * (never `.push()`ed in place) — safe even if the same NodeDef object is reused across
+ * more than one NodeGraph construction. The `_timedSynthesized` guard on the *new*
+ * object then only has to protect against re-running synthesis on an
+ * already-synthesized node (idempotency), not against cross-node sharing.
+ */
+
+/** @typedef {import('./runtime.js').NodeState} NodeState */
+/** @typedef {import('./types.js').NodeDef} NodeDef */
+
+import { getTimedActionAttrNames, timedActiveAttr } from "./timed-actions.js";
+
+/**
+ * @param {NodeState | NodeDef} node - the node object under construction; mutated in place
+ *   (`node.operators` / `node.actions` are reassigned to new arrays).
+ */
+export function synthesizeTimedActions(node) {
+  if (!node.actions || node.actions.length === 0) return;
+
+  let operators = node.operators ?? [];
+
+  const actions = node.actions.map((action) => {
+    if (!action.timed || action._timedSynthesized) return action;
+
+    const activeAttr = timedActiveAttr(action.id);
+    const { progressAttr, durationAttr } = getTimedActionAttrNames(action.id);
+
+    operators = [
+      ...operators,
+      {
+        name: "timed-action",
+        action: action.id,
+        activeAttr,
+        ...(action.timed.durationTable ? { durationTable: action.timed.durationTable } : {}),
+        onComplete: action.effects,
+      },
+    ];
+
+    /** @type {import('./types.js').Effect[]} */
+    const armEffects = [
+      { effect: "set-attr", attr: activeAttr, value: true },
+      { effect: "set-attr", attr: progressAttr, value: 0 },
+    ];
+    if (action.timed.duration != null) {
+      armEffects.push({ effect: "set-attr", attr: durationAttr, value: action.timed.duration });
+    }
+
+    return { ...action, _timedSynthesized: true, effects: armEffects };
+  });
+
+  node.operators = operators;
+  node.actions = actions;
+}

--- a/js/core/node-graph/timed-synthesis.js
+++ b/js/core/node-graph/timed-synthesis.js
@@ -61,6 +61,10 @@ export function synthesizeTimedActions(node) {
         activeAttr,
         ...(action.timed.durationTable ? { durationTable: action.timed.durationTable } : {}),
         onComplete: action.effects,
+        // Wired through for the ABORT/nav-cancel structural checks (review fix,
+        // #187 Phase 2): defaults to abortable unless the ActionDef explicitly
+        // opts out via `timed.abortable: false`.
+        _abortable: action.timed.abortable !== false,
       },
     ];
 

--- a/js/core/node-graph/traits.js
+++ b/js/core/node-graph/traits.js
@@ -377,6 +377,9 @@ registerTrait("volatile", {
     activeAttr: "_volatile_armed",
     durationAttrSource: "volatileDelay",
     onComplete: [{ effect: "ctx-call", method: "volatileDetonate", args: ["$nodeId"] }],
+    // Involuntary, like reboot: it self-arms on an owned node and detonates on
+    // its own — ABORT must not be able to disarm it (final review, #187).
+    _abortable: false,
   }],
   actions: [],
   triggers: [{

--- a/js/core/node-graph/triggers.js
+++ b/js/core/node-graph/triggers.js
@@ -9,6 +9,7 @@ import { applyEffect } from "./effects.js";
  * @typedef {Object} StateAccessors
  * @property {(nodeId: string, attr: string) => any} getNodeAttr
  * @property {(name: string) => number} getQuality
+ * @property {(nodeId: string) => boolean} isNodeBusy
  */
 
 /**

--- a/js/core/node-graph/triggers.js
+++ b/js/core/node-graph/triggers.js
@@ -10,6 +10,7 @@ import { applyEffect } from "./effects.js";
  * @property {(nodeId: string, attr: string) => any} getNodeAttr
  * @property {(name: string) => number} getQuality
  * @property {(nodeId: string) => boolean} isNodeBusy
+ * @property {(nodeId: string) => boolean} hasActiveAbortableTimedAction
  */
 
 /**

--- a/js/core/node-graph/types.js
+++ b/js/core/node-graph/types.js
@@ -57,6 +57,10 @@
  * @property {ActionFeedbackSpec} [feedback] - timed-action: inline feedback-profile override
  *   (#187 Phase 3), threaded from ActionDef.feedback by timed-synthesis.js and echoed on the
  *   "start" ACTION_FEEDBACK payload — see js/ui/feedback-profiles.js
+ * @property {boolean} [emitStartOnArm] - timed-action (synthesized only): set by
+ *   timed-synthesis.js for a flat `duration` (no durationTable); makes the operator emit
+ *   "start" on the first counting tick instead of the grade-table branch, which flat
+ *   durations bypass (#187 review fix — flatstart bug)
  */
 
 /**

--- a/js/core/node-graph/types.js
+++ b/js/core/node-graph/types.js
@@ -133,7 +133,7 @@
 
 /**
  * Condition — union of supported condition shapes.
- * @typedef {NodeAttrCondition | QualityGteCondition | QualityEqCondition | QualityFromAttrCondition | AllOfCondition | AnyOfCondition | NotCondition} Condition
+ * @typedef {NodeAttrCondition | QualityGteCondition | QualityEqCondition | QualityFromAttrCondition | NoActiveTimedActionCondition | AllOfCondition | AnyOfCondition | NotCondition} Condition
  */
 
 /**
@@ -165,6 +165,15 @@
  * @property {string} attr           - node attribute containing the quality name
  * @property {number} [gte]          - quality value >= threshold
  * @property {number} [eq]           - quality value === threshold
+ */
+
+/**
+ * Passes when the node has NO active timed-action operator (#187 Phase 2) — a
+ * structural check (via NodeGraph#isNodeBusy) rather than a named-attribute one,
+ * so it also catches a synthesized `timed` action's dynamically-named activeAttr.
+ * @typedef {Object} NoActiveTimedActionCondition
+ * @property {'no-active-timed-action'} type
+ * @property {string} [nodeId]        - omitted in action requires (runtime fills it in)
  */
 
 /**

--- a/js/core/node-graph/types.js
+++ b/js/core/node-graph/types.js
@@ -51,6 +51,9 @@
  * @property {any[]} [onProgressEffects] - timed-action: effects at progress milestones
  * @property {string} [enabledAttr]     - if set, operator is skipped when this node attribute is false
  * @property {boolean} [armable]      - watchdog: stay dormant until the first non-tick message arms it
+ * @property {boolean} [_abortable]   - timed-action (synthesized only): whether ABORT/nav-cancel may
+ *   cancel this action; set by timed-synthesis.js from ActionDef.timed.abortable, defaults to true
+ *   when absent (#187 Phase 2 review fix)
  */
 
 /**
@@ -121,7 +124,9 @@
  * @typedef {Object} TimedActionSpec
  * @property {number} [duration]        - fixed duration in ticks, seeded directly by the arm effects
  * @property {Record<string, number>} [durationTable] - grade → ticks, resolved by the timed-action operator itself
- * @property {boolean} [abortable]      - reserved for a later phase (nav-cancel/ABORT wiring); unused by Phase 1
+ * @property {boolean} [abortable]      - whether ABORT/nav-cancel can cancel this synthesized action;
+ *   defaults to true. Wired onto the synthesized operator as `_abortable` (timed-synthesis.js) and
+ *   read by the `active-abortable-timed-action` condition / getActiveAbortableTimedAction (#187 Phase 2 review fix)
  */
 
 /**
@@ -133,7 +138,7 @@
 
 /**
  * Condition — union of supported condition shapes.
- * @typedef {NodeAttrCondition | QualityGteCondition | QualityEqCondition | QualityFromAttrCondition | NoActiveTimedActionCondition | AllOfCondition | AnyOfCondition | NotCondition} Condition
+ * @typedef {NodeAttrCondition | QualityGteCondition | QualityEqCondition | QualityFromAttrCondition | NoActiveTimedActionCondition | ActiveAbortableTimedActionCondition | AllOfCondition | AnyOfCondition | NotCondition} Condition
  */
 
 /**
@@ -173,6 +178,16 @@
  * so it also catches a synthesized `timed` action's dynamically-named activeAttr.
  * @typedef {Object} NoActiveTimedActionCondition
  * @property {'no-active-timed-action'} type
+ * @property {string} [nodeId]        - omitted in action requires (runtime fills it in)
+ */
+
+/**
+ * Passes when the node HAS an active timed-action operator that ABORT is allowed
+ * to cancel (review fix, #187 Phase 2) — narrower than NoActiveTimedActionCondition:
+ * excludes an action registered `abortable: false` (reboot) or a synthesized action
+ * whose operator carries `_abortable: false`. Drives ABORT_ACTION.requires.
+ * @typedef {Object} ActiveAbortableTimedActionCondition
+ * @property {'active-abortable-timed-action'} type
  * @property {string} [nodeId]        - omitted in action requires (runtime fills it in)
  */
 

--- a/js/core/node-graph/types.js
+++ b/js/core/node-graph/types.js
@@ -104,6 +104,31 @@
  * @property {FollowupStep} [followup]  - if set, choosing this action opens a node-anchored choice panel instead of executing immediately
  * @property {Condition[]} requires   - implicit all-of; all must pass
  * @property {Effect[]} effects
+ * @property {TimedActionSpec} [timed]  - if set, synthesizeTimedActions() (timed-synthesis.js) rewrites
+ *   this action into a timed one at node construction: a `timed-action` operator (operators.js) is
+ *   generated with `onComplete` set to this action's original `effects`, and `effects` itself is
+ *   replaced with the "arm" pattern (set active flag, zero progress, seed duration if given). See #187.
+ * @property {ActionFeedbackSpec} [feedback]  - reserved for a later phase: periodic progress-milestone
+ *   effects (mirrors the timed-action operator's onProgressInterval/onProgressEffects). Not read by
+ *   Phase 1 synthesis.
+ * @property {boolean} [_timedSynthesized]  - set by synthesizeTimedActions() on the *replacement*
+ *   action object it returns; guards against re-synthesizing an already-synthesized node. Never set
+ *   on an author-supplied ActionDef directly (see timed-synthesis.js for why).
+ */
+
+/**
+ * Declares an ActionDef as a timed action (#187, Phase 1). See `timed` on ActionDef.
+ * @typedef {Object} TimedActionSpec
+ * @property {number} [duration]        - fixed duration in ticks, seeded directly by the arm effects
+ * @property {Record<string, number>} [durationTable] - grade → ticks, resolved by the timed-action operator itself
+ * @property {boolean} [abortable]      - reserved for a later phase (nav-cancel/ABORT wiring); unused by Phase 1
+ */
+
+/**
+ * Reserved for a later phase — see `feedback` on ActionDef.
+ * @typedef {Object} ActionFeedbackSpec
+ * @property {number} [interval]
+ * @property {any[]} [effects]
  */
 
 /**

--- a/js/core/node-graph/types.js
+++ b/js/core/node-graph/types.js
@@ -118,6 +118,11 @@
  *   this action into a timed one at node construction: a `timed-action` operator (operators.js) is
  *   generated with `onComplete` set to this action's original `effects`, and `effects` itself is
  *   replaced with the "arm" pattern (set active flag, zero progress, seed duration if given). See #187.
+ * @property {boolean} [instant]  - opts a script/set-piece action OUT of the timed-by-default flip
+ *   (#187 default-flip): a non-core-verb action is synthesized as timed even without an explicit
+ *   `timed` block (default duration) UNLESS `instant: true` is set. For UI/panic/exit actions that
+ *   are not in-world timed work (e.g. CANCEL_TRACE, ACCESS_DARKNET, DISCONNECT). Ignored if `timed`
+ *   is also set (explicit `timed` always wins).
  * @property {ActionFeedbackSpec} [feedback]  - per-action feedback profile override (#187 Phase 3):
  *   { overlay?, drone?, completionCue? }. Layered inline → ACTION_FEEDBACK_PROFILES[actionId]
  *   (central) → DEFAULT_PROFILE — see js/ui/feedback-profiles.js `resolveFeedback()`. Threaded onto

--- a/js/core/node-graph/types.js
+++ b/js/core/node-graph/types.js
@@ -54,6 +54,9 @@
  * @property {boolean} [_abortable]   - timed-action (synthesized only): whether ABORT/nav-cancel may
  *   cancel this action; set by timed-synthesis.js from ActionDef.timed.abortable, defaults to true
  *   when absent (#187 Phase 2 review fix)
+ * @property {ActionFeedbackSpec} [feedback] - timed-action: inline feedback-profile override
+ *   (#187 Phase 3), threaded from ActionDef.feedback by timed-synthesis.js and echoed on the
+ *   "start" ACTION_FEEDBACK payload — see js/ui/feedback-profiles.js
  */
 
 /**
@@ -111,9 +114,12 @@
  *   this action into a timed one at node construction: a `timed-action` operator (operators.js) is
  *   generated with `onComplete` set to this action's original `effects`, and `effects` itself is
  *   replaced with the "arm" pattern (set active flag, zero progress, seed duration if given). See #187.
- * @property {ActionFeedbackSpec} [feedback]  - reserved for a later phase: periodic progress-milestone
- *   effects (mirrors the timed-action operator's onProgressInterval/onProgressEffects). Not read by
- *   Phase 1 synthesis.
+ * @property {ActionFeedbackSpec} [feedback]  - per-action feedback profile override (#187 Phase 3):
+ *   { overlay?, drone?, completionCue? }. Layered inline → ACTION_FEEDBACK_PROFILES[actionId]
+ *   (central) → DEFAULT_PROFILE — see js/ui/feedback-profiles.js `resolveFeedback()`. Threaded onto
+ *   the synthesized timed-action operator's config by timed-synthesis.js and emitted on the
+ *   ACTION_FEEDBACK "start" payload by operators.js so overlay dispatch + the Strudel audio module
+ *   can honor a set-piece author's inline override.
  * @property {boolean} [_timedSynthesized]  - set by synthesizeTimedActions() on the *replacement*
  *   action object it returns; guards against re-synthesizing an already-synthesized node. Never set
  *   on an author-supplied ActionDef directly (see timed-synthesis.js for why).
@@ -130,10 +136,12 @@
  */
 
 /**
- * Reserved for a later phase — see `feedback` on ActionDef.
+ * Per-action feedback profile override (#187 Phase 3) — see `feedback` on ActionDef and
+ * js/ui/feedback-profiles.js.
  * @typedef {Object} ActionFeedbackSpec
- * @property {number} [interval]
- * @property {any[]} [effects]
+ * @property {string} [overlay]        - overlay element name (js/ui/overlays/registry.js)
+ * @property {string} [drone]          - Strudel drone id (js/audio/strudel/data/drones.js)
+ * @property {string} [completionCue]  - Strudel one-shot cue id fired on completion
  */
 
 /**

--- a/js/ui/feedback-profiles.js
+++ b/js/ui/feedback-profiles.js
@@ -1,0 +1,68 @@
+// @ts-check
+// Central per-action feedback profile registry (#187 Phase 3). A timed action's feedback —
+// its overlay animation, sustained drone, and completion cue — resolves by field-level layered
+// lookup: inline (ActionDef.feedback, threaded onto the ACTION_FEEDBACK "start" payload by
+// timed-synthesis.js/operators.js) → ACTION_FEEDBACK_PROFILES[actionId] (this module's central
+// map) → DEFAULT_PROFILE.
+//
+// This module is pure and only does the generic 3-layer lookup. Overlay dispatch
+// (js/ui/overlays/dispatch.js) uses it directly. The Strudel audio module does NOT use
+// resolveFeedback() for drone/completionCue — its resolution order is inline → central →
+// resolveDrone(action) → DEFAULT.drone (js/audio/strudel/data/drones.js `resolveActionDrone`),
+// inserting the legacy resolveDrone() fallback BETWEEN central and DEFAULT so every core verb
+// keeps its bespoke drone with zero enumeration here. That's why ACTION_FEEDBACK_PROFILES below
+// only lists `overlay` overrides for the core verbs — listing their drones here too would create
+// a second, redundant source of truth ahead of the real fallback.
+//
+// DEFAULT_PROFILE's ids ("generic-process" overlay, "generic" drone, "process.done" cue) are not
+// yet backed by real assets — that's Phase 4. Until then they must resolve to "nothing" wherever
+// they're consumed (unregistered overlay name → no element; unregistered drone/cue id → the
+// existing lookups already no-op on an unknown id, same as any other unmapped id today).
+
+import { A } from "../core/action-ids.js";
+
+/**
+ * @typedef {Object} FeedbackProfile
+ * @property {string} [overlay]        - overlay element name (js/ui/overlays/registry.js)
+ * @property {string} [drone]          - Strudel drone id (js/audio/strudel/data/drones.js)
+ * @property {string} [completionCue]  - Strudel one-shot cue id fired on timed-action completion
+ */
+
+/** Fallback profile for any action with no inline or central override. */
+export const DEFAULT_PROFILE = Object.freeze({
+  overlay: "generic-process",
+  drone: "generic",
+  completionCue: "process.done",
+});
+
+/**
+ * Central feedback overrides, keyed by action id. Only the core verbs' bespoke overlay names are
+ * listed — their drone/completion cue are preserved by the audio module's own resolveDrone()
+ * fallback (see the module doc comment above), not re-listed here.
+ * @type {Record<string, FeedbackProfile>}
+ */
+export const ACTION_FEEDBACK_PROFILES = {
+  [A.PROBE]: { overlay: "probe-sweep" },
+  [A.XPLOIT]: { overlay: "exploit-brackets" },
+  [A.DUMP]: { overlay: "read-sectors" },
+  [A.FETCH]: { overlay: "loot-rings" },
+  [A.MINE]: { overlay: "mine-scan" },
+  [A.LIE_LOW]: { overlay: "lie-low-clock" },
+};
+
+/**
+ * Resolve an action's feedback profile via field-level layered lookup: inline → central →
+ * DEFAULT_PROFILE, independently per field.
+ * @param {string} actionId
+ * @param {FeedbackProfile} [inline] - e.g. ActionDef.feedback or an ACTION_FEEDBACK payload's `feedback`
+ * @returns {{ overlay: string, drone: string, completionCue: string }}
+ */
+export function resolveFeedback(actionId, inline = {}) {
+  const central = ACTION_FEEDBACK_PROFILES[actionId] ?? {};
+  const pick = (/** @type {keyof FeedbackProfile} */ key) => inline[key] ?? central[key] ?? DEFAULT_PROFILE[key];
+  return {
+    overlay: /** @type {string} */ (pick("overlay")),
+    drone: /** @type {string} */ (pick("drone")),
+    completionCue: /** @type {string} */ (pick("completionCue")),
+  };
+}

--- a/js/ui/feedback-profiles.js
+++ b/js/ui/feedback-profiles.js
@@ -50,6 +50,12 @@ export const ACTION_FEEDBACK_PROFILES = {
   [A.FETCH]: { overlay: "loot-rings" },
   [A.MINE]: { overlay: "mine-scan" },
   [A.LIE_LOW]: { overlay: "lie-low-clock" },
+  // reboot uses its own bespoke node-pulse treatment (not a generic-overlay ring). "none"
+  // isn't a registered overlay name, so overlay dispatch no-ops for it (#187 default-flip:
+  // reboot is a core verb excluded from the timed-by-default flip, but it emits "start" via
+  // ctx and, having no central overlay entry until now, was resolving to the generic ring
+  // stacked on top of its bespoke pulse).
+  [A.REBOOT]: { overlay: "none" },
 };
 
 /**

--- a/js/ui/feedback-profiles.js
+++ b/js/ui/feedback-profiles.js
@@ -14,10 +14,12 @@
 // only lists `overlay` overrides for the core verbs — listing their drones here too would create
 // a second, redundant source of truth ahead of the real fallback.
 //
-// DEFAULT_PROFILE's ids ("generic-process" overlay, "generic" drone, "process.done" cue) are not
-// yet backed by real assets — that's Phase 4. Until then they must resolve to "nothing" wherever
-// they're consumed (unregistered overlay name → no element; unregistered drone/cue id → the
-// existing lookups already no-op on an unknown id, same as any other unmapped id today).
+// DEFAULT_PROFILE's ids ("generic-process" overlay, "generic" drone, "process.done" cue) are
+// real, registered assets as of #187 Phase 4b (js/ui/overlays/generic-process.js,
+// js/audio/strudel/data/drones.js, js/audio/strudel/data/cues.js) — feel-DRAFT defaults (the
+// Phase 4a session tuned the *visual* overlay with Les; the drone/cue are neutral placeholders,
+// tunable later via preview/sfx.html) so every timed action without a bespoke profile still gets
+// legible feedback.
 
 import { A } from "../core/action-ids.js";
 

--- a/js/ui/generic-process-glyph.js
+++ b/js/ui/generic-process-glyph.js
@@ -1,0 +1,83 @@
+// @ts-check
+// Pure geometry for the generic default "process running" overlay (#187 Phase 4b) — a segmented
+// polygon ring around a node whose edges light up clockwise from the top as progress goes 0→1.
+// Straight polygon-edge chords (NOT arcs) per the retro-vector "no easy curves" rule (CLAUDE.md).
+// No DOM here — unit-testable; consumed by both the overlay element
+// (js/ui/overlays/generic-process.js) and the preview harness.
+//
+// Each of the `segments` edges is a chord centered on its own "slot" angle — 12 o'clock plus
+// `i * step`, stepping clockwise (same convention as facet.js's vertex angles) — shortened
+// symmetrically by `gapFrac` so a small gap separates neighboring edges. `rotationRad` lets the
+// caller apply the idle CW spin (~8deg/s, see the overlay element) without this module knowing
+// about wall-clock time. This module does NOT compute opacity/pulse — it only reports geometry +
+// lit/leading classification; the overlay element layers the (time-driven) shimmer on top.
+
+/** Default segment count — matches the node dodecagon (facet.js FACET_SIDES). */
+export const GENERIC_PROCESS_SEGMENTS = 12;
+
+/** Default inter-segment gap, as a fraction of each segment's angular span. */
+export const GENERIC_PROCESS_GAP_FRAC = 0.18;
+
+/** First segment centered at 12 o'clock (straight up); SVG y is down, so up = -PI/2. */
+const TOP = -Math.PI / 2;
+
+/**
+ * @typedef {Object} ProcessRingEdge
+ * @property {number} index
+ * @property {number} x1 @property {number} y1
+ * @property {number} x2 @property {number} y2
+ * @property {boolean} lit       - fully filled (progress has passed this segment)
+ * @property {boolean} leading   - the currently-filling segment (pulses in the overlay)
+ */
+
+/**
+ * @typedef {Object} ProcessRingGeometry
+ * @property {ProcessRingEdge[]} edges
+ * @property {number} litCount
+ * @property {number|null} leadingIndex - index of the currently-filling edge, or null once
+ *   progress reaches 1 (nothing left to fill).
+ */
+
+/**
+ * Compute the segmented-ring geometry for a given progress.
+ * @param {number} progress       0..1 (clamped; non-finite treated as 0)
+ * @param {number} [segments]
+ * @param {number} [gapFrac]      fraction of each segment's angular span omitted (split evenly
+ *   between both ends, so the drawn chord stays centered on the segment's slot angle)
+ * @param {number} [rotationRad]  additional clockwise rotation applied to every edge (idle spin)
+ * @param {number} [radius]       ring radius; edges are centered on (0,0) — the caller translates
+ *   to the node's screen position
+ * @returns {ProcessRingGeometry}
+ */
+export function generateProcessRing(
+  progress,
+  segments = GENERIC_PROCESS_SEGMENTS,
+  gapFrac = GENERIC_PROCESS_GAP_FRAC,
+  rotationRad = 0,
+  radius = 1,
+) {
+  const p = Number.isFinite(progress) ? Math.max(0, Math.min(1, progress)) : 0;
+  const litFloat = p * segments;
+  const litCount = Math.min(segments, Math.floor(litFloat));
+  const leadingIndex = litCount >= segments ? null : litCount;
+
+  const step = (2 * Math.PI) / segments;
+  const half = (step * (1 - gapFrac)) / 2;
+
+  /** @type {ProcessRingEdge[]} */
+  const edges = [];
+  for (let i = 0; i < segments; i++) {
+    const center = TOP + i * step + rotationRad;
+    const a1 = center - half;
+    const a2 = center + half;
+    edges.push({
+      index: i,
+      x1: radius * Math.cos(a1), y1: radius * Math.sin(a1),
+      x2: radius * Math.cos(a2), y2: radius * Math.sin(a2),
+      lit: i < litCount,
+      leading: i === leadingIndex,
+    });
+  }
+
+  return { edges, litCount, leadingIndex };
+}

--- a/js/ui/overlays/dispatch.js
+++ b/js/ui/overlays/dispatch.js
@@ -2,9 +2,19 @@
 // Pure ACTION_FEEDBACK state machine for the overlay animations. Extracted from
 // visual-renderer so the start→progress→complete/cancel transitions and the
 // active-node tracking can be unit-tested without a DOM. The visual-renderer
-// passes its mounted `byAction` map and a persistent `activeNodeIds` map.
+// passes its mounted `byName` map and a persistent `activeByAction` map.
+//
+// Overlay resolution is name-keyed (#187 Phase 3): on "start", the action's feedback profile
+// (inline payload.feedback → central ACTION_FEEDBACK_PROFILES → DEFAULT_PROFILE, see
+// feedback-profiles.js) resolves an overlay NAME, remembered per in-flight action for the rest of
+// its lifecycle — the "progress"/"complete"/"cancel" payloads don't carry `feedback`, only
+// "start" does (operators.js), so re-resolving on every phase could pick a different overlay than
+// the one actually driven at "start" if an inline override was used. An unregistered overlay name
+// (e.g. the Phase-4-pending "generic-process" default) is a safe no-op — the same "no overlay"
+// degrade an unmapped action (e.g. "reboot") already gets today.
 
 import { A } from "../../core/action-ids.js";
+import { resolveFeedback } from "../feedback-profiles.js";
 
 /**
  * @typedef {{ sync: (nodeId: string, progress: number) => void, clear: () => void }} OverlayLike
@@ -12,23 +22,33 @@ import { A } from "../../core/action-ids.js";
 
 /**
  * Drive the overlay for one ACTION_FEEDBACK event.
- * @param {Map<string, OverlayLike>} byAction - action id → mounted overlay
- * @param {Map<string, string>} activeNodeIds - action id → in-flight node id (mutated)
- * @param {{ nodeId?: string, action: string, phase: string, progress?: number }} payload
+ * @param {Map<string, OverlayLike>} byName - overlay name → mounted overlay
+ * @param {Map<string, { nodeId: string, overlayName: string }>} activeByAction - action id → in-flight { nodeId, overlayName } (mutated)
+ * @param {{ nodeId?: string, action: string, phase: string, progress?: number, feedback?: { overlay?: string } }} payload
  * @param {{ onXploitProgress?: (progress: number) => void }} [hooks]
  */
-export function dispatchActionFeedback(byAction, activeNodeIds, payload, hooks = {}) {
-  const { nodeId, action, phase, progress } = payload;
-  const ov = byAction.get(action);
-  if (!ov) return;
+export function dispatchActionFeedback(byName, activeByAction, payload, hooks = {}) {
+  const { nodeId, action, phase, progress, feedback } = payload;
 
   if (phase === "start") {
-    if (nodeId) activeNodeIds.set(action, nodeId);
-  } else if (phase === "progress" && activeNodeIds.get(action)) {
-    ov.sync(/** @type {string} */ (activeNodeIds.get(action)), /** @type {number} */ (progress));
-    if (action === A.XPLOIT) hooks.onXploitProgress?.(/** @type {number} */ (progress));
+    if (nodeId) {
+      const overlayName = resolveFeedback(action, feedback).overlay;
+      activeByAction.set(action, { nodeId, overlayName });
+    }
+    return;
+  }
+
+  const active = activeByAction.get(action);
+  if (!active) return;
+  const ov = byName.get(active.overlayName);
+
+  if (phase === "progress") {
+    if (ov) {
+      ov.sync(active.nodeId, /** @type {number} */ (progress));
+      if (action === A.XPLOIT) hooks.onXploitProgress?.(/** @type {number} */ (progress));
+    }
   } else if (phase === "complete" || phase === "cancel") {
-    ov.clear();
-    activeNodeIds.delete(action);
+    ov?.clear();
+    activeByAction.delete(action);
   }
 }

--- a/js/ui/overlays/generic-process.js
+++ b/js/ui/overlays/generic-process.js
@@ -10,7 +10,7 @@
 //
 // Locked values from the Phase 4a feel loop with Les (docs/dev-sessions/2026-07-02-1031-timed-
 // actions-phase1/notes.md): hue 141 (green), stroke 2.0, unlit opacity ~0.10, gap 0.18, idle spin
-// ~8deg/s CW, leading-edge pulse amplitude ~0.5, ring radius ~3.4x the node's rendered radius
+// ~8deg/s CW, leading-edge pulse amplitude ~0.5, ring radius = the node's rendered radius (node edge)
 // (the lab used ~54px around a ~16px node).
 
 import { html } from "lit";
@@ -22,7 +22,9 @@ const COLOR = "hsl(141, 100%, 60%)";
 const STROKE_WIDTH = "2";
 const OFF = 0.10; // unlit edge opacity
 const ON = 1;      // lit edge opacity
-const RADIUS_FACTOR = 3.4; // ring radius as a multiple of the node's rendered radius
+// Ring is drawn at the node's rendered radius — matching probe-sweep/lie-low, which size to the
+// node's outer edge (probe-sweep uses r-1). So the ring's diameter equals the node's.
+const RADIUS_FACTOR = 1.0;
 const SPIN_RAD_PER_MS = (8 * Math.PI) / 180 / 1000; // ~8deg/s clockwise idle spin
 const PULSE_PARAM = 0.5;    // leading-edge shimmer amplitude (locked value)
 const PULSE_RATE_MS = 120;  // fast shimmer
@@ -64,8 +66,8 @@ class GenericProcessOverlay extends NodeOverlay {
     const a = this._anchor();
     if (!a) { svg.style.opacity = "0"; return; }
     const { pos, r } = a;
-    // The ring is wider than the node itself (the lab used ~54px around a ~16px node), so give
-    // the SVG enough padding to draw it without clipping.
+    // Ring sits just outside the node's outer edge (see RADIUS_FACTOR) — sized to the node like the
+    // other overlays, not the oversized lab ratio.
     const ringRadius = r * RADIUS_FACTOR;
     this._place(svg, pos, ringRadius);
     const cx = ringRadius, cy = ringRadius;

--- a/js/ui/overlays/generic-process.js
+++ b/js/ui/overlays/generic-process.js
@@ -1,0 +1,106 @@
+// @ts-check
+// GENERIC PROCESS overlay (#187 Phase 4b): the fallback "something is happening" overlay for any
+// timed action without a bespoke one — DEFAULT_PROFILE.overlay in feedback-profiles.js. A
+// 12-sided segmented polygon ring around the node whose edges light up clockwise from the top as
+// progress goes 0→1, plus a slow idle CW spin and a pulsing leading edge so the effect still
+// reads even while progress sits still between ticks. Stroke-only, straight polygon-edge chords
+// (not arcs) per the retro-vector "no easy curves" rule; relies on the shared #overlay-bloom
+// layer filter for glow — no per-element filter/drop-shadow (CLAUDE.md "one glow owner per
+// layer"). Geometry comes from js/ui/generic-process-glyph.js (pure, unit-tested).
+//
+// Locked values from the Phase 4a feel loop with Les (docs/dev-sessions/2026-07-02-1031-timed-
+// actions-phase1/notes.md): hue 141 (green), stroke 2.0, unlit opacity ~0.10, gap 0.18, idle spin
+// ~8deg/s CW, leading-edge pulse amplitude ~0.5, ring radius ~3.4x the node's rendered radius
+// (the lab used ~54px around a ~16px node).
+
+import { html } from "lit";
+import { NodeOverlay } from "./node-overlay.js";
+import { GENERIC_PROCESS_SEGMENTS, GENERIC_PROCESS_GAP_FRAC, generateProcessRing } from "../generic-process-glyph.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const COLOR = "hsl(141, 100%, 60%)";
+const STROKE_WIDTH = "2";
+const OFF = 0.10; // unlit edge opacity
+const ON = 1;      // lit edge opacity
+const RADIUS_FACTOR = 3.4; // ring radius as a multiple of the node's rendered radius
+const SPIN_RAD_PER_MS = (8 * Math.PI) / 180 / 1000; // ~8deg/s clockwise idle spin
+const PULSE_PARAM = 0.5;    // leading-edge shimmer amplitude (locked value)
+const PULSE_RATE_MS = 120;  // fast shimmer
+
+class GenericProcessOverlay extends NodeOverlay {
+  constructor() {
+    super();
+    // Accumulated active time (ms) — drives the idle spin + leading-edge pulse continuously,
+    // same managed-loop idiom as lie-low-clock.js, so this never adds an ad-hoc per-element RAF.
+    this._spinMs = 0;
+  }
+
+  render() {
+    return html`
+      <svg style="position:absolute; opacity:0; pointer-events:none; overflow:visible; z-index:5; transition:opacity 0.15s ease;">
+        <g class="edges"></g>
+      </svg>`;
+  }
+
+  /** @param {string} nodeId @param {number} progress */
+  sync(nodeId, progress) {
+    super.sync(nodeId, progress);
+    this.startTimeLoop(); // idle spin + leading-edge pulse run continuously while active
+  }
+
+  _timeFrame(now, dtMs) {
+    this._spinMs += dtMs;
+    this._render();
+  }
+
+  clear() {
+    super.clear(); // stops the time loop + hides
+    this._spinMs = 0;
+  }
+
+  _render() {
+    const svg = this._svg();
+    if (!svg) return;
+    const a = this._anchor();
+    if (!a) { svg.style.opacity = "0"; return; }
+    const { pos, r } = a;
+    // The ring is wider than the node itself (the lab used ~54px around a ~16px node), so give
+    // the SVG enough padding to draw it without clipping.
+    const ringRadius = r * RADIUS_FACTOR;
+    this._place(svg, pos, ringRadius);
+    const cx = ringRadius, cy = ringRadius;
+
+    const group = svg.querySelector(".edges");
+    if (group.childElementCount !== GENERIC_PROCESS_SEGMENTS) {
+      group.replaceChildren();
+      for (let i = 0; i < GENERIC_PROCESS_SEGMENTS; i++) {
+        const seg = document.createElementNS(SVG_NS, "line");
+        seg.setAttribute("stroke", COLOR);
+        seg.setAttribute("stroke-width", STROKE_WIDTH);
+        seg.setAttribute("stroke-linecap", "round");
+        group.appendChild(seg);
+      }
+    }
+
+    const rotationRad = (this._spinMs * SPIN_RAD_PER_MS) % (2 * Math.PI);
+    const { edges } = generateProcessRing(
+      this.progress, GENERIC_PROCESS_SEGMENTS, GENERIC_PROCESS_GAP_FRAC, rotationRad, ringRadius,
+    );
+    // Subtle shimmer on the leading (currently-filling) edge only — a fast sine wobble around
+    // full brightness, same shape as the Phase 4a lab's `1 + pulse*0.5*sin(t/120)`.
+    const shimmer = 1 + PULSE_PARAM * 0.5 * Math.sin(this._spinMs / PULSE_RATE_MS);
+    const leadOpacity = Math.max(OFF, Math.min(1, ON * 0.9 * shimmer));
+
+    for (const edge of edges) {
+      const seg = group.children[edge.index];
+      seg.setAttribute("x1", (cx + edge.x1).toFixed(2));
+      seg.setAttribute("y1", (cy + edge.y1).toFixed(2));
+      seg.setAttribute("x2", (cx + edge.x2).toFixed(2));
+      seg.setAttribute("y2", (cy + edge.y2).toFixed(2));
+      const op = edge.lit ? ON : edge.leading ? leadOpacity : OFF;
+      seg.setAttribute("stroke-opacity", op.toFixed(3));
+    }
+  }
+}
+
+customElements.define("generic-process-overlay", GenericProcessOverlay);

--- a/js/ui/overlays/index.js
+++ b/js/ui/overlays/index.js
@@ -1,6 +1,6 @@
 // @ts-check
 // Browser-only barrel for node-graph overlay animations. Importing this file
-// registers all six overlay custom elements. mountOverlays() creates one
+// registers all overlay custom elements. mountOverlays() creates one
 // element per registry descriptor, appends them into a container, and returns
 // lookup maps for the game's dispatch (by overlay name, #187 Phase 3) and
 // shared iteration (by key).
@@ -12,6 +12,7 @@ import "./loot-rings.js";
 import "./exploit-brackets.js";
 import "./ice-detect.js";
 import "./lie-low-clock.js";
+import "./generic-process.js";
 import { OVERLAY_DESCRIPTORS } from "./registry.js";
 import { onViewport, setReticleOverlay } from "../graph.js";
 import { mountReticle } from "./selection-reticle.js";

--- a/js/ui/overlays/index.js
+++ b/js/ui/overlays/index.js
@@ -2,7 +2,8 @@
 // Browser-only barrel for node-graph overlay animations. Importing this file
 // registers all six overlay custom elements. mountOverlays() creates one
 // element per registry descriptor, appends them into a container, and returns
-// lookup maps for the game's dispatch (by action) and shared iteration (by key).
+// lookup maps for the game's dispatch (by overlay name, #187 Phase 3) and
+// shared iteration (by key).
 
 import "./probe-sweep.js";
 import "./mine-scan.js";
@@ -18,18 +19,18 @@ import { FlowLayer } from "./flow-layer.js";
 
 /**
  * @param {HTMLElement} container
- * @returns {{ byKey: Map<string, any>, byAction: Map<string, any> }}
+ * @returns {{ byKey: Map<string, any>, byName: Map<string, any> }}
  */
 export function mountOverlays(container) {
   const byKey = new Map();
-  const byAction = new Map();
+  const byName = new Map();
   for (const d of OVERLAY_DESCRIPTORS) {
     const el = document.createElement(d.tag);
     container.appendChild(el);
     byKey.set(d.key, el);
-    if (d.driver === "action-feedback" && d.action) byAction.set(d.action, el);
+    if (d.driver === "action-feedback") byName.set(d.name, el);
   }
-  return { byKey, byAction };
+  return { byKey, byName };
 }
 
 /**

--- a/js/ui/overlays/registry.js
+++ b/js/ui/overlays/registry.js
@@ -4,12 +4,19 @@
 // (./index.js) maps these descriptors to mounted custom elements; the game's
 // visual-renderer dispatch, the pan/zoom re-render, the RUN_STARTED reset, and
 // the preview harness all iterate this list instead of hardcoded switches.
+//
+// `name` (#187 Phase 3) is the canonical overlay identifier used by the feedback-profile system
+// (js/ui/feedback-profiles.js) — the central ACTION_FEEDBACK_PROFILES map and any inline
+// ActionDef.feedback override name overlays by this id, not by action id. dispatch.js resolves
+// action → resolveFeedback(action, inline).overlay → this name → the mounted element.
 
 import { A } from "../../core/action-ids.js";
+import { resolveFeedback } from "../feedback-profiles.js";
 
 /**
  * @typedef {Object} OverlayDescriptor
  * @property {string} key - stable short key (also the preview demo node suffix)
+ * @property {string} name - canonical overlay name resolved by feedback-profiles.js
  * @property {string|null} action - action id that triggers this overlay, or null for non-action drivers
  * @property {string} tag - custom element tag name (registered by ./index.js)
  * @property {string} label - human label (preview controls / demo node)
@@ -19,20 +26,31 @@ import { A } from "../../core/action-ids.js";
 
 /** @type {OverlayDescriptor[]} */
 export const OVERLAY_DESCRIPTORS = [
-  { key: "probe",   action: A.PROBE,  tag: "probe-sweep-overlay",      label: "PROBE",   driver: "action-feedback", demo: { type: "router",      grade: "C" } },
-  { key: "mine",    action: A.MINE,   tag: "mine-scan-overlay",        label: "MINE",    driver: "action-feedback", demo: { type: "cryptovault", grade: "A" } },
-  { key: "read",    action: A.DUMP,   tag: "read-sectors-overlay",     label: "DUMP",    driver: "action-feedback", demo: { type: "fileserver",  grade: "C" } },
-  { key: "loot",    action: A.FETCH,  tag: "loot-rings-overlay",       label: "FETCH",   driver: "action-feedback", demo: { type: "fileserver",  grade: "B" } },
-  { key: "exploit", action: A.XPLOIT, tag: "exploit-brackets-overlay", label: "XPLOIT",  driver: "action-feedback", demo: { type: "firewall",     grade: "B" } },
-  { key: "ice",     action: null,     tag: "ice-detect-overlay",       label: "ICE DET", driver: "ice-timer",       demo: { type: "ids",          grade: "A" } },
-  { key: "lielow",  action: A.LIE_LOW, tag: "lie-low-clock-overlay",    label: "LIE LOW", driver: "action-feedback", demo: { type: "wan",          grade: "F" } },
+  { key: "probe",   name: "probe-sweep",      action: A.PROBE,   tag: "probe-sweep-overlay",      label: "PROBE",   driver: "action-feedback", demo: { type: "router",      grade: "C" } },
+  { key: "mine",    name: "mine-scan",        action: A.MINE,    tag: "mine-scan-overlay",        label: "MINE",    driver: "action-feedback", demo: { type: "cryptovault", grade: "A" } },
+  { key: "read",    name: "read-sectors",     action: A.DUMP,    tag: "read-sectors-overlay",     label: "DUMP",    driver: "action-feedback", demo: { type: "fileserver",  grade: "C" } },
+  { key: "loot",    name: "loot-rings",       action: A.FETCH,   tag: "loot-rings-overlay",       label: "FETCH",   driver: "action-feedback", demo: { type: "fileserver",  grade: "B" } },
+  { key: "exploit", name: "exploit-brackets", action: A.XPLOIT,  tag: "exploit-brackets-overlay", label: "XPLOIT",  driver: "action-feedback", demo: { type: "firewall",     grade: "B" } },
+  { key: "ice",     name: "ice-detect",       action: null,      tag: "ice-detect-overlay",       label: "ICE DET", driver: "ice-timer",       demo: { type: "ids",          grade: "A" } },
+  { key: "lielow",  name: "lie-low-clock",    action: A.LIE_LOW, tag: "lie-low-clock-overlay",    label: "LIE LOW", driver: "action-feedback", demo: { type: "wan",          grade: "F" } },
 ];
 
 /**
- * Resolve the action-feedback overlay for an action id.
+ * Resolve a descriptor by its canonical overlay name (#187 Phase 3). Unknown/not-yet-registered
+ * names (e.g. the Phase-4-pending "generic-process" default) resolve to null.
+ * @param {string} name
+ * @returns {OverlayDescriptor|null}
+ */
+export function descriptorForName(name) {
+  return OVERLAY_DESCRIPTORS.find((d) => d.name === name) ?? null;
+}
+
+/**
+ * Resolve the action-feedback overlay for an action id, via the action's resolved feedback
+ * profile (central ACTION_FEEDBACK_PROFILES override, else the Phase-4-pending DEFAULT).
  * @param {string} action
  * @returns {OverlayDescriptor|null}
  */
 export function overlayDescriptorForAction(action) {
-  return OVERLAY_DESCRIPTORS.find((d) => d.driver === "action-feedback" && d.action === action) ?? null;
+  return descriptorForName(resolveFeedback(action).overlay);
 }

--- a/js/ui/overlays/registry.js
+++ b/js/ui/overlays/registry.js
@@ -33,11 +33,16 @@ export const OVERLAY_DESCRIPTORS = [
   { key: "exploit", name: "exploit-brackets", action: A.XPLOIT,  tag: "exploit-brackets-overlay", label: "XPLOIT",  driver: "action-feedback", demo: { type: "firewall",     grade: "B" } },
   { key: "ice",     name: "ice-detect",       action: null,      tag: "ice-detect-overlay",       label: "ICE DET", driver: "ice-timer",       demo: { type: "ids",          grade: "A" } },
   { key: "lielow",  name: "lie-low-clock",    action: A.LIE_LOW, tag: "lie-low-clock-overlay",    label: "LIE LOW", driver: "action-feedback", demo: { type: "wan",          grade: "F" } },
+  // #187 Phase 4b: the DEFAULT_PROFILE.overlay fallback (feedback-profiles.js) — not keyed to a
+  // single action id (action: null, like ice-detect's timer-driven action: null), used whenever
+  // an action has no bespoke central/inline overlay.
+  { key: "generic", name: "generic-process",  action: null,      tag: "generic-process-overlay",  label: "GENERIC", driver: "action-feedback", demo: { type: "workstation", grade: "C" } },
 ];
 
 /**
- * Resolve a descriptor by its canonical overlay name (#187 Phase 3). Unknown/not-yet-registered
- * names (e.g. the Phase-4-pending "generic-process" default) resolve to null.
+ * Resolve a descriptor by its canonical overlay name (#187 Phase 3). Any truly unregistered name
+ * resolves to null; as of Phase 4b, the DEFAULT_PROFILE fallback name ("generic-process") is a
+ * real registered descriptor, so it no longer degrades to null here.
  * @param {string} name
  * @returns {OverlayDescriptor|null}
  */
@@ -47,7 +52,8 @@ export function descriptorForName(name) {
 
 /**
  * Resolve the action-feedback overlay for an action id, via the action's resolved feedback
- * profile (central ACTION_FEEDBACK_PROFILES override, else the Phase-4-pending DEFAULT).
+ * profile (central ACTION_FEEDBACK_PROFILES override, else DEFAULT_PROFILE — the "generic-process"
+ * fallback, registered as of #187 Phase 4b).
  * @param {string} action
  * @returns {OverlayDescriptor|null}
  */

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -87,10 +87,12 @@ export function initVisualRenderer() {
   on(E.NODE_REVEALED, refreshFlows);
   on(E.RUN_STARTED, () => flowLayer.clear());
 
-  // action id → node id of the in-flight animation (tracked across feedback events)
+  // action id → { nodeId, overlayName } of the in-flight animation (tracked across feedback
+  // events; the overlay name is resolved once at "start" — see dispatch.js — since later
+  // phases don't carry the action's feedback profile)
   const activeNodeIds = new Map();
   on(E.ACTION_FEEDBACK, (payload) =>
-    dispatchActionFeedback(overlays.byAction, activeNodeIds, payload, { onXploitProgress: updateExploitProgress }));
+    dispatchActionFeedback(overlays.byName, activeNodeIds, payload, { onXploitProgress: updateExploitProgress }));
 
   // Exploit result flash — driven by ACTION_RESOLVED
   on(E.ACTION_RESOLVED, ({ action, nodeId, success }) => {

--- a/scripts/bot/execute.js
+++ b/scripts/bot/execute.js
@@ -8,12 +8,27 @@ import { emitEvent, on, off, E, tick, getState } from "../lib/headless-engine.js
 import { buyFromStore } from "../../js/core/store-logic.js";
 import { A } from "../../js/core/action-ids.js";
 
-/** Actions that start a timed process and need tick-forward */
-const TIMED_ACTIONS = new Set([A.PROBE, A.XPLOIT, A.DUMP, A.FETCH, A.REBOOT, A.MINE]);
+/**
+ * Actions that start a timed process and need tick-forward. CORRUPT joined this set
+ * in #187 Phase 5 (was instant) — it now emits ACTION_RESOLVED on completion
+ * (reconfigureNode), same as the other timed verbs here, so tickUntilResolved can wait
+ * for it properly.
+ */
+const TIMED_ACTIONS = new Set([A.PROBE, A.XPLOIT, A.DUMP, A.FETCH, A.REBOOT, A.MINE, A.CORRUPT]);
 
-/** Actions that are instant (no ticking needed) */
+/**
+ * Actions that are instant (no ticking needed). crack-vault/extract-key became timed
+ * node-graph actions in #187 Phase 5, but they're kept here deliberately: they don't
+ * emit ACTION_RESOLVED (only giveReward/set-attr/log via onComplete), so
+ * tickUntilResolved would never see them resolve and would spin to the tick budget.
+ * They're one-shot puzzle actions the bot proposes at most once per node
+ * (puzzleStrategy's `completed` set) — firing-and-forgetting is safe, since the main
+ * loop always advances at least one tick per cycle (`totalTicks += result.ticksUsed || 1`
+ * in loop.js), so the armed action completes naturally in the background over the
+ * following cycles.
+ */
 const INSTANT_ACTIONS = new Set([
-  A.TARGET, A.UNTARGET, A.JACKOUT, A.CORRUPT, A.CANCEL_TRACE,
+  A.TARGET, A.UNTARGET, A.JACKOUT, A.CANCEL_TRACE,
   A.ABORT, A.KICK, A.ACCESS_DARKNET,
   // Set-piece puzzle actions
   "activate", "scan-lock", "scan-vault", "crack-vault",

--- a/tests/feedback-profiles.test.js
+++ b/tests/feedback-profiles.test.js
@@ -11,7 +11,7 @@ import assert from "node:assert/strict";
 import { resolveFeedback, ACTION_FEEDBACK_PROFILES, DEFAULT_PROFILE } from "../js/ui/feedback-profiles.js";
 import { A } from "../js/core/action-ids.js";
 
-test("DEFAULT_PROFILE is the Phase-4-pending generic profile", () => {
+test("DEFAULT_PROFILE is the generic fallback profile (ids registered as of #187 Phase 4b)", () => {
   assert.deepEqual(DEFAULT_PROFILE, {
     overlay: "generic-process",
     drone: "generic",

--- a/tests/feedback-profiles.test.js
+++ b/tests/feedback-profiles.test.js
@@ -57,6 +57,16 @@ test("an unmapped verb resolves overlay/drone/cue all to the DEFAULT ids", () =>
   assert.equal(resolved.completionCue, "process.done");
 });
 
+test("reboot resolves to the 'none' overlay sentinel, not the generic-process default (#187 default-flip)", () => {
+  // reboot is a core verb (excluded from the timed-by-default flip) with its own bespoke
+  // node-pulse treatment. Before this central entry existed, an unmapped reboot fell through
+  // to DEFAULT_PROFILE's "generic-process" overlay and mounted the generic ring on top of its
+  // bespoke pulse. "none" isn't a registered overlay name, so overlay dispatch no-ops for it.
+  const resolved = resolveFeedback(A.REBOOT);
+  assert.equal(resolved.overlay, "none");
+  assert.notEqual(resolved.overlay, DEFAULT_PROFILE.overlay);
+});
+
 test("every core verb in the central profile only declares overlay (drone/cue stay the audio module's job)", () => {
   for (const [id, profile] of Object.entries(ACTION_FEEDBACK_PROFILES)) {
     assert.ok(profile.overlay, `${id} should declare a central overlay override`);

--- a/tests/feedback-profiles.test.js
+++ b/tests/feedback-profiles.test.js
@@ -1,0 +1,66 @@
+// @ts-check
+// #187 Phase 3: per-action feedback profile ({ overlay, drone, completionCue }) resolved by a
+// field-level layered lookup: inline (ActionDef.feedback / ACTION_FEEDBACK payload.feedback) →
+// ACTION_FEEDBACK_PROFILES[actionId] (central) → DEFAULT_PROFILE. Pure resolution only — the
+// audio module composes its OWN drone/cue resolution on top of this (see strudel-drones.test.js /
+// strudel-cues.test.js) because the legacy resolveDrone() fallback sits BETWEEN central and
+// DEFAULT for drones, which this generic 3-layer resolver doesn't know about.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveFeedback, ACTION_FEEDBACK_PROFILES, DEFAULT_PROFILE } from "../js/ui/feedback-profiles.js";
+import { A } from "../js/core/action-ids.js";
+
+test("DEFAULT_PROFILE is the Phase-4-pending generic profile", () => {
+  assert.deepEqual(DEFAULT_PROFILE, {
+    overlay: "generic-process",
+    drone: "generic",
+    completionCue: "process.done",
+  });
+});
+
+test("an unmapped action resolves entirely to DEFAULT_PROFILE", () => {
+  const resolved = resolveFeedback("some-setpiece-verb");
+  assert.deepEqual(resolved, DEFAULT_PROFILE);
+});
+
+test("a core verb's central overlay override wins over DEFAULT", () => {
+  const resolved = resolveFeedback(A.PROBE);
+  assert.equal(resolved.overlay, ACTION_FEEDBACK_PROFILES[A.PROBE].overlay);
+  assert.notEqual(resolved.overlay, DEFAULT_PROFILE.overlay);
+});
+
+test("central profile only overrides the fields it lists — others still fall to DEFAULT", () => {
+  // Core verbs list only `overlay` centrally (drone/cue are preserved by the audio module's own
+  // resolveDrone fallback, not re-listed here — see js/audio/strudel/index.js).
+  const resolved = resolveFeedback(A.PROBE);
+  assert.equal(resolved.drone, DEFAULT_PROFILE.drone);
+  assert.equal(resolved.completionCue, DEFAULT_PROFILE.completionCue);
+});
+
+test("inline wins over central for a field it sets", () => {
+  const resolved = resolveFeedback(A.PROBE, { overlay: "custom-overlay" });
+  assert.equal(resolved.overlay, "custom-overlay");
+});
+
+test("inline layering is per-field — an inline field left unset still falls through to central/DEFAULT", () => {
+  const resolved = resolveFeedback(A.PROBE, { drone: "custom-drone" });
+  assert.equal(resolved.drone, "custom-drone");
+  assert.equal(resolved.overlay, ACTION_FEEDBACK_PROFILES[A.PROBE].overlay, "overlay still falls to central");
+  assert.equal(resolved.completionCue, DEFAULT_PROFILE.completionCue, "cue still falls to DEFAULT");
+});
+
+test("an unmapped verb resolves overlay/drone/cue all to the DEFAULT ids", () => {
+  const resolved = resolveFeedback("crack-vault");
+  assert.equal(resolved.overlay, "generic-process");
+  assert.equal(resolved.drone, "generic");
+  assert.equal(resolved.completionCue, "process.done");
+});
+
+test("every core verb in the central profile only declares overlay (drone/cue stay the audio module's job)", () => {
+  for (const [id, profile] of Object.entries(ACTION_FEEDBACK_PROFILES)) {
+    assert.ok(profile.overlay, `${id} should declare a central overlay override`);
+    assert.equal(profile.drone, undefined, `${id} should not re-list a drone centrally (resolveDrone fallback owns it)`);
+    assert.equal(profile.completionCue, undefined, `${id} should not re-list a completion cue centrally`);
+  }
+});

--- a/tests/generic-process-glyph.test.js
+++ b/tests/generic-process-glyph.test.js
@@ -1,0 +1,147 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  GENERIC_PROCESS_SEGMENTS,
+  GENERIC_PROCESS_GAP_FRAC,
+  generateProcessRing,
+} from "../js/ui/generic-process-glyph.js";
+
+const near = (a, b, eps = 1e-6) => Math.abs(a - b) <= eps;
+
+test("GENERIC_PROCESS_SEGMENTS is 12, GENERIC_PROCESS_GAP_FRAC is 0.18", () => {
+  assert.equal(GENERIC_PROCESS_SEGMENTS, 12);
+  assert.equal(GENERIC_PROCESS_GAP_FRAC, 0.18);
+});
+
+test("progress 0 lights no edges", () => {
+  const { edges, litCount } = generateProcessRing(0, 12);
+  assert.equal(litCount, 0);
+  assert.ok(edges.every((e) => e.lit === false));
+});
+
+test("progress 0.5 with 12 segments lights 6 edges", () => {
+  const { edges, litCount } = generateProcessRing(0.5, 12);
+  assert.equal(litCount, 6);
+  assert.equal(edges.filter((e) => e.lit).length, 6);
+});
+
+test("progress 1 lights all 12 edges", () => {
+  const { edges, litCount } = generateProcessRing(1, 12);
+  assert.equal(litCount, 12);
+  assert.ok(edges.every((e) => e.lit === true));
+});
+
+test("edges is always `segments` long, indexed 0..segments-1", () => {
+  const { edges } = generateProcessRing(0.3, 12);
+  assert.equal(edges.length, 12);
+  edges.forEach((e, i) => assert.equal(e.index, i));
+});
+
+test("lit edges advance clockwise starting from the top (index 0 is 12 o'clock)", () => {
+  // At progress just past the 5th slot (5/12), edges 0..4 should be lit, 5..11 not yet.
+  const { edges } = generateProcessRing(5 / 12 + 0.01, 12);
+  for (let i = 0; i < 5; i++) assert.equal(edges[i].lit, true, `edge ${i} should be lit`);
+  for (let i = 5; i < 12; i++) assert.equal(edges[i].lit, false, `edge ${i} should not be lit yet`);
+
+  // Edge 0 is centered at 12 o'clock: (x1+x2)/2, (y1+y2)/2 points straight up (x~0, y<0).
+  const e0 = edges[0];
+  assert.ok(near((e0.x1 + e0.x2) / 2, 0, 1e-3), "edge 0 midpoint x ~ 0 (top)");
+  assert.ok((e0.y1 + e0.y2) / 2 < 0, "edge 0 midpoint y is negative (above center)");
+
+  // Edge 1 (the next clockwise slot) should sit to the right and below edge 0's midpoint,
+  // matching facet.js's established clockwise convention (next vertex is right-of and below top).
+  const e1 = edges[1];
+  const mid0y = (e0.y1 + e0.y2) / 2;
+  const mid1x = (e1.x1 + e1.x2) / 2;
+  const mid1y = (e1.y1 + e1.y2) / 2;
+  assert.ok(mid1x > 0, "edge 1 midpoint is to the right of edge 0");
+  assert.ok(mid1y > mid0y, "edge 1 midpoint is below (clockwise from) edge 0");
+});
+
+test("leading edge index is floor(progress * segments)", () => {
+  assert.equal(generateProcessRing(0, 12).leadingIndex, 0);
+  assert.equal(generateProcessRing(0.5, 12).leadingIndex, Math.floor(0.5 * 12));
+  assert.equal(generateProcessRing(0.5, 12).leadingIndex, 6);
+  assert.equal(generateProcessRing(0.3, 12).leadingIndex, Math.floor(0.3 * 12));
+  assert.equal(generateProcessRing(0.7, 12).leadingIndex, Math.floor(0.7 * 12));
+});
+
+test("leading edge index is null once progress reaches 1 (nothing left to fill)", () => {
+  assert.equal(generateProcessRing(1, 12).leadingIndex, null);
+});
+
+test("the `leading` flag on an edge matches leadingIndex", () => {
+  const { edges, leadingIndex } = generateProcessRing(0.3, 12);
+  edges.forEach((e) => assert.equal(e.leading, e.index === leadingIndex));
+});
+
+test("out-of-range progress is clamped (negative -> 0, >1 -> 1)", () => {
+  assert.equal(generateProcessRing(-0.5, 12).litCount, 0);
+  assert.equal(generateProcessRing(1.5, 12).litCount, 12);
+});
+
+test("non-finite progress is treated as 0", () => {
+  assert.equal(generateProcessRing(NaN, 12).litCount, 0);
+});
+
+test("gap fraction shortens each drawn edge symmetrically around its center", () => {
+  // 4 segments, radius 1, no rotation: edge 0 is centered at 12 o'clock (angle -90deg).
+  // With gapFrac 0, adjacent edges touch (chord length = 2*sin(45deg) = sqrt(2)).
+  // With gapFrac 0.2, edge 0's half-angle shrinks from 45deg to 36deg (chord = 2*sin(36deg)).
+  const noGap = generateProcessRing(1, 4, 0, 0, 1);
+  const withGap = generateProcessRing(1, 4, 0.2, 0, 1);
+  const chordLen = (e) => Math.hypot(e.x2 - e.x1, e.y2 - e.y1);
+
+  assert.ok(near(chordLen(noGap.edges[0]), Math.SQRT2, 1e-6), "gapFrac 0 chord is the full sqrt(2) span");
+  assert.ok(near(chordLen(withGap.edges[0]), 2 * Math.sin(36 * Math.PI / 180), 1e-6), "gapFrac 0.2 chord matches the shrunk half-angle");
+  assert.ok(chordLen(withGap.edges[0]) < chordLen(noGap.edges[0]), "a bigger gap yields a shorter drawn edge");
+
+  // Symmetry: the gap removed from each end is equal, so the endpoints' angles straddle the
+  // segment's center angle (-90deg) evenly — check via atan2 that ang1 and -90deg are as far
+  // apart as ang2 and -90deg.
+  const e = withGap.edges[0];
+  const ang1 = Math.atan2(e.y1, e.x1);
+  const ang2 = Math.atan2(e.y2, e.x2);
+  const center = -Math.PI / 2;
+  assert.ok(near(Math.abs(ang1 - center), Math.abs(ang2 - center), 1e-6), "endpoints are equidistant (in angle) from the segment center");
+});
+
+test("exact vertex coordinates for a known small case (4 segments, no gap, no rotation, unit radius)", () => {
+  // segments=4 -> step = 90deg, half = 45deg (gapFrac 0). Edge i is centered at
+  // -90deg + i*90deg (top, right, bottom, left), spanning +/-45deg around that center.
+  const SQRT2_2 = Math.SQRT1_2; // 0.7071067811865476
+  const { edges } = generateProcessRing(1, 4, 0, 0, 1);
+
+  // Edge 0: centered at top (-90deg), spans -135deg..-45deg.
+  assert.ok(near(edges[0].x1, -SQRT2_2) && near(edges[0].y1, -SQRT2_2), "edge0 p1 at -135deg");
+  assert.ok(near(edges[0].x2, SQRT2_2) && near(edges[0].y2, -SQRT2_2), "edge0 p2 at -45deg");
+
+  // Edge 1: centered at right (0deg), spans -45deg..45deg — its first point coincides with
+  // edge 0's second point (gapFrac 0, so adjacent edges touch).
+  assert.ok(near(edges[1].x1, SQRT2_2) && near(edges[1].y1, -SQRT2_2), "edge1 p1 at -45deg");
+  assert.ok(near(edges[1].x2, SQRT2_2) && near(edges[1].y2, SQRT2_2), "edge1 p2 at 45deg");
+
+  // Edge 2: centered at bottom (90deg), spans 45deg..135deg.
+  assert.ok(near(edges[2].x1, SQRT2_2) && near(edges[2].y1, SQRT2_2), "edge2 p1 at 45deg");
+  assert.ok(near(edges[2].x2, -SQRT2_2) && near(edges[2].y2, SQRT2_2), "edge2 p2 at 135deg");
+
+  // Edge 3: centered at left (180deg), spans 135deg..225deg.
+  assert.ok(near(edges[3].x1, -SQRT2_2) && near(edges[3].y1, SQRT2_2), "edge3 p1 at 135deg");
+  assert.ok(near(edges[3].x2, -SQRT2_2) && near(edges[3].y2, -SQRT2_2), "edge3 p2 at 225deg");
+});
+
+test("rotationRad rotates every edge by the same offset (idle spin)", () => {
+  const base = generateProcessRing(1, 4, 0, 0, 1).edges[0];
+  const rotated = generateProcessRing(1, 4, 0, Math.PI / 2, 1).edges[0]; // rotate 90deg CW
+  // Rotating the whole ring 90deg CW moves edge 0's span to where edge 1 was.
+  const unrotatedEdge1 = generateProcessRing(1, 4, 0, 0, 1).edges[1];
+  assert.ok(near(rotated.x1, unrotatedEdge1.x1, 1e-6) && near(rotated.y1, unrotatedEdge1.y1, 1e-6));
+  assert.ok(near(rotated.x2, unrotatedEdge1.x2, 1e-6) && near(rotated.y2, unrotatedEdge1.y2, 1e-6));
+});
+
+test("radius scales the geometry linearly", () => {
+  const unit = generateProcessRing(1, 4, 0, 0, 1).edges[0];
+  const scaled = generateProcessRing(1, 4, 0, 0, 10).edges[0];
+  assert.ok(near(scaled.x1, unit.x1 * 10, 1e-6));
+  assert.ok(near(scaled.y1, unit.y1 * 10, 1e-6));
+});

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -981,6 +981,7 @@ describe("gate-access: nodes behind gates are inaccessible until conditions met"
         graph.setNodeAttr(sw, "accessLevel", "owned");
         graph.executeAction(sw, "activate");
       }
+      graph.tick(20); // activate is timed-by-default (#187 default-flip) — let it complete
 
       const vault = s.nodes["sp/vault"];
       assert.equal(vault.concealed, false,
@@ -1306,6 +1307,7 @@ describe("security grid cooldown: scrub logs (#174)", () => {
 
     graph.setNodeAttr("sp/monitor", "accessLevel", "open");
     graph.executeAction("sp/monitor", "scrub-logs");
+    graph.tick(20); // scrub-logs is timed-by-default (#187 default-flip) — let it complete
 
     assert.equal(graph.getNodeState("sp/monitor").alertCount, 0, "scrub resets the monitor's count");
     assert.equal(ORDER.indexOf(getState().globalAlert), ORDER.indexOf(before) - 1,
@@ -1356,6 +1358,7 @@ describe("security grid: IDS->monitor escalation (#173)", () => {
     const graph = getState().nodeGraph;
     graph.setNodeAttr("sp/ids", "accessLevel", "owned");
     graph.executeAction("sp/ids", "corrupt");
+    graph.tick(20); // corrupt is timed-by-default (#187 default-flip) — let it complete
     assert.equal(graph.getNodeState("sp/ids").forwardingEnabled, false, "corrupt should disable forwarding");
 
     for (let i = 0; i < 30; i++) sendAlert(graph); // far past any grade threshold

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1618,12 +1618,15 @@ describe("EXEC synthetic action injection", () => {
     assert.ok(!actions.some((a) => a.id === A.EXEC), "no EXEC when no scripts");
   });
 
-  it("EXEC.execute runs the chosen script (forwarding disabled), same as dispatching it directly", () => {
+  it("EXEC.execute runs the chosen script (forwarding disabled on completion), same as dispatching it directly", () => {
     const s = getState();
     s.nodeGraph.setNodeAttr("ids-1", "accessLevel", "owned");
     s.nodeGraph.setNodeAttr("ids-1", "forwardingEnabled", true);
     const exec = getAvailableActions(s.nodes["ids-1"], s).find((a) => a.id === A.EXEC);
     exec.execute(s.nodes["ids-1"], s, {}, { scriptId: "corrupt", nodeId: "ids-1" });
+    // corrupt is timed (#187 Phase 5) — EXEC only arms it; tick to completion (grade C: 15 ticks
+    // + 1 to resolve duration from the table).
+    s.nodeGraph.tick(16);
     assert.equal(s.nodes["ids-1"].forwardingEnabled, false);
   });
 });
@@ -1669,6 +1672,10 @@ describe("EXEC dispatch echo", () => {
     off(E.COMMAND_ISSUED, h);
 
     assert.deepEqual(echoes, ["exec corrupt"], "exactly one echo reading 'exec corrupt'");
+
+    // corrupt is timed (#187 Phase 5) — the dispatch only arms it; tick to completion
+    // (grade C: 15 ticks + 1 to resolve duration from the table).
+    s.nodeGraph.tick(16);
     assert.equal(getState().nodes["ids-1"].forwardingEnabled, false, "script ran");
   });
 });

--- a/tests/overlay-dispatch.test.js
+++ b/tests/overlay-dispatch.test.js
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { dispatchActionFeedback } from "../js/ui/overlays/dispatch.js";
+import { resolveFeedback } from "../js/ui/feedback-profiles.js";
 import { A } from "../js/core/action-ids.js";
 
 // Fake overlay recording sync/clear calls.
@@ -13,64 +14,101 @@ function fakeOverlay() {
   };
 }
 
+// #187 Phase 3: dispatch is name-keyed — byName maps a resolved overlay NAME (not an action id)
+// to a mounted overlay. Use the real resolved names so these tests track the actual profile
+// resolution instead of a parallel hardcoded mapping.
+const PROBE_OVERLAY = resolveFeedback(A.PROBE).overlay;
+const XPLOIT_OVERLAY = resolveFeedback(A.XPLOIT).overlay;
+
 function setup() {
   const probe = fakeOverlay();
   const xploit = fakeOverlay();
-  const byAction = new Map([[A.PROBE, probe], [A.XPLOIT, xploit]]);
+  const byName = new Map([[PROBE_OVERLAY, probe], [XPLOIT_OVERLAY, xploit]]);
   const active = new Map();
-  return { probe, xploit, byAction, active };
+  return { probe, xploit, byName, active };
 }
 
-test("start tracks the node id without syncing", () => {
-  const { probe, byAction, active } = setup();
-  dispatchActionFeedback(byAction, active, { nodeId: "n1", action: A.PROBE, phase: "start", progress: 0 });
-  assert.equal(active.get(A.PROBE), "n1");
+test("start resolves and tracks the overlay name without syncing", () => {
+  const { probe, byName, active } = setup();
+  dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.PROBE, phase: "start", progress: 0 });
+  assert.deepEqual(active.get(A.PROBE), { nodeId: "n1", overlayName: PROBE_OVERLAY });
   assert.equal(probe.syncs.length, 0);
 });
 
 test("progress after start syncs the tracked node", () => {
-  const { probe, byAction, active } = setup();
-  dispatchActionFeedback(byAction, active, { nodeId: "n1", action: A.PROBE, phase: "start", progress: 0 });
-  dispatchActionFeedback(byAction, active, { nodeId: "n1", action: A.PROBE, phase: "progress", progress: 0.5 });
+  const { probe, byName, active } = setup();
+  dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.PROBE, phase: "start", progress: 0 });
+  dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.PROBE, phase: "progress", progress: 0.5 });
   assert.deepEqual(probe.syncs, [["n1", 0.5]]);
 });
 
 test("progress without a prior start does nothing", () => {
-  const { probe, byAction, active } = setup();
-  dispatchActionFeedback(byAction, active, { nodeId: "n1", action: A.PROBE, phase: "progress", progress: 0.5 });
+  const { probe, byName, active } = setup();
+  dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.PROBE, phase: "progress", progress: 0.5 });
   assert.equal(probe.syncs.length, 0);
 });
 
-test("complete clears the overlay and forgets the node", () => {
-  const { probe, byAction, active } = setup();
-  dispatchActionFeedback(byAction, active, { nodeId: "n1", action: A.PROBE, phase: "start", progress: 0 });
-  dispatchActionFeedback(byAction, active, { nodeId: "n1", action: A.PROBE, phase: "complete", progress: 1 });
+test("complete clears the overlay and forgets the action", () => {
+  const { probe, byName, active } = setup();
+  dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.PROBE, phase: "start", progress: 0 });
+  dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.PROBE, phase: "complete", progress: 1 });
   assert.equal(probe.clears, 1);
   assert.equal(active.has(A.PROBE), false);
 });
 
-test("cancel clears the overlay and forgets the node", () => {
-  const { probe, byAction, active } = setup();
-  dispatchActionFeedback(byAction, active, { nodeId: "n1", action: A.PROBE, phase: "start", progress: 0 });
-  dispatchActionFeedback(byAction, active, { nodeId: "n1", action: A.PROBE, phase: "cancel" });
+test("cancel clears the overlay and forgets the action", () => {
+  const { probe, byName, active } = setup();
+  dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.PROBE, phase: "start", progress: 0 });
+  dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.PROBE, phase: "cancel" });
   assert.equal(probe.clears, 1);
   assert.equal(active.has(A.PROBE), false);
 });
 
 test("unknown action is ignored (no throw)", () => {
-  const { byAction, active } = setup();
+  const { byName, active } = setup();
   assert.doesNotThrow(() =>
-    dispatchActionFeedback(byAction, active, { nodeId: "n1", action: A.JACKOUT, phase: "progress", progress: 0.5 }));
+    dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.JACKOUT, phase: "progress", progress: 0.5 }));
   assert.equal(active.size, 0);
 });
 
 test("XPLOIT progress fires the onXploitProgress hook; others don't", () => {
-  const { byAction, active } = setup();
+  const { byName, active } = setup();
   const calls = [];
   const hooks = { onXploitProgress: (p) => calls.push(p) };
-  dispatchActionFeedback(byAction, active, { nodeId: "x", action: A.XPLOIT, phase: "start", progress: 0 }, hooks);
-  dispatchActionFeedback(byAction, active, { nodeId: "x", action: A.XPLOIT, phase: "progress", progress: 0.7 }, hooks);
-  dispatchActionFeedback(byAction, active, { nodeId: "n1", action: A.PROBE, phase: "start", progress: 0 }, hooks);
-  dispatchActionFeedback(byAction, active, { nodeId: "n1", action: A.PROBE, phase: "progress", progress: 0.3 }, hooks);
+  dispatchActionFeedback(byName, active, { nodeId: "x", action: A.XPLOIT, phase: "start", progress: 0 }, hooks);
+  dispatchActionFeedback(byName, active, { nodeId: "x", action: A.XPLOIT, phase: "progress", progress: 0.7 }, hooks);
+  dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.PROBE, phase: "start", progress: 0 }, hooks);
+  dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.PROBE, phase: "progress", progress: 0.3 }, hooks);
   assert.deepEqual(calls, [0.7]);
+});
+
+// #187 Phase 3 — layered feedback resolution driving overlay dispatch.
+test("an inline feedback.overlay override on 'start' picks the overridden overlay for the rest of the lifecycle", () => {
+  const custom = fakeOverlay();
+  const byName = new Map([[PROBE_OVERLAY, fakeOverlay()], ["custom-overlay", custom]]);
+  const active = new Map();
+  dispatchActionFeedback(byName, active, {
+    nodeId: "n1", action: A.PROBE, phase: "start", progress: 0, feedback: { overlay: "custom-overlay" },
+  });
+  assert.deepEqual(active.get(A.PROBE), { nodeId: "n1", overlayName: "custom-overlay" });
+
+  dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.PROBE, phase: "progress", progress: 0.4 });
+  assert.deepEqual(custom.syncs, [["n1", 0.4]]);
+
+  dispatchActionFeedback(byName, active, { nodeId: "n1", action: A.PROBE, phase: "complete", progress: 1 });
+  assert.equal(custom.clears, 1);
+});
+
+// Safe-degrade: an action whose resolved overlay name has no registered element (e.g. an
+// unmapped set-piece verb resolving to the Phase-4-pending "generic-process" default, or any
+// other not-yet-built name) never throws across the whole start→progress→complete lifecycle.
+test("an unregistered resolved overlay name degrades safely (no throw, no sync/clear calls)", () => {
+  const byName = new Map(); // nothing registered
+  const active = new Map();
+  assert.doesNotThrow(() => {
+    dispatchActionFeedback(byName, active, { nodeId: "n1", action: "crack-vault", phase: "start", progress: 0 });
+    dispatchActionFeedback(byName, active, { nodeId: "n1", action: "crack-vault", phase: "progress", progress: 0.5 });
+    dispatchActionFeedback(byName, active, { nodeId: "n1", action: "crack-vault", phase: "complete", progress: 1 });
+  });
+  assert.equal(active.has("crack-vault"), false, "complete should still forget the action even with no overlay element");
 });

--- a/tests/overlay-registry.test.js
+++ b/tests/overlay-registry.test.js
@@ -68,6 +68,13 @@ test("descriptorForName resolves a registered name and rejects an unregistered o
 
 test("every core verb's central feedback profile names a real registered overlay", () => {
   for (const [actionId, profile] of Object.entries(ACTION_FEEDBACK_PROFILES)) {
+    // reboot is the deliberate exception (#187 default-flip): "none" is an intentionally
+    // unregistered sentinel name so overlay dispatch no-ops for it, leaving reboot's bespoke
+    // node-pulse as the only visual treatment — see feedback-profiles.js.
+    if (actionId === A.REBOOT) {
+      assert.equal(descriptorForName(profile.overlay), null, "reboot's 'none' sentinel must NOT resolve to a real descriptor");
+      continue;
+    }
     assert.ok(descriptorForName(profile.overlay), `${actionId}'s central overlay "${profile.overlay}" should resolve to a real descriptor`);
   }
 });

--- a/tests/overlay-registry.test.js
+++ b/tests/overlay-registry.test.js
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { OVERLAY_DESCRIPTORS, overlayDescriptorForAction } from "../js/ui/overlays/registry.js";
+import { OVERLAY_DESCRIPTORS, overlayDescriptorForAction, descriptorForName } from "../js/ui/overlays/registry.js";
+import { ACTION_FEEDBACK_PROFILES } from "../js/ui/feedback-profiles.js";
 import { A } from "../js/core/action-ids.js";
 
 test("registry has seven overlays", () => {
@@ -33,5 +34,24 @@ test("every descriptor is well-formed", () => {
     assert.match(d.tag, /-overlay$/);
     assert.ok(d.label && typeof d.label === "string");
     assert.ok(d.demo?.type && d.demo?.grade);
+    assert.ok(d.name && typeof d.name === "string");
+  }
+});
+
+// #187 Phase 3 — name-keyed overlay resolution.
+test("every descriptor has a unique name", () => {
+  const names = OVERLAY_DESCRIPTORS.map((d) => d.name);
+  assert.equal(new Set(names).size, names.length, "no duplicate overlay names");
+});
+
+test("descriptorForName resolves a registered name and rejects an unregistered one", () => {
+  assert.equal(descriptorForName("probe-sweep")?.key, "probe");
+  assert.equal(descriptorForName("generic-process"), null, "Phase 4 has not registered the default overlay yet");
+  assert.equal(descriptorForName("nonsense"), null);
+});
+
+test("every core verb's central feedback profile names a real registered overlay", () => {
+  for (const [actionId, profile] of Object.entries(ACTION_FEEDBACK_PROFILES)) {
+    assert.ok(descriptorForName(profile.overlay), `${actionId}'s central overlay "${profile.overlay}" should resolve to a real descriptor`);
   }
 });

--- a/tests/overlay-registry.test.js
+++ b/tests/overlay-registry.test.js
@@ -1,15 +1,17 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { OVERLAY_DESCRIPTORS, overlayDescriptorForAction, descriptorForName } from "../js/ui/overlays/registry.js";
-import { ACTION_FEEDBACK_PROFILES } from "../js/ui/feedback-profiles.js";
+import { ACTION_FEEDBACK_PROFILES, DEFAULT_PROFILE } from "../js/ui/feedback-profiles.js";
 import { A } from "../js/core/action-ids.js";
 
-test("registry has seven overlays", () => {
-  assert.equal(OVERLAY_DESCRIPTORS.length, 7);
+test("registry has eight overlays", () => {
+  assert.equal(OVERLAY_DESCRIPTORS.length, 8);
 });
 
-test("action-feedback overlays map 1:1 to the timed/cooldown actions", () => {
-  const af = OVERLAY_DESCRIPTORS.filter((d) => d.driver === "action-feedback");
+test("action-feedback overlays keyed to a specific action map 1:1 to the timed/cooldown actions", () => {
+  // Excludes "generic-process" (#187 Phase 4b) — like ice-detect, it's action-agnostic
+  // (action: null) even though its driver is "action-feedback".
+  const af = OVERLAY_DESCRIPTORS.filter((d) => d.driver === "action-feedback" && d.action !== null);
   const actions = af.map((d) => d.action).sort();
   assert.deepEqual(actions, [A.PROBE, A.XPLOIT, A.DUMP, A.FETCH, A.MINE, A.LIE_LOW].sort());
   assert.equal(new Set(actions).size, actions.length, "no duplicate action mappings");
@@ -22,11 +24,25 @@ test("ice-detect is the lone timer-driven sibling", () => {
   assert.equal(ice[0].action, null);
 });
 
+// #187 Phase 4b — generic-process is the action-agnostic action-feedback fallback, analogous to
+// ice-detect being the action-agnostic ice-timer sibling.
+test("generic-process is the lone action-agnostic action-feedback sibling", () => {
+  const generic = OVERLAY_DESCRIPTORS.filter((d) => d.driver === "action-feedback" && d.action === null);
+  assert.equal(generic.length, 1);
+  assert.equal(generic[0].key, "generic");
+  assert.equal(generic[0].name, "generic-process");
+});
+
 test("overlayDescriptorForAction resolves and rejects correctly", () => {
   assert.equal(overlayDescriptorForAction(A.PROBE)?.key, "probe");
   assert.equal(overlayDescriptorForAction(A.MINE)?.key, "mine");
-  assert.equal(overlayDescriptorForAction(A.JACKOUT), null);
-  assert.equal(overlayDescriptorForAction("nonsense"), null);
+});
+
+// #187 Phase 4b — an action with no central override now resolves the registered
+// "generic-process" default overlay instead of null (Phase 3 left this a safe no-op).
+test("an action with no central feedback override resolves the generic-process default overlay", () => {
+  assert.equal(overlayDescriptorForAction(A.JACKOUT)?.name, "generic-process");
+  assert.equal(overlayDescriptorForAction("nonsense")?.name, "generic-process");
 });
 
 test("every descriptor is well-formed", () => {
@@ -46,7 +62,7 @@ test("every descriptor has a unique name", () => {
 
 test("descriptorForName resolves a registered name and rejects an unregistered one", () => {
   assert.equal(descriptorForName("probe-sweep")?.key, "probe");
-  assert.equal(descriptorForName("generic-process"), null, "Phase 4 has not registered the default overlay yet");
+  assert.equal(descriptorForName("generic-process")?.key, "generic", "#187 Phase 4b registers the default overlay");
   assert.equal(descriptorForName("nonsense"), null);
 });
 
@@ -54,4 +70,11 @@ test("every core verb's central feedback profile names a real registered overlay
   for (const [actionId, profile] of Object.entries(ACTION_FEEDBACK_PROFILES)) {
     assert.ok(descriptorForName(profile.overlay), `${actionId}'s central overlay "${profile.overlay}" should resolve to a real descriptor`);
   }
+});
+
+// #187 Phase 4b — DEFAULT_PROFILE.overlay now maps to a real, mountable element (not a no-op).
+test("DEFAULT_PROFILE.overlay resolves to a real registered descriptor", () => {
+  const d = descriptorForName(DEFAULT_PROFILE.overlay);
+  assert.ok(d, "DEFAULT_PROFILE.overlay should resolve to a registered descriptor");
+  assert.equal(d.name, "generic-process");
 });

--- a/tests/strudel-cues.test.js
+++ b/tests/strudel-cues.test.js
@@ -24,8 +24,14 @@ test("resolveActionCue falls to DEFAULT_PROFILE.completionCue when nothing else 
   assert.equal(resolveActionCue("crack-vault"), DEFAULT_PROFILE.completionCue);
 });
 
-test("the DEFAULT completion cue id isn't backed by a real CUES entry until Phase 4", () => {
-  assert.equal(CUES[DEFAULT_PROFILE.completionCue], undefined);
+// #187 Phase 4b — the DEFAULT completion cue is real (feel-DRAFT) audio, not a silent no-op.
+test("the DEFAULT completion cue is registered and well-formed", () => {
+  const spec = CUES[DEFAULT_PROFILE.completionCue];
+  assert.ok(spec, "process.done should be registered as of Phase 4b");
+  assert.equal(typeof spec.note, "string");
+  assert.equal(typeof spec.s, "string");
+  assert.equal(typeof spec._dur, "number");
+  assert.equal(typeof spec.gain, "number");
 });
 
 test("resolveActionCue: inline wins over central and DEFAULT", () => {

--- a/tests/strudel-cues.test.js
+++ b/tests/strudel-cues.test.js
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CUES, resolveCue, resolveActionCue } from "../js/audio/strudel/data/cues.js";
+import { E } from "../js/core/events.js";
+import { DEFAULT_PROFILE, ACTION_FEEDBACK_PROFILES } from "../js/ui/feedback-profiles.js";
+import { A } from "../js/core/action-ids.js";
+
+// Existing event→cue resolution (unaffected by #187 Phase 3) — regression coverage.
+test("resolveCue maps known event types to their cue spec, unknown → null", () => {
+  assert.equal(resolveCue(E.NODE_REVEALED), CUES.reveal);
+  assert.equal(resolveCue(E.NODE_ACCESSED), CUES.access);
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { success: true }), CUES["xploit.ok"]);
+  assert.equal(resolveCue(E.ACTION_RESOLVED, { success: false }), CUES["xploit.fail"]);
+  assert.equal(resolveCue(E.ICE_DETECTED), CUES["ice.detected"]);
+  assert.equal(resolveCue(E.ALERT_TRACE_STARTED), CUES["trace.start"]);
+  assert.equal(resolveCue("some:other:event"), null);
+});
+
+// #187 Phase 3 — resolveActionCue resolves a *timed-action completion* cue id, a new concept with
+// no legacy per-action map to fall back to (resolveCue above is keyed by event TYPE, not action
+// id, and serves a different moment — ACTION_RESOLVED, not ACTION_FEEDBACK completion).
+test("resolveActionCue falls to DEFAULT_PROFILE.completionCue when nothing else is set", () => {
+  assert.equal(resolveActionCue(A.PROBE), DEFAULT_PROFILE.completionCue);
+  assert.equal(resolveActionCue("crack-vault"), DEFAULT_PROFILE.completionCue);
+});
+
+test("the DEFAULT completion cue id isn't backed by a real CUES entry until Phase 4", () => {
+  assert.equal(CUES[DEFAULT_PROFILE.completionCue], undefined);
+});
+
+test("resolveActionCue: inline wins over central and DEFAULT", () => {
+  assert.equal(resolveActionCue(A.PROBE, { completionCue: "custom.cue" }), "custom.cue");
+});
+
+test("resolveActionCue: a central completionCue override (if one existed) would win over DEFAULT", () => {
+  const original = ACTION_FEEDBACK_PROFILES[A.PROBE];
+  ACTION_FEEDBACK_PROFILES[A.PROBE] = { ...original, completionCue: "central.cue" };
+  try {
+    assert.equal(resolveActionCue(A.PROBE), "central.cue");
+  } finally {
+    ACTION_FEEDBACK_PROFILES[A.PROBE] = original;
+  }
+});

--- a/tests/strudel-drones.test.js
+++ b/tests/strudel-drones.test.js
@@ -1,7 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { DRONES, DRONE_IDS, resolveDrone } from "../js/audio/strudel/data/drones.js";
+import { DRONES, DRONE_IDS, resolveDrone, resolveActionDrone } from "../js/audio/strudel/data/drones.js";
 import { noteToFreq, droneRange } from "../js/audio/strudel/drones.js";
+import { DEFAULT_PROFILE, ACTION_FEEDBACK_PROFILES } from "../js/ui/feedback-profiles.js";
+import { A } from "../js/core/action-ids.js";
 
 test("resolveDrone maps the 7 timed actions to themselves, unknown → null", () => {
   for (const id of ["probe", "xploit", "dump", "fetch", "mine", "lie-low", "reboot"]) {
@@ -39,5 +41,35 @@ test("amp-LFO drones do not also declare a progress-driven gain (engine constrai
       assert.ok(!(spec.gain && typeof spec.gain === "object"),
         `${id}: amp-LFO drone must not have a {from,to} gain`);
     }
+  }
+});
+
+// #187 Phase 3 — resolveActionDrone layers inline → central → resolveDrone() (legacy, preserved
+// as-is) → DEFAULT_PROFILE.drone. Every core verb's bespoke drone must resolve exactly as
+// resolveDrone() alone already resolved it — zero regression, zero re-enumeration.
+test("resolveActionDrone preserves every core verb's bespoke drone via the resolveDrone fallback", () => {
+  for (const id of ["probe", "xploit", "dump", "fetch", "mine", "lie-low", "reboot"]) {
+    assert.equal(resolveActionDrone(id), resolveDrone(id), `${id} should resolve identically to legacy resolveDrone()`);
+  }
+});
+
+test("resolveActionDrone falls to DEFAULT_PROFILE.drone for an action resolveDrone doesn't know", () => {
+  assert.equal(resolveActionDrone("crack-vault"), DEFAULT_PROFILE.drone);
+  assert.equal(DRONES[DEFAULT_PROFILE.drone], undefined, "the generic drone spec isn't registered until Phase 4");
+});
+
+test("resolveActionDrone: inline wins over central and the resolveDrone fallback", () => {
+  assert.equal(resolveActionDrone(A.PROBE, { drone: "custom" }), "custom");
+});
+
+test("resolveActionDrone: a central drone override (if one existed) would win over resolveDrone", () => {
+  // No core verb centrally lists a drone today (by design — resolveDrone() already preserves it,
+  // see feedback-profiles.js's module doc). Temporarily inject one to prove the ordering.
+  const original = ACTION_FEEDBACK_PROFILES[A.PROBE];
+  ACTION_FEEDBACK_PROFILES[A.PROBE] = { ...original, drone: "central-override" };
+  try {
+    assert.equal(resolveActionDrone(A.PROBE), "central-override");
+  } finally {
+    ACTION_FEEDBACK_PROFILES[A.PROBE] = original;
   }
 });

--- a/tests/strudel-drones.test.js
+++ b/tests/strudel-drones.test.js
@@ -14,8 +14,8 @@ test("resolveDrone maps the 7 timed actions to themselves, unknown → null", ()
   assert.equal(resolveDrone(undefined), null);
 });
 
-test("DRONE_IDS covers exactly the 7 timed actions", () => {
-  assert.deepEqual([...DRONE_IDS].sort(), ["dump", "fetch", "lie-low", "mine", "probe", "reboot", "xploit"]);
+test("DRONE_IDS covers exactly the 7 timed actions plus the generic default (#187 Phase 4b)", () => {
+  assert.deepEqual([...DRONE_IDS].sort(), ["dump", "fetch", "generic", "lie-low", "mine", "probe", "reboot", "xploit"]);
 });
 
 test("noteToFreq converts note names to Hz", () => {
@@ -55,7 +55,15 @@ test("resolveActionDrone preserves every core verb's bespoke drone via the resol
 
 test("resolveActionDrone falls to DEFAULT_PROFILE.drone for an action resolveDrone doesn't know", () => {
   assert.equal(resolveActionDrone("crack-vault"), DEFAULT_PROFILE.drone);
-  assert.equal(DRONES[DEFAULT_PROFILE.drone], undefined, "the generic drone spec isn't registered until Phase 4");
+});
+
+// #187 Phase 4b — the generic drone spec is real (feel-DRAFT) audio, not a silent no-op.
+test("the DEFAULT drone spec is registered and well-formed", () => {
+  const spec = DRONES[DEFAULT_PROFILE.drone];
+  assert.ok(spec, "the generic drone spec should be registered as of Phase 4b");
+  assert.ok(["sawtooth", "sine", "square", "triangle", "noise", "fm", "dual"].includes(spec.source));
+  assert.equal(typeof spec.volume, "number");
+  assert.equal(typeof spec.fade, "number");
 });
 
 test("resolveActionDrone: inline wins over central and the resolveDrone fallback", () => {

--- a/tests/timed-busy.test.js
+++ b/tests/timed-busy.test.js
@@ -1,0 +1,166 @@
+// @ts-check
+// Phase 2 (#187): unify "is this node busy?" into a single structural predicate —
+// NodeGraph#isNodeBusy / the `no-active-timed-action` condition — that spans BOTH
+// the enumerated core timed-action flags (probe/xploit/… via ABORTABLE_FLAGS) AND
+// any synthesized `timed` action (declarative ActionDef.timed, Phase 1, #187), and
+// composes with the separate #282 process-framework busy check (activeProcessOnNode)
+// at the getAvailableActions layer (node-actions.js).
+//
+// Additive: ABORTABLE_FLAGS / TIMED_ACTIONS / the processes.js contract are untouched.
+// NOT_BUSY keeps its enumerated flags and gains the structural check alongside them;
+// ABORT keeps its enumerated any-of and gains the structural check alongside it too.
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+
+import { createGateway, createRouter } from "../js/core/node-graph/node-factories.js";
+import { initGame, getState } from "../js/core/state.js";
+import { emitEvent, on, off, E, clearHandlers } from "../js/core/events.js";
+import { initNavigationCancelHandler } from "../js/core/node-graph/game-ctx.js";
+import { A } from "../js/core/action-ids.js";
+import { addProcess } from "../js/core/state/process.js";
+import { registerProcess } from "../js/core/processes.js";
+import { getAvailableActions } from "../js/core/actions/node-actions.js";
+import { timedActiveAttr, getTimedActionAttrNames } from "../js/core/node-graph/timed-actions.js";
+
+const BUSY_ACTION_ID = "busy-act";
+
+/**
+ * A router carrying its normal trait actions (PROBE, ABORT, …) PLUS one inline
+ * declarative `timed` action — a synthesized timed-action operator with a
+ * dynamically-named activeAttr (`_ta_active_busy-act`) that isn't (and can't be)
+ * named in the enumerated ABORTABLE_FLAGS list.
+ * @param {string} [id]
+ */
+function busyRouter(id = "router-a") {
+  return {
+    ...createRouter(id),
+    actions: [
+      {
+        id: BUSY_ACTION_ID,
+        label: "BUSY",
+        requires: [],
+        timed: { duration: 5 },
+        effects: [{ effect: "set-attr", attr: "done", value: true }],
+      },
+    ],
+  };
+}
+
+function buildBusyLAN() {
+  return {
+    graphDef: {
+      nodes: [
+        createGateway("gateway", { attributes: { visibility: "accessible" } }),
+        busyRouter("router-a"),
+      ],
+      edges: [["gateway", "router-a"]],
+      triggers: [],
+    },
+    meta: { startNode: "gateway", startCash: 0, moneyCost: "F" },
+  };
+}
+
+describe("NodeGraph#isNodeBusy (#187 Phase 2)", () => {
+  it("is false when idle and true once a synthesized timed action is armed", () => {
+    initGame(() => buildBusyLAN(), "busy-isbusy");
+    const graph = getState().nodeGraph;
+
+    assert.equal(graph.isNodeBusy("router-a"), false, "idle before dispatch");
+    graph.executeAction("router-a", BUSY_ACTION_ID);
+    assert.equal(graph.isNodeBusy("router-a"), true, "busy once armed");
+  });
+});
+
+describe("NOT_BUSY / ABORT structural check for a synthesized timed action (#187 Phase 2)", () => {
+  it("blocks a second startable (NOT_BUSY-gated) action while the synthesized action runs", () => {
+    initGame(() => buildBusyLAN(), "busy-notbusy");
+    const graph = getState().nodeGraph;
+    graph.executeAction("router-a", BUSY_ACTION_ID);
+
+    const available = graph.getAvailableActions("router-a").map((a) => a.id);
+    assert.ok(!available.includes(A.PROBE), "PROBE (NOT_BUSY-gated) unavailable while busy-act runs");
+  });
+
+  it("shows ABORT while the synthesized action runs", () => {
+    initGame(() => buildBusyLAN(), "busy-abort-shown");
+    const graph = getState().nodeGraph;
+    graph.executeAction("router-a", BUSY_ACTION_ID);
+
+    const available = graph.getAvailableActions("router-a").map((a) => a.id);
+    assert.ok(available.includes(A.ABORT), "ABORT available while a synthesized timed action runs");
+  });
+
+  it("firing ABORT clears the synthesized action's active flag + progress and fires one cancel feedback", () => {
+    initGame(() => buildBusyLAN(), "busy-abort-fire");
+    const graph = getState().nodeGraph;
+    graph.executeAction("router-a", BUSY_ACTION_ID);
+
+    const cancels = [];
+    const h = (p) => { if (p?.phase === "cancel") cancels.push(p); };
+    on(E.ACTION_FEEDBACK, h);
+    graph.executeAction("router-a", A.ABORT);
+    off(E.ACTION_FEEDBACK, h);
+
+    const { progressAttr, durationAttr } = getTimedActionAttrNames(BUSY_ACTION_ID);
+    const attrs = graph.getNodeState("router-a");
+    assert.equal(attrs[timedActiveAttr(BUSY_ACTION_ID)], false, "active flag cleared");
+    assert.equal(attrs[progressAttr], 0, "progress reset");
+    assert.equal(attrs[durationAttr], 0, "duration reset");
+    assert.equal(graph.isNodeBusy("router-a"), false, "no longer busy after ABORT");
+
+    assert.equal(cancels.length, 1, "exactly one cancel feedback");
+    assert.equal(cancels[0].nodeId, "router-a");
+    assert.equal(cancels[0].action, BUSY_ACTION_ID);
+  });
+});
+
+describe("nav-cancel generalization for a synthesized timed action (#187 Phase 2)", () => {
+  before(() => { clearHandlers(); initNavigationCancelHandler(); });
+
+  it("PLAYER_NAVIGATED cancels an in-progress synthesized timed action", () => {
+    initGame(() => buildBusyLAN(), "busy-nav");
+    const graph = getState().nodeGraph;
+    graph.executeAction("router-a", BUSY_ACTION_ID);
+    assert.equal(graph.isNodeBusy("router-a"), true, "armed before nav");
+
+    const cancels = [];
+    const h = (p) => { if (p?.phase === "cancel") cancels.push(p); };
+    on(E.ACTION_FEEDBACK, h);
+    emitEvent(E.PLAYER_NAVIGATED, {});
+    off(E.ACTION_FEEDBACK, h);
+
+    assert.equal(graph.isNodeBusy("router-a"), false, "cancelled by nav-away");
+    assert.equal(cancels.length, 1, "exactly one cancel feedback");
+    assert.equal(cancels[0].nodeId, "router-a");
+    assert.equal(cancels[0].action, BUSY_ACTION_ID);
+  });
+
+  it("does not disturb a node with no active timed action", () => {
+    initGame(() => buildBusyLAN(), "busy-nav-idle");
+    const cancels = [];
+    const h = (p) => { if (p?.phase === "cancel") cancels.push(p); };
+    on(E.ACTION_FEEDBACK, h);
+    emitEvent(E.PLAYER_NAVIGATED, {});
+    off(E.ACTION_FEEDBACK, h);
+    assert.equal(cancels.length, 0, "no cancel feedback when nothing was running");
+  });
+});
+
+describe("process-side busy composes with the graph-side check (#282 + #187 Phase 2)", () => {
+  const PROC_TYPE = "timed-busy-test-proc";
+  registerProcess(PROC_TYPE, { step: () => false, onAbort: () => {} });
+
+  it("activeProcessOnNode makes a node busy at the getAvailableActions layer, independent of the graph", () => {
+    initGame(() => buildBusyLAN(), "busy-proc");
+    addProcess({ id: 1, type: PROC_TYPE, nodeId: "router-a" });
+
+    const available = getAvailableActions(getState().nodes["router-a"], getState()).map((a) => a.id);
+    assert.ok(available.includes(A.ABORT), "ABORT offered while a process is active");
+    assert.ok(!available.includes(A.PROBE), "no other node verbs while a process is active");
+
+    // The two busy mechanisms are independent: the graph itself has no active
+    // timed-action operator, only the process-layer check makes the node busy.
+    assert.equal(getState().nodeGraph.isNodeBusy("router-a"), false, "graph-level timed action still idle");
+  });
+});

--- a/tests/timed-busy.test.js
+++ b/tests/timed-busy.test.js
@@ -147,6 +147,76 @@ describe("nav-cancel generalization for a synthesized timed action (#187 Phase 2
   });
 });
 
+function buildRouterLAN() {
+  return {
+    graphDef: {
+      nodes: [
+        createGateway("gateway", { attributes: { visibility: "accessible" } }),
+        createRouter("router-a"),
+      ],
+      edges: [["gateway", "router-a"]],
+      triggers: [],
+    },
+    meta: { startNode: "gateway", startCash: 0, moneyCost: "F" },
+  };
+}
+
+describe("ABORT must not cancel involuntary reboot (review fix, #187)", () => {
+  it("does not offer ABORT while rebooting, and abortTimedAction is a no-op on reboot", () => {
+    initGame(() => buildRouterLAN(), "reboot-abort-guard");
+    const graph = getState().nodeGraph;
+    const nodeId = "router-a";
+    const { progressAttr, durationAttr } = getTimedActionAttrNames("reboot");
+
+    // Arm the reboot the same way ctx.startReboot does, without exercising the
+    // rest of the reboot side effects (ICE eviction, etc.) — this test is only
+    // about the ABORT/busy plumbing.
+    graph.setNodeAttr(nodeId, "rebooting", true);
+    graph.setNodeAttr(nodeId, progressAttr, 5);
+    graph.setNodeAttr(nodeId, durationAttr, 20);
+
+    assert.equal(graph.isNodeBusy(nodeId), true, "node is busy while rebooting");
+
+    const available = graph.getAvailableActions(nodeId).map((a) => a.id);
+    assert.ok(!available.includes(A.ABORT), "ABORT is NOT offered during an involuntary reboot");
+
+    // Defense in depth: even calling the ctx abort path directly must not touch reboot.
+    const cancels = [];
+    const h = (p) => { if (p?.phase === "cancel") cancels.push(p); };
+    on(E.ACTION_FEEDBACK, h);
+    graph._ctx.abortTimedAction(nodeId);
+    off(E.ACTION_FEEDBACK, h);
+
+    const attrs = graph.getNodeState(nodeId);
+    assert.equal(attrs.rebooting, true, "rebooting is NOT cleared by abortTimedAction");
+    assert.equal(attrs[progressAttr], 5, "reboot progress untouched");
+    assert.equal(attrs[durationAttr], 20, "reboot duration untouched");
+    assert.equal(cancels.length, 0, "no cancel feedback fired for a blocked reboot abort");
+
+    // The reboot still completes normally on tick — advance progress to duration
+    // (20, set above) and let the timed-action operator fire onComplete
+    // (completeReboot clears rebooting).
+    graph.tick(20);
+    assert.equal(graph.getNodeState(nodeId).rebooting, false, "reboot completes normally on tick");
+  });
+
+  it("an abortable action (probe) still offers ABORT and cancels normally", () => {
+    initGame(() => buildRouterLAN(), "reboot-abort-guard-probe-still-works");
+    const graph = getState().nodeGraph;
+    const nodeId = "router-a";
+
+    graph.executeAction(nodeId, A.PROBE);
+    assert.equal(graph.isNodeBusy(nodeId), true, "busy while probing");
+
+    const available = graph.getAvailableActions(nodeId).map((a) => a.id);
+    assert.ok(available.includes(A.ABORT), "ABORT is still offered for an abortable action (probe)");
+
+    graph.executeAction(nodeId, A.ABORT);
+    assert.equal(graph.getNodeState(nodeId).probing, false, "probe cancelled by ABORT");
+    assert.equal(graph.isNodeBusy(nodeId), false, "no longer busy after ABORT");
+  });
+});
+
 describe("process-side busy composes with the graph-side check (#282 + #187 Phase 2)", () => {
   const PROC_TYPE = "timed-busy-test-proc";
   registerProcess(PROC_TYPE, { step: () => false, onAbort: () => {} });

--- a/tests/timed-feedback-payload.test.js
+++ b/tests/timed-feedback-payload.test.js
@@ -1,0 +1,91 @@
+// @ts-check
+// #187 Phase 3: an ActionDef's inline `feedback` ({ overlay?, drone?, completionCue? }) is
+// threaded through synthesis (timed-synthesis.js copies it onto the synthesized timed-action
+// operator's config) and echoed on the operator's "start" ACTION_FEEDBACK payload (operators.js),
+// so overlay dispatch and the Strudel audio module can layer it over the central/DEFAULT profile.
+// Additive payload field only — the "complete"/"progress"/"cancel" payloads are untouched.
+//
+// Same bare-NodeGraph + mockCtx harness as tests/timed-synthesis.test.js.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { NodeGraph } from "../js/core/node-graph/runtime.js";
+import { mockCtx } from "../js/core/node-graph/ctx.js";
+
+// A grade-table duration (not a flat `duration`) is required to observe the "start"
+// ACTION_FEEDBACK phase: the timed-action operator only emits "start" on the first tick after
+// arming when it still has to resolve the duration from `durationTable` (operators.js). A flat
+// `duration` is seeded directly by the arm effects, so the first tick already has a non-zero
+// duration and goes straight to "progress" — see tests/timed-synthesis.test.js, which only
+// asserts "complete" for that flat-duration case.
+function makeTimedActionNode(feedback) {
+  return {
+    id: "test-node",
+    type: "test",
+    attributes: { label: "test-node", grade: "D", visibility: "accessible", done: false },
+    actions: [
+      {
+        id: "test-act",
+        label: "TEST",
+        requires: [],
+        timed: { durationTable: { D: 5 } },
+        feedback,
+        effects: [{ effect: "set-attr", attr: "done", value: true }],
+      },
+    ],
+  };
+}
+
+describe("timed-action feedback payload threading (#187 Phase 3)", () => {
+  it("echoes the ActionDef's inline feedback on the 'start' ACTION_FEEDBACK payload", () => {
+    /** @type {{type: string, payload: any}[]} */
+    const events = [];
+    const graph = new NodeGraph(
+      { nodes: [makeTimedActionNode({ overlay: "x" })], edges: [] },
+      mockCtx(),
+      (type, payload) => events.push({ type, payload }),
+    );
+
+    graph.executeAction("test-node", "test-act");
+    graph.tick(1);
+
+    const starts = events.filter((e) => e.type === "action-feedback" && e.payload.phase === "start");
+    assert.equal(starts.length, 1);
+    assert.equal(starts[0].payload.feedback?.overlay, "x");
+  });
+
+  it("omits `feedback` from the start payload when the ActionDef declares none", () => {
+    /** @type {{type: string, payload: any}[]} */
+    const events = [];
+    const graph = new NodeGraph(
+      { nodes: [makeTimedActionNode(undefined)], edges: [] },
+      mockCtx(),
+      (type, payload) => events.push({ type, payload }),
+    );
+
+    graph.executeAction("test-node", "test-act");
+    graph.tick(1);
+
+    const starts = events.filter((e) => e.type === "action-feedback" && e.payload.phase === "start");
+    assert.equal(starts.length, 1);
+    assert.equal("feedback" in starts[0].payload, false);
+  });
+
+  it("does not add `feedback` to the 'complete' payload (only 'start' threads it)", () => {
+    /** @type {{type: string, payload: any}[]} */
+    const events = [];
+    const graph = new NodeGraph(
+      { nodes: [makeTimedActionNode({ overlay: "x" })], edges: [] },
+      mockCtx(),
+      (type, payload) => events.push({ type, payload }),
+    );
+
+    graph.executeAction("test-node", "test-act");
+    graph.tick(6); // 1 tick to resolve duration from the grade table + 5 progress ticks to complete
+
+    const completes = events.filter((e) => e.type === "action-feedback" && e.payload.phase === "complete");
+    assert.equal(completes.length, 1);
+    assert.equal("feedback" in completes[0].payload, false);
+  });
+});

--- a/tests/timed-proof-slice.test.js
+++ b/tests/timed-proof-slice.test.js
@@ -1,0 +1,347 @@
+// @ts-check
+// #187 Phase 5 — proof slice: convert three previously-instant actions to timed ones,
+// exercising the full Phase 1-4 chain (declarable `timed` → synthesis → arm/tick/complete,
+// unified abortable busy/abort, generic default overlay/drone/cue) on real gameplay verbs
+// rather than a synthetic test fixture.
+//
+//   - `corrupt` (core verb, RECONFIGURE_ACTION in action-templates.js): trait-supplied via
+//     the `detectable` trait, shared by reference across every IDS node — exercises the
+//     Phase-1 new-object-per-node synthesis and the durationTable branch (previously
+//     untested in a real-action context, only via the bare-operator/synthetic-fixture tests).
+//   - `crack-vault` / `extract-key` (set-piece verbs, data/biomes/corporate-pieces/scattered.js):
+//     inline ActionDefs on hand-authored puzzle nodes — exercises a flat `duration` and proves
+//     "duds" (instant, feedback-less puzzle payouts) now get the generic-process overlay/drone/
+//     completion cue via the layered feedback-profile fallback.
+//
+// Real gameplay setups are used throughout (initGame + node-factories / the actual exported
+// set-piece defs), not a synthetic fixture — per the "node graph / set-piece test honesty"
+// testing practice, intermediate state is only ever set up-front (never reset mid-scenario),
+// and completion is asserted via the observable consequence (forwardingEnabled, cash, quality),
+// not an intermediate flag.
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+
+import { NodeGraph } from "../js/core/node-graph/runtime.js";
+import { mockCtx } from "../js/core/node-graph/ctx.js";
+import { createGateway, createIDS } from "../js/core/node-graph/node-factories.js";
+import { buildMiniNetwork } from "../js/core/node-graph/mini-network.js";
+import { initGame, getState } from "../js/core/state.js";
+import { emitEvent, on, off, E, clearHandlers } from "../js/core/events.js";
+import { initNavigationCancelHandler } from "../js/core/node-graph/game-ctx.js";
+import { A } from "../js/core/action-ids.js";
+import { timedActiveAttr, getTimedActionAttrNames } from "../js/core/node-graph/timed-actions.js";
+import { resolveFeedback, DEFAULT_PROFILE } from "../js/ui/feedback-profiles.js";
+import { scatteredLock1, scatteredEncryptedVault2 } from "../data/biomes/corporate-pieces/scattered.js";
+
+/** Capture ACTION_FEEDBACK "cancel" payloads fired during fn(). */
+function withCancelFeedback(fn) {
+  /** @type {any[]} */
+  const cancels = [];
+  const h = (p) => { if (p?.phase === "cancel") cancels.push(p); };
+  on(E.ACTION_FEEDBACK, h);
+  fn();
+  off(E.ACTION_FEEDBACK, h);
+  return cancels;
+}
+
+function buildTwoIdsLAN() {
+  return {
+    graphDef: {
+      nodes: [
+        createGateway("gateway", { attributes: { visibility: "accessible" } }),
+        createIDS("ids-1"),
+        createIDS("ids-2"),
+      ],
+      edges: [["gateway", "ids-1"], ["gateway", "ids-2"]],
+      triggers: [],
+    },
+    meta: { startNode: "gateway", startCash: 0, moneyCost: "F" },
+  };
+}
+
+function buildOneIdsLAN() {
+  return {
+    graphDef: {
+      nodes: [
+        createGateway("gateway", { attributes: { visibility: "accessible" } }),
+        createIDS("ids-1"),
+      ],
+      edges: [["gateway", "ids-1"]],
+      triggers: [],
+    },
+    meta: { startNode: "gateway", startCash: 0, moneyCost: "F" },
+  };
+}
+
+/** The real scatteredLock1 (n=1) set-piece, unprefixed via buildMiniNetwork (no instantiate()) —
+ * node/quality names stay exactly as authored: "switch-a", "gate", "vault", "locks-opened". */
+function buildLockLAN() {
+  return buildMiniNetwork({
+    nodes: scatteredLock1.nodes,
+    edges: scatteredLock1.internalEdges,
+    triggers: scatteredLock1.triggers,
+  });
+}
+
+/** The real scatteredEncryptedVault2 (n=2) set-piece, unprefixed — "key-gen-1"/"key-gen-2"/"vault". */
+function buildKeyVaultLAN() {
+  return buildMiniNetwork({
+    nodes: scatteredEncryptedVault2.nodes,
+    edges: scatteredEncryptedVault2.internalEdges,
+    triggers: scatteredEncryptedVault2.triggers,
+  });
+}
+
+describe("corrupt (#187 Phase 5): timed IDS subversion", () => {
+  before(() => { clearHandlers(); initNavigationCancelHandler(); });
+
+  it("does not disable forwarding on dispatch — only arms", () => {
+    initGame(buildOneIdsLAN, "corrupt-arm");
+    const graph = getState().nodeGraph;
+    graph.setNodeAttr("ids-1", "accessLevel", "owned");
+
+    graph.executeAction("ids-1", A.CORRUPT);
+
+    assert.equal(graph.getNodeState("ids-1").forwardingEnabled, true, "forwarding untouched at dispatch");
+    assert.equal(getState().nodes["ids-1"].forwardingEnabled, true, "game state mirrors the graph");
+    assert.equal(graph.getNodeState("ids-1")[timedActiveAttr(A.CORRUPT)], true, "arm flag set");
+  });
+
+  it("completes at the grade-scaled duration, disabling forwarding and firing reconfigureNode/ACTION_RESOLVED exactly once", () => {
+    initGame(buildOneIdsLAN, "corrupt-complete");
+    const graph = getState().nodeGraph;
+    graph.setNodeAttr("ids-1", "accessLevel", "owned");
+    assert.equal(graph.getNodeState("ids-1").grade, "C", "default IDS grade is C (durationTable C:15)");
+
+    /** @type {any[]} */
+    const resolved = [];
+    on(E.ACTION_RESOLVED, (p) => { if (p.action === A.CORRUPT) resolved.push(p); });
+
+    graph.executeAction("ids-1", A.CORRUPT);
+    graph.tick(16); // 1 tick to resolve duration from the grade table + 15 progress ticks (grade C)
+
+    assert.equal(graph.getNodeState("ids-1").forwardingEnabled, false, "forwarding disabled on completion");
+    assert.equal(resolved.length, 1, "ACTION_RESOLVED fires exactly once");
+    assert.equal(resolved[0].nodeId, "ids-1");
+  });
+
+  it("durationTable branch: a C-grade IDS completes at exactly 15 progress ticks (16 total with the resolve tick)", () => {
+    initGame(buildOneIdsLAN, "corrupt-duration-table");
+    const graph = getState().nodeGraph;
+    graph.setNodeAttr("ids-1", "accessLevel", "owned");
+    const { durationAttr } = getTimedActionAttrNames(A.CORRUPT);
+
+    graph.executeAction("ids-1", A.CORRUPT);
+    graph.tick(1); // resolves duration from the grade table
+    assert.equal(graph.getNodeState("ids-1")[durationAttr], 15, "duration resolved from durationTable[C]");
+    assert.equal(graph.getNodeState("ids-1").forwardingEnabled, true, "not complete yet");
+
+    graph.tick(14); // 14 of 15 progress ticks
+    assert.equal(graph.getNodeState("ids-1").forwardingEnabled, true, "still one tick short of completion");
+
+    graph.tick(1); // the 15th progress tick completes it
+    assert.equal(graph.getNodeState("ids-1").forwardingEnabled, false, "completes at exactly 15 progress ticks");
+  });
+
+  it("mid-action ABORT cancels the subversion — forwarding stays enabled, no reconfigure", () => {
+    initGame(buildOneIdsLAN, "corrupt-abort");
+    const graph = getState().nodeGraph;
+    graph.setNodeAttr("ids-1", "accessLevel", "owned");
+
+    graph.executeAction("ids-1", A.CORRUPT);
+    graph.tick(5); // partway through
+
+    const cancels = withCancelFeedback(() => graph.executeAction("ids-1", A.ABORT));
+
+    assert.equal(cancels.length, 1, "exactly one cancel feedback");
+    assert.equal(cancels[0].nodeId, "ids-1");
+    assert.equal(cancels[0].action, A.CORRUPT);
+    assert.equal(graph.getNodeState("ids-1").forwardingEnabled, true, "forwarding untouched by an aborted corrupt");
+    assert.equal(graph.getNodeState("ids-1")[timedActiveAttr(A.CORRUPT)], false, "arm flag cleared");
+
+    // Ticking further must not complete a cancelled action.
+    graph.tick(20);
+    assert.equal(graph.getNodeState("ids-1").forwardingEnabled, true, "still untouched after further ticks");
+  });
+
+  it("PLAYER_NAVIGATED cancels an in-progress corrupt — forwarding stays enabled", () => {
+    initGame(buildOneIdsLAN, "corrupt-nav-cancel");
+    const graph = getState().nodeGraph;
+    graph.setNodeAttr("ids-1", "accessLevel", "owned");
+
+    graph.executeAction("ids-1", A.CORRUPT);
+    graph.tick(3);
+
+    const cancels = withCancelFeedback(() => emitEvent(E.PLAYER_NAVIGATED, {}));
+
+    assert.equal(cancels.length, 1, "exactly one cancel feedback");
+    assert.equal(cancels[0].action, A.CORRUPT);
+    assert.equal(graph.getNodeState("ids-1").forwardingEnabled, true, "nav-away cancels the subversion");
+  });
+
+  it("shared-trait synthesis: a two-IDS network gets its OWN synthesized corrupt operator on BOTH nodes", () => {
+    // Bare NodeGraph, no initGame needed — this is pure trait/synthesis wiring, the same
+    // level as tests/timed-synthesis.test.js's idempotency check.
+    const graph = new NodeGraph(
+      { nodes: [createGateway("gateway"), createIDS("ids-1"), createIDS("ids-2")], edges: [] },
+      mockCtx(),
+    );
+    const ids1 = /** @type {any} */ (graph)._nodes.get("ids-1");
+    const ids2 = /** @type {any} */ (graph)._nodes.get("ids-2");
+
+    const op1 = ids1.operators.find((o) => o.name === "timed-action" && o.action === A.CORRUPT);
+    const op2 = ids2.operators.find((o) => o.name === "timed-action" && o.action === A.CORRUPT);
+    assert.ok(op1, "ids-1 has its own synthesized corrupt operator");
+    assert.ok(op2, "ids-2 has its own synthesized corrupt operator");
+    assert.notEqual(op1, op2, "each node got a distinct operator object, not a shared reference");
+
+    // Both nodes must be independently armable — arming one must not affect the other
+    // (would indicate the underlying ActionDef/operator was mutated in place and shared).
+    graph.setNodeAttr("ids-1", "accessLevel", "owned");
+    graph.setNodeAttr("ids-2", "accessLevel", "owned");
+    graph.executeAction("ids-1", A.CORRUPT);
+    assert.equal(graph.getNodeState("ids-1")[timedActiveAttr(A.CORRUPT)], true, "ids-1 armed");
+    assert.ok(!graph.getNodeState("ids-2")[timedActiveAttr(A.CORRUPT)], "ids-2 untouched");
+  });
+});
+
+describe("crack-vault (#187 Phase 5): timed set-piece verb", () => {
+  before(() => { clearHandlers(); initNavigationCancelHandler(); });
+
+  /** Bring the real scatteredLock1 vault to its unlockable state directly (per the brief:
+   * "you may set attrs directly" — the lock-opening circuit itself is exercised elsewhere,
+   * this test is about crack-vault's own timed behavior). */
+  function armLock() {
+    initGame(buildLockLAN, "crack-vault-" + Math.random());
+    const graph = getState().nodeGraph;
+    graph.setQuality("locks-opened", 1);
+    graph.setNodeAttr("vault", "accessLevel", "owned");
+    return graph;
+  }
+
+  it("does not grant the reward on dispatch — only arms", () => {
+    const graph = armLock();
+    const cashBefore = getState().player.cash;
+
+    graph.executeAction("vault", "crack-vault");
+
+    assert.equal(getState().player.cash, cashBefore, "no reward at dispatch");
+    assert.equal(graph.getNodeState("vault").cracked, false, "cracked stays false at dispatch");
+    assert.equal(graph.getNodeState("vault")[timedActiveAttr("crack-vault")], true, "arm flag set");
+  });
+
+  it("completes after the flat duration — reward granted once, cracked flips true", () => {
+    const graph = armLock();
+    const cashBefore = getState().player.cash;
+
+    graph.executeAction("vault", "crack-vault");
+    graph.tick(20); // flat duration:20
+
+    assert.equal(getState().player.cash, cashBefore + 1500, "reward granted exactly once on completion");
+    assert.equal(graph.getNodeState("vault").cracked, true, "cracked flips true on completion");
+
+    // No re-payout on further ticks (the operator resets progress/active and the action's
+    // own `cracked:false` requirement now blocks re-arming).
+    graph.tick(20);
+    assert.equal(getState().player.cash, cashBefore + 1500, "no double payout");
+  });
+
+  it("nav-away mid-action cancels — no reward, cracked stays false", () => {
+    const graph = armLock();
+    const cashBefore = getState().player.cash;
+
+    graph.executeAction("vault", "crack-vault");
+    graph.tick(10); // partway through the 20-tick duration
+
+    const cancels = withCancelFeedback(() => emitEvent(E.PLAYER_NAVIGATED, {}));
+
+    assert.equal(cancels.length, 1, "exactly one cancel feedback");
+    assert.equal(cancels[0].action, "crack-vault");
+    assert.equal(getState().player.cash, cashBefore, "no reward from a cancelled crack");
+    assert.equal(graph.getNodeState("vault").cracked, false, "cracked stays false");
+
+    graph.tick(20); // further ticks must not resurrect a cancelled action
+    assert.equal(getState().player.cash, cashBefore, "still no reward after further ticks");
+  });
+});
+
+describe("extract-key (#187 Phase 5): timed set-piece verb", () => {
+  before(() => { clearHandlers(); initNavigationCancelHandler(); });
+
+  function armKeyGen() {
+    initGame(buildKeyVaultLAN, "extract-key-" + Math.random());
+    const graph = getState().nodeGraph;
+    graph.setNodeAttr("key-gen-1", "accessLevel", "owned");
+    return graph;
+  }
+
+  it("does not extract on dispatch — only arms", () => {
+    const graph = armKeyGen();
+
+    graph.executeAction("key-gen-1", "extract-key");
+
+    assert.equal(graph.getNodeState("key-gen-1").keyExtracted, false, "not extracted at dispatch");
+    assert.equal(graph.getQuality("decryption-keys"), 0, "quality untouched at dispatch");
+    assert.equal(graph.getNodeState("key-gen-1")[timedActiveAttr("extract-key")], true, "arm flag set");
+  });
+
+  it("completes after the flat duration — keyExtracted flips true, quality increments once", () => {
+    const graph = armKeyGen();
+
+    graph.executeAction("key-gen-1", "extract-key");
+    graph.tick(20); // flat duration:20
+
+    assert.equal(graph.getNodeState("key-gen-1").keyExtracted, true, "extracted on completion");
+    assert.equal(graph.getQuality("decryption-keys"), 1, "quality incremented exactly once");
+  });
+
+  it("nav-away mid-action cancels — no extraction, quality stays at 0", () => {
+    const graph = armKeyGen();
+
+    graph.executeAction("key-gen-1", "extract-key");
+    graph.tick(10);
+
+    const cancels = withCancelFeedback(() => emitEvent(E.PLAYER_NAVIGATED, {}));
+
+    assert.equal(cancels.length, 1, "exactly one cancel feedback");
+    assert.equal(cancels[0].action, "extract-key");
+    assert.equal(graph.getNodeState("key-gen-1").keyExtracted, false, "still not extracted");
+    assert.equal(graph.getQuality("decryption-keys"), 0, "quality still untouched");
+
+    graph.tick(20);
+    assert.equal(graph.getQuality("decryption-keys"), 0, "still untouched after further ticks");
+  });
+});
+
+describe("legibility (#187 Phase 5): converted actions resolve to the generic-process default, not a silent dud", () => {
+  it("corrupt has no central feedback-profile entry — resolves entirely to DEFAULT_PROFILE", () => {
+    assert.deepEqual(resolveFeedback(A.CORRUPT), DEFAULT_PROFILE);
+  });
+
+  it("crack-vault has no central feedback-profile entry — resolves entirely to DEFAULT_PROFILE", () => {
+    assert.deepEqual(resolveFeedback("crack-vault"), DEFAULT_PROFILE);
+  });
+
+  it("extract-key has no central feedback-profile entry — resolves entirely to DEFAULT_PROFILE", () => {
+    assert.deepEqual(resolveFeedback("extract-key"), DEFAULT_PROFILE);
+  });
+
+  it("corrupt's live 'start' ACTION_FEEDBACK (durationTable branch) carries no inline override, so it resolves to DEFAULT_PROFILE too", () => {
+    initGame(buildOneIdsLAN, "corrupt-legibility");
+    const graph = getState().nodeGraph;
+    graph.setNodeAttr("ids-1", "accessLevel", "owned");
+
+    /** @type {any[]} */
+    const starts = [];
+    const h = (p) => { if (p.phase === "start") starts.push(p); };
+    on(E.ACTION_FEEDBACK, h);
+    graph.executeAction("ids-1", A.CORRUPT);
+    graph.tick(1); // durationTable branch resolves duration + emits "start"
+    off(E.ACTION_FEEDBACK, h);
+
+    assert.equal(starts.length, 1, "corrupt emits a 'start' ACTION_FEEDBACK (durationTable branch)");
+    assert.equal("feedback" in starts[0], false, "no inline feedback override declared on RECONFIGURE_ACTION");
+    assert.deepEqual(resolveFeedback(starts[0].action, starts[0].feedback), DEFAULT_PROFILE);
+  });
+});

--- a/tests/timed-synthesis.test.js
+++ b/tests/timed-synthesis.test.js
@@ -1,0 +1,110 @@
+// @ts-check
+// Phase 1 (#187): declarable `timed` block on a node-graph ActionDef synthesizes the
+// existing `timed-action` operator (operators.js) at node construction, rather than
+// hand-authoring the operator + "arm" effects per action (as the `encrypted` trait's
+// dump action does manually today). Dispatching a `timed` action arms it (flips the
+// active flag, zeroes progress, seeds a flat duration); the operator ticks progress and
+// fires the action's *original* effects as onComplete.
+//
+// Uses the same bare-NodeGraph + mockCtx pattern as js/core/node-graph/timed-action.test.js
+// (the sibling test for the operator itself) rather than the full game-state harness —
+// this is pure node-graph runtime behavior, no game state layer involved.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { NodeGraph } from "../js/core/node-graph/runtime.js";
+import { mockCtx } from "../js/core/node-graph/ctx.js";
+import { timedActiveAttr, getTimedActionAttrNames } from "../js/core/node-graph/timed-actions.js";
+
+/**
+ * A single node carrying one inline action with a `timed` block: fixed duration of 5
+ * ticks, onComplete effect sets `done` on the node itself.
+ * @param {object} [overrides]
+ */
+function makeTimedActionNode(overrides = {}) {
+  return {
+    id: "test-node",
+    type: "test",
+    attributes: { label: "test-node", visibility: "accessible", done: false },
+    actions: [
+      {
+        id: "test-act",
+        label: "TEST",
+        requires: [],
+        timed: { duration: 5 },
+        effects: [{ effect: "set-attr", attr: "done", value: true }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("timed-action synthesis (#187)", () => {
+  it("synthesizes a timed-action operator and arms the action's own effects at construction", () => {
+    const graph = new NodeGraph({ nodes: [makeTimedActionNode()], edges: [] }, mockCtx());
+    const node = /** @type {any} */ (graph)._nodes.get("test-node");
+
+    const activeAttr = timedActiveAttr("test-act");
+    const { progressAttr, durationAttr } = getTimedActionAttrNames("test-act");
+
+    const op = node.operators.find((/** @type {any} */ o) => o.name === "timed-action" && o.action === "test-act");
+    assert.ok(op, "expected a synthesized timed-action operator for test-act");
+    assert.equal(op.activeAttr, activeAttr);
+    assert.deepStrictEqual(op.onComplete, [{ effect: "set-attr", attr: "done", value: true }]);
+
+    const action = node.actions.find((/** @type {any} */ a) => a.id === "test-act");
+    assert.ok(action, "expected the test-act action to still be present after synthesis");
+    assert.deepStrictEqual(action.effects, [
+      { effect: "set-attr", attr: activeAttr, value: true },
+      { effect: "set-attr", attr: progressAttr, value: 0 },
+      { effect: "set-attr", attr: durationAttr, value: 5 },
+    ]);
+  });
+
+  it("is idempotent — synthesizing twice does not double the operator or re-wrap effects", () => {
+    const nodeDef = makeTimedActionNode();
+    // Constructing two graphs from the *same* node-def object simulates the shared-object
+    // risk with trait-supplied actions (a trait's ActionDef instance is reused, by
+    // reference, across every node that composes that trait).
+    new NodeGraph({ nodes: [nodeDef], edges: [] }, mockCtx());
+    const graph2 = new NodeGraph({ nodes: [nodeDef], edges: [] }, mockCtx());
+    const node = /** @type {any} */ (graph2)._nodes.get("test-node");
+
+    const timedOps = node.operators.filter((/** @type {any} */ o) => o.name === "timed-action" && o.action === "test-act");
+    assert.equal(timedOps.length, 1, "expected exactly one synthesized operator, not one per construction");
+  });
+
+  it("dispatching the action arms it instead of running effects immediately, then completes on tick", () => {
+    const ctx = mockCtx();
+    /** @type {{type: string, payload: any}[]} */
+    const events = [];
+    const graph = new NodeGraph(
+      { nodes: [makeTimedActionNode()], edges: [] },
+      ctx,
+      (type, payload) => events.push({ type, payload }),
+    );
+
+    graph.executeAction("test-node", "test-act");
+    assert.equal(graph.getNodeState("test-node").done, false, "effects should not run immediately on dispatch");
+    assert.equal(
+      graph.getNodeState("test-node")[timedActiveAttr("test-act")],
+      true,
+      "arm flag should be set immediately",
+    );
+
+    graph.tick(5); // flat duration:5 — no grade-table "set duration" tick needed, ticks straight to completion
+
+    assert.equal(graph.getNodeState("test-node").done, true, "onComplete effects should fire once duration elapses");
+    assert.equal(
+      graph.getNodeState("test-node")[timedActiveAttr("test-act")],
+      false,
+      "arm flag should clear on completion",
+    );
+
+    const completes = events.filter(
+      (e) => e.type === "action-feedback" && e.payload.phase === "complete" && e.payload.action === "test-act",
+    );
+    assert.equal(completes.length, 1, "expected exactly one complete action-feedback event for test-act");
+  });
+});

--- a/tests/timed-synthesis.test.js
+++ b/tests/timed-synthesis.test.js
@@ -17,6 +17,8 @@ import { NodeGraph } from "../js/core/node-graph/runtime.js";
 import { mockCtx } from "../js/core/node-graph/ctx.js";
 import { timedActiveAttr, getTimedActionAttrNames } from "../js/core/node-graph/timed-actions.js";
 import { dispatchActionFeedback } from "../js/ui/overlays/dispatch.js";
+import { DEFAULT_SCRIPT_ACTION_DURATION } from "../js/core/node-graph/timed-synthesis.js";
+import { A } from "../js/core/action-ids.js";
 
 /**
  * A single node carrying one inline action with a `timed` block: fixed duration of 5
@@ -239,5 +241,121 @@ describe("flat-duration 'start' feedback (#187 review fix — flatstart bug)", (
     const starts = events.filter((e) => e.type === "action-feedback" && e.payload.phase === "start");
     assert.equal(starts.length, 1, "exactly one start event, from the grade-table branch only");
     assert.equal(graph.getNodeState("test-node").done, true, "still completes at the grade-table duration");
+  });
+});
+
+// Timed-by-default flip (#187 default-flip): a script/set-piece action with NO explicit
+// `timed` block is synthesized anyway, using DEFAULT_SCRIPT_ACTION_DURATION, as long as it
+// isn't a core verb, isn't marked `instant`, and doesn't already have a hand-wired
+// timed-action operator for its id.
+describe("timed-by-default synthesis for script actions (#187 default-flip)", () => {
+  it("a plain script action with no timed/instant block is synthesized with the default duration", () => {
+    const node = {
+      id: "test-node",
+      type: "test",
+      attributes: { label: "test-node", visibility: "accessible", pressed: false },
+      actions: [
+        {
+          id: "press-button",
+          label: "PRESS",
+          requires: [],
+          effects: [{ effect: "set-attr", attr: "pressed", value: true }],
+        },
+      ],
+    };
+    const graph = new NodeGraph({ nodes: [node], edges: [] }, mockCtx());
+    const state = /** @type {any} */ (graph)._nodes.get("test-node");
+
+    const activeAttr = timedActiveAttr("press-button");
+    const { progressAttr, durationAttr } = getTimedActionAttrNames("press-button");
+
+    const op = state.operators.find((/** @type {any} */ o) => o.name === "timed-action" && o.action === "press-button");
+    assert.ok(op, "expected a synthesized timed-action operator for the default-timed script action");
+    assert.equal(op.activeAttr, activeAttr);
+    assert.equal(op.emitStartOnArm, true, "flat default duration should still emit start on arm");
+    assert.deepStrictEqual(op.onComplete, [{ effect: "set-attr", attr: "pressed", value: true }]);
+
+    const action = state.actions.find((/** @type {any} */ a) => a.id === "press-button");
+    assert.deepStrictEqual(action.effects, [
+      { effect: "set-attr", attr: activeAttr, value: true },
+      { effect: "set-attr", attr: progressAttr, value: 0 },
+      { effect: "set-attr", attr: durationAttr, value: DEFAULT_SCRIPT_ACTION_DURATION },
+    ]);
+  });
+
+  it("an action marked instant:true is not synthesized, even though it's a script action", () => {
+    const node = {
+      id: "test-node",
+      type: "test",
+      attributes: { label: "test-node", visibility: "accessible", pressed: false },
+      actions: [
+        {
+          id: "press-button",
+          label: "PRESS",
+          instant: true,
+          requires: [],
+          effects: [{ effect: "set-attr", attr: "pressed", value: true }],
+        },
+      ],
+    };
+    const graph = new NodeGraph({ nodes: [node], edges: [] }, mockCtx());
+    const state = /** @type {any} */ (graph)._nodes.get("test-node");
+
+    const op = state.operators.find((/** @type {any} */ o) => o.name === "timed-action" && o.action === "press-button");
+    assert.equal(op, undefined, "instant:true script action must not be synthesized");
+
+    const action = state.actions.find((/** @type {any} */ a) => a.id === "press-button");
+    assert.deepStrictEqual(action.effects, [{ effect: "set-attr", attr: "pressed", value: true }], "instant action effects run immediately, unmodified");
+  });
+
+  it("a core verb id with no explicit timed block is not auto-synthesized here", () => {
+    const node = {
+      id: "test-node",
+      type: "test",
+      attributes: { label: "test-node", visibility: "accessible" },
+      actions: [
+        {
+          id: A.DUMP,
+          label: "DUMP",
+          requires: [],
+          effects: [{ effect: "set-attr", attr: "read", value: true }],
+        },
+      ],
+    };
+    const graph = new NodeGraph({ nodes: [node], edges: [] }, mockCtx());
+    const state = /** @type {any} */ (graph)._nodes.get("test-node");
+
+    const op = state.operators.find((/** @type {any} */ o) => o.name === "timed-action" && o.action === A.DUMP);
+    assert.equal(op, undefined, "core verb without an explicit timed block is not auto-synthesized");
+
+    const action = state.actions.find((/** @type {any} */ a) => a.id === A.DUMP);
+    assert.deepStrictEqual(action.effects, [{ effect: "set-attr", attr: "read", value: true }], "core verb effects untouched");
+  });
+
+  it("does not double-wire when the node already has a hand-wired timed-action operator for that id", () => {
+    const node = {
+      id: "test-node",
+      type: "test",
+      attributes: { label: "test-node", visibility: "accessible", lyingLow: false },
+      operators: [
+        { name: "timed-action", action: "lie-low", activeAttr: "lyingLow", duration: 50, onComplete: [] },
+      ],
+      actions: [
+        {
+          id: "lie-low",
+          label: "LIE LOW",
+          requires: [],
+          effects: [{ effect: "set-attr", attr: "lyingLow", value: true }],
+        },
+      ],
+    };
+    const graph = new NodeGraph({ nodes: [node], edges: [] }, mockCtx());
+    const state = /** @type {any} */ (graph)._nodes.get("test-node");
+
+    const timedOps = state.operators.filter((/** @type {any} */ o) => o.name === "timed-action" && o.action === "lie-low");
+    assert.equal(timedOps.length, 1, "must not add a second timed-action operator for an id that already has one");
+
+    const action = state.actions.find((/** @type {any} */ a) => a.id === "lie-low");
+    assert.deepStrictEqual(action.effects, [{ effect: "set-attr", attr: "lyingLow", value: true }], "action effects left as-is when an operator already handles it");
   });
 });

--- a/tests/timed-synthesis.test.js
+++ b/tests/timed-synthesis.test.js
@@ -16,6 +16,7 @@ import assert from "node:assert/strict";
 import { NodeGraph } from "../js/core/node-graph/runtime.js";
 import { mockCtx } from "../js/core/node-graph/ctx.js";
 import { timedActiveAttr, getTimedActionAttrNames } from "../js/core/node-graph/timed-actions.js";
+import { dispatchActionFeedback } from "../js/ui/overlays/dispatch.js";
 
 /**
  * A single node carrying one inline action with a `timed` block: fixed duration of 5
@@ -33,6 +34,31 @@ function makeTimedActionNode(overrides = {}) {
         label: "TEST",
         requires: [],
         timed: { duration: 5 },
+        effects: [{ effect: "set-attr", attr: "done", value: true }],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+/**
+ * A single node carrying one inline action with a `timed` block using a `durationTable`
+ * (grade-scaled duration, resolved by the operator's own grade-table branch) instead of a
+ * flat `duration`. Used to confirm the flat-duration "start" fix does not also fire for
+ * this path, which already emits "start" from the grade-table branch.
+ * @param {object} [overrides]
+ */
+function makeDurationTableActionNode(overrides = {}) {
+  return {
+    id: "test-node",
+    type: "test",
+    attributes: { label: "test-node", visibility: "accessible", grade: "D", done: false },
+    actions: [
+      {
+        id: "table-act",
+        label: "TABLE",
+        requires: [],
+        timed: { durationTable: { D: 4 } },
         effects: [{ effect: "set-attr", attr: "done", value: true }],
       },
     ],
@@ -106,5 +132,112 @@ describe("timed-action synthesis (#187)", () => {
       (e) => e.type === "action-feedback" && e.payload.phase === "complete" && e.payload.action === "test-act",
     );
     assert.equal(completes.length, 1, "expected exactly one complete action-feedback event for test-act");
+  });
+});
+
+// #187 review fix: a flat-`duration` synthesized action (e.g. the set-piece extract-key/
+// crack-vault conversion in Phase 5) never emitted a "start" ACTION_FEEDBACK — its duration
+// is seeded directly by the arm effects (see timed-synthesis.js), which bypasses the
+// operator's grade-table first-tick branch, the only place "start" was emitted. Without
+// "start", the overlay dispatcher (js/ui/overlays/dispatch.js) never records the action in
+// `activeByAction`, so its "progress" events are silently dropped and no overlay animation
+// ever mounts. Fixed by emitting "start" on the first counting tick for flat-duration
+// actions, scoped via `emitStartOnArm` (set only by timed-synthesis.js's flat-duration path).
+describe("flat-duration 'start' feedback (#187 review fix — flatstart bug)", () => {
+  it("emits a 'start' action-feedback on the first tick for a flat duration (the regression)", () => {
+    /** @type {{type: string, payload: any}[]} */
+    const events = [];
+    const graph = new NodeGraph(
+      { nodes: [makeTimedActionNode()], edges: [] },
+      mockCtx(),
+      (type, payload) => events.push({ type, payload }),
+    );
+
+    graph.executeAction("test-node", "test-act");
+    graph.tick(1);
+
+    const starts = events.filter((e) => e.type === "action-feedback" && e.payload.phase === "start");
+    assert.equal(starts.length, 1, "expected exactly one start action-feedback for the flat-duration action");
+    assert.equal(starts[0].payload.action, "test-act");
+    assert.equal(starts[0].payload.nodeId, "test-node");
+    assert.equal(starts[0].payload.durationTicks, 5);
+
+    // Tick 1 must still carry its own progress event alongside the new start event — the
+    // fix must not swallow or delay the tick's regular output.
+    const progresses = events.filter((e) => e.type === "action-feedback" && e.payload.phase === "progress");
+    assert.equal(progresses.length, 1, "tick 1 should still emit its own progress event");
+  });
+
+  it("does not shift completion timing — still completes at exactly tick(duration), not duration+1", () => {
+    /** @type {{type: string, payload: any}[]} */
+    const events = [];
+    const graph = new NodeGraph(
+      { nodes: [makeTimedActionNode()], edges: [] },
+      mockCtx(),
+      (type, payload) => events.push({ type, payload }),
+    );
+
+    graph.executeAction("test-node", "test-act");
+    graph.tick(4);
+    assert.equal(graph.getNodeState("test-node").done, false, "not yet complete at tick 4 of a 5-tick duration");
+
+    graph.tick(1); // the 5th tick — completes
+    assert.equal(graph.getNodeState("test-node").done, true, "completes at exactly tick(5), no extra setup tick");
+
+    const completes = events.filter((e) => e.type === "action-feedback" && e.payload.phase === "complete");
+    assert.equal(completes.length, 1, "exactly one complete event, still at tick(duration)");
+  });
+
+  it("the emitted 'start' payload wires the overlay dispatcher — activeByAction is populated and the next progress is not dropped", () => {
+    /** @type {{type: string, payload: any}[]} */
+    const events = [];
+    const graph = new NodeGraph(
+      { nodes: [makeTimedActionNode()], edges: [] },
+      mockCtx(),
+      (type, payload) => events.push({ type, payload }),
+    );
+
+    graph.executeAction("test-node", "test-act");
+    graph.tick(1);
+
+    const start = events.find((e) => e.type === "action-feedback" && e.payload.phase === "start");
+    assert.ok(start, "expected a start event to feed into the overlay dispatcher");
+
+    const activeByAction = new Map();
+    const byName = new Map(); // overlay resolution itself is out of scope here
+    dispatchActionFeedback(byName, activeByAction, start.payload);
+    assert.ok(activeByAction.has("test-act"), "overlay dispatcher should now track the flat-duration action");
+
+    // A subsequent progress payload must no longer be dropped (dispatch.js:42 returns early
+    // when the action isn't in activeByAction — that's the observable symptom of the bug).
+    events.length = 0;
+    graph.tick(1);
+    const progress = events.find((e) => e.type === "action-feedback" && e.payload.phase === "progress");
+    assert.ok(progress, "expected a progress event on the next tick");
+    dispatchActionFeedback(byName, activeByAction, progress.payload);
+    assert.ok(activeByAction.has("test-act"), "progress should not have been dropped as unrecorded");
+  });
+
+  it("a durationTable-synthesized action still emits exactly ONE 'start', from the grade-table branch, not doubled", () => {
+    /** @type {{type: string, payload: any}[]} */
+    const events = [];
+    const graph = new NodeGraph(
+      { nodes: [makeDurationTableActionNode()], edges: [] },
+      mockCtx(),
+      (type, payload) => events.push({ type, payload }),
+    );
+
+    const op = /** @type {any} */ (graph)._nodes.get("test-node").operators
+      .find((/** @type {any} */ o) => o.name === "timed-action" && o.action === "table-act");
+    assert.ok(op, "expected a synthesized timed-action operator for table-act");
+    assert.equal(op.emitStartOnArm, undefined, "durationTable synthesis must not set emitStartOnArm");
+
+    graph.executeAction("test-node", "table-act");
+    graph.tick(1); // grade-table branch resolves duration + emits start (no progress yet)
+    graph.tick(4); // all 4 progress ticks of the grade-D duration
+
+    const starts = events.filter((e) => e.type === "action-feedback" && e.payload.phase === "start");
+    assert.equal(starts.length, 1, "exactly one start event, from the grade-table branch only");
+    assert.equal(graph.getNodeState("test-node").done, true, "still completes at the grade-table duration");
   });
 });

--- a/tests/volatile-not-abortable.test.js
+++ b/tests/volatile-not-abortable.test.js
@@ -1,0 +1,56 @@
+// @ts-check
+// Hardening fix, final review of #187 Phase 1/2: the `volatile` trait
+// (js/core/node-graph/traits.js) defines a hand-authored `timed-action` operator
+// that is NOT in the TIMED_ACTIONS registry and (before this fix) carried no
+// `_abortable` field. isOperatorAbortable() in runtime.js defaults an
+// unregistered `timed-action` operator to abortable — fine for synthesized
+// `timed` actions (#187 Phase 1), wrong for `volatile`: it self-arms on an
+// owned node and detonates involuntarily, like `reboot` (the one
+// TIMED_ACTIONS entry with `abortable:false`). ABORT must not be able to
+// disarm it.
+//
+// This is currently LATENT — no shipping node/biome composes the `volatile`
+// trait — but it's a trap for the next author of a volatile node.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { NodeGraph } from "../js/core/node-graph/runtime.js";
+import { getTimedActionAttrNames } from "../js/core/node-graph/timed-actions.js";
+import { A } from "../js/core/action-ids.js";
+
+// `hackable` supplies ABORT (and PROBE/EXPLOIT/MINE); `volatile` is the trait
+// under test. Composing both mirrors how a real volatile node would be built.
+function buildVolatileGraph() {
+  return new NodeGraph({
+    nodes: [
+      { id: "vault", type: "cryptovault", traits: ["hackable", "volatile"], attributes: {} },
+    ],
+    edges: [],
+  });
+}
+
+describe("volatile timed-action is not ABORT-cancellable (involuntary, like reboot)", () => {
+  it("arms busy but hides ABORT and reports no active abortable timed action", () => {
+    const graph = buildVolatileGraph();
+    const nodeId = "vault";
+    const { progressAttr, durationAttr } = getTimedActionAttrNames("volatile");
+
+    // Arm volatile directly (bypassing the owned-access trigger), the same way
+    // the reboot-guard test in tests/timed-busy.test.js arms reboot: set the
+    // activeAttr plus progress/duration.
+    graph.setNodeAttr(nodeId, "_volatile_armed", true);
+    graph.setNodeAttr(nodeId, progressAttr, 5);
+    graph.setNodeAttr(nodeId, durationAttr, 30);
+
+    assert.equal(graph.isNodeBusy(nodeId), true, "an armed volatile node is busy");
+    assert.equal(
+      graph.getActiveAbortableTimedAction(nodeId),
+      null,
+      "volatile must not be reported as an abortable timed action"
+    );
+
+    const available = graph.getAvailableActions(nodeId).map((a) => a.id);
+    assert.ok(!available.includes(A.ABORT), "ABORT is NOT offered while volatile is armed");
+  });
+});


### PR DESCRIPTION
Phase 1 of #187 — makes timing **declarable per action** and gives every timed action a **legible** default (overlay + drone + completion cue), so set-piece "duds" like *Extract Key* become real, abortable, on-screen events. Brainstormed + spec/plan under `docs/dev-sessions/2026-07-02-1031-timed-actions-phase1/`.

## What landed
- **Declarable `ActionDef.timed`** — at node construction, any action carrying `timed:{duration|durationTable, abortable?}` synthesizes the *existing* `timed-action` operator (effects → `onComplete`, action armed instead of run instantly). One runtime engine; core trait-verbs and inline set-piece actions share the same path. (Synthesis returns a new action object per node — trait `ActionDef`s are shared by reference, so in-place mutation would corrupt sibling nodes.)
- **Unified `isNodeBusy` / abortable-scoped ABORT** — one notion of "busy" spanning the node-graph operators **and** the #282 process framework (`isNodeBusy = active timed operator OR activeProcessOnNode`); ABORT + nav-cancel are scoped to *abortable* actions so involuntary ones (`reboot`, `volatile`) cant be cancelled.
- **Action → feedback profiles** — `{overlay, drone, completionCue}` resolved field-level **inline → central → default**. Set-piece authors set `feedback` inline; core verbs keep their bespoke overlays via central entries; drone/cue fall back to the existing maps; unmapped actions get the **generic default**.
- **Generic default overlay** (feel-tuned with Les in a slider lab): a stroked, clockwise-filling 12-segment ring (green, phosphene glow), pure geometry module + preview demo, driven off the managed overlay loop (no per-element RAF/filter — respects the redraw-perf rule). Feel-draft default drone + completion cue.
- **Proof slice:** `corrupt` (core, grade-scaled), `extract-key`, `crack-vault` (set-piece) → timed, abortable, legible.

## Verification
- `make check` green — **1437 tests** (baseline + 74 new across the phases).
- `make census SEEDS=50` **byte-identical to the branch base** (successRate 0.20 / traceFiredRate 0.88 / avgNodesOwned 3.44 / avgCash 4949) — zero balance regression. The bot was updated (`A.CORRUPT` → its timed set) to keep this stable.
- Headless-Chromium smoke: `generic-process-overlay` mounts in-game + renders stroked segments in the preview harness; zero same-origin console errors.
- Subagent-driven execution with per-phase spec+quality review; the review gate caught a real **reboot-abort exploit** (fixed) and the volatile-abortable landmine (fixed).

## Coordination / deferrals
- **#286 (reactive substrate):** strictly additive — the `processes.js` contract + `timed-actions.js`/`ABORTABLE_FLAGS` names are untouched. One shared-surface change relayed: overlay dispatch is now name-keyed (`mountOverlays()` returns `byName`).
- **#288:** full operator↔process runtime convergence + core-verb migration onto `timed` (deferred north-star).
- **Under #187:** Phase 2 breadth (remaining instant verbs + the rest of the set-piece actions + per-action duration tuning).
- **Future palette arc:** the three unchosen lab overlay styles are captured as candidates (session notes + the retained lab artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)