### PR TITLE
Flow packets: fade in/out + 12-sided container ring

### DIFF
--- a/js/ui/flow-glyphs.js
+++ b/js/ui/flow-glyphs.js
@@ -4,6 +4,10 @@
 // (centered point arrays); both the SVG body (preview swatches) and the canvas draw path
 // (live flow layer) are derived from it, so they can't drift.
 //
+// Every packet is drawn as an inner type glyph wrapped in a faceted 12-sided container ring
+// (mirrors the dodecagon node container in node-glyphs.js), so a packet reads as one discrete
+// encapsulated object travelling the wire. Coordinates are centered on the origin.
+//
 // Vector-beam aesthetic: stroke-only, no fills. Shape carries type (colorblind-safe); color
 // is the redundant cue. "encrypted" is a render/concealment state, not a sixth type.
 
@@ -19,6 +23,18 @@ const STROKE_WIDTH = 0.7;
 const GLYPH_GLOW = 4;
 
 /**
+ * Encapsulating container: a stroke-only 12-sided ring drawn around every packet glyph so it
+ * reads as a discrete encapsulated object on the wire. Circumradius comfortably clears the
+ * ~5-unit glyphs. First vertex at 12 o'clock, going clockwise — the same faceted dodecagon
+ * the node containers use (node-glyphs.js CONTAINER_POLYGON_POINTS), scaled to glyph space.
+ */
+const CONTAINER_RADIUS = 7;
+const CONTAINER_PTS = [
+  [0, -1], [0.5, -0.866], [0.866, -0.5], [1, 0], [0.866, 0.5], [0.5, 0.866],
+  [0, 1], [-0.5, 0.866], [-0.866, 0.5], [-1, 0], [-0.866, -0.5], [-0.5, -0.866],
+].map(([x, y]) => [x * CONTAINER_RADIUS, y * CONTAINER_RADIUS]);
+
+/**
  * Canonical glyph geometry, centered on the origin in a ~[-5,5] space. `closed` polygons
  * close their path; open ones (the control chevron) don't.
  * @type {Record<string, { color: string, pts: number[][], closed: boolean }>}
@@ -31,11 +47,21 @@ const GLYPH_GEOM = {
   credential: { color: "#ff6cc7", closed: true,  pts: [[5, 0], [2.5, 4.3], [-2.5, 4.3], [-5, 0], [-2.5, -4.3], [2.5, -4.3]] }, // ⬡ hexagon
 };
 
-/** Build an SVG body string from geometry, shifting the centered points into a 0 0 12 12 box. */
+/** Serialize a centered point array as an SVG polygon/polyline element. */
+function svgPoly(/** @type {number[][]} */ pts, /** @type {string} */ color, /** @type {boolean} */ closed) {
+  const points = pts.map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`).join(" ");
+  const tag = closed ? "polygon" : "polyline";
+  return `<${tag} points="${points}" fill="none" stroke="${color}" stroke-width="${STROKE_WIDTH}"/>`;
+}
+
+/** Build the inner-glyph SVG body from geometry (centered coords, matching the canvas path). */
 function svgBody(/** @type {{color:string,pts:number[][],closed:boolean}} */ g) {
-  const points = g.pts.map(([x, y]) => `${(x + 6).toFixed(2)},${(y + 6).toFixed(2)}`).join(" ");
-  const tag = g.closed ? "polygon" : "polyline";
-  return `<${tag} points="${points}" fill="none" stroke="${g.color}" stroke-width="${STROKE_WIDTH}"/>`;
+  return svgPoly(g.pts, g.color, g.closed);
+}
+
+/** The encapsulating container ring as an SVG polygon in the given color. */
+function containerSvg(/** @type {string} */ color) {
+  return svgPoly(CONTAINER_PTS, color, true);
 }
 
 /**
@@ -57,26 +83,34 @@ export function flowGlyphFor(type) {
 
 
 /**
- * Inner glyph markup (no <svg> wrapper), 0 0 12 12 space. When `encrypted`, a dim "?" replaces
- * the type glyph. Single source of the encrypted treatment, shared by flowSvg and the layer.
+ * Packet markup (no <svg> wrapper), centered coords: the encapsulating container ring plus the
+ * inner glyph. When `encrypted`, a dim "?" inside a dim container replaces the type glyph.
+ * Single source of the container + encrypted treatment, shared by flowSvg and the canvas layer.
  * @param {string} type
  * @param {{ encrypted?: boolean }} [opts]
  * @returns {string}
  */
 export function flowGlyphBody(type, opts = {}) {
-  return opts.encrypted
-    ? `<text x="6" y="9.2" font-size="9" font-family="monospace" text-anchor="middle" fill="${ENCRYPTED_COLOR}">?</text>`
-    : flowGlyphFor(type).body;
+  if (opts.encrypted) {
+    return (
+      containerSvg(ENCRYPTED_COLOR) +
+      `<text x="0" y="3.2" font-size="9" font-family="monospace" text-anchor="middle" fill="${ENCRYPTED_COLOR}">?</text>`
+    );
+  }
+  const g = flowGlyphFor(type);
+  if (!g.body) return ""; // unknown type: nothing (matches the canvas no-op)
+  return containerSvg(g.color) + g.body;
 }
 
 /**
- * Standalone packet SVG string (viewBox 0 0 12 12, stroke-only).
+ * Standalone packet SVG string (centered viewBox, stroke-only). The viewBox spans the container
+ * ring plus a stroke's-worth of margin.
  * @param {string} type
  * @param {{ encrypted?: boolean }} [opts]
  * @returns {string}
  */
 export function flowSvg(type, opts = {}) {
-  return `<svg viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg">${flowGlyphBody(type, opts)}</svg>`;
+  return `<svg viewBox="-8 -8 16 16" xmlns="http://www.w3.org/2000/svg">${flowGlyphBody(type, opts)}</svg>`;
 }
 
 /**
@@ -90,10 +124,20 @@ export function flowGlyphDataUri(type, opts = {}) {
   return "data:image/svg+xml," + encodeURIComponent(flowSvg(type, opts));
 }
 
+/** Stroke a centered point array as a path on the canvas (caller has set stroke color/width). */
+function strokePoly(/** @type {CanvasRenderingContext2D} */ ctx, /** @type {number[][]} */ pts, /** @type {boolean} */ closed) {
+  ctx.beginPath();
+  ctx.moveTo(pts[0][0], pts[0][1]);
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i][0], pts[i][1]);
+  if (closed) ctx.closePath();
+  ctx.stroke();
+}
+
 /**
- * Draw a packet glyph onto a 2D canvas context, centered on the current origin in the same
- * ~[-5,5] space (the caller has already translated/scaled the context and set lineWidth).
- * Stroke-only, matching the vector aesthetic. Used by the live canvas flow layer.
+ * Draw a packet glyph onto a 2D canvas context, centered on the current origin (the caller has
+ * already translated/scaled the context and set lineWidth). Draws the encapsulating container
+ * ring plus the inner type glyph — or a dim container + "?" when encrypted. Stroke-only,
+ * matching the vector aesthetic. Used by the live canvas flow layer.
  * @param {CanvasRenderingContext2D} ctx
  * @param {string} type
  * @param {{ encrypted?: boolean }} [opts]
@@ -103,9 +147,11 @@ export function drawFlowGlyph(ctx, type, opts = {}) {
   // extra compositing layer). The caller save()/restore()s per packet, so these reset on their
   // own. shadowBlur is in device px (not affected by the ctx scale), so it reads consistently.
   if (opts.encrypted) {
+    ctx.strokeStyle = ENCRYPTED_COLOR;
     ctx.fillStyle = ENCRYPTED_COLOR;
     ctx.shadowColor = ENCRYPTED_COLOR;
     ctx.shadowBlur = GLYPH_GLOW;
+    strokePoly(ctx, CONTAINER_PTS, true); // encapsulating container ring
     ctx.font = "9px monospace";
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
@@ -117,9 +163,6 @@ export function drawFlowGlyph(ctx, type, opts = {}) {
   ctx.strokeStyle = g.color;
   ctx.shadowColor = g.color;
   ctx.shadowBlur = GLYPH_GLOW;
-  ctx.beginPath();
-  ctx.moveTo(g.pts[0][0], g.pts[0][1]);
-  for (let i = 1; i < g.pts.length; i++) ctx.lineTo(g.pts[i][0], g.pts[i][1]);
-  if (g.closed) ctx.closePath();
-  ctx.stroke();
+  strokePoly(ctx, CONTAINER_PTS, true); // encapsulating container ring
+  strokePoly(ctx, g.pts, g.closed); // inner type glyph
 }

--- a/js/ui/overlays/flow-layer.js
+++ b/js/ui/overlays/flow-layer.js
@@ -30,9 +30,22 @@ const LANE_GAP = 3;
 const PHASE_STAGGER = 0.4;
 const PHASE_JITTER = 0.12;
 // Extra clearance (glyph-space px, scaled by zoom) between a packet's endpoints and node rims.
-const RIM_PAD = 5;
+// Kept small: the fade (below) makes packets invisible at the endpoints, so they can spawn /
+// despawn right up against the rim without popping — they only read solid once well clear.
+const RIM_PAD = 2;
 // Glyph stroke width in glyph-space (scaled with zoom at draw time).
 const STROKE = 0.7;
+// Fraction of a packet's traversal spent fading in (leaving the source) and fading out
+// (arriving at the destination), so packets don't pop in/out at the t=0↔1 wrap. Feel-tuned.
+const FADE = 0.15;
+
+/**
+ * Opacity ramp for a packet at position `t` (0 = source rim, 1 = destination rim): 0 at both
+ * ends, rising linearly to 1 over the first/last FADE of the traversal. Pure. @param {number} t
+ */
+export function fadeAlpha(t) {
+  return Math.max(0, Math.min(1, Math.min(t, 1 - t) / FADE));
+}
 
 /**
  * Flows whose BOTH endpoints are currently present (revealed) in the graph. Pure.
@@ -249,6 +262,7 @@ export class FlowLayer {
           const x = sx + segX * p.t + offX;
           const y = sy + segY * p.t + offY;
           ctx.save();
+          ctx.globalAlpha = fadeAlpha(p.t); // fade in leaving the source, out arriving
           ctx.translate(x, y);
           ctx.scale(zoom, zoom);
           drawFlowGlyph(ctx, fl.type, { encrypted: fl.encrypted });

--- a/tests/flow-glyphs.test.js
+++ b/tests/flow-glyphs.test.js
@@ -5,7 +5,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { FLOW_TYPES, FLOW_GLYPHS, flowGlyphFor, flowSvg, drawFlowGlyph } from "../js/ui/flow-glyphs.js";
+import { FLOW_TYPES, FLOW_GLYPHS, ENCRYPTED_COLOR, flowGlyphFor, flowSvg, drawFlowGlyph } from "../js/ui/flow-glyphs.js";
+
+// The encapsulating container ring's top vertex sits at (0, -CONTAINER_RADIUS) = (0, -7),
+// a stable marker for "the container was drawn" in both the SVG body and the canvas path.
+const CONTAINER_TOP = "0.00,-7.00";
 
 /** Minimal canvas-2d stub that records the calls drawFlowGlyph makes. */
 function fakeCtx() {
@@ -41,6 +45,27 @@ test("encrypted render hides the type glyph behind a ? treatment", () => {
   assert.ok(!enc.includes(FLOW_GLYPHS.money.color), "encrypted glyph hides the type color");
 });
 
+test("every packet is wrapped in the 12-sided container ring (SVG)", () => {
+  for (const t of FLOW_TYPES) {
+    assert.ok(flowSvg(t).includes(CONTAINER_TOP), `${t} SVG wraps the container ring`);
+  }
+  // Encrypted packets are encapsulated too — a dim container around the ?.
+  const enc = flowSvg("money", { encrypted: true });
+  assert.ok(enc.includes(CONTAINER_TOP), "encrypted packet is encapsulated");
+  assert.ok(enc.includes(ENCRYPTED_COLOR), "encrypted container uses the dim color");
+});
+
+test("drawFlowGlyph draws the container ring around the type glyph (canvas)", () => {
+  const ctx = fakeCtx();
+  drawFlowGlyph(ctx, "money");
+  assert.ok(
+    ctx.calls.some((c) => c[0] === "moveTo" && c[1] === 0 && c[2] === -7),
+    "path starts at the container's top vertex",
+  );
+  // Container + inner glyph = two stroked subpaths.
+  assert.ok(ctx.calls.filter((c) => c[0] === "stroke").length >= 2, "strokes container and glyph");
+});
+
 test("flowGlyphFor returns a fallback for unknown types without throwing", () => {
   assert.doesNotThrow(() => flowGlyphFor("bogus"));
   assert.doesNotThrow(() => flowSvg("bogus"));
@@ -62,11 +87,20 @@ test("drawFlowGlyph strokes a path in the type color for every type", () => {
   }
 });
 
-test("drawFlowGlyph renders a ? (fillText) when encrypted, no stroke", () => {
+test("drawFlowGlyph renders a ? (fillText) inside a dim container when encrypted", () => {
   const ctx = fakeCtx();
   drawFlowGlyph(ctx, "money", { encrypted: true });
-  assert.ok(ctx.calls.some((c) => c[0] === "fillText" && c[1] === "?"));
-  assert.ok(!ctx.calls.some((c) => c[0] === "stroke"));
+  assert.ok(ctx.calls.some((c) => c[0] === "fillText" && c[1] === "?"), "shows ?");
+  // The encapsulating container ring is still drawn — dim, not in the type color.
+  assert.ok(ctx.calls.some((c) => c[0] === "stroke"), "strokes the container");
+  assert.ok(
+    ctx.calls.some((c) => c[0] === "strokeStyle" && c[1] === ENCRYPTED_COLOR),
+    "container is the dim encrypted color",
+  );
+  assert.ok(
+    !ctx.calls.some((c) => c[0] === "strokeStyle" && c[1] === FLOW_GLYPHS.money.color),
+    "never strokes in the concealed type's color",
+  );
 });
 
 test("drawFlowGlyph no-ops for an unknown type without throwing", () => {

--- a/tests/flow-layer.test.js
+++ b/tests/flow-layer.test.js
@@ -6,7 +6,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { renderableFlows, flowsSignature } from "../js/ui/overlays/flow-layer.js";
+import { renderableFlows, flowsSignature, fadeAlpha } from "../js/ui/overlays/flow-layer.js";
 
 const flows = [
   { from: "a", to: "b", type: "money", rate: 1 },
@@ -49,4 +49,23 @@ test("flowsSignature changes when an encrypted flow is revealed (SNIFF decrypts 
   const enc = flowsSignature([{ from: "x", to: "y", type: "credential", rate: 0.5, encrypted: true }]);
   const revealed = flowsSignature([{ from: "x", to: "y", type: "credential", rate: 0.5, encrypted: true, revealed: true }]);
   assert.notEqual(enc, revealed);
+});
+
+// Packets fade in as they leave the source (t→0) and out as they arrive (t→1) so they don't
+// pop in/out at the t=0↔1 loop wrap.
+test("fadeAlpha is 0 at both endpoints and 1 across the middle", () => {
+  assert.equal(fadeAlpha(0), 0, "invisible at the source rim");
+  assert.equal(fadeAlpha(1), 0, "invisible at the destination rim");
+  assert.equal(fadeAlpha(0.5), 1, "fully opaque mid-traversal");
+});
+
+test("fadeAlpha ramps linearly over the fade zone and clamps to [0,1]", () => {
+  // Rising edge: half-way through the 0.15 fade zone → 0.5.
+  assert.ok(Math.abs(fadeAlpha(0.075) - 0.5) < 1e-9);
+  // Symmetric on the falling edge.
+  assert.ok(Math.abs(fadeAlpha(0.925) - 0.5) < 1e-9);
+  // Never exceeds 1 in the plateau, never below 0 out of range.
+  assert.equal(fadeAlpha(0.3), 1);
+  assert.equal(fadeAlpha(-0.2), 0);
+  assert.equal(fadeAlpha(1.2), 0);
 });


### PR DESCRIPTION
Two tweaks to the typed-flow packet glyphs that travel along edges to signal network traffic.

## Changes

**1. Fade in / fade out** — `js/ui/overlays/flow-layer.js`
- New pure, exported `fadeAlpha(t)`: opacity is `0` at both endpoints and ramps linearly to `1` over the first/last 15% of each traversal (`FADE = 0.15`), applied via `ctx.globalAlpha`. Packets fade in as they leave the source and fade out as they arrive — no pop at the `t: 0↔1` loop wrap.

**2. 12-sided container ring** — `js/ui/flow-glyphs.js`
- Every packet is wrapped in a stroke-only faceted dodecagon (circumradius 7, first vertex at 12 oclock — same convention as the `node-glyphs.js` node container), so a packet reads as one discrete encapsulated object. Baked into the shared geometry, so the live canvas layer, preview swatches, and the `<img>` glyphs in the program-action UI all pick it up. Encrypted packets get the same ring in the dim `ENCRYPTED_COLOR`.
- SVG side refactored from the `0 0 12 12`-with-`+6`-shift box to centered coords + a `-8 -8 16 16` viewBox so the ring fits with stroke margin.

**3. Tighter spawn/despawn** — `RIM_PAD` 5 → 2, since the fade masks the endpoints so packets can emerge/vanish right against the node rims.

## Verification
- Lint clean; 18 flow tests pass — added `fadeAlpha` ramp tests and container-presence tests for both the SVG and canvas paths. Updated the old "encrypted draws no stroke" test to reflect the new contract (encrypted packets are now encapsulated too).
- Both effects render live in the preview harness (FLOW SUBSTRATE controls) since it drives the real `FlowLayer`.

Tunable feel knobs: `FADE` (fade fraction), `CONTAINER_RADIUS` (ring vs. glyph), `RIM_PAD` (spawn distance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)