### PR TITLE
Heat history strip ("Ember Scope") + manual heat cheat (#295)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -546,9 +546,13 @@ and the global alert ratchets up a level (it can climb all the way to a trace). 
 different, **unadvertised** tolerance: a sleepy low-threat LAN absorbs a flurry that a hardened one
 would trip on instantly — you learn a network's patience by feel, not from a number.
 
-Heat shows as a **gauge** beside the alert in the status bar (cool → warm → hot). It's deliberately
-*relative* — it tells you how hot you're running, never exactly how close the line is. The skill is
-pacing: read the network, act in measured steps, and let it cool between moves rather than blitzing.
+Heat shows two ways. A **gauge** beside the alert in the status bar reads your heat *right now*
+(cool → warm → hot). And in the upper-right vitals stack — below the HEALTH and DECK traces — a
+**heat strip** draws it *over time* as a rising vector flame: it climbs as you act and sinks back as
+you pace or lie low, so you can watch a spike building and the cooldown taking hold. Both are
+deliberately *relative* — they tell you how hot you're running, never exactly how close the line is
+(the network's tolerance stays hidden). The skill is pacing: read the network, act in measured
+steps, and let it cool between moves rather than blitzing.
 
 ---
 

--- a/docs/dev-sessions/2026-07-02-1440-heat-history-strip/heat-strip-lab.html
+++ b/docs/dev-sessions/2026-07-02-1440-heat-history-strip/heat-strip-lab.html
@@ -1,0 +1,350 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Heat Strip Lab — Ember Scope (vector phosphor flame)</title>
+<!--
+  Throwaway tuning harness for issue #295 — "HUD: heat history strip below the vital waveforms".
+  Self-contained: open directly in a browser (file:// is fine, no modules).
+
+  Treatment D — "EMBER SCOPE": a hybrid of the earlier A (ridgeline) + C (stacked bands),
+  drawn with the REAL <starnet-waveform> mechanic — a standing oscilloscope. A sweep head
+  redraws left→right on repeat; each swept column is time-stamped into a buffer and the whole
+  thing is re-rendered per frame with age→alpha phosphor fade (NB bands). NOT a scrolling graph.
+
+  - Top edge   = jagged flame contour at the CURRENT heat height (ripples in behind the head).
+  - Fill       = per column, a stack of horizontal "electron-gun" scan-ticks from baseline up to
+                 the top edge. More heat → taller stack → denser raster fill. Stroke-only (no fill).
+  - Phosphor   = a painted column holds still and fades; shimmer comes from fresh jitter the beam
+                 lays down as it sweeps past (matches real-scope behavior).
+
+  Heat model mirrors the game: probe(+1)/xploit(+2)/replay(+3), decay ~0.6/sec, grade-keyed TRIP
+  threshold; crossing trip discharges heat to ~50% (HEAT_DISCHARGE_FRAC). Tune by eye, then port.
+-->
+<style>
+  :root { --bg:#0a0a0f; --fg:#9fb3c8; }
+  html,body { margin:0; background:var(--bg); color:var(--fg);
+              font:13px/1.5 ui-monospace,Menlo,Consolas,monospace; }
+  .wrap { max-width:820px; margin:22px auto; padding:0 16px 60px; }
+  h1 { font-size:14px; color:#ffd9a0; font-weight:600; letter-spacing:.08em; }
+  p.note { color:#6b7a90; }
+  .panel { background:#06060a; border:1px solid #20283a; border-radius:6px; padding:12px 14px; margin:12px 0;
+           box-shadow:inset 0 0 40px #000a; }
+  .lab-label { font-size:11px; letter-spacing:.12em; color:#7d5a3a; margin:0 0 6px; text-transform:uppercase; }
+  canvas { display:block; width:100%; height:auto; image-rendering:auto; }
+  .stack { display:flex; flex-direction:column; gap:5px; }
+  .stack .mini { border-top:1px dashed #1c2436; padding-top:6px; }
+  .stack .mini .lab-label { color:#42506a; }
+  .realrow { display:flex; gap:14px; align-items:flex-start; flex-wrap:wrap; }
+  .realrow .cell { background:#06060a; border:1px solid #20283a; border-radius:4px; padding:6px; }
+  .realrow .cell p { margin:0 0 4px; font-size:10px; letter-spacing:.1em; color:#7d5a3a; }
+  .realrow canvas { width:204px; height:44px; }
+  .controls { display:grid; grid-template-columns:auto 1fr auto; gap:9px 14px; align-items:center; margin-top:6px; }
+  .controls label { color:#8aa; font-size:12px; }
+  .controls output { color:#ffd9a0; min-width:52px; text-align:right; }
+  input[type=range]{ width:100%; accent-color:#ff6a1a; }
+  .row { display:flex; gap:16px; flex-wrap:wrap; align-items:center; margin-top:12px; }
+  .row label { font-size:12px; color:#8aa; display:flex; gap:6px; align-items:center; }
+  button { background:#1a120a; color:#ffd9a0; border:1px solid #4a3520; border-radius:4px;
+           padding:5px 11px; font:inherit; cursor:pointer; }
+  button:hover { background:#241808; }
+  button.hot { border-color:#7a3a10; }
+  .hp { color:#ffd9a0; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>★ EMBER SCOPE — vector phosphor flame (issue #295)</h1>
+  <p class="note">Standing oscilloscope, not a scroll: the sweep head redraws left→right on repeat,
+     phosphor trail fades behind it. Jagged top edge = current heat; the raster "fill" of horizontal
+     electron-gun ticks below grows denser/taller with heat. Drag HEAT or hit ▶ SIMULATE PLAY. Watch
+     the <span class="hp">real 204×44 HUD size</span> at the bottom — that's the true legibility test.</p>
+
+  <div class="panel">
+    <p class="lab-label">Ember Scope — tuning view (2× zoom)</p>
+    <canvas id="big" width="792" height="150"></canvas>
+  </div>
+
+  <div class="panel">
+    <p class="lab-label">In context — stacked under the vitals (approx)</p>
+    <div class="stack">
+      <div class="mini"><p class="lab-label" style="color:#39ff7a">HEALTH · ecg (placeholder)</p>
+        <canvas id="ph1" width="408" height="34"></canvas></div>
+      <div class="mini"><p class="lab-label" style="color:#b06cff">DECK · pulse (placeholder)</p>
+        <canvas id="ph2" width="408" height="34"></canvas></div>
+      <div class="mini"><p class="lab-label" style="color:#ff6a1a">HEAT · ember scope</p>
+        <canvas id="ctx1" width="408" height="44"></canvas></div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <p class="lab-label">Real HUD strip size — 204 × 44 (this is what actually ships)</p>
+    <div class="realrow">
+      <div class="cell"><p>heat ember scope</p><canvas id="real" width="204" height="44"></canvas></div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="controls">
+      <label for="heat">HEAT (manual)</label>
+      <input id="heat" type="range" min="0" max="15" step="0.1" value="4" /><output id="heatv">4.0</output>
+      <label for="trip">TRIP threshold</label>
+      <input id="trip" type="range" min="3" max="15" step="1" value="7" /><output id="tripv">7</output>
+      <label for="speed">Sweep speed (px/s)</label>
+      <input id="speed" type="range" min="30" max="220" value="90" /><output id="speedv">90</output>
+      <label for="trail">Trail (× sweep)</label>
+      <input id="trail" type="range" min="30" max="150" value="90" /><output id="trailv">0.90</output>
+      <label for="bandgap">Band spacing (px)</label>
+      <input id="bandgap" type="range" min="2" max="14" step="0.5" value="4" /><output id="bandgapv">4.0</output>
+      <label for="maxbands">Max bands (cap)</label>
+      <input id="maxbands" type="range" min="2" max="12" step="1" value="12" /><output id="maxbandsv">12</output>
+      <label for="bandfade">Lower-band transparency</label>
+      <input id="bandfade" type="range" min="0" max="100" value="60" /><output id="bandfadev">60</output>
+      <label for="jag">Jaggedness</label>
+      <input id="jag" type="range" min="0" max="100" value="50" /><output id="jagv">50</output>
+      <label for="bloom">Bloom</label>
+      <input id="bloom" type="range" min="0" max="16" value="6" /><output id="bloomv">6</output>
+    </div>
+    <div class="row">
+      <button id="sim" class="hot">▶ SIMULATE PLAY</button>
+      <button id="probe">probe +1</button>
+      <button id="xploit">xploit +2</button>
+      <button id="replay">replay +3</button>
+      <button id="lielow">LIE LOW −6</button>
+      <label><input type="checkbox" id="showtrip" /> show TRIP line (lab-only; won't ship)</label>
+      <label><input type="checkbox" id="ramp" checked /> amber→red ramp</label>
+      <span id="status" class="hp"></span>
+    </div>
+  </div>
+</div>
+
+<script>
+"use strict";
+// ---- shared params + heat model ------------------------------------------
+const P = {
+  heat: 4, trip: 7, speed: 90, trail: 0.9, bandgap: 4, maxbands: 12, bandfade: 60, jag: 50, bloom: 6,
+  showtrip: false, ramp: true, sim: false,
+};
+const MAXBANDS_CEIL = 12;
+const HMAX = 15;            // y-scale ceiling (F-grade max)
+const DECAY = 0.6;          // per second
+const DISCHARGE_FRAC = 0.5; // trip discharges to ~50%
+let tripFlash = 0, armed = true;
+
+// ---- controls wiring ------------------------------------------------------
+function bind(id, key, fmt) {
+  const el = document.getElementById(id), out = document.getElementById(id + "v");
+  const upd = () => { P[key] = parseFloat(el.value); if (out) out.textContent = fmt ? fmt(P[key]) : el.value; };
+  el.addEventListener("input", upd); upd();
+}
+bind("heat","heat",v=>v.toFixed(1)); bind("trip","trip",v=>String(v|0));
+bind("speed","speed"); bind("trail","trail",v=>(v/100).toFixed(2));
+bind("bandgap","bandgap",v=>v.toFixed(1)); bind("maxbands","maxbands",v=>String(v|0)); bind("bandfade","bandfade");
+bind("jag","jag"); bind("bloom","bloom");
+// trail slider is 30..150 meaning 0.30..1.50
+document.getElementById("trail").addEventListener("input", e => P.trail = parseFloat(e.target.value)/100);
+P.trail = 0.9;
+document.getElementById("heat").addEventListener("input", () => { P.sim = false; setSimBtn(); });
+["showtrip","ramp"].forEach(id =>
+  document.getElementById(id).addEventListener("change", e => P[id] = e.target.checked));
+function bump(a){ P.heat = Math.min(HMAX, P.heat + a); syncHeat(); }
+document.getElementById("probe").onclick  = () => bump(1);
+document.getElementById("xploit").onclick = () => bump(2);
+document.getElementById("replay").onclick = () => bump(3);
+document.getElementById("lielow").onclick = () => { P.heat = Math.max(0, P.heat-6); syncHeat(); };
+function syncHeat(){ const el=document.getElementById("heat"); el.value=P.heat;
+  document.getElementById("heatv").textContent=P.heat.toFixed(1); }
+const simBtn = document.getElementById("sim");
+function setSimBtn(){ simBtn.textContent = P.sim ? "⏸ PAUSE SIM" : "▶ SIMULATE PLAY"; }
+simBtn.onclick = () => { P.sim=!P.sim; setSimBtn(); };
+
+// ---- color ----------------------------------------------------------------
+function heatColor(frac){
+  if (!P.ramp) return "#ff8a2a";
+  const t = Math.max(0, Math.min(1, frac));
+  const stops = [[255,176,32],[255,106,26],[255,42,42]];
+  const seg = t<0.5?0:1, lt = t<0.5?t/0.5:(t-0.5)/0.5;
+  const a=stops[seg], b=stops[seg+1];
+  const c=a.map((v,i)=>Math.round(v+(b[i]-v)*lt));
+  return `rgb(${c[0]},${c[1]},${c[2]})`;
+}
+// stack color: u=0 (base) yellow → u=1 (crown) red
+function stackColor(u){
+  if (!P.ramp) return "#ff7a2a";
+  const t = Math.max(0, Math.min(1, u));
+  const yellow=[255,225,55], red=[255,40,40];
+  const c = yellow.map((v,i)=>Math.round(v+(red[i]-v)*t));
+  return `rgb(${c[0]},${c[1]},${c[2]})`;
+}
+// stable per-column pseudo-noise from a frozen seed r (no time term → phosphor holds still)
+function noise(r, k){ return Math.sin(r*12.9898 + k*4.1414)*43758.5453 % 1; }
+
+// ---- Ember Scope: one instance per canvas --------------------------------
+const NB = 12, STEP = 2;
+function makeScope(canvas){
+  const dpr = window.devicePixelRatio || 1;
+  const W = canvas.width / dpr || canvas.width, H = canvas.height / dpr || canvas.height;
+  // size for dpr crispness
+  const cssW = canvas.getAttribute("width")|0, cssH = canvas.getAttribute("height")|0;
+  canvas.width = Math.round(cssW*dpr); canvas.height = Math.round(cssH*dpr);
+  canvas.style.width = cssW+"px"; canvas.style.height = cssH+"px";
+  const ctx = canvas.getContext("2d");
+  ctx.setTransform(dpr,0,0,dpr,0,0);
+  return { ctx, W:cssW, H:cssH, buf:[], head:0, last:null };
+}
+function frameScope(s, now){
+  const { ctx, W, H } = s;
+  const dt = s.last!=null ? Math.min(now-s.last, 0.05) : 0; s.last = now;
+  const base = H-3, top = 4, span = base-top;
+  const level = P.heat/HMAX;                    // 0..1 of y-scale
+  const jag = P.jag/100;
+
+  // advance sweep head, sampling current shape into buffer
+  const sweepT = W/Math.max(1,P.speed);
+  const trailDur = sweepT*Math.max(0.05,P.trail);
+  const target = s.head + P.speed*dt;
+  while (s.head < target){
+    const segStart = s.head;
+    const next = Math.min(s.head+STEP, target);
+    const x = next % W;
+    const gap = Math.floor(next/W) !== Math.floor(segStart/W);
+    const r = Math.random();                    // frozen jitter seed for this column
+    s.buf.push({ x, t:now, gap, level, r });
+    s.head = next;
+  }
+  const cutoff = now - trailDur;
+  while (s.buf.length && s.buf[0].t < cutoff) s.buf.shift();
+
+  ctx.clearRect(0,0,W,H);
+  drawTrip(ctx, W, base, span);
+
+  ctx.lineCap = "round"; ctx.lineJoin = "round";
+  const bandOf = (p)=>Math.floor(((now-p.t)/trailDur)*NB);
+  const fade = P.bandfade/100;
+
+  // Fixed-spacing bands anchored to the crown. j=0 is the crown (top edge); each lower
+  // band sits GAP px below the one above. A band exists for a column only while it stays
+  // above the baseline — so lines are added/removed ONLY at the bottom, never redistributed.
+  const GAP = P.bandgap;
+  const MAXB = Math.min(MAXBANDS_CEIL, P.maxbands|0);
+
+  const crownYof = (p) => base - p.level*span - noise(p.r,1)*jag*3*(0.4+p.level);
+  const yOf = (p, j) => {                             // j=0 crown, j>0 lower tongues
+    const crown = crownYof(p);
+    const jitDamp = Math.max(0, 1 - j*0.14);          // base is calmer than the crown
+    const jit = noise(p.r,1)*jag*3*(0.4+p.level)*(1 - jitDamp);
+    return crown + j*GAP + jit;                        // fixed GAP below crown
+  };
+  const exists = (p, j) => (base - crownYof(p)) >= j*GAP + 0.5;  // room for this band?
+
+  // draw bottom → top so the bright crown lands on top
+  for (let j=MAXB-1; j>=0; j--){
+    const u = MAXB>1 ? 1 - j/(MAXB-1) : 1;            // crown red(1) → deeper base orange(0)
+    const col = stackColor(u);
+    const isCrown = j===0;
+    ctx.lineWidth = isCrown ? 1.4 : 1.1;
+    ctx.strokeStyle = col; ctx.shadowColor = col; ctx.shadowBlur = isCrown ? P.bloom : Math.max(0,P.bloom-2);
+    const dim = isCrown ? 1 : (1 - fade*(1-u));       // lower bands optionally dimmer
+    let curBand=-1, open=false;
+    const flush=()=>{ if(open){ ctx.globalAlpha = dim*(1-(curBand+0.5)/NB); ctx.stroke(); open=false; } };
+    for (let i=1;i<s.buf.length;i++){
+      const a=s.buf[i-1], b=s.buf[i];
+      const band=bandOf(b);
+      if (b.gap || band>=NB || !exists(a,j) || !exists(b,j)){ flush(); curBand=-1; continue; }
+      if (band!==curBand){ flush(); ctx.beginPath(); ctx.moveTo(a.x, yOf(a,j)); curBand=band; open=true; }
+      ctx.lineTo(b.x, yOf(b,j));
+    }
+    flush();
+  }
+  ctx.globalAlpha=1;
+
+  // leading head dot rides the crown
+  if (s.buf.length){
+    const p=s.buf[s.buf.length-1], y=yOf(p,0);
+    const col=stackColor(1);
+    ctx.fillStyle=col; ctx.shadowColor=col; ctx.shadowBlur=P.bloom+3;
+    ctx.beginPath(); ctx.arc(p.x,y,2,0,Math.PI*2); ctx.fill();
+    ctx.fillStyle="#fff6e8"; ctx.shadowBlur=0;
+    ctx.beginPath(); ctx.arc(p.x,y,0.8,0,Math.PI*2); ctx.fill();
+  }
+  ctx.shadowBlur=0;
+
+  if (tripFlash>0){
+    const al=Math.min(1,tripFlash/0.4);
+    ctx.strokeStyle=`rgba(255,40,40,${al})`; ctx.lineWidth=2;
+    ctx.strokeRect(1,1,W-2,H-2);
+  }
+}
+function drawTrip(ctx, W, base, span){
+  if (!P.showtrip) return;
+  const y = base - (P.trip/HMAX)*span;
+  ctx.save();
+  ctx.setLineDash([4,4]); ctx.lineWidth=1; ctx.shadowBlur=0;
+  ctx.strokeStyle="rgba(255,60,60,0.5)";
+  ctx.beginPath(); ctx.moveTo(0,y); ctx.lineTo(W,y); ctx.stroke();
+  ctx.setLineDash([]); ctx.font="9px ui-monospace,monospace";
+  ctx.fillStyle="rgba(255,90,90,0.65)"; ctx.fillText("TRIP",3,y-2);
+  ctx.restore();
+}
+
+// ---- placeholder vital scopes (green ecg-ish, violet pulse-ish) -----------
+function makePlain(canvas){ return makeScope(canvas); }
+function framePlain(s, now, kind, col){
+  const { ctx, W, H } = s;
+  const dt = s.last!=null?Math.min(now-s.last,0.05):0; s.last=now;
+  const mid=H/2;
+  const sweepT=W/120, trailDur=sweepT*0.8;
+  const target=s.head+120*dt;
+  while(s.head<target){ const seg=s.head, next=Math.min(s.head+STEP,target);
+    const x=next%W; const gap=Math.floor(next/W)!==Math.floor(seg/W);
+    let y=mid;
+    if(kind==="ecg"){ const ph=(x/W)*4%1; y=mid - (ph>0.5&&ph<0.56?18:ph>0.56&&ph<0.6?-8:0); }
+    else { const ph=(x/W)*4%1; y=mid - (ph<0.5?10:-10); }
+    s.buf.push({x,t:now,gap,y}); s.head=next; }
+  const cutoff=now-trailDur; while(s.buf.length&&s.buf[0].t<cutoff) s.buf.shift();
+  ctx.clearRect(0,0,W,H);
+  ctx.strokeStyle=col; ctx.shadowColor=col; ctx.shadowBlur=6; ctx.lineWidth=1.3;
+  const bandOf=(p)=>Math.floor(((now-p.t)/trailDur)*NB);
+  let cur=-1,open=false; const flush=()=>{if(open){ctx.globalAlpha=1-(cur+0.5)/NB;ctx.stroke();open=false;}};
+  for(let i=1;i<s.buf.length;i++){const a=s.buf[i-1],b=s.buf[i];const band=bandOf(b);
+    if(b.gap||band>=NB){flush();cur=-1;continue;}
+    if(band!==cur){flush();ctx.beginPath();ctx.moveTo(a.x,a.y);cur=band;open=true;} ctx.lineTo(b.x,b.y);}
+  flush(); ctx.globalAlpha=1; ctx.shadowBlur=0;
+}
+
+// ---- main loop ------------------------------------------------------------
+const big = makeScope(document.getElementById("big"));
+const ctx1 = makeScope(document.getElementById("ctx1"));
+const real = makeScope(document.getElementById("real"));
+const ph1 = makePlain(document.getElementById("ph1"));
+const ph2 = makePlain(document.getElementById("ph2"));
+let nextSpike = 0.8;
+function tick(nowMs){
+  const now = nowMs/1000;
+  const dtGlobal = big.last!=null ? Math.min(now-big.last,0.1) : 0;
+  if (P.sim){
+    P.heat = Math.max(0, P.heat - DECAY*dtGlobal);
+    nextSpike -= dtGlobal;
+    if (nextSpike<=0){ const r=Math.random();
+      P.heat=Math.min(HMAX,P.heat+(r<0.45?1:r<0.8?2:3)); nextSpike=0.5+Math.random()*1.4; }
+    syncHeat();
+  }
+  if (armed && P.heat>=P.trip){ tripFlash=0.4; armed=false; P.heat=P.trip*DISCHARGE_FRAC; syncHeat(); }
+  if (!armed && P.heat<P.trip*0.9) armed=true;
+  if (tripFlash>0) tripFlash-=dtGlobal;
+
+  frameScope(big, now);
+  frameScope(ctx1, now);
+  frameScope(real, now);
+  framePlain(ph1, now, "ecg", "#39ff7a");
+  framePlain(ph2, now, "pulse", "#b06cff");
+
+  document.getElementById("status").textContent =
+    `heat ${P.heat.toFixed(1)} / trip ${P.trip}` + (P.heat>=P.trip*0.9?"  ⚠ near trip":"");
+  requestAnimationFrame(tick);
+}
+setSimBtn();
+requestAnimationFrame(tick);
+</script>
+</body>
+</html>

--- a/docs/dev-sessions/2026-07-02-1440-heat-history-strip/notes.md
+++ b/docs/dev-sessions/2026-07-02-1440-heat-history-strip/notes.md
@@ -1,0 +1,48 @@
+# Notes — heat history strip ("Ember Scope")
+
+## Summary
+
+Added a third phosphor strip ("Ember Scope") to the HUD vitals stack that renders `state.heat`
+over time as a stroke-only vector flame — issue #295. The existing heat *lamp* shows heat right
+now; this shows its *trajectory* (rise toward the hidden alarm, decay after lying low).
+
+Shipped:
+- `js/ui/heat-flame.js` — pure, tested flame geometry (crown + fixed-gap contour bands,
+  add-from-bottom, red-crown→yellow-base, index-keyed color + transparency).
+- `<starnet-heat-scope>` — thin canvas component reusing the `<starnet-waveform>` sweep+phosphor
+  plumbing over the pure geometry. Wired into the preview harness (heat/speed/gap/bloom sliders).
+- Mounted in `#vital-stack` between DECK and VISIT WAN; `syncVitals` drives `frac` from
+  `state.heat / HEAT_GAUGE_MAX` (shared scale with the lamp; the alarm threshold stays hidden —
+  no trip line shown).
+- `cheat hurt heat <amount>` / `cheat heal heat [amount]` for manual testing (real
+  recordHeat / decayHeat pathways).
+- MANUAL.md updated (the heat section now describes both gauge and strip).
+
+## Process notes
+
+- **Feel-driven work → prototype first.** The look was dialed in live in a throwaway slider lab
+  (`heat-strip-lab.html`, kept in this dir as the tuned reference) before any production code. The
+  design went through several turns with Les: dense-fill → discrete chunky lines; even-redistribute
+  → fixed-gap add-from-bottom; orange→ red→yellow palette; a visible idle baseline at heat 0 that
+  keeps a subtle shimmer (deliberately NOT dead-flat — Les overrode a Copilot suggestion to flatten
+  it); sweep speed synced to the vitals (100 px/s). Seeing beat specifying.
+- **Component is a documented TDD opt-out** — canvas/RAF/dpr plumbing with no logic beyond the
+  pure module (`getContext` isn't available under `node:test`). Verified via headless-Chrome
+  screenshots (frac 0 / low / high + zoom) instead; the geometry carries the unit tests.
+
+## Tuned defaults (starting values; fine-tune in-game)
+
+band gap 4px · max bands 12 · jaggedness 0.5 · lower-band transparency 0.6 · sweep 100 px/s ·
+trail 0.9 · bloom 6. Y-scale = `HEAT_GAUGE_MAX` (12).
+
+## Follow-ups / possible later
+
+- If the sweep bookkeeping duplicated between `<starnet-waveform>` and `<starnet-heat-scope>` ever
+  grows, extract a shared scope-sweep helper (deliberately deferred — small duplication).
+- Heat trail left at 0.9 (vitals are 0.72) for a slightly longer flame persistence — flagged to
+  Les; keep unless it reads out of place.
+
+## Verification
+
+`make check` green (1394 tests, lint clean). `make census SEEDS=10` 10/10 (pure-UI change, bot
+path untouched). Live in-game confirmation via `cheat hurt/heal heat`.

--- a/docs/dev-sessions/2026-07-02-1440-heat-history-strip/plan.md
+++ b/docs/dev-sessions/2026-07-02-1440-heat-history-strip/plan.md
@@ -1,0 +1,249 @@
+# Heat History Strip ("Ember Scope") Implementation Plan
+
+**Goal:** Add a third phosphor strip below HEALTH/DECK in the HUD that renders `state.heat` over
+time as a stroke-only vector flame.
+
+**Approach:** New pure geometry module `js/ui/heat-flame.js` (tested) + a thin canvas component
+`<starnet-heat-scope>` (canvas/RAF/dpr plumbing, sweep+phosphor loop), mirroring the
+`waveform.js` / `<starnet-waveform>` split. The existing heat gauge lamp stays. Y-scale reuses
+`HEAT_GAUGE_MAX`. No mechanic changes; read-only visualization.
+
+**Tech stack:** Vanilla ES modules, Lit (light-DOM component base `starnet-element.js`), Canvas 2D,
+`node:test` for the pure module. The tuned reference is `heat-strip-lab.html` in this session dir.
+
+---
+
+## Phase 1: Pure flame geometry module + tests
+
+Deliver `js/ui/heat-flame.js` — deterministic, DOM-free geometry + color/alpha for the flame,
+with unit tests. This is the testable core; the component (Phase 2) is plumbing over it.
+
+**Files:**
+- Create: `js/ui/heat-flame.js`
+- Create: `tests/heat-flame.test.js`
+- Modify: `js/ui/indicator-glyphs.js` — export the existing scale: `const HEAT_GAUGE_MAX = 12;`
+  → `export const HEAT_GAUGE_MAX = 12;` (no value change; Phase 3 imports it).
+
+**Key changes** (all pure; `geom` bundles the per-frame canvas metrics):
+```js
+// js/ui/heat-flame.js  — @ts-check, no DOM, no Math.random (seeds passed in)
+
+const YELLOW = [255, 225, 55], RED = [255, 40, 40];
+
+/** Deterministic bounded pseudo-noise in (-1, 1) from a frozen column seed r and index k. */
+export function flameNoise(r, k) {
+  return (Math.sin(r * 12.9898 + k * 4.1414) * 43758.5453) % 1;
+}
+
+/** y of contour band j (j=0 = crown/top edge; higher j = lower tongues) for a column.
+ *  level = heat fraction 0..1; r = frozen per-column seed; geom = {base, span, gap, jag}. */
+export function bandY(level, r, j, { base, span, gap, jag }) {
+  const jitMag = flameNoise(r, 1) * jag * 3 * (0.4 + level);
+  const jitDamp = Math.max(0, 1 - j * 0.14);   // base is calmer than the crown
+  return base - level * span + j * gap - jitMag * jitDamp;
+}
+
+/** Does band j have room above the baseline for this column's flame height?
+ *  Bands are added/removed ONLY at the bottom → monotone in j and in level. */
+export function bandExists(level, j, { span, gap }) {
+  return level * span >= j * gap + 0.5;
+}
+
+/** Stroke color for band index j: crown (j=0) red → deepest band (j=maxBands-1) yellow. */
+export function bandColor(j, maxBands) {
+  const u = maxBands > 1 ? 1 - j / (maxBands - 1) : 1;   // 1 red .. 0 yellow
+  const c = YELLOW.map((v, i) => Math.round(v + (RED[i] - v) * u));
+  return `rgb(${c[0]},${c[1]},${c[2]})`;
+}
+
+/** Alpha multiplier by band index: crown = 1, lower bands progressively more transparent. */
+export function bandAlpha(j, maxBands, fade) {
+  if (j === 0) return 1;
+  const t = maxBands > 1 ? j / (maxBands - 1) : 0;
+  return 1 - fade * t;
+}
+```
+
+**Tests** (`tests/heat-flame.test.js`, `node:test`):
+```js
+// flameNoise: deterministic + bounded
+assert.equal(flameNoise(0.3, 1), flameNoise(0.3, 1));
+assert.ok(Math.abs(flameNoise(0.7, 2)) <= 1);
+
+// bandY: jag=0 → clean geometry; crown = base-span*level; constant gap; band 0 == crown
+const g = { base: 40, span: 36, gap: 4, jag: 0 };
+assert.equal(bandY(0.5, 0.9, 0, g), 40 - 0.5 * 36);            // crown height
+assert.equal(bandY(0.5, 0.9, 2, g) - bandY(0.5, 0.9, 1, g), 4); // fixed spacing
+assert.ok(bandY(1, 0.5, 0, g) < bandY(0.2, 0.5, 0, g));         // hotter → higher crown (smaller y)
+
+// bandExists: add-from-bottom invariants
+assert.ok(bandExists(1, 0, g));                                 // crown present when hot
+assert.ok(!bandExists(0.01, 3, g));                             // no room when cold
+// if band j exists, every shallower band exists (monotone in j)
+for (const lvl of [0.2, 0.5, 0.9]) for (let j = 1; j < 8; j++)
+  if (bandExists(lvl, j, g)) assert.ok(bandExists(lvl, j - 1, g));
+// monotone in level for fixed j
+assert.ok(!(bandExists(0.3, 4, g) && !bandExists(0.9, 4, g)));
+
+// bandColor: endpoints red crown, yellow base
+assert.equal(bandColor(0, 6), "rgb(255,40,40)");
+assert.equal(bandColor(5, 6), "rgb(255,225,55)");
+
+// bandAlpha: crown opaque, decreasing, non-negative
+assert.equal(bandAlpha(0, 6, 0.6), 1);
+assert.ok(bandAlpha(5, 6, 0.6) < bandAlpha(1, 6, 0.6));
+assert.ok(bandAlpha(5, 6, 0.6) >= 0);
+```
+
+**Verification — automated:**
+- [x] `node --test tests/heat-flame.test.js` passes (11/11)
+- [x] `make check` passes (lint + full test suite; 1389 tests)
+
+**Verification — manual:**
+- [x] (none — pure module; visual verification in Phase 2)
+
+---
+
+## Phase 2: `<starnet-heat-scope>` component + preview demo
+
+Deliver the canvas component and wire it into the preview harness so the flame is viewable and
+tuneable in isolation (CLAUDE.md: new visual effects MUST be added to the preview harness).
+
+**Files:**
+- Create: `js/ui/components/starnet-heat-scope.js`
+- Modify: `preview.html` — add a "Heat Scope" section mirroring the "Vital Waveforms" panel
+  (`preview.html:268-300`): a `#heat-scope-demo` mount + a HEAT slider (`#heat-scope-val`) and
+  optional SPEED/BLOOM/GAP sliders.
+- Modify: `js/ui/preview.js` — mirror the waveform demo (`preview.js:403-430`): create a
+  `<starnet-heat-scope>`, wire the HEAT slider to its `frac`.
+- Modify: `preview.html` — add `<script type="module" src="js/ui/components/starnet-heat-scope.js"></script>`
+  alongside the other component scripts (and it will be loaded on index in Phase 3).
+
+**Key changes** — component mirrors `<starnet-waveform>` (`starnet-waveform.js:111-222`) for dpr
+setup, color-var resolution, the RAF loop, sweep-head advance (`STEP=2`), trail cutoff, and
+age-band batching (`NB=12`). Differences: buffer schema and the multi-band draw via `heat-flame`.
+
+```js
+// js/ui/components/starnet-heat-scope.js
+import { html, nothing } from "lit";
+import { StarnetElement } from "./starnet-element.js";
+import { bandY, bandExists, bandColor, bandAlpha } from "../heat-flame.js";
+
+const STEP = 2, NB = 12, CEIL = 12;
+
+class StarnetHeatScope extends StarnetElement {
+  static properties = {
+    frac: { type: Number }, label: { type: String },
+    w: { type: Number }, h: { type: Number },
+    speed: { type: Number }, trail: { type: Number }, bloom: { type: Number },
+    bandGap: { type: Number }, maxBands: { type: Number }, jag: { type: Number }, fade: { type: Number },
+    autosize: { type: Boolean },
+  };
+  constructor() {
+    super();
+    this.frac = 0; this.label = "HEAT";
+    this.w = 204; this.h = 44;
+    this.speed = 90; this.trail = 0.9; this.bloom = 6;         // tuned defaults (lab)
+    this.bandGap = 4; this.maxBands = 12; this.jag = 0.5; this.fade = 0.6;
+    this.autosize = false;
+    this._buf = []; this._head = 0; this._lastTs = null; this._rafId = null; this._ctx = null;
+    this._W = this.w; this._H = this.h; this._ro = null;
+  }
+  render() {
+    return html`
+      ${this.label ? html`<div class="vital-head"><span class="vital-label">${this.label}</span></div>` : nothing}
+      <span class="hud-waveform"><canvas></canvas></span>`;
+  }
+  // firstUpdated/updated/connected/disconnected/_setupCanvas/_startLoop/_stopLoop:
+  //   copy verbatim from starnet-waveform.js:82-157 (no color-var needed → drop _resolveColor).
+  _frame(ts) {
+    // 1. advance sweep head, pushing {x, level: frac, r: Math.random(), t: now, gap} each STEP px
+    //    (frozen r per column so phosphor holds still); drop buf entries older than trail cutoff.
+    // 2. clear; for j = maxBands-1 .. 0: batch columns by age band into one path per band,
+    //    skipping p.gap and columns where !bandExists(p.level, j, {span, gap}); stroke with
+    //    strokeStyle/shadowColor = bandColor(j, MAXB), globalAlpha = bandAlpha(j,MAXB,fade)*ageAlpha.
+    // 3. leading head dot at bandY(head.level, head.r, 0, geom), color bandColor(0, MAXB).
+    // Geometry: base = H-3, span = (H-3) - 4, gap = bandGap, jag = jag; MAXB = min(CEIL, maxBands).
+    // Exact draw is ported from heat-strip-lab.html (frameScope) in this session dir.
+  }
+}
+customElements.define("starnet-heat-scope", StarnetHeatScope);
+```
+
+Preview wiring:
+```js
+// js/ui/preview.js — after the waveform demo block
+const heatDemo = $("heat-scope-demo"), heatSlider = $("heat-scope"), heatVal = $("heat-scope-val");
+if (heatDemo && heatSlider) {
+  const scope = document.createElement("starnet-heat-scope");
+  scope.frac = 0.4; scope.style.width = "204px"; scope.className = "vital-strip";
+  heatDemo.append(scope);
+  heatSlider.addEventListener("input", () => {
+    scope.frac = +heatSlider.value / 100;            // slider 0..100 = frac 0..1 (HEAT_GAUGE_MAX scale)
+    if (heatVal) heatVal.textContent = String(heatSlider.value);
+  });
+}
+```
+
+**Test opt-out:** The component is canvas/RAF/dpr plumbing with no logic beyond what Phase 1
+already unit-tests; `getContext("2d")` isn't available under `node:test`. Verified manually in the
+preview harness instead. (Documented per plan TDD opt-out for rendering scaffolding.)
+
+**Verification — automated:**
+- [x] `make check` passes (lint sees the new component + preview edits; 1389 tests)
+
+**Verification — manual:** _(self-verified via headless-Chrome screenshot of a focused mount at
+frac 0.25 / 0.6 / 0.95 + a 520×110 zoom; awaiting Les's live confirmation in `/preview.html`)_
+- [x] Heat Scope panel shows a swept flame
+- [x] Crown rises with heat; lines add **only at the bottom** (no redistribution)
+- [x] Red crown → yellow base; lower lines more transparent
+- [x] Reads legibly at the 204×44 strip size
+
+---
+
+## Phase 3: Live HUD integration + manual
+
+Mount the strip in `#vital-stack` between DECK and the VISIT WAN button, drive its `frac` from
+`state.heat`, style it, and document it.
+
+**Files:**
+- Modify: `index.html` — add the component script tag; add the strip markup in `#vital-stack`
+  (`index.html:43-52`) between `#vital-deck` and `<starnet-uplink>`:
+  ```html
+  <starnet-heat-scope id="vital-heat" class="vital-strip" autosize
+    label="HEAT" h="44" speed="90" trail="0.9" bloom="6"></starnet-heat-scope>
+  ```
+- Modify: `js/ui/visual-renderer.js` — in `syncVitals` (`:406`), set the heat strip frac:
+  ```js
+  import { HEAT_GAUGE_MAX } from "./indicator-glyphs.js";   // top of file
+  // inside syncVitals:
+  const heatEl = /** @type {any} */ (document.getElementById("vital-heat"));
+  if (heatEl) heatEl.frac = Math.max(0, Math.min(1, (state.heat || 0) / HEAT_GAUGE_MAX));
+  ```
+- Modify: `css/style.css` — the heat scope reuses `.vital-strip` (already `width:100%`, dark bg,
+  border) and `.vital-head`/`.vital-label`; no new rule required unless the label header needs a
+  warm tint. If tinting: add `#vital-heat .vital-label { color: #b5794a; }` near the vital CSS
+  (`:1782`). Verify no layout regression in `#vital-stack`.
+- Modify: `MANUAL.md` — in the heat/HUD section, document the HEAT strip: a scrolling flame
+  showing heat over time (rises with activity, decays when you lie low); complements the heat lamp;
+  does not reveal the alarm threshold.
+
+**Verification — automated:**
+- [x] `make check` passes (1389 tests, lint clean)
+- [x] `make census SEEDS=10` shows no regression (10/10 complete; pure-UI change, bot path untouched)
+
+**Verification — manual:**
+- [x] HEAT strip sits between DECK and VISIT WAN (headless hub screenshot: HEALTH → DECK → HEAT order,
+  warm-tinted HEAT label; empty at heat=0 as expected)
+- [x] Strip never blocks graph interaction (`#vital-stack` is `pointer-events:none`; unchanged CSS)
+- [x] No trip/threshold line is visible (component never draws one — `drawTrip` was not ported)
+- [ ] _Les to confirm live:_ probing/xploiting raises the flame; waiting/lie-low lowers it (matches
+  the heat lamp's direction)
+
+---
+
+## Notes
+
+- One commit per phase (`Phase N: <name>`). Session docs (spec+plan) committed before execution.
+- Palette (red crown/yellow base) and placement (between DECK and VISIT WAN) are locked per spec.
+- Fine-tuning of bloom/speed/gap/fade happens live in-game after landing; defaults are the lab values.

--- a/docs/dev-sessions/2026-07-02-1440-heat-history-strip/research.md
+++ b/docs/dev-sessions/2026-07-02-1440-heat-history-strip/research.md
@@ -1,0 +1,65 @@
+# Research — heat history strip (Ember Scope)
+
+Factual pointers gathered before writing the spec. `file:line` refs reflect the codebase at
+session start (branch `heat-history-strip`, off `origin/main` @ 4782763).
+
+## Heat model (game state)
+
+- `state.heat` (number, no hard cap) + `state.heatDecayTimerId` — `js/core/state/index.js:169-170`.
+- Mutations: `addHeat` / `decayHeat` / `setHeatDecayTimerId` — `js/core/state/flow.js:31-51`.
+- Orchestration: `recordHeat` (trip ratchet), `startHeatDecay`, `handleHeatDecay` —
+  `js/core/alert.js:174-206`.
+- Constants — `js/core/balance.js:79-84`:
+  - `HEAT_COST = { probe:1, xploit:2, sniff:1, replay:3, sweep:2 }`
+  - `HEAT_ALARM_THRESHOLD = { S:4, A:5, B:7, C:9, D:12, F:15 }` (hidden, grade-keyed)
+  - `HEAT_DECAY_PER_TICK = 0.6`, `HEAT_DECAY_MS = 1000`, `HEAT_DISCHARGE_FRAC = 0.5`,
+    `LIE_LOW_HEAT_DROP = 6`
+- Events: `HEAT_CHANGED`, `HEAT_ALARM`.
+
+## Existing heat display (the gauge — stays)
+
+- `heat-gauge` lamp in HUD — `js/ui/components/starnet-hud.js:95-97`; fed by `hudEl.heat = state.heat`
+  in `js/ui/visual-renderer.js:436`.
+- Gauge geometry — `js/ui/indicator-glyphs.js`: `heatGaugeSvg` (215), `heatZone` (203),
+  `heatGaugeDataUri` (237). **Fixed visual scale `HEAT_GAUGE_MAX = 12`** (line 191, currently a
+  private const — will export to share with the strip so both agree on scale).
+
+## Vital waveforms (the pattern to mirror)
+
+- Component `<starnet-waveform>` — `js/ui/components/starnet-waveform.js`. Standing-oscilloscope
+  sweep: head advances `speed` px/s, wraps at width, samples current shape into a time-stamped
+  buffer, redraws every frame with age→alpha phosphor banding (`NB=12`, `STEP=2`). `_frame` at
+  lines 159-222; per-band batched stroke at 197-207; leading head dot 211-220; dpr canvas setup
+  `_setupCanvas` (119-140); color-var resolution `_resolveColor` (111-117).
+  - Props: `kind` (`ecg`|`pulse`), `frac` 0..1, `color`, `w`/`h`, `label`, `speed`, `trail`,
+    `bloom`, `autosize`, `meter`.
+- Pure geometry lives in a separate module `js/ui/waveform.js` (`ecgPoints`, `pulsePoints`,
+  `sampleY`) — this is the split to mirror (pure module + thin canvas component).
+- HUD markup — `index.html:43-52`: `#vital-stack` contains `#vital-ecg`, `#vital-deck`,
+  then `<starnet-uplink id="uplink-btn">`.
+- CSS — `css/style.css`: `#vital-stack` (absolute top-right, 220px, flex column, gap 4px,
+  pointer-events:none) and `.vital-strip`.
+- Data flow — `js/ui/visual-renderer.js`: `syncVitals(state)` (406) sets `frac` on the vital
+  elements on `E.STATE_CHANGED` (called at 55). Line 436 already sets `hudEl.heat`.
+
+## Preview harness
+
+- `js/ui/preview.js:403-417` — waveform demo (creates `<starnet-waveform>` ecg + pulse). Mirror
+  this for a heat-scope demo + a heat slider. (CLAUDE.md: new visual effects MUST be added to the
+  preview harness.)
+
+## Aesthetic constraints (CLAUDE.md)
+
+- Stroke-only vector beam: no fills, no bitmap idioms, no easy curves. Straight segments/polygons.
+- Hostile/enemy elements use red `#ff2a2a` / magenta `#ff00aa`.
+- Geometry in pure, testable modules (cf. `js/ui/node-glyphs.js`, `js/ui/ice-glyphs.js`),
+  consumed by both live UI and `preview.js`.
+- Glow ownership: canvas vitals use `ctx.shadowBlur`/`shadowColor` (not a stacked SVG filter).
+
+## Gotchas (from project memory)
+
+- Worktree Read/Edit needs FULL worktree paths.
+- `visual-renderer` has multiple HTML entrypoints (index/preview/playground) — the heat strip
+  lives in `#vital-stack` (index only), but the preview needs its own demo instance.
+- Bot/playtest/main are three parallel entry points — this is a pure UI/render change (reads
+  `state.heat`), so it touches none of the engine dispatch; no bot changes expected.

--- a/docs/dev-sessions/2026-07-02-1440-heat-history-strip/spec.md
+++ b/docs/dev-sessions/2026-07-02-1440-heat-history-strip/spec.md
@@ -1,0 +1,109 @@
+# Heat History Strip ("Ember Scope") Spec
+
+**Goal:** Give the player a scrolling-phosphor sense of `state.heat` *over time* — a stroke-only
+vector "flame" strip below the HEALTH/DECK vital waveforms — so the rise toward the (hidden) heat
+alarm and the decay after lying low are legible and anticipatable, not just an instantaneous gauge.
+
+**Source:** Issue #295 + live design session in the visual companion (see `heat-strip-lab.html`
+in this session dir — the tuned reference implementation).
+
+## Current state
+
+- Heat is modeled in game state and already has ONE HUD display: the `heat-gauge` lamp
+  (`starnet-hud.js:95-97`, geometry in `indicator-glyphs.js`), a stroke-only tick-ladder showing
+  *instantaneous* heat on a fixed scale `HEAT_GAUGE_MAX = 12` (`indicator-glyphs.js:191`). It
+  cannot show trajectory.
+- Vital waveforms are a proven standing-oscilloscope pattern: pure geometry in `js/ui/waveform.js`,
+  a thin canvas component `<starnet-waveform>` (`starnet-waveform.js`) with a sweep-head +
+  time-stamped buffer + age→alpha phosphor redraw, placed in `#vital-stack` (`index.html:43-52`),
+  fed `frac` by `syncVitals()` (`visual-renderer.js:406`) on `E.STATE_CHANGED`.
+- See `research.md` for the load-bearing `file:line` pointers.
+
+## Desired end state
+
+A third strip in `#vital-stack` (order: HEALTH → DECK → **HEAT** → uplink button), same
+204×44 footprint and phosphor sweep mechanic as the vitals, rendering heat as a vector flame:
+
+- **Crown:** a jagged stroked contour rides the current heat height (heat/`HEAT_GAUGE_MAX`,
+  clamped to 0..1), swept left→right with the same wrap + phosphor-fade as the vitals. A heat
+  change ripples in behind the sweep head.
+- **Body:** discrete contour lines stacked below the crown at a **fixed pixel gap** (~4px).
+  Lines are added/removed **only at the bottom** as the flame grows/shrinks — they never
+  redistribute. Capped at a max count (~12; rarely binds at 44px).
+- **Color:** red crown → yellow base progression, keyed to band index (stable, so lines don't
+  shimmer color as they add/remove). Lower lines progressively more transparent.
+- **No trip line / threshold marker** is shown to the player (the alarm threshold stays hidden,
+  per the heat design). The flame height is relative to the fixed gauge scale, same as the lamp.
+- The strip animates continuously (phosphor keeps sweeping even when heat is static), like the
+  vitals. It reads as adversarial (warm palette) next to the green/violet vitals.
+- The existing `heat-gauge` lamp **stays** (instantaneous readout); the strip adds the trend view.
+- A preview-harness demo with a heat slider exists in `preview.html` / `preview.js`.
+- The final tuned constants match the lab defaults: band gap 4px, max bands 12, jaggedness ~0.5,
+  transparency falloff ~0.6, sweep speed ~90 px/s, trail ~0.9, bloom ~6. These are the starting
+  values; fine-tuning happens live in-game.
+
+## Design decisions
+
+- **Decision:** New dedicated component `<starnet-heat-scope>` + pure geometry module
+  `js/ui/heat-flame.js`, mirroring the `waveform.js` + `starnet-waveform.js` split.
+  - **Why:** The flame needs a different per-column buffer (`{x, level, r, t, gap}` with a frozen
+    jitter seed) and a multi-band draw — folding that into `<starnet-waveform>` via a new `kind`
+    would heavily branch `_frame` and couple two unrelated render concerns in one growing file.
+    A focused component keeps each file doing one thing (CLAUDE.md: large file = doing too much).
+  - **Rejected:** (a) extend `<starnet-waveform>` with `kind:"ember"` — bloats the shipped
+    component, risks regressing the vitals. (b) Extract a shared sweep-engine module used by both
+    — a bigger refactor of shipped code for marginal DRY gain; the sweep bookkeeping duplicated
+    is small. Deferred as a possible follow-up, noted in NOT-doing.
+- **Decision:** Y-scale = `heat / HEAT_GAUGE_MAX` (reuse the gauge's constant; export it from
+  `indicator-glyphs.js`).
+  - **Why:** The strip and the lamp then agree on "how hot is hot" — one mental scale for the
+    player, no second magic number to tune.
+  - **Rejected:** grade-scaling the strip to the run's hidden `HEAT_ALARM_THRESHOLD`. It would
+    make "full flame ≈ about to trip," but it desyncs from the lamp and leaks the hidden threshold
+    through the visual. Keep the threshold hidden.
+- **Decision:** Fixed-gap, crown-anchored bands (add/remove at bottom), not count-scaled even
+  spacing.
+  - **Why:** Even redistribution makes every line jump when the count changes; fixed-gap lines
+    translate smoothly and only the bottom line pops in/out. (Settled by eye in the lab.)
+  - **Rejected:** `nb = round(heat/trip * MAX)` with fractions `j/nb` — the jumpy version.
+- **Decision:** Band color keyed to band index (capped), not to current visible count.
+  - **Why:** Keeps a given line's color stable as lines add/remove — no shimmer. A tall flame
+    reveals the full red→yellow spectrum; a short one is all-red crown.
+- **Decision:** Pure geometry (band Y offsets, existence test, color ramp, per-column jitter) lives
+  in `heat-flame.js` and is unit-tested; the component owns only canvas/RAF/dpr plumbing.
+  - **Why:** Matches the vector-glyph pattern (testable geometry, thin renderer) and lets us test
+    the add-from-bottom / no-negative / ramp-endpoint invariants without a browser.
+
+## Patterns to follow
+
+- Sweep + phosphor loop, dpr canvas setup, color-var resolution, leading head dot:
+  `js/ui/components/starnet-waveform.js:111-222`.
+- Pure-geometry-module split: `js/ui/waveform.js` consumed by the component.
+- HUD placement + autosize strip: `index.html:43-52`, `.vital-strip` / `#vital-stack` in
+  `css/style.css`.
+- Frac sync on `STATE_CHANGED`: `js/ui/visual-renderer.js:406-436` (`syncVitals`) — add the heat
+  strip's `frac = clamp(state.heat / HEAT_GAUGE_MAX)` alongside the ecg/deck sets.
+- Preview demo: `js/ui/preview.js:403-417` (waveform demo) — mirror with a heat slider.
+- Testing UI modules in node: pure module tested directly; component geometry via the exported
+  functions (see project memory "Testing js/ui/ modules in node").
+
+## What we're NOT doing
+
+- **Not** removing or changing the existing `heat-gauge` lamp — both displays coexist.
+- **Not** showing the alarm threshold / trip line to the player.
+- **Not** changing any heat *mechanics* (costs, decay, thresholds, trip/discharge) — this is a
+  pure read-only visualization of existing `state.heat`.
+- **Not** refactoring `<starnet-waveform>` or extracting a shared sweep-engine — the small
+  duplication of the sweep bookkeeping is accepted for now (possible later cleanup).
+- **Not** touching the bot / playtest / engine dispatch — no gameplay surface changes.
+- **Not** adding a numeric heat readout or a colorblind shape-channel to the strip (the lamp
+  already carries the redundant/legible readout; the strip is mood+trend). Revisit only if
+  playtest says the strip is illegible without color.
+
+## Open questions
+
+_Both resolved with the user before planning:_
+
+- **Palette:** red crown → yellow base (as tuned in the lab). Confirmed.
+- **Placement:** third waveform in the upper-right `#vital-stack`, between the DECK waveform and
+  the VISIT WAN (uplink) button. Confirmed.

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
           <starnet-store id="darknet-store"></starnet-store>
           <starnet-level-select id="level-select"></starnet-level-select>
           <!-- Vital-sign traces: floated upper-right over the graph.
-               Driven by visual-renderer.syncVitals via #vital-ecg / #vital-deck ids. -->
+               Driven by visual-renderer.syncVitals via #vital-ecg / #vital-deck / #vital-heat ids. -->
           <div id="vital-stack">
             <starnet-waveform id="vital-ecg" class="vital-strip" autosize
               kind="ecg" color="var(--green)" label="HEALTH"
@@ -47,6 +47,10 @@
             <starnet-waveform id="vital-deck" class="vital-strip" autosize
               kind="pulse" color="var(--violet)" label="DECK"
               h="44" speed="100" trail="0.72" bloom="14" meter></starnet-waveform>
+            <!-- Heat history: vector flame of state.heat over time (issue #295).
+                 Adversarial warm palette; frac = heat / HEAT_GAUGE_MAX. No trip line shown. -->
+            <starnet-heat-scope id="vital-heat" class="vital-strip" autosize
+              label="HEAT" h="44" speed="100" trail="0.9" bloom="6"></starnet-heat-scope>
             <!-- Uplink control: VISIT WAN normally, JACK OUT under alert/trace.
                  Driven by visual-renderer.syncHud. -->
             <starnet-uplink id="uplink-btn"></starnet-uplink>
@@ -81,6 +85,7 @@
   <script type="module" src="js/ui/components/starnet-log.js"></script>
   <script type="module" src="js/ui/components/starnet-ice-timers.js"></script>
   <script type="module" src="js/ui/components/starnet-waveform.js"></script>
+  <script type="module" src="js/ui/components/starnet-heat-scope.js"></script>
   <script type="module" src="js/ui/components/starnet-uplink.js"></script>
   <script type="module" src="js/ui/components/starnet-hud.js"></script>
   <script type="module" src="js/ui/components/starnet-context-menu.js"></script>

--- a/js/core/cheats.js
+++ b/js/core/cheats.js
@@ -16,7 +16,8 @@ import {
   setPlayerHealth, setPlayerDeckIntegrity,
 } from "./player-orchestration.js";
 import { setCheating } from "./state/game.js";
-import { forceGlobalAlert, cancelTraceCountdown } from "./alert.js";
+import { forceGlobalAlert, cancelTraceCountdown, recordHeat } from "./alert.js";
+import { decayHeat } from "./state/flow.js";
 import { teleportIce } from "./ice.js";
 import { activeIceInstances, hasActiveIce } from "./state/ice.js";
 import { addLogEntry } from "./log.js";
@@ -192,11 +193,12 @@ function resolvePool(token) {
   }
 }
 
-// CHEAT: hurt <health|deck> <amount> — deal damage (ends the run if it depletes the pool).
+// CHEAT: hurt <health|deck|heat> <amount> — damage a pool (ends run if depleted), or RAISE heat.
 function cheatHurt(args) {
+  if (args[0]?.toLowerCase() === "heat") return cheatHeatAdjust("hurt", args.slice(1));
   const pool = resolvePool(args[0]);
   if (!pool) {
-    addLogEntry("Usage: cheat hurt <health|deck> <amount>", "error");
+    addLogEntry("Usage: cheat hurt <health|deck|heat> <amount>", "error");
     return false;
   }
   const amount = parseInt(args[1], 10);
@@ -212,11 +214,12 @@ function cheatHurt(args) {
   return true;
 }
 
-// CHEAT: heal <health|deck> [amount] — restore by amount, or to full if amount omitted.
+// CHEAT: heal <health|deck|heat> [amount] — restore a pool (or to full), or LOWER heat (or to 0).
 function cheatHeal(args) {
+  if (args[0]?.toLowerCase() === "heat") return cheatHeatAdjust("heal", args.slice(1));
   const pool = resolvePool(args[0]);
   if (!pool) {
-    addLogEntry("Usage: cheat heal <health|deck> [amount]", "error");
+    addLogEntry("Usage: cheat heal <health|deck|heat> [amount]", "error");
     return false;
   }
   const p = getState().player[pool.key];
@@ -235,6 +238,37 @@ function cheatHeal(args) {
   pool.set(target);
   const cur = getState().player[pool.key].current;
   addLogEntry(`[CHEAT] ${pool.label} restored to ${cur}/${p.max}.`, "success");
+  emitEvent(E.STATE_CHANGED, getState());
+  return true;
+}
+
+// CHEAT: hurt/heal heat — heat isn't a pooled vital (bare number, no max), so it's handled apart
+// from resolvePool. `hurt heat <amount>` RAISES heat via the real recordHeat pathway (so it can
+// trip the alarm just like real activity); `heal heat [amount]` LOWERS it via decayHeat (no trip),
+// falling all the way to 0 when no amount is given.
+function cheatHeatAdjust(verb, args) {
+  if (verb === "hurt") {
+    const amount = parseInt(args[0], 10);
+    if (isNaN(amount) || amount <= 0) {
+      addLogEntry("Usage: cheat hurt heat <amount>", "error");
+      return false;
+    }
+    activateCheat();
+    recordHeat(amount); // emits HEAT_CHANGED + runs the trip ratchet
+    addLogEntry(`[CHEAT] +${amount} HEAT (${Math.round(getState().heat)} total).`, "warning");
+  } else {
+    const cur = getState().heat;
+    const amount = args[0] === undefined ? cur : parseInt(args[0], 10);
+    if (args[0] !== undefined && (isNaN(amount) || amount <= 0)) {
+      addLogEntry("Usage: cheat heal heat [amount]", "error");
+      return false;
+    }
+    activateCheat();
+    const dropped = Math.min(amount, cur);
+    const total = decayHeat(amount);
+    emitEvent(E.HEAT_CHANGED, { amount: -dropped, total });
+    addLogEntry(`[CHEAT] −${dropped} HEAT (${Math.round(total)} total).`, "success");
+  }
   emitEvent(E.STATE_CHANGED, getState());
   return true;
 }
@@ -371,8 +405,8 @@ function cheatHelp() {
     "  cheat give cash <amount>    Add credits to wallet.",
     "  cheat alert set <level>     Force alert level: green yellow red trace",
     "  cheat alert raise|lower     Step the global alert up/down one level",
-    "  cheat hurt <pool> <amount>  Damage health|deck (ends run if depleted).",
-    "  cheat heal <pool> [amount]  Restore health|deck by amount, or to full.",
+    "  cheat hurt <pool> <amount>  Damage health|deck (ends run if depleted), or raise heat.",
+    "  cheat heal <pool> [amount]  Restore health|deck (or to full), or lower heat (or to 0).",
     "  cheat own <node>            Set node to owned + reveal neighbors.",
     "  cheat own-all               Own every node, reveal entire map.",
     "  cheat trace start           Start the 60s trace countdown immediately.",

--- a/js/ui/components/starnet-heat-scope.js
+++ b/js/ui/components/starnet-heat-scope.js
@@ -1,0 +1,226 @@
+// <starnet-heat-scope> — animated heat history strip ("Ember Scope").
+//
+// A standing vector-CRT scope, like <starnet-waveform>: a sweep head redraws left-to-right on
+// repeat, leaving a phosphor trail that fades over one sweep. Unlike the vitals it draws a FLAME
+// rather than a single trace — a jagged crown contour rides the current heat height (`frac`), with
+// discrete contour lines stacked below it at a fixed gap, added/removed only at the bottom. Color
+// runs red (crown) → yellow (base); lower lines fade out. All flame geometry is the pure, tested
+// heat-flame.js module; this component owns only canvas/RAF/dpr plumbing and the sweep buffer.
+//
+// The buffer stores a frozen per-column seed `r` (its only entropy) so a painted column holds
+// still and just fades — the shimmer comes from fresh jitter the beam lays down as it sweeps past.
+// All animation state (_buf/_head/_lastTs) is ephemeral render state — NOT game state.
+
+import { html, nothing } from "lit";
+import { StarnetElement } from "./starnet-element.js";
+import { bandY, bandExists, bandColor, bandAlpha } from "../heat-flame.js";
+
+const STEP = 2;   // px between trail samples
+const NB = 12;    // glow age-bands per frame
+const CEIL = 12;  // hard cap on contour lines
+
+class StarnetHeatScope extends StarnetElement {
+  static properties = {
+    frac:  { type: Number },   // 0..1 heat fraction (heat / HEAT_GAUGE_MAX)
+    label: { type: String },
+    w:     { type: Number },
+    h:     { type: Number },
+    speed: { type: Number },   // px/sec sweep
+    trail: { type: Number },   // trail length as a multiple of one sweep
+    bloom: { type: Number },   // glow blur radius
+    bandGap:  { type: Number }, // px between contour lines
+    maxBands: { type: Number }, // contour-line cap (<= CEIL)
+    jag:   { type: Number },    // jitter amount 0..1
+    fade:  { type: Number },    // lower-band transparency falloff 0..1
+    autosize: { type: Boolean }, // track host width (full-width strips); ignores `w`
+  };
+
+  constructor() {
+    super();
+    this.frac = 0;
+    this.label = "HEAT";
+    this.w = 204;
+    this.h = 44;
+    this.speed = 100; // matches the vital waveforms so the sweep heads stay in phase
+    this.trail = 0.9;
+    this.bloom = 6;
+    this.bandGap = 4;
+    this.maxBands = 12;
+    this.jag = 0.5;
+    this.fade = 0.6;
+    this.autosize = false;
+
+    // Ephemeral render state — not reactive, not serialised.
+    this._buf = [];
+    this._head = 0;
+    this._lastTs = null;
+    this._rafId = null;
+    this._ctx = null;
+    this._W = this.w;
+    this._H = this.h;
+    this._ro = null;
+  }
+
+  render() {
+    return html`
+      ${this.label
+        ? html`<div class="vital-head"><span class="vital-label">${this.label}</span></div>`
+        : nothing}
+      <span class="hud-waveform"><canvas></canvas></span>
+    `;
+  }
+
+  firstUpdated() {
+    if (this.autosize && typeof ResizeObserver !== "undefined") {
+      this._ro = new ResizeObserver(() => { this._setupCanvas(); });
+      this._ro.observe(this);
+    }
+    this._setupCanvas();
+    this._startLoop();
+  }
+
+  updated(changed) {
+    if (changed.has("w") || changed.has("h")) this._setupCanvas();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._startLoop(); // no-op until firstUpdated has the canvas; re-arms on reattach
+  }
+
+  disconnectedCallback() {
+    this._stopLoop();
+    if (this._ro) { this._ro.disconnect(); this._ro = null; }
+    super.disconnectedCallback();
+  }
+
+  // ── internals ──────────────────────────────────────────────────────────────
+
+  _setupCanvas() {
+    const canvas = this.querySelector("canvas");
+    if (!canvas) return;
+    const W = this.autosize ? Math.round(this.clientWidth || this.w) : this.w;
+    const H = this.h;
+    if (W < 1 || H < 1) return; // not laid out yet — ResizeObserver will re-fire
+    if (this._ctx && this._W === W && this._H === H) return; // unchanged (keep the trail)
+    this._W = W;
+    this._H = H;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = Math.round(W * dpr);
+    canvas.height = Math.round(H * dpr);
+    canvas.style.width = W + "px";
+    canvas.style.height = H + "px";
+    const ctx = canvas.getContext("2d");
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0); // draw in CSS px; crisp on hi-dpi
+    this._ctx = ctx;
+    this._buf = [];
+    this._head = 0;
+    this._lastTs = null;
+    ctx.clearRect(0, 0, W, H);
+  }
+
+  _startLoop() {
+    if (this._rafId != null || !this._ctx) return; // guard against double-start
+    const tick = (ts) => {
+      this._frame(ts);
+      this._rafId = requestAnimationFrame(tick);
+    };
+    this._rafId = requestAnimationFrame(tick);
+  }
+
+  _stopLoop() {
+    if (this._rafId != null) {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = null;
+    }
+    this._lastTs = null;
+  }
+
+  _frame(ts) {
+    const ctx = this._ctx;
+    if (!ctx) return;
+    const now = ts / 1000;
+    const dt = this._lastTs != null ? Math.min(now - this._lastTs, 0.05) : 0;
+    this._lastTs = now;
+
+    const W = this._W, H = this._H;
+    const frac = Math.max(0, Math.min(1, Number(this.frac) || 0));
+    const geom = { base: H - 3, span: H - 3 - 4, gap: this.bandGap, jag: this.jag };
+    const MAXB = Math.min(CEIL, this.maxBands | 0);
+    const fade = this.fade;
+
+    // Advance the sweep head, sampling the CURRENT level into the buffer with a frozen jitter
+    // seed per column (older columns keep their level/shape — a frac change ripples in behind).
+    const sweepT = W / Math.max(1, this.speed);
+    const trailDur = sweepT * Math.max(0.05, this.trail);
+    const target = this._head + this.speed * dt;
+    while (this._head < target) {
+      const segStart = this._head;
+      const next = Math.min(this._head + STEP, target);
+      const x = next % W;
+      const gap = Math.floor(next / W) !== Math.floor(segStart / W); // crossed the edge
+      this._buf.push({ x, level: frac, r: Math.random(), t: now, gap });
+      this._head = next;
+    }
+    const cutoff = now - trailDur;
+    while (this._buf.length && this._buf[0].t < cutoff) this._buf.shift();
+
+    ctx.clearRect(0, 0, W, H);
+    ctx.lineCap = "round";
+    ctx.lineJoin = "round";
+    const bandOf = (p) => Math.floor(((now - p.t) / trailDur) * NB);
+
+    // Draw bottom → top so the bright crown lands on top. Each contour line is batched by age
+    // band (one glowing stroke per band), skipping wrap gaps and columns with no room for it.
+    for (let j = MAXB - 1; j >= 0; j--) {
+      const col = bandColor(j, MAXB);
+      const isCrown = j === 0;
+      ctx.lineWidth = isCrown ? 1.4 : 1.1;
+      ctx.strokeStyle = col;
+      ctx.shadowColor = col;
+      ctx.shadowBlur = isCrown ? this.bloom : Math.max(0, this.bloom - 2);
+      const dim = bandAlpha(j, MAXB, fade);
+      // The crown (j=0) always draws — at heat 0 it rests as a faint flat baseline rather than
+      // vanishing, like the vitals' idle flatline. Lower bands appear only when there's room.
+      const alwaysDraw = j === 0;
+      let curBand = -1, open = false;
+      const flush = () => {
+        if (open) { ctx.globalAlpha = dim * (1 - (curBand + 0.5) / NB); ctx.stroke(); open = false; }
+      };
+      for (let i = 1; i < this._buf.length; i++) {
+        const a = this._buf[i - 1], b = this._buf[i];
+        const band = bandOf(b);
+        if (b.gap || band >= NB ||
+            (!alwaysDraw && (!bandExists(a.level, j, geom) || !bandExists(b.level, j, geom)))) {
+          flush(); curBand = -1; continue;
+        }
+        if (band !== curBand) {
+          flush();
+          ctx.beginPath();
+          ctx.moveTo(a.x, bandY(a.level, a.r, j, geom));
+          curBand = band; open = true;
+        }
+        ctx.lineTo(b.x, bandY(b.level, b.r, j, geom));
+      }
+      flush();
+    }
+    ctx.globalAlpha = 1;
+
+    // Leading head dot rides the crown (always present, even at heat 0).
+    if (this._buf.length) {
+      const p = this._buf[this._buf.length - 1];
+      const y = bandY(p.level, p.r, 0, geom);
+      const col = bandColor(0, MAXB);
+      ctx.fillStyle = col;
+      ctx.shadowColor = col;
+      ctx.shadowBlur = this.bloom + 3;
+      ctx.beginPath(); ctx.arc(p.x, y, 2, 0, Math.PI * 2); ctx.fill();
+      ctx.fillStyle = "#fff6e8";
+      ctx.shadowBlur = 0;
+      ctx.beginPath(); ctx.arc(p.x, y, 0.8, 0, Math.PI * 2); ctx.fill();
+    }
+    ctx.shadowBlur = 0;
+  }
+}
+
+customElements.define("starnet-heat-scope", StarnetHeatScope);

--- a/js/ui/heat-flame.js
+++ b/js/ui/heat-flame.js
@@ -1,0 +1,88 @@
+// @ts-check
+// Pure vector-flame geometry for the heat history strip ("Ember Scope") — no DOM, no Math.random.
+// Renders `state.heat` (as a 0..1 fraction of the fixed gauge scale) as a stroke-only flame: a
+// jagged crown contour riding the current heat height, with discrete contour lines stacked below
+// it at a FIXED pixel gap. Lines are added/removed only at the bottom as the flame grows/shrinks —
+// they never redistribute. Color runs red (crown) → yellow (base); lower lines fade out.
+//
+// The animated sweep + phosphor persistence lives in the <starnet-heat-scope> component, which
+// samples a frozen per-column seed `r` (its only entropy) and calls these functions. Keeping the
+// geometry pure and deterministic makes it unit-testable without a browser — mirroring the
+// waveform.js / <starnet-waveform> split.
+
+const YELLOW = [255, 225, 55];
+const RED = [255, 40, 40];
+
+/**
+ * Deterministic bounded pseudo-noise in (-1, 1) from a frozen column seed `r` and index `k`.
+ * @param {number} r frozen per-column seed (the component's only source of entropy)
+ * @param {number} k sample index (e.g. band index) for decorrelated values per column
+ * @returns {number}
+ */
+export function flameNoise(r, k) {
+  return (Math.sin(r * 12.9898 + k * 4.1414) * 43758.5453) % 1;
+}
+
+/**
+ * @typedef {{ base: number, span: number, gap: number, jag: number }} FlameGeom
+ * base = baseline y (bottom of the strip), span = full drawable height, gap = px between bands,
+ * jag = jitter amount 0..1.
+ */
+
+/**
+ * Y of contour band `j` for a column. j=0 is the crown (top edge); higher j are lower tongues,
+ * each a fixed `gap` px below the one above. Jitter is strongest at the crown and damps toward
+ * the base, so the top reads flame-y and the bottom stays calm. Even at `level === 0` the crown
+ * keeps a small idle jitter (the `0.4` floor) so the resting baseline shimmers rather than
+ * sitting dead-flat — a deliberate liveliness choice.
+ * @param {number} level heat fraction 0..1
+ * @param {number} r frozen per-column seed
+ * @param {number} j band index (0 = crown)
+ * @param {FlameGeom} geom
+ * @returns {number}
+ */
+export function bandY(level, r, j, { base, span, gap, jag }) {
+  const jitMag = flameNoise(r, 1) * jag * 3 * (0.4 + level); // 0.4 floor → idle shimmer at heat 0
+  const jitDamp = Math.max(0, 1 - j * 0.14); // 1 at the crown → 0 lower down
+  return base - level * span + j * gap - jitMag * jitDamp;
+}
+
+/**
+ * Does band `j` have room above the baseline for this column's flame height? Bands are added and
+ * removed ONLY at the bottom, so this is monotone in both `j` and `level`.
+ * @param {number} level heat fraction 0..1
+ * @param {number} j band index (0 = crown)
+ * @param {{ span: number, gap: number }} geom
+ * @returns {boolean}
+ */
+export function bandExists(level, j, { span, gap }) {
+  return level * span >= j * gap + 0.5;
+}
+
+/**
+ * Stroke color for band index `j`: crown (j=0) red → deepest band (j=maxBands-1) yellow.
+ * Keyed to band index (not the current visible count) so a line's color stays stable as bands
+ * add/remove — a tall flame reveals the full spectrum, a short one is all-red crown.
+ * @param {number} j band index (0 = crown)
+ * @param {number} maxBands band-count cap
+ * @returns {string} `rgb(r,g,b)`
+ */
+export function bandColor(j, maxBands) {
+  const u = maxBands > 1 ? 1 - j / (maxBands - 1) : 1; // 1 = red crown, 0 = yellow base
+  const c = YELLOW.map((v, i) => Math.round(v + (RED[i] - v) * u));
+  return `rgb(${c[0]},${c[1]},${c[2]})`;
+}
+
+/**
+ * Alpha multiplier by band index: crown is opaque (1), lower bands progressively more transparent
+ * so the newest bottom line emerges faintly. `fade` (0..1) scales the falloff.
+ * @param {number} j band index (0 = crown)
+ * @param {number} maxBands band-count cap
+ * @param {number} fade falloff strength 0..1
+ * @returns {number}
+ */
+export function bandAlpha(j, maxBands, fade) {
+  if (j === 0) return 1;
+  const t = maxBands > 1 ? j / (maxBands - 1) : 0;
+  return 1 - fade * t;
+}

--- a/js/ui/indicator-glyphs.js
+++ b/js/ui/indicator-glyphs.js
@@ -188,7 +188,7 @@ export function tickMeterDataUri(frac, opts = {}) {
 
 // Fixed visual scale for the heat gauge. Deliberately NOT any network's real alarm threshold
 // (those are hidden) — the gauge shows *how hot* you are, never *how close to the line*.
-const HEAT_GAUGE_MAX = 12;
+export const HEAT_GAUGE_MAX = 12;
 
 /** Heat tier color: cool (low) green → warm amber → hot (high) red — the inverse of tierColor. */
 function heatColor(frac) {

--- a/js/ui/preview.js
+++ b/js/ui/preview.js
@@ -464,6 +464,36 @@ if (wfDemo && waveHealth && waveDeck && waveToggle) {
   });
 }
 
+// Heat scope demo — <starnet-heat-scope>. Slider is 0..100 = frac 0..1 (the HEAT_GAUGE_MAX scale).
+const heatDemo = $("heat-scope-demo");
+const heatSlider = $("heat-scope");
+if (heatDemo && heatSlider) {
+  const scope = /** @type {any} */ (document.createElement("starnet-heat-scope"));
+  scope.className = "vital-strip";
+  scope.style.width = "204px";
+  scope.frac = +heatSlider.value / 100;
+  heatDemo.append(scope);
+
+  const heatVal = $("heat-scope-val");
+  heatSlider.addEventListener("input", () => {
+    scope.frac = +heatSlider.value / 100;
+    if (heatVal) heatVal.textContent = String(heatSlider.value);
+  });
+
+  const bindHeat = (id, valId, prop, scale, fmt) => {
+    const el = $(id);
+    if (!el) return;
+    const out = $(valId);
+    el.addEventListener("input", () => {
+      scope[prop] = scale ? +el.value / scale : +el.value;
+      if (out) out.textContent = fmt ? fmt(el.value) : String(el.value);
+    });
+  };
+  bindHeat("heat-scope-speed", "heat-scope-speed-val", "speed", 0);
+  bindHeat("heat-scope-gap", "heat-scope-gap-val", "bandGap", 0, (v) => (+v).toFixed(1));
+  bindHeat("heat-scope-bloom", "heat-scope-bloom-val", "bloom", 0);
+}
+
 // FPS meter toggle — dev frame-time readout (js/ui/fps-meter.js; `cheat fps` in game).
 const fpsToggleBtn = document.getElementById("btn-fps-toggle");
 if (fpsToggleBtn) {

--- a/js/ui/visual-renderer.js
+++ b/js/ui/visual-renderer.js
@@ -18,6 +18,7 @@ import { initializeGraphOverlays } from "./overlays/index.js";
 import { dispatchActionFeedback } from "./overlays/dispatch.js";
 import { getVisibleTimers } from "../core/timers.js";
 import { exploitSortKey } from "../core/exploits.js";
+import { HEAT_GAUGE_MAX } from "./indicator-glyphs.js";
 import { initGraphDegradation, updateFromState as updateGraphDegradation } from "./graph-degradation/index.js";
 import { computeInspectorPosition } from "./inspector-position.js";
 
@@ -406,9 +407,12 @@ function syncOverlays(state) {
 function syncVitals(state) {
   const ecgEl = /** @type {any} */ (document.getElementById("vital-ecg"));
   const deckEl = /** @type {any} */ (document.getElementById("vital-deck"));
+  const heatEl = /** @type {any} */ (document.getElementById("vital-heat"));
   const h = state.player.health, d = state.player.deckIntegrity;
   if (ecgEl) ecgEl.frac = h.max > 0 ? h.current / h.max : 0;
   if (deckEl) deckEl.frac = d.max > 0 ? d.current / d.max : 0;
+  // Heat strip shares the gauge's fixed scale (never reveals the hidden alarm threshold).
+  if (heatEl) heatEl.frac = Math.max(0, Math.min(1, (state.heat || 0) / HEAT_GAUGE_MAX));
 }
 
 // ── Uplink control (floats under the vitals) ──────────────

--- a/preview.html
+++ b/preview.html
@@ -300,6 +300,32 @@
         </div>
       </div>
 
+      <!-- Heat Scope — <starnet-heat-scope> component demo (js/ui/preview.js). -->
+      <div class="section">
+        <h2>Heat Scope</h2>
+        <div id="heat-scope-demo"></div>
+        <div class="btn-row">
+          <label>HEAT</label>
+          <input type="range" id="heat-scope" min="0" max="100" step="1" value="40">
+          <span id="heat-scope-val">40</span>
+        </div>
+        <div class="btn-row">
+          <label>SPEED</label>
+          <input type="range" id="heat-scope-speed" min="20" max="220" step="5" value="100">
+          <span id="heat-scope-speed-val">100</span>
+        </div>
+        <div class="btn-row">
+          <label>GAP</label>
+          <input type="range" id="heat-scope-gap" min="2" max="14" step="0.5" value="4">
+          <span id="heat-scope-gap-val">4.0</span>
+        </div>
+        <div class="btn-row">
+          <label>BLOOM</label>
+          <input type="range" id="heat-scope-bloom" min="0" max="16" step="1" value="6">
+          <span id="heat-scope-bloom-val">6</span>
+        </div>
+      </div>
+
       <!-- FPS Meter — dev frame-time readout (js/ui/fps-meter.js, `cheat fps` in game). -->
       <div class="section">
         <h2>FPS Meter</h2>
@@ -314,6 +340,7 @@
   <script src="dist/vendor.js"></script>
   <script type="module" src="js/ui/components/starnet-hand.js"></script>
   <script type="module" src="js/ui/components/starnet-waveform.js"></script>
+  <script type="module" src="js/ui/components/starnet-heat-scope.js"></script>
   <script type="module" src="js/ui/preview.js"></script>
 </body>
 </html>

--- a/tests/heat-flame.test.js
+++ b/tests/heat-flame.test.js
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  flameNoise,
+  bandY,
+  bandExists,
+  bandColor,
+  bandAlpha,
+} from "../js/ui/heat-flame.js";
+
+// Canonical geometry used across cases: 44px strip → base=41, span=37 (see component).
+const g = { base: 41, span: 37, gap: 4, jag: 0 };
+
+test("flameNoise is deterministic and bounded to (-1, 1)", () => {
+  assert.equal(flameNoise(0.3, 1), flameNoise(0.3, 1));
+  assert.equal(flameNoise(0.72, 5), flameNoise(0.72, 5));
+  for (const [r, k] of [[0, 0], [0.7, 2], [0.999, 9], [0.15, 3]]) {
+    assert.ok(Math.abs(flameNoise(r, k)) <= 1, `|flameNoise(${r},${k})| <= 1`);
+  }
+});
+
+test("bandY: heat 0 keeps a small idle jitter near the baseline (deliberate liveliness)", () => {
+  const jg = { base: 41, span: 37, gap: 4, jag: 0.5 };
+  const bound = jg.jag * 3 * 0.4; // jitMag at level 0 = |noise|*jag*3*0.4, |noise| <= 1
+  let sawJitter = false;
+  for (const r of [0.1, 0.3, 0.55, 0.8, 0.95]) {
+    const y = bandY(0, r, 0, jg);
+    assert.ok(Math.abs(y - jg.base) <= bound + 1e-9, `idle jitter stays bounded near baseline (r=${r})`);
+    if (y !== jg.base) sawJitter = true;
+  }
+  assert.ok(sawJitter, "some columns jitter at heat 0 — the resting baseline shimmers, not dead-flat");
+  // With jitter disabled entirely (jag=0), heat 0 is exactly flat.
+  assert.equal(bandY(0, 0.42, 0, { ...jg, jag: 0 }), jg.base);
+});
+
+test("bandY: with jag=0 the crown sits at heat height", () => {
+  assert.equal(bandY(0.5, 0.9, 0, g), g.base - 0.5 * g.span);
+  assert.equal(bandY(1, 0.5, 0, g), g.base - g.span);
+  assert.equal(bandY(0, 0.5, 0, g), g.base);
+});
+
+test("bandY: bands are equidistant (fixed gap) below the crown", () => {
+  assert.equal(bandY(0.8, 0.3, 2, g) - bandY(0.8, 0.3, 1, g), g.gap);
+  assert.equal(bandY(0.8, 0.3, 3, g) - bandY(0.8, 0.3, 2, g), g.gap);
+});
+
+test("bandY: hotter flame lifts the crown (smaller y)", () => {
+  assert.ok(bandY(1, 0.5, 0, g) < bandY(0.2, 0.5, 0, g));
+});
+
+test("bandExists: crown present whenever there is any flame", () => {
+  assert.ok(bandExists(1, 0, g));
+  assert.ok(bandExists(0.3, 0, g));
+  assert.ok(!bandExists(0, 0, g));
+});
+
+test("bandExists: no room for deep bands when cold", () => {
+  assert.ok(!bandExists(0.02, 4, g));
+});
+
+test("bandExists: bands are added/removed only from the bottom (monotone in j)", () => {
+  for (const level of [0.1, 0.35, 0.6, 0.9, 1]) {
+    for (let j = 1; j < 12; j++) {
+      if (bandExists(level, j, g)) {
+        assert.ok(bandExists(level, j - 1, g), `level ${level}: band ${j} implies band ${j - 1}`);
+      }
+    }
+  }
+});
+
+test("bandExists: monotone in level for a fixed band", () => {
+  for (let j = 0; j < 8; j++) {
+    if (bandExists(0.4, j, g)) assert.ok(bandExists(0.95, j, g), `band ${j} survives more heat`);
+  }
+});
+
+test("bandColor: crown is red, deepest band is yellow", () => {
+  assert.equal(bandColor(0, 6), "rgb(255,40,40)");
+  assert.equal(bandColor(5, 6), "rgb(255,225,55)");
+});
+
+test("bandColor: single-band cap yields the red crown", () => {
+  assert.equal(bandColor(0, 1), "rgb(255,40,40)");
+});
+
+test("bandAlpha: crown opaque, lower bands progressively more transparent, non-negative", () => {
+  assert.equal(bandAlpha(0, 6, 0.6), 1);
+  assert.ok(bandAlpha(5, 6, 0.6) < bandAlpha(1, 6, 0.6));
+  assert.ok(bandAlpha(5, 6, 0.6) >= 0);
+  assert.equal(bandAlpha(3, 6, 0), 1); // fade=0 → all opaque
+});

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1209,6 +1209,44 @@ describe("cheat alert set/raise/lower (#174)", () => {
   });
 });
 
+describe("cheat hurt/heal heat (#295 — manual heat testing)", () => {
+  beforeEach(() => { clearAll(); initGame(() => buildBasicLAN(), "cheat-heat"); });
+
+  it("hurt heat raises heat; a small amount stays under the alarm", () => {
+    assert.equal(getState().heat, 0);
+    handleCheatCommand(["hurt", "heat", "5"]);
+    assert.equal(getState().heat, 5);
+    assert.equal(getState().globalAlert, "green", "5 heat is under the threshold — no trip");
+  });
+
+  it("heal heat lowers heat by an amount, floored at 0", () => {
+    handleCheatCommand(["hurt", "heat", "5"]);
+    handleCheatCommand(["heal", "heat", "2"]);
+    assert.equal(getState().heat, 3);
+    handleCheatCommand(["heal", "heat", "10"]); // over-heal floors at 0
+    assert.equal(getState().heat, 0);
+  });
+
+  it("heal heat with no amount drops heat to 0", () => {
+    handleCheatCommand(["hurt", "heat", "7"]);
+    handleCheatCommand(["heal", "heat"]);
+    assert.equal(getState().heat, 0);
+  });
+
+  it("hurt heat over the threshold trips the alarm and discharges (real recordHeat path)", () => {
+    handleCheatCommand(["hurt", "heat", "50"]);
+    assert.notEqual(getState().globalAlert, "green", "a big heat spike must trip the ladder");
+    assert.ok(getState().heat < 50, "heat is discharged on a trip so it must rebuild");
+  });
+
+  it("rejects a non-positive hurt amount without changing heat", () => {
+    handleCheatCommand(["hurt", "heat", "0"]);
+    assert.equal(getState().heat, 0);
+    handleCheatCommand(["hurt", "heat", "-3"]);
+    assert.equal(getState().heat, 0);
+  });
+});
+
 describe("lie low → heat cooling (anti-tedium arc)", () => {
   beforeEach(() => { clearAll(); });
   const sendAlert = (graph) => graph.sendMessage("sp/ids", { type: "alert", payload: {} });


### PR DESCRIPTION
Adds a third phosphor strip to the HUD vitals stack — an **Ember Scope** that renders `state.heat` over time as a stroke-only vector flame, below the HEALTH and DECK traces. The existing heat *lamp* shows how hot you are *right now*; this shows the *trajectory* — the rise toward the (hidden) alarm and the decay after you pace or lie low.

## What it looks like
- A jagged **crown** contour rides the current heat height, swept left→right with the same standing-oscilloscope + phosphor-fade mechanic as the vitals.
- Discrete **contour lines** stack below it at a fixed pixel gap, added/removed **only at the bottom** as the flame grows/shrinks (no redistribution jump).
- **Red crown → yellow base**, lower lines progressively more transparent. Idle flat baseline at heat 0.
- Reads as adversarial next to the green/violet vitals; the sweep is synced to the vitals (100 px/s).

## Design decisions
- **New `<starnet-heat-scope>` + pure `js/ui/heat-flame.js`**, mirroring the `waveform.js` / `<starnet-waveform>` split — rather than branching a `kind:"ember"` into the shipped waveform (which the flame’s different buffer + multi-band draw would bloat).
- **Y-scale reuses `HEAT_GAUGE_MAX` (12)** so the strip and the heat lamp agree on “how hot is hot.”
- **No trip line shown** — the alarm threshold stays hidden (no grade-scaling that would leak it).
- **The heat lamp stays** — lamp = instant, strip = trend.
- Pure geometry is **unit-tested** (add-from-bottom monotonicity, fixed spacing, color/alpha endpoints); the canvas component is a documented TDD opt-out verified via headless screenshots.

## Also included (folded in per request)
- `cheat hurt heat <amount>` / `cheat heal heat [amount]` for manual heat testing — `hurt` raises heat via the real `recordHeat` path (can trip the alarm), `heal` lowers it via `decayHeat` (to 0 if omitted). Tests + `cheat help` updated.

## Testing
- `make check` green — **1394 tests**, lint clean.
- `make census SEEDS=10` — 10/10 (pure-UI change; bot path untouched).
- Preview harness gained a Heat Scope panel; live in-game confirmation via the heat cheat.

## Notes
- Design was tuned live in a throwaway slider lab, kept as a session artifact (`docs/dev-sessions/2026-07-02-1440-heat-history-strip/heat-strip-lab.html`).
- Spec + plan: `docs/dev-sessions/2026-07-02-1440-heat-history-strip/`.
- Deferred: extracting a shared sweep-engine helper (small duplication, not worth the churn yet).

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)