### PR TITLE
Fix timed-action feedback dropping after save/load (#302)

### DIFF
--- a/js/core/state/index.js
+++ b/js/core/state/index.js
@@ -68,6 +68,31 @@ export function getVersion() {
 
 // ── Initialization ───────────────────────────────────────
 
+/**
+ * Build the graph→game bridge: syncs node attribute changes into `state.nodes`
+ * and forwards graph events onto the game event bus. Shared by `initGame` and
+ * `deserializeState` so the two can't drift — a missing branch here once silently
+ * dropped all timed-action feedback after any save/load round-trip (#302).
+ * @returns {(type: string, payload: any) => void}
+ */
+function buildGraphEventBridge() {
+  return (type, payload) => {
+    if (type === "node-state-changed") {
+      // Sync graph attribute changes to state.nodes (skip if change came from a setter)
+      if (!isSyncingToGraph() && getState()?.nodes?.[payload.nodeId]) {
+        mutate(s => { s.nodes[payload.nodeId][payload.attr] = payload.value; });
+      }
+      emitEvent(E.NODE_STATE_CHANGED, payload);
+    } else if (type === "message-delivered") {
+      emitEvent(E.MESSAGE_PROPAGATED, payload);
+    } else if (type === "quality-changed") {
+      emitEvent(E.QUALITY_CHANGED, payload);
+    } else if (type === "action-feedback") {
+      emitEvent(E.ACTION_FEEDBACK, payload);
+    }
+  };
+}
+
 // ── NodeGraph-based initialization ────────────────────────
 
 /**
@@ -93,21 +118,7 @@ export function initGame(buildNetworkFn, seedString, opts = {}) {
   const gameCtx = buildGameCtx({ openDarknetsStore: opts.openDarknetsStore });
 
   // Build the onEvent bridge: graph → state.nodes sync + game event bus
-  const onEvent = (type, payload) => {
-    if (type === "node-state-changed") {
-      // Sync graph attribute changes to state.nodes (skip if change came from a setter)
-      if (!isSyncingToGraph() && getState()?.nodes?.[payload.nodeId]) {
-        mutate(s => { s.nodes[payload.nodeId][payload.attr] = payload.value; });
-      }
-      emitEvent(E.NODE_STATE_CHANGED, payload);
-    } else if (type === "message-delivered") {
-      emitEvent(E.MESSAGE_PROPAGATED, payload);
-    } else if (type === "quality-changed") {
-      emitEvent(E.QUALITY_CHANGED, payload);
-    } else if (type === "action-feedback") {
-      emitEvent(E.ACTION_FEEDBACK, payload);
-    }
-  };
+  const onEvent = buildGraphEventBridge();
 
   // Construct the NodeGraph
   const graph = new NodeGraph(graphDef, gameCtx, onEvent);
@@ -418,18 +429,7 @@ export function deserializeState(snapshot, opts = {}) {
   // Restore NodeGraph from snapshot
   if (_nodeGraph) {
     const gameCtx = buildGameCtx(opts);
-    const onEvent = (type, payload) => {
-      if (type === "node-state-changed") {
-        if (!isSyncingToGraph() && getState()?.nodes?.[payload.nodeId]) {
-          mutate(s => { s.nodes[payload.nodeId][payload.attr] = payload.value; });
-        }
-        emitEvent(E.NODE_STATE_CHANGED, payload);
-      } else if (type === "message-delivered") {
-        emitEvent(E.MESSAGE_PROPAGATED, payload);
-      } else if (type === "quality-changed") {
-        emitEvent(E.QUALITY_CHANGED, payload);
-      }
-    };
+    const onEvent = buildGraphEventBridge();
     const graph = NodeGraph.fromSnapshot(_nodeGraph, gameCtx, onEvent);
     gameCtx._graph = graph;
     ctx.state.nodeGraph = graph;

--- a/tests/deserialize-action-feedback.test.js
+++ b/tests/deserialize-action-feedback.test.js
@@ -1,0 +1,76 @@
+// @ts-check
+// Regression for #302: the graph→event `onEvent` bridge built in deserializeState
+// (js/core/state/index.js) had drifted from the initGame bridge — it was missing the
+// `action-feedback` branch. On a restored graph, ACTION_FEEDBACK (start/progress/cancel/
+// complete) was emitted by the timed-action operator but never bridged to the event bus,
+// so the log lines, the generic-process overlay ring, and the audio drones all silently
+// went dead after ANY save/load round-trip. The completion *effects* still fired (separate
+// operator-effect path), so the action "worked" — only the legible feedback vanished.
+//
+// This test arms a synthesized timed action, serializes + deserializes mid-progress, then
+// ticks the RESTORED graph to completion while subscribed to E.ACTION_FEEDBACK. Before the
+// fix, no feedback is heard on the bus; after it, progress + complete fire normally.
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { createGateway, createRouter } from "../js/core/node-graph/node-factories.js";
+import { initGame, getState, serializeState, deserializeState } from "../js/core/state.js";
+import { on, off, E, clearHandlers } from "../js/core/events.js";
+import { clearAll } from "../js/core/timers.js";
+
+const TIMED_ACTION_ID = "feedback-act";
+
+function buildTimedLAN() {
+  return {
+    graphDef: {
+      nodes: [
+        createGateway("gateway", { attributes: { visibility: "accessible" } }),
+        {
+          ...createRouter("router-a"),
+          actions: [
+            {
+              id: TIMED_ACTION_ID,
+              label: "FEEDBACK",
+              requires: [],
+              timed: { duration: 6 },
+              effects: [{ effect: "set-attr", attr: "done", value: true }],
+            },
+          ],
+        },
+      ],
+      edges: [["gateway", "router-a"]],
+      triggers: [],
+    },
+    meta: { startNode: "gateway", startCash: 0, moneyCost: "F" },
+  };
+}
+
+describe("timed-action feedback survives save/load (#302)", () => {
+  beforeEach(() => { clearAll(); clearHandlers(); });
+
+  it("bridges ACTION_FEEDBACK from a restored graph to the event bus", () => {
+    initGame(() => buildTimedLAN(), "deser-feedback");
+    getState().nodeGraph.executeAction("router-a", TIMED_ACTION_ID);
+    getState().nodeGraph.tick(2); // advance partway through the 6-tick action
+
+    // Faithful save/load round-trip through JSON, then restore.
+    const snap = JSON.parse(JSON.stringify(serializeState()));
+    clearAll();
+    deserializeState(snap);
+    const restored = getState().nodeGraph;
+
+    // Listen on the real event bus, then tick the restored graph to completion.
+    /** @type {any[]} */ const feedback = [];
+    const h = (p) => feedback.push(p);
+    on(E.ACTION_FEEDBACK, h);
+    restored.tick(6); // finish the remaining progress + complete
+    off(E.ACTION_FEEDBACK, h);
+
+    const phases = feedback.map((p) => p.phase);
+    assert.ok(phases.includes("complete"), "complete feedback must reach the bus after restore");
+    assert.ok(phases.includes("progress"), "progress feedback must reach the bus after restore");
+    // The completion effect still fires via the operator-effect path either way.
+    assert.equal(restored.getNodeState("router-a").done, true, "action still completes");
+  });
+});


