### PR TITLE
Declare soundfont2 as an explicit devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "esbuild": "^0.27.3",
+        "soundfont2": "^0.5.0",
         "typescript": "^5.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "devDependencies": {
     "esbuild": "^0.27.3",
+    "soundfont2": "^0.5.0",
     "typescript": "^5.9.3"
   },
   "dependencies": {


### PR DESCRIPTION
Splits a dependency-hygiene fix out of #303 (discovered while diagnosing why 3 soundfont tests failed in `make check`).

## Problem

`tests/sf2-prune`, `tests/sf2-writer`, `tests/cull-soundfonts`, and the build scripts `scripts/cull-soundfonts.js` / `scripts/split-musescore-topical.js` all `import sf2pkg from "soundfont2"` **directly** — but `soundfont2` was never declared in `package.json`. It resolved only because it is a transitive dependency of the declared `@strudel/soundfonts`, hoisted to the top of `node_modules`.

That is a **phantom dependency**: it works today purely by hoisting, and would break for a non-obvious reason if `@strudel/soundfonts` ever dropped or bumped it. (It also made the failure mode confusing — a stale/absent `node_modules` surfaced as `Cannot find package 'soundfont2'` with no hint that a first-party import depended on a transitive package.)

## Fix

Declare `soundfont2` explicitly in `devDependencies` at `^0.5.0` — the same range `@strudel/soundfonts` already resolves, so there is **no version churn** (the lockfile change is a single line marking the already-present package as a direct dep). It is dev-only: imported solely by scripts and tests, never by browser-shipped `js/` runtime, consistent with the game code carrying no npm dependencies.

## Verification

`make check` — lint clean, all 1522 tests pass (including the 3 soundfont tooling suites that motivated this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)