### PR DESCRIPTION
Fixes #302.

## Problem

The graph→event `onEvent` bridge is built in two places in `js/core/state/index.js` that should be identical but had drifted: `initGame` handled `node-state-changed`, `message-delivered`, `quality-changed`, **and `action-feedback`**, while `deserializeState` was missing the `action-feedback` branch.

Result: after **any** save/load round-trip, every timed action (`probe`, `xploit`, `dump`, `fetch`, `mine`, `kick`, `corrupt`, `sniff`, `replay`, and all script actions) silently lost its start/progress/cancel/complete feedback — log lines, the generic-process overlay ring, and audio drones all went dead. The action still *completed* (via the separate `operator-effect` path), so it "worked" — only the legible feedback vanished. Hits the browser too, not just the CLI harness.

## Fix

Extract the shared bridge into `buildGraphEventBridge()` and use it in both `initGame` and `deserializeState`, so the two byte-identical builders can no longer drift. This kills the whole drift class, not just this one instance (the same pair had drifted before).

## Test

New state-level round-trip regression test (`tests/deserialize-action-feedback.test.js`): arm a timed action, tick partway, serialize + deserialize through JSON, then tick the **restored** graph to completion while subscribed to `E.ACTION_FEEDBACK`. Asserts `progress` + `complete` reach the bus and the action still completes. Confirmed red before the fix (feedback dropped, action still completed), green after.

## Verification

`make check` — lint clean, all tests pass except 3 pre-existing soundfont failures (`Cannot find package 'soundfont2'`, an undeclared/uninstalled dependency unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)