### PR TITLE
Exploit combat feel labs (Lab A: autopwn barrage) — WIP

### DIFF
--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/lab-a-flamethrower/index.html
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/lab-a-flamethrower/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Lab A — Flamethrower (smash feel)</title>
+<title>Lab A — Autopwn Barrage (smash feel)</title>
 <style>
   :root {
     --bg: #0a0a0f; --fg: #9ff7c4; --dim: #4a6a5a; --cyan: #21e6ff; --amber: #ffb020;
@@ -20,7 +20,7 @@
   h1 { font-size: 15px; letter-spacing: 2px; margin: 0 0 2px; color: var(--cyan); text-shadow: var(--glow-md); text-transform: uppercase; }
   .sub { color: var(--dim); margin: 0 0 12px; font-size: 11px; }
   .stage-wrap { position: relative; }
-  canvas { width: 100%; height: auto; display: block; border: 1px solid #1c2630; background: #070a0e; border-radius: 3px; }
+  canvas { width: 100%; max-width: 506px; height: auto; display: block; margin: 0 auto; border: 1px solid #1c2630; background: #070a0e; border-radius: 3px; }
   .readout { display: flex; gap: 18px; flex-wrap: wrap; margin: 8px 0; font-size: 12px; }
   .readout b { color: var(--cyan); font-weight: normal; }
   .readout .v { color: var(--fg); text-shadow: var(--glow-sm); }
@@ -56,39 +56,39 @@
 </head>
 <body>
 <div class="left">
-  <h1>Lab A — Flamethrower</h1>
-  <p class="sub">smash feel · coherence erosion vs. hoard attrition · does the burst stay fun the 20th time?</p>
+  <h1>Lab A — Autopwn Barrage</h1>
+  <p class="sub">smash feel · a Metasploit-style module barrage · service coherence vs. module-library attrition · does it stay fun the 20th time?</p>
 
-  <div class="stage-wrap"><canvas id="cv" width="900" height="340"></canvas></div>
+  <div class="stage-wrap"><canvas id="cv" width="500" height="455"></canvas></div>
 
   <div class="outcome" id="outcome"></div>
 
   <div class="readout">
-    <span><b>target</b> <span class="v grade-pill" id="r-grade">—</span></span>
+    <span><b>host posture</b> <span class="v grade-pill" id="r-grade">—</span></span>
     <span><b>coherence</b> <span class="v" id="r-coh">—</span></span>
-    <span><b>hoard</b> <span class="v" id="r-hoard">—</span></span>
-    <span><b>heat</b> <span class="v" id="r-heat">—</span></span>
-    <span><b>shots</b> <span class="v" id="r-shots">0</span></span>
-    <span><b>burned</b> <span class="v" id="r-burned">0</span></span>
+    <span><b>library</b> <span class="v" id="r-hoard">—</span></span>
+    <span><b>IDS noise</b> <span class="v" id="r-heat">—</span></span>
+    <span><b>attempts</b> <span class="v" id="r-shots">0</span></span>
+    <span><b>flagged</b> <span class="v" id="r-burned">0</span></span>
   </div>
 
   <div class="controls">
-    <button class="go" id="btn-go">▶ Smash</button>
-    <button class="stop" id="btn-abort" disabled>■ Abort</button>
-    <button id="btn-target">New Target</button>
-    <button id="btn-refill">Refill Hoard</button>
-    <label class="inline">grade
+    <button class="go" id="btn-go">▶ Autopwn</button>
+    <button class="stop" id="btn-abort" disabled>■ Halt</button>
+    <button id="btn-target">New Host</button>
+    <button id="btn-refill">Refill Library</button>
+    <label class="inline">posture
       <select id="sel-grade">
         <option value="random">random</option>
         <option>S</option><option>A</option><option>B</option>
         <option selected>C</option><option>D</option><option>E</option><option>F</option>
       </select>
     </label>
-    <label class="inline"><input type="checkbox" id="chk-gear" checked /> gear (best-match-first)</label>
+    <label class="inline"><input type="checkbox" id="chk-gear" checked /> ranking engine (fire best-ranked first)</label>
   </div>
 
   <div id="log"></div>
-  <p class="hint">Two bars race: the node's <span style="color:var(--red)">coherence</span> (its composure under fuzzing) vs. your <span style="color:var(--cyan)">hoard</span> (burning down via disclosure). Set the heat ceiling → the bail wager. Crack it before you run dry or cook.</p>
+  <p class="hint">Two bars race: the target service's <span style="color:var(--red)">coherence</span> (its composure under the fuzzing barrage) vs. your <span style="color:var(--cyan)">module library</span> (thinning as signatures get flagged). Set the IDS-noise ceiling → the abort wager. Pop a session before you exhaust the library or trip detection.</p>
 </div>
 
 <div class="panel">
@@ -99,9 +99,10 @@
 <script>
 "use strict";
 // ---------- config / knobs ----------
-const GRADES = ["S","A","B","C","D","E","F"];               // 0 = hardest
-const TYPES  = ["web","auth","kernel","net","mem"];
+const GRADES = ["S","A","B","C","D","E","F"];               // 0 = hardest (patch/hardening posture)
+const TYPES  = ["smb","http","ssh","rdp","kernel"];         // target service classes (Metasploit-flavored)
 const RARITIES = ["common","uncommon","rare"];
+const RANK = { common: "normal", uncommon: "good", rare: "excellent" }; // module reliability-rank display
 const RARITY_WEIGHT = { common: 11/15, uncommon: 3/15, rare: 1/15 };
 const RARITY_PUNCH  = { common: 1, uncommon: 2.2, rare: 5 };
 
@@ -112,24 +113,26 @@ const DISC_BASE  = [0.90,0.72,0.52,0.34,0.18,0.07,0.02]; // per-shot disclosure 
 // Star Castle shield: ring count by grade (S..F), segments per ring, nested radii by ring count
 const RING_COUNT = [3,3,2,2,2,1,1];
 const SEG = 12;
-const RADII_BY_COUNT = { 1:[96], 2:[104,66], 3:[104,74,46] };
-const CORE_R = 20;
+const RADII_BY_COUNT = { 1:[67], 2:[67,47], 3:[67,51,32] };
+const CORE_R = 14;
 
 // live-tunable multipliers (bound to sliders)
 const K = {
   cohScale: 1.0, chipScale: 1.0, typeBite: 1.5, discScale: 1.0,
   heatPerShot: 1.0, heatCeil: 40, cadence: 90, hoardSize: 200, jitter: 0.25,
+  showSplash: false, showDamage: false, // off by default; toggles in the tuning panel
 };
+const TOGGLES = [["showSplash","impact splashes"], ["showDamage","damage numbers"]];
 const SLIDER_DEFS = [
   ["cohScale","coherence ×",0.25,3,0.05],
-  ["chipScale","chip ×",0.25,3,0.05],
-  ["typeBite","type-match bite +×",0,4,0.1],
-  ["discScale","disclosure ×",0,2,0.05],
-  ["heatPerShot","heat / shot",0,4,0.1],
-  ["heatCeil","heat ceiling (bail)",5,120,1],
-  ["cadence","shot cadence (ms)",20,300,5],
-  ["hoardSize","hoard size",20,600,10],
-  ["jitter","chip jitter ±",0,0.9,0.05],
+  ["chipScale","exploit bite ×",0.25,3,0.05],
+  ["typeBite","service-match bonus +×",0,4,0.1],
+  ["discScale","signature-flag ×",0,2,0.05],
+  ["heatPerShot","noise / attempt",0,4,0.1],
+  ["heatCeil","IDS-noise ceiling (abort)",5,120,1],
+  ["cadence","attempt cadence (ms)",20,300,5],
+  ["hoardSize","library size",20,600,10],
+  ["jitter","bite jitter ±",0,0.9,0.05],
 ];
 
 // ---------- rng / helpers ----------
@@ -155,25 +158,44 @@ function makeExploit(){
 }
 function makeHoard(size){ return Array.from({length: size}, makeExploit); }
 
-// hoard shown as a collection: a tick-grid tinted by rarity composition
-const HCOLS = 8, HROWS = 14, HCELLS = HCOLS*HROWS;
+// module glyph tint by rarity
 const rarityCellColor = (r) => r==="rare" ? "#b98bff" : r==="uncommon" ? "#21e6ff" : "#2f6a4a";
-function buildHoardCells(){
-  const counts = { common:0, uncommon:0, rare:0 };
-  for (const e of hoard) counts[e.rarity]++;
-  const total = hoard.length || 1, colors = [];
-  for (const r of RARITIES){ const n = Math.round(counts[r]/total*HCELLS); for (let i=0;i<n;i++) colors.push(rarityCellColor(r)); }
-  while (colors.length < HCELLS) colors.push(rarityCellColor("common"));
-  colors.length = HCELLS;
-  for (let i=HCELLS-1;i>0;i--){ const j=Math.floor(rnd()*(i+1)); [colors[i],colors[j]]=[colors[j],colors[i]]; }
-  hoardCells = colors.map(c => ({ c, dark:false, g:0, r:0 }));
+function buildExploitRings(){
+  // 2 bounded rotating rings that REPRESENT the library (not 1:1) and fire zaps inward
+  exploitRings = ER_RADII.map((r, idx) => {
+    const n = Math.max(12, Math.floor(2*Math.PI*r / ER_SPACING));
+    const slots = Array.from({length:n}, () => {
+      const e = hoard[Math.floor(rnd()*hoard.length)] || { rarity:"common", types:["smb"] };
+      return { c: rarityCellColor(e.rarity), type: e.types[0], dark:false, g:0, r:0 };
+    });
+    return { r, rot: rnd()*Math.PI*2, dir: 1, speed: 0.0032 + idx*0.0012, slots }; // dir +1 = clockwise (player)
+  });
+  noiseRadius = ER_RADII[ER_RADII.length-1] + 20;
 }
-function flashHoard(didBurn){
-  const lit = hoardCells.filter(c => !c.dark);
-  if (!lit.length) return;
-  const cell = lit[Math.floor(rnd()*lit.length)];
-  if (didBurn){ cell.r = 12; if (rnd() < HCELLS / Math.max(hoard.length, HCELLS)) cell.dark = true; }
-  else cell.g = 8;
+const totalSlots = () => exploitRings.reduce((s,r) => s + r.slots.length, 0);
+const slotAngle = (ring, j) => -Math.PI/2 + j/ring.slots.length*Math.PI*2 + ring.rot;
+function pickExploitSlot(){
+  const lit = [];
+  for (const ring of exploitRings) for (let j=0;j<ring.slots.length;j++) if (!ring.slots[j].dark) lit.push({ ring, j });
+  return lit.length ? lit[Math.floor(rnd()*lit.length)] : null;
+}
+// staged (lit) slots ≈ min(capacity, usable library) — the gear keeps the rings topped up from the
+// library; monotonic during a run (only empties as you burn down), refills on Refill Library.
+function reconcileStaging(){
+  const flat = [];
+  for (const ring of exploitRings) for (const c of ring.slots) flat.push(c);
+  const litTarget = Math.min(flat.length, usable());
+  let lit = flat.filter(c => !c.dark).length;
+  if (lit > litTarget){
+    const pool = flat.filter(c => !c.dark);
+    for (let n=lit-litTarget; n>0 && pool.length; n--) pool.splice(Math.floor(rnd()*pool.length),1)[0].dark = true;
+  } else if (lit < litTarget){
+    const pool = flat.filter(c => c.dark);
+    for (let n=litTarget-lit; n>0 && pool.length; n--){
+      const c = pool.splice(Math.floor(rnd()*pool.length),1)[0], ex = hoard[Math.floor(rnd()*hoard.length)];
+      c.dark = false; if (ex){ c.c = rarityCellColor(ex.rarity); c.type = ex.types[0]; }
+    }
+  }
 }
 function makeNode(grade){
   if (grade === "random") grade = pick(GRADES);
@@ -192,19 +214,18 @@ function makeNode(grade){
 // ---------- state ----------
 let hoard = [], node = null, heat = 0, shots = 0, burned = 0;
 let running = false, ended = null, tickTimer = null;
-let emitAngle = 0, hoardCells = [];
-const EMIT = 4;
-const fx = { shots: [], impacts: [], shards: [], shake: 0, flash: 0, emitFlash: [0,0,0,0] };
+let exploitRings = [], noiseRadius = 115;
+const fx = { shots: [], impacts: [], shards: [], shake: 0, flash: 0 };
 
 function usable(){ return hoard.filter(e => !e.dead); }
 
 function reset(newHoard){
-  if (newHoard || hoard.length === 0){ hoard = makeHoard(Math.round(K.hoardSize)); buildHoardCells(); }
+  if (newHoard || hoard.length === 0){ hoard = makeHoard(Math.round(K.hoardSize)); buildExploitRings(); }
   node = makeNode(document.getElementById("sel-grade").value);
   heat = 0; shots = 0; burned = hoard.filter(e=>e.dead).length; ended = null;
   fx.shots.length = fx.impacts.length = fx.shards.length = 0; fx.shake = 0; fx.flash = 0;
   setOutcome("");
-  render(); log(`── new target · grade ${node.grade} · coherence ${node.cohMax} · weak: ${node.profile.join("/")} ──`);
+  render(); log(`── new host · posture ${node.grade} · coherence ${node.cohMax} · services: ${node.profile.join("/")} ──`);
 }
 
 // ---------- combat ----------
@@ -236,17 +257,21 @@ function fireShot(){
   const { chip, match } = chipFor(e);
   node.coh = Math.max(0, node.coh - chip);
   heat += K.heatPerShot;
-  const emitter = shots % EMIT;
   shots++;
   // disclosure roll → burn
   const discChance = clamp(DISC_BASE[node.g] * K.discScale, 0, 0.99);
   const didBurn = rnd() < discChance;
   if (didBurn){ e.dead = true; burned++; }
-  const radii = RADII_BY_COUNT[node.nRings], orbitR = radii[0] + 34, ea = emitAngle + emitter * (Math.PI*2/EMIT);
+  // fire from a module slot on the rotating exploit rings, zapping inward to the outermost intact shield
+  const radii = RADII_BY_COUNT[node.nRings];
   const alive = Math.ceil(clamp(node.coh/node.cohMax,0,1) * node.totalSegs), impactR = outerIntactRadius(node, alive, radii);
-  spawnShot(e, chip, match, didBurn, NODE_X + orbitR*Math.cos(ea), H/2 + orbitR*Math.sin(ea), NODE_X + impactR*Math.cos(ea), H/2 + impactR*Math.sin(ea));
-  fx.emitFlash[emitter] = 1;
-  flashHoard(didBurn);
+  const slot = pickExploitSlot();
+  if (slot){
+    const a = slotAngle(slot.ring, slot.j), sx = CX + slot.ring.r*Math.cos(a), sy = CY + slot.ring.r*Math.sin(a);
+    spawnShot(e, chip, match, didBurn, sx, sy, CX + impactR*Math.cos(a), CY + impactR*Math.sin(a));
+    const cell = slot.ring.slots[slot.j]; cell.g = 8;
+    if (didBurn) cell.r = 12; // flash red; the slot's occupancy is reconciled to the library level in draw
+  }
   fx.shake = Math.min(14, fx.shake + Math.min(8, chip / (node.cohMax*0.02)));
   logShot(e, chip, match, didBurn);
   render();
@@ -272,18 +297,19 @@ function stop(){
 }
 function finish(kind){
   ended = kind; stop();
-  if (kind === "crack"){ fx.flash = 1; burstShards(); setOutcome("⌁ NODE CRACKED — access granted","crack"); log(`<span class="crack">CRACK — faulted after ${shots} shots, ${burned} burned</span>`); }
-  if (kind === "bail"){ setOutcome("↩ BAILED — heat ceiling hit","bail"); log(`<span class="burn">BAIL — heat ${Math.round(heat)} ≥ ceiling ${K.heatCeil} · coherence ${Math.round(node.coh)}/${node.cohMax} left</span>`); }
-  if (kind === "dry"){ setOutcome("✕ HOARD DRY — access denied","dry"); log(`<span class="burn">DRY — out of ammo · coherence ${Math.round(node.coh)}/${node.cohMax} left</span>`); }
+  if (kind === "crack"){ fx.flash = 1; burstShards(); setOutcome("⌁ SESSION OPENED — meterpreter","crack"); log(`<span class="crack">SESSION — service faulted after ${shots} attempts, ${burned} modules flagged</span>`); }
+  if (kind === "bail"){ setOutcome("↩ ABORTED — IDS noise ceiling","bail"); log(`<span class="burn">ABORT — noise ${Math.round(heat)} ≥ ceiling ${K.heatCeil} · coherence ${Math.round(node.coh)}/${node.cohMax} left</span>`); }
+  if (kind === "dry"){ setOutcome("✕ LIBRARY EXHAUSTED — no modules left","dry"); log(`<span class="burn">EXHAUSTED — no viable modules · coherence ${Math.round(node.coh)}/${node.cohMax} left</span>`); }
 }
 
 // ---------- visuals ----------
 const cv = document.getElementById("cv"), ctx = cv.getContext("2d");
 const W = cv.width, H = cv.height;
-const NODE_X = W - 150, HOARD_X = 90;
+const CX = W/2, CY = H/2;                              // everything is one centered radial instrument
+const ER_RADII = [87, 109], ER_SPACING = 17, NOISE_TICKS = 56; // 2 bounded rotating staging rings + outer noise bezel
 
 function spawnShot(e, chip, match, burn, ox, oy, tx, ty){
-  fx.shots.push({ x: ox, y: oy, tx, ty, id: e.id, rarity: e.rarity, match, burn, t: 0, chip });
+  fx.shots.push({ x: ox, y: oy, tx, ty, id: e.id, type: e.types[0], rarity: e.rarity, match, burn, t: 0, chip, ang: Math.atan2(ty-oy, tx-ox) });
 }
 // radius of the outermost ring that still has intact segments (zaps stop here); core if all gone
 function outerIntactRadius(node, aliveCount, radii){
@@ -292,7 +318,7 @@ function outerIntactRadius(node, aliveCount, radii){
   return CORE_R;
 }
 function burstShards(){
-  for (let i=0;i<60;i++){ const a = rnd()*Math.PI*2, s = 2+rnd()*7; fx.shards.push({ x: NODE_X, y: H/2, vx: Math.cos(a)*s, vy: Math.sin(a)*s, life: 1, c: "#21e6ff" }); }
+  for (let i=0;i<60;i++){ const a = rnd()*Math.PI*2, s = 2+rnd()*7; fx.shards.push({ x: CX, y: CY, vx: Math.cos(a)*s, vy: Math.sin(a)*s, life: 1, c: "#21e6ff" }); }
 }
 function segShards(x,y){
   for (let i=0;i<5;i++){ const a = rnd()*Math.PI*2, s = 1.5+rnd()*4; fx.shards.push({ x, y, vx: Math.cos(a)*s, vy: Math.sin(a)*s, life: 1, c: "#ff5a5a" }); }
@@ -305,91 +331,87 @@ function draw(){
   fx.shake *= 0.85; if (fx.shake < 0.3) fx.shake = 0;
   ctx.save(); ctx.translate(sx, sy);
 
-  // heat meter (top)
-  const heatFrac = node ? clamp(heat / K.heatCeil, 0, 1) : 0;
-  ctx.fillStyle = "#141a12"; ctx.fillRect(40, 18, W-80, 10);
-  const hc = heatFrac < .5 ? "#9ff7c4" : heatFrac < .8 ? "#ffb020" : "#ff2a2a";
-  ctx.fillStyle = hc; ctx.shadowColor = hc; ctx.shadowBlur = 10; ctx.fillRect(40, 18, (W-80)*heatFrac, 10); ctx.shadowBlur = 0;
-  ctx.fillStyle = "#4a6a5a"; ctx.font = "10px monospace"; ctx.textAlign = "left"; ctx.fillText("HEAT", 40, 14);
-
   if (node){
-    // node = Star Castle-style segmented shield rings, eroded outer→inward
-    const cx = NODE_X, cy = H/2, step = Math.PI*2/SEG, radii = RADII_BY_COUNT[node.nRings];
-    const aliveCount = Math.ceil(clamp(node.coh/node.cohMax,0,1) * node.totalSegs);
-    // draw living segments — rings peel outer→inner, but WHICH segment dies within a ring is
-    // shuffled (ring.order) so the gaps look chaotic, not a clock-hand sweep.
+    const step = Math.PI*2/SEG, radii = RADII_BY_COUNT[node.nRings];
+    const aliveCount = Math.ceil(clamp(node.coh/node.cohMax,0,1) * node.totalSegs), u = usable().length;
+
+    // --- outermost: NOISE bezel (faceted tick ring filling toward the ceiling) ---
+    const noiseFrac = clamp(heat / K.heatCeil, 0, 1), litN = Math.round(noiseFrac*NOISE_TICKS);
+    const nc = noiseFrac < .5 ? "#9ff7c4" : noiseFrac < .8 ? "#ffb020" : "#ff2a2a";
+    for (let i=0;i<NOISE_TICKS;i++){
+      const a = -Math.PI/2 + i/NOISE_TICKS*Math.PI*2, lit = i < litN;
+      ctx.strokeStyle = lit ? nc : "#20302a"; ctx.shadowColor = nc; ctx.shadowBlur = lit ? 8 : 0; ctx.lineWidth = 2;
+      ctx.beginPath(); ctx.moveTo(CX + noiseRadius*Math.cos(a), CY + noiseRadius*Math.sin(a)); ctx.lineTo(CX + (noiseRadius+7)*Math.cos(a), CY + (noiseRadius+7)*Math.sin(a)); ctx.stroke();
+    }
+    ctx.shadowBlur = 0; ctx.fillStyle = "#4a6a5a"; ctx.font = "10px monospace"; ctx.textAlign = "center";
+    ctx.fillText("NOISE", CX, CY - noiseRadius - 13);
+
+    // --- STAGING rings: the gear enqueues modules from the library into these rotating rings
+    //     (CW = player), which fire inward. Occupancy tracks the library level. ---
+    reconcileStaging();
+    for (const ring of exploitRings){
+      ring.rot += ring.dir * ring.speed;
+      for (let j=0;j<ring.slots.length;j++){
+        const cell = ring.slots[j], a = -Math.PI/2 + j/ring.slots.length*Math.PI*2 + ring.rot;
+        const x = CX + ring.r*Math.cos(a), y = CY + ring.r*Math.sin(a);
+        let color = cell.dark ? "#0c110d" : cell.c, glow = 0, lw = 1.5;  // empty slot → all but invisible
+        if (cell.g > 0){ color = "#7dffb0"; glow = 8; lw = 2; cell.g--; }
+        if (cell.r > 0){ color = "#ff5a5a"; glow = 8; lw = 2; cell.r--; }
+        ctx.strokeStyle = color; ctx.shadowColor = color; ctx.shadowBlur = glow; ctx.lineWidth = lw;
+        drawGlyph(cell.type, x, y, 10);
+      }
+    }
+    ctx.shadowBlur = 0; ctx.fillStyle = "#4a6a5a"; ctx.textAlign = "center"; ctx.font = "10px monospace";
+    ctx.fillText("STAGING · LIBRARY " + u + "/" + hoard.length, CX, CY + noiseRadius + 16);
+
+    // --- shield rings (coherence), eroded outer→inner, shuffled within each ring ---
     for (let j=0;j<node.nRings;j++){
       const ring = node.rings[j], r = radii[j], base = (node.nRings-1-j)*SEG;
       ring.rot += ring.dir * ring.speed;
       ctx.strokeStyle = "#ff2a2a"; ctx.shadowColor = "#ff2a2a"; ctx.shadowBlur = 8; ctx.lineWidth = 2.5;
       for (let k=0;k<SEG;k++){
         const dead = base + ring.order[k] >= aliveCount;
-        if (dead){
-          if (!ring.dead[k]){ ring.dead[k] = true; const a = (k+0.5)*step + ring.rot; segShards(cx + r*Math.cos(a), cy + r*Math.sin(a)); }
-          continue;
-        }
-        ring.dead[k] = false; // lets segments regrow cleanly if the reboot rule is added later
-        const a0 = ring.rot + k*step, a1 = ring.rot + (k+0.9)*step; // 0.9 → faceted gap between segments
-        ctx.beginPath(); ctx.moveTo(cx + r*Math.cos(a0), cy + r*Math.sin(a0)); ctx.lineTo(cx + r*Math.cos(a1), cy + r*Math.sin(a1)); ctx.stroke();
+        if (dead){ if (!ring.dead[k]){ ring.dead[k] = true; const a=(k+0.5)*step+ring.rot; segShards(CX + r*Math.cos(a), CY + r*Math.sin(a)); } continue; }
+        ring.dead[k] = false;
+        const a0 = ring.rot + k*step, a1 = ring.rot + (k+0.9)*step; // faceted gap
+        ctx.beginPath(); ctx.moveTo(CX + r*Math.cos(a0), CY + r*Math.sin(a0)); ctx.lineTo(CX + r*Math.cos(a1), CY + r*Math.sin(a1)); ctx.stroke();
       }
     }
     ctx.shadowBlur = 0;
-    // core (turns cyan + blooms when the last ring falls)
+
+    // --- core (blooms cyan when the last ring falls) ---
     const cracked = aliveCount <= 0;
     ctx.strokeStyle = cracked ? "#21e6ff" : "#ff5a5a"; ctx.shadowColor = ctx.strokeStyle; ctx.shadowBlur = fx.flash>0?30:10; ctx.lineWidth = 2;
-    polygon(cx, cy, CORE_R, 6); ctx.stroke(); ctx.shadowBlur = 0;
-    ctx.fillStyle = cracked ? "#7fefff" : "#ff8a8a"; ctx.textAlign = "center"; ctx.font = "12px monospace";
-    ctx.fillText(node.grade, cx, cy+4);
-    ctx.fillStyle = "#ff8a8a"; ctx.font = "10px monospace";
-    ctx.fillText("COHERENCE " + Math.round(node.coh) + "/" + node.cohMax, cx, cy + radii[0] + 22);
-
-    // orbiting exploit emitters (player = clockwise), counter-rotating vs. the CCW shield
-    emitAngle += 0.0042; // orbit speed (slowed 30% from 0.006)
-    const oR = radii[0] + 34, impactR = outerIntactRadius(node, aliveCount, radii);
-    for (let i=0;i<EMIT;i++){
-      const a = emitAngle + i*(Math.PI*2/EMIT), ex = cx + oR*Math.cos(a), ey = cy + oR*Math.sin(a);
-      const inx = Math.cos(a+Math.PI), iny = Math.sin(a+Math.PI), px = -Math.sin(a), py = Math.cos(a);
-      const fl = fx.emitFlash[i] || 0, sz = 7;
-      ctx.strokeStyle = fl>0 ? "#e8ffff" : "#21e6ff"; ctx.shadowColor = "#21e6ff"; ctx.shadowBlur = fl>0?14:6; ctx.lineWidth = 2;
-      ctx.beginPath(); // chevron reticle pointing inward
-      ctx.moveTo(ex + px*sz, ey + py*sz); ctx.lineTo(ex + inx*sz*1.4, ey + iny*sz*1.4); ctx.lineTo(ex - px*sz, ey - py*sz); ctx.stroke();
-      if (fl>0){ ctx.globalAlpha = fl; ctx.beginPath(); ctx.moveTo(ex, ey); ctx.lineTo(cx + impactR*Math.cos(a), cy + impactR*Math.sin(a)); ctx.stroke(); ctx.globalAlpha = 1; fx.emitFlash[i] = Math.max(0, fl - 0.15); }
-    }
-    ctx.shadowBlur = 0;
-
-    // hoard as a *collection* — stroked tick-grid; base tint = rarity, green flash = fired, red→dark = burned
-    const u = usable().length, px0 = 26, py0 = 54, cw = 12, chh = (H - 100) / HROWS, gw = HCOLS*cw;
-    ctx.textAlign = "center"; ctx.fillStyle = "#7fefff"; ctx.font = "10px monospace";
-    ctx.fillText("HOARD " + u + "/" + hoard.length, px0 + gw/2 - cw/2, py0 - 12);
-    for (let i=0;i<hoardCells.length;i++){
-      const cell = hoardCells[i], x = px0 + (i%HCOLS)*cw, y = py0 + Math.floor(i/HCOLS)*chh, s = Math.min(cw,chh) - 4;
-      let color = cell.dark ? "#16241c" : cell.c, glow = 0, lw = 1.5;
-      if (cell.g > 0){ color = "#7dffb0"; glow = 8; lw = 2; cell.g--; }
-      if (cell.r > 0){ color = "#ff5a5a"; glow = 8; lw = 2; cell.r--; }
-      ctx.strokeStyle = color; ctx.shadowColor = color; ctx.shadowBlur = glow; ctx.lineWidth = lw;
-      ctx.strokeRect(x, y, s, s);
-    }
-    ctx.shadowBlur = 0;
+    polygon(CX, CY, CORE_R, 6); ctx.stroke(); ctx.shadowBlur = 0;
+    ctx.fillStyle = cracked ? "#7fefff" : "#ff8a8a"; ctx.textAlign = "center"; ctx.font = "13px monospace";
+    ctx.fillText(node.grade, CX, CY+5);
   }
 
   // in-flight shots
   for (const s of fx.shots){
-    s.t += 0.16; const x = s.x + (s.tx - s.x) * Math.min(1, s.t); const y = s.y + (s.ty - s.y) * Math.min(1, s.t);
-    ctx.fillStyle = s.burn ? "#ff2a2a" : rarityColor(s.rarity);
-    ctx.shadowColor = ctx.fillStyle; ctx.shadowBlur = 8; ctx.font = "10px monospace"; ctx.textAlign = "left";
-    ctx.fillText(s.id, x, y); ctx.shadowBlur = 0;
+    s.t += 0.16; const p = Math.min(1, s.t), x = s.x + (s.tx - s.x)*p, y = s.y + (s.ty - s.y)*p;
+    const col = s.burn ? "#ff2a2a" : rarityColor(s.rarity);
+    ctx.save(); ctx.translate(x, y); ctx.rotate(s.ang); // hex + glyph ride along the zap's trajectory
+    ctx.strokeStyle = col; ctx.fillStyle = col; ctx.shadowColor = col; ctx.shadowBlur = 8; ctx.lineWidth = 1.5;
+    drawGlyph(s.type, -9, 0, 10);
+    ctx.font = "9px monospace"; ctx.textAlign = "left"; ctx.textBaseline = "middle"; ctx.fillText(s.id, 0, 0);
+    ctx.restore(); ctx.shadowBlur = 0; ctx.textBaseline = "alphabetic";
     if (s.t >= 1 && !s.done){ s.done = true; fx.impacts.push({ x: s.tx, y: s.ty, r: 4, chip: s.chip, match: s.match, burn: s.burn, life: 1 }); }
   }
   fx.shots = fx.shots.filter(s => s.t < 1.4);
 
-  // impacts + floating chip numbers
+  // impacts + floating chip numbers (both optional — off by default, toggled in tuning)
   for (const im of fx.impacts){
     im.life -= 0.04; im.r += 2.5;
-    ctx.strokeStyle = im.match ? "#b98bff" : "#ffb020"; ctx.globalAlpha = Math.max(0, im.life);
-    ctx.shadowColor = ctx.strokeStyle; ctx.shadowBlur = 10; ctx.lineWidth = 2;
-    ctx.beginPath(); ctx.arc(im.x, im.y, im.r, 0, Math.PI*2); ctx.stroke(); ctx.shadowBlur = 0;
-    ctx.fillStyle = im.match ? "#d9c2ff" : "#ffd48a"; ctx.textAlign = "center"; ctx.font = "11px monospace";
-    ctx.fillText("-" + Math.round(im.chip), im.x, im.y - 20 - (1-im.life)*24);
+    ctx.globalAlpha = Math.max(0, im.life);
+    if (K.showSplash){
+      ctx.strokeStyle = im.match ? "#b98bff" : "#ffb020"; ctx.shadowColor = ctx.strokeStyle; ctx.shadowBlur = 10; ctx.lineWidth = 2;
+      ctx.beginPath(); ctx.arc(im.x, im.y, im.r, 0, Math.PI*2); ctx.stroke(); ctx.shadowBlur = 0;
+    }
+    if (K.showDamage){
+      ctx.fillStyle = im.match ? "#d9c2ff" : "#ffd48a"; ctx.textAlign = "center"; ctx.font = "11px monospace";
+      ctx.fillText("-" + Math.round(im.chip), im.x, im.y - 20 - (1-im.life)*24);
+    }
     ctx.globalAlpha = 1;
   }
   fx.impacts = fx.impacts.filter(im => im.life > 0);
@@ -406,6 +428,17 @@ function draw(){
 }
 function polygon(cx, cy, r, n){ ctx.beginPath(); for (let i=0;i<n;i++){ const a = -Math.PI/2 + i*2*Math.PI/n; const x=cx+r*Math.cos(a), y=cy+r*Math.sin(a); i?ctx.lineTo(x,y):ctx.moveTo(x,y);} ctx.closePath(); }
 
+// small stroked service-class glyph centered at (x,y); caller sets strokeStyle/shadow
+function drawGlyph(type, x, y, s){
+  const h = s*0.42; ctx.beginPath();
+  if (type === "smb"){ for (let i=-1;i<=1;i++){ ctx.moveTo(x-h, y+i*h*0.8); ctx.lineTo(x+h, y+i*h*0.8); } }        // stacked shares
+  else if (type === "http"){ ctx.moveTo(x-h*0.2,y-h); ctx.lineTo(x-h,y); ctx.lineTo(x-h*0.2,y+h); ctx.moveTo(x+h*0.2,y-h); ctx.lineTo(x+h,y); ctx.lineTo(x+h*0.2,y+h); } // <>
+  else if (type === "ssh"){ ctx.moveTo(x-h,y-h); ctx.lineTo(x,y); ctx.lineTo(x-h,y+h); ctx.moveTo(x+h*0.1,y+h); ctx.lineTo(x+h,y+h); } // >_ prompt
+  else if (type === "rdp"){ ctx.rect(x-h, y-h*0.8, h*2, h*1.4); ctx.moveTo(x-h*0.4, y+h*0.95); ctx.lineTo(x+h*0.4, y+h*0.95); } // monitor
+  else { for (let i=0;i<3;i++){ const a=i*Math.PI/3; ctx.moveTo(x-h*Math.cos(a), y-h*Math.sin(a)); ctx.lineTo(x+h*Math.cos(a), y+h*Math.sin(a)); } } // kernel asterisk
+  ctx.stroke();
+}
+
 // ---------- dom ----------
 function render(){
   const $ = id => document.getElementById(id);
@@ -417,11 +450,11 @@ function render(){
   $("r-burned").textContent = burned;
 }
 function setOutcome(txt, cls){ const el = document.getElementById("outcome"); el.textContent = txt; el.className = "outcome" + (cls?" "+cls:""); }
-function log(html){ const el = document.getElementById("log"); el.insertAdjacentHTML("afterbegin", `<div>${html}</div>`); while (el.children.length > 200) el.lastChild.remove(); }
+function log(html){ const el = document.getElementById("log"); el.insertAdjacentHTML("beforeend", `<div>${html}</div>`); while (el.children.length > 200) el.firstChild.remove(); el.scrollTop = el.scrollHeight; }
 function logShot(e, chip, match, burn){
-  const m = match ? '<span style="color:#b98bff">◆</span>' : '';
-  const b = burn ? ' <span class="burn">✕burned</span>' : '';
-  log(`<span class="hit">${e.id}</span> <span style="color:${rarityColor(e.rarity)}">${e.rarity[0]}</span>${m} −${Math.round(chip)}${b}`);
+  const m = match ? ` <span style="color:#b98bff">◆${node.profile.find(t=>e.types.includes(t))||"svc"}</span>` : '';
+  const b = burn ? ' <span class="burn">⚑flagged</span>' : '';
+  log(`<span class="hit">${e.id}</span> <span style="color:${rarityColor(e.rarity)}">${RANK[e.rarity]}</span>${m} −${Math.round(chip)}${b}`);
 }
 
 function buildSliders(){
@@ -436,6 +469,12 @@ function buildSliders(){
       if (key === "heatCeil" || key === "cohScale") render();
       if (key === "cadence" && running){ clearInterval(tickTimer); tickTimer = setInterval(fireShot, K.cadence); }
     });
+  }
+  for (const [key,label] of TOGGLES){
+    const div = document.createElement("div"); div.className = "slider";
+    div.innerHTML = `<label class="inline"><input type="checkbox" id="tg-${key}" ${K[key]?"checked":""}/> ${label}</label>`;
+    wrap.appendChild(div);
+    div.querySelector("input").addEventListener("change", (ev) => { K[key] = ev.target.checked; });
   }
 }
 

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/lab-a-flamethrower/index.html
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/lab-a-flamethrower/index.html
@@ -1,0 +1,452 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lab A — Flamethrower (smash feel)</title>
+<style>
+  :root {
+    --bg: #0a0a0f; --fg: #9ff7c4; --dim: #4a6a5a; --cyan: #21e6ff; --amber: #ffb020;
+    --red: #ff2a2a; --mag: #ff00aa; --violet: #b98bff; --panel: #10141a;
+    --glow-sm: 0 0 4px currentColor; --glow-md: 0 0 8px currentColor;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--fg);
+    font: 13px/1.45 "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    padding: 14px; display: grid; grid-template-columns: 1fr 300px; gap: 14px;
+    align-items: start; min-height: 100vh;
+  }
+  h1 { font-size: 15px; letter-spacing: 2px; margin: 0 0 2px; color: var(--cyan); text-shadow: var(--glow-md); text-transform: uppercase; }
+  .sub { color: var(--dim); margin: 0 0 12px; font-size: 11px; }
+  .stage-wrap { position: relative; }
+  canvas { width: 100%; height: auto; display: block; border: 1px solid #1c2630; background: #070a0e; border-radius: 3px; }
+  .readout { display: flex; gap: 18px; flex-wrap: wrap; margin: 8px 0; font-size: 12px; }
+  .readout b { color: var(--cyan); font-weight: normal; }
+  .readout .v { color: var(--fg); text-shadow: var(--glow-sm); }
+  .outcome { font-size: 14px; letter-spacing: 1px; min-height: 20px; margin: 4px 0 10px; text-transform: uppercase; }
+  .outcome.crack { color: var(--cyan); text-shadow: var(--glow-md); }
+  .outcome.bail { color: var(--amber); text-shadow: var(--glow-sm); }
+  .outcome.dry { color: var(--red); text-shadow: var(--glow-sm); }
+  .controls { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin-bottom: 10px; }
+  button {
+    background: #0e1620; color: var(--cyan); border: 1px solid #24424e; padding: 7px 13px;
+    font: inherit; letter-spacing: 1px; cursor: pointer; border-radius: 3px; text-transform: uppercase;
+  }
+  button:hover { border-color: var(--cyan); box-shadow: var(--glow-sm); }
+  button.go { color: var(--fg); border-color: #2a6a4a; }
+  button.stop { color: var(--red); border-color: #6a2424; }
+  button:disabled { opacity: .35; cursor: default; box-shadow: none; }
+  label.inline { color: var(--dim); display: inline-flex; gap: 6px; align-items: center; }
+  select, input[type=range] { accent-color: var(--cyan); }
+  select { background: #0e1620; color: var(--fg); border: 1px solid #24424e; font: inherit; padding: 4px; border-radius: 3px; }
+  .panel { background: var(--panel); border: 1px solid #1c2630; border-radius: 3px; padding: 12px; }
+  .panel h2 { font-size: 11px; letter-spacing: 1.5px; color: var(--amber); margin: 0 0 10px; text-transform: uppercase; }
+  .slider { margin-bottom: 11px; }
+  .slider .lbl { display: flex; justify-content: space-between; color: var(--dim); font-size: 11px; margin-bottom: 2px; }
+  .slider .lbl .num { color: var(--fg); }
+  .slider input { width: 100%; }
+  #log { height: 150px; overflow: auto; background: #070a0e; border: 1px solid #1c2630; border-radius: 3px; padding: 6px 8px; font-size: 11px; color: var(--dim); }
+  #log .crack { color: var(--cyan); }
+  #log .burn { color: var(--red); }
+  #log .hit { color: var(--fg); }
+  .hint { color: var(--dim); font-size: 11px; margin-top: 8px; }
+  .grade-pill { color: var(--red); text-shadow: var(--glow-sm); }
+</style>
+</head>
+<body>
+<div class="left">
+  <h1>Lab A — Flamethrower</h1>
+  <p class="sub">smash feel · coherence erosion vs. hoard attrition · does the burst stay fun the 20th time?</p>
+
+  <div class="stage-wrap"><canvas id="cv" width="900" height="340"></canvas></div>
+
+  <div class="outcome" id="outcome"></div>
+
+  <div class="readout">
+    <span><b>target</b> <span class="v grade-pill" id="r-grade">—</span></span>
+    <span><b>coherence</b> <span class="v" id="r-coh">—</span></span>
+    <span><b>hoard</b> <span class="v" id="r-hoard">—</span></span>
+    <span><b>heat</b> <span class="v" id="r-heat">—</span></span>
+    <span><b>shots</b> <span class="v" id="r-shots">0</span></span>
+    <span><b>burned</b> <span class="v" id="r-burned">0</span></span>
+  </div>
+
+  <div class="controls">
+    <button class="go" id="btn-go">▶ Smash</button>
+    <button class="stop" id="btn-abort" disabled>■ Abort</button>
+    <button id="btn-target">New Target</button>
+    <button id="btn-refill">Refill Hoard</button>
+    <label class="inline">grade
+      <select id="sel-grade">
+        <option value="random">random</option>
+        <option>S</option><option>A</option><option>B</option>
+        <option selected>C</option><option>D</option><option>E</option><option>F</option>
+      </select>
+    </label>
+    <label class="inline"><input type="checkbox" id="chk-gear" checked /> gear (best-match-first)</label>
+  </div>
+
+  <div id="log"></div>
+  <p class="hint">Two bars race: the node's <span style="color:var(--red)">coherence</span> (its composure under fuzzing) vs. your <span style="color:var(--cyan)">hoard</span> (burning down via disclosure). Set the heat ceiling → the bail wager. Crack it before you run dry or cook.</p>
+</div>
+
+<div class="panel">
+  <h2>Tuning</h2>
+  <div id="sliders"></div>
+</div>
+
+<script>
+"use strict";
+// ---------- config / knobs ----------
+const GRADES = ["S","A","B","C","D","E","F"];               // 0 = hardest
+const TYPES  = ["web","auth","kernel","net","mem"];
+const RARITIES = ["common","uncommon","rare"];
+const RARITY_WEIGHT = { common: 11/15, uncommon: 3/15, rare: 1/15 };
+const RARITY_PUNCH  = { common: 1, uncommon: 2.2, rare: 5 };
+
+// per-grade baseline tables (index by grade position S..F)
+const COH_BASE   = [2000,1200,700,400,220,140,90];  // node coherence reserve
+const CHIP_FACTOR= [6,10,16,26,40,60,90];           // how much a unit of punch bites this grade
+const DISC_BASE  = [0.90,0.72,0.52,0.34,0.18,0.07,0.02]; // per-shot disclosure (burn) chance
+// Star Castle shield: ring count by grade (S..F), segments per ring, nested radii by ring count
+const RING_COUNT = [3,3,2,2,2,1,1];
+const SEG = 12;
+const RADII_BY_COUNT = { 1:[96], 2:[104,66], 3:[104,74,46] };
+const CORE_R = 20;
+
+// live-tunable multipliers (bound to sliders)
+const K = {
+  cohScale: 1.0, chipScale: 1.0, typeBite: 1.5, discScale: 1.0,
+  heatPerShot: 1.0, heatCeil: 40, cadence: 90, hoardSize: 200, jitter: 0.25,
+};
+const SLIDER_DEFS = [
+  ["cohScale","coherence ×",0.25,3,0.05],
+  ["chipScale","chip ×",0.25,3,0.05],
+  ["typeBite","type-match bite +×",0,4,0.1],
+  ["discScale","disclosure ×",0,2,0.05],
+  ["heatPerShot","heat / shot",0,4,0.1],
+  ["heatCeil","heat ceiling (bail)",5,120,1],
+  ["cadence","shot cadence (ms)",20,300,5],
+  ["hoardSize","hoard size",20,600,10],
+  ["jitter","chip jitter ±",0,0.9,0.05],
+];
+
+// ---------- rng / helpers ----------
+const rnd = Math.random;
+const pick = (arr) => arr[Math.floor(rnd()*arr.length)];
+const hex = (n=6) => Math.floor(rnd()*0xffffff).toString(16).padStart(6,"0").slice(0,n);
+const gi = (g) => GRADES.indexOf(g);
+const clamp = (v,a,b) => Math.max(a,Math.min(b,v));
+const shuffle = (n) => { const a = [...Array(n).keys()]; for (let i=n-1;i>0;i--){ const j = Math.floor(rnd()*(i+1)); [a[i],a[j]]=[a[j],a[i]]; } return a; };
+
+function rollRarity(){
+  let r = rnd();
+  for (const rar of RARITIES){ r -= RARITY_WEIGHT[rar]; if (r < 0) return rar; }
+  return "common";
+}
+function makeExploit(){
+  const rarity = rollRarity();
+  // rare exploits carry multiple types (more valuable); commons a single type
+  const nTypes = rarity === "rare" ? (rnd()<0.5?3:2) : rarity === "uncommon" ? (rnd()<0.35?2:1) : 1;
+  const types = [];
+  while (types.length < nTypes){ const t = pick(TYPES); if (!types.includes(t)) types.push(t); }
+  return { id: hex(), rarity, types, dead: false };
+}
+function makeHoard(size){ return Array.from({length: size}, makeExploit); }
+
+// hoard shown as a collection: a tick-grid tinted by rarity composition
+const HCOLS = 8, HROWS = 14, HCELLS = HCOLS*HROWS;
+const rarityCellColor = (r) => r==="rare" ? "#b98bff" : r==="uncommon" ? "#21e6ff" : "#2f6a4a";
+function buildHoardCells(){
+  const counts = { common:0, uncommon:0, rare:0 };
+  for (const e of hoard) counts[e.rarity]++;
+  const total = hoard.length || 1, colors = [];
+  for (const r of RARITIES){ const n = Math.round(counts[r]/total*HCELLS); for (let i=0;i<n;i++) colors.push(rarityCellColor(r)); }
+  while (colors.length < HCELLS) colors.push(rarityCellColor("common"));
+  colors.length = HCELLS;
+  for (let i=HCELLS-1;i>0;i--){ const j=Math.floor(rnd()*(i+1)); [colors[i],colors[j]]=[colors[j],colors[i]]; }
+  hoardCells = colors.map(c => ({ c, dark:false, g:0, r:0 }));
+}
+function flashHoard(didBurn){
+  const lit = hoardCells.filter(c => !c.dark);
+  if (!lit.length) return;
+  const cell = lit[Math.floor(rnd()*lit.length)];
+  if (didBurn){ cell.r = 12; if (rnd() < HCELLS / Math.max(hoard.length, HCELLS)) cell.dark = true; }
+  else cell.g = 8;
+}
+function makeNode(grade){
+  if (grade === "random") grade = pick(GRADES);
+  const g = gi(grade);
+  const cohMax = Math.round(COH_BASE[g] * K.cohScale);
+  // vuln profile: 1-2 weak types
+  const profile = []; const n = rnd()<0.5?1:2;
+  while (profile.length < n){ const t = pick(TYPES); if (!profile.includes(t)) profile.push(t); }
+  // Star Castle shield: more concentric rings for tougher grades (j=0 outer)
+  const nRings = RING_COUNT[g], rings = [];
+  for (let i=0;i<nRings;i++) rings.push({ rot: rnd()*Math.PI*2, dir: (i%2?1:-1), speed: 0.004 + i*0.002, order: shuffle(SEG), dead: new Array(SEG).fill(false) });
+  const totalSegs = nRings * SEG;
+  return { grade, g, cohMax, coh: cohMax, profile, rings, nRings, totalSegs };
+}
+
+// ---------- state ----------
+let hoard = [], node = null, heat = 0, shots = 0, burned = 0;
+let running = false, ended = null, tickTimer = null;
+let emitAngle = 0, hoardCells = [];
+const EMIT = 4;
+const fx = { shots: [], impacts: [], shards: [], shake: 0, flash: 0, emitFlash: [0,0,0,0] };
+
+function usable(){ return hoard.filter(e => !e.dead); }
+
+function reset(newHoard){
+  if (newHoard || hoard.length === 0){ hoard = makeHoard(Math.round(K.hoardSize)); buildHoardCells(); }
+  node = makeNode(document.getElementById("sel-grade").value);
+  heat = 0; shots = 0; burned = hoard.filter(e=>e.dead).length; ended = null;
+  fx.shots.length = fx.impacts.length = fx.shards.length = 0; fx.shake = 0; fx.flash = 0;
+  setOutcome("");
+  render(); log(`── new target · grade ${node.grade} · coherence ${node.cohMax} · weak: ${node.profile.join("/")} ──`);
+}
+
+// ---------- combat ----------
+function chooseExploit(){
+  const pool = usable();
+  if (!pool.length) return null;
+  if (!document.getElementById("chk-gear").checked) return pool[Math.floor(rnd()*pool.length)];
+  // gear: best-match-first — matched type, then higher rarity punch
+  let best = pool[0], bestScore = -1;
+  for (const e of pool){
+    const match = e.types.some(t => node.profile.includes(t)) ? 1 : 0;
+    const score = match*100 + RARITY_PUNCH[e.rarity];
+    if (score > bestScore){ bestScore = score; best = e; }
+  }
+  return best;
+}
+function chipFor(e){
+  const match = e.types.some(t => node.profile.includes(t));
+  let chip = CHIP_FACTOR[node.g] * RARITY_PUNCH[e.rarity] * K.chipScale;
+  if (match) chip *= (1 + K.typeBite);
+  const j = 1 + (rnd()*2 - 1) * K.jitter;
+  return { chip: Math.max(1, chip * j), match };
+}
+
+function fireShot(){
+  if (ended) return stop();
+  const e = chooseExploit();
+  if (!e){ finish("dry"); return; }
+  const { chip, match } = chipFor(e);
+  node.coh = Math.max(0, node.coh - chip);
+  heat += K.heatPerShot;
+  const emitter = shots % EMIT;
+  shots++;
+  // disclosure roll → burn
+  const discChance = clamp(DISC_BASE[node.g] * K.discScale, 0, 0.99);
+  const didBurn = rnd() < discChance;
+  if (didBurn){ e.dead = true; burned++; }
+  const radii = RADII_BY_COUNT[node.nRings], orbitR = radii[0] + 34, ea = emitAngle + emitter * (Math.PI*2/EMIT);
+  const alive = Math.ceil(clamp(node.coh/node.cohMax,0,1) * node.totalSegs), impactR = outerIntactRadius(node, alive, radii);
+  spawnShot(e, chip, match, didBurn, NODE_X + orbitR*Math.cos(ea), H/2 + orbitR*Math.sin(ea), NODE_X + impactR*Math.cos(ea), H/2 + impactR*Math.sin(ea));
+  fx.emitFlash[emitter] = 1;
+  flashHoard(didBurn);
+  fx.shake = Math.min(14, fx.shake + Math.min(8, chip / (node.cohMax*0.02)));
+  logShot(e, chip, match, didBurn);
+  render();
+  // end checks (after the visual registers this shot)
+  if (node.coh <= 0) return finish("crack");
+  if (heat >= K.heatCeil) return finish("bail");
+  if (!usable().length) return finish("dry");
+}
+
+function start(){
+  if (running) return;
+  if (ended) reset(false);
+  running = true;
+  document.getElementById("btn-go").disabled = true;
+  document.getElementById("btn-abort").disabled = false;
+  tickTimer = setInterval(fireShot, K.cadence);
+}
+function stop(){
+  running = false;
+  clearInterval(tickTimer); tickTimer = null;
+  document.getElementById("btn-go").disabled = false;
+  document.getElementById("btn-abort").disabled = true;
+}
+function finish(kind){
+  ended = kind; stop();
+  if (kind === "crack"){ fx.flash = 1; burstShards(); setOutcome("⌁ NODE CRACKED — access granted","crack"); log(`<span class="crack">CRACK — faulted after ${shots} shots, ${burned} burned</span>`); }
+  if (kind === "bail"){ setOutcome("↩ BAILED — heat ceiling hit","bail"); log(`<span class="burn">BAIL — heat ${Math.round(heat)} ≥ ceiling ${K.heatCeil} · coherence ${Math.round(node.coh)}/${node.cohMax} left</span>`); }
+  if (kind === "dry"){ setOutcome("✕ HOARD DRY — access denied","dry"); log(`<span class="burn">DRY — out of ammo · coherence ${Math.round(node.coh)}/${node.cohMax} left</span>`); }
+}
+
+// ---------- visuals ----------
+const cv = document.getElementById("cv"), ctx = cv.getContext("2d");
+const W = cv.width, H = cv.height;
+const NODE_X = W - 150, HOARD_X = 90;
+
+function spawnShot(e, chip, match, burn, ox, oy, tx, ty){
+  fx.shots.push({ x: ox, y: oy, tx, ty, id: e.id, rarity: e.rarity, match, burn, t: 0, chip });
+}
+// radius of the outermost ring that still has intact segments (zaps stop here); core if all gone
+function outerIntactRadius(node, aliveCount, radii){
+  if (aliveCount <= 0) return CORE_R;
+  for (let j=0;j<node.nRings;j++){ if ((node.nRings-1-j)*SEG < aliveCount) return radii[j]; }
+  return CORE_R;
+}
+function burstShards(){
+  for (let i=0;i<60;i++){ const a = rnd()*Math.PI*2, s = 2+rnd()*7; fx.shards.push({ x: NODE_X, y: H/2, vx: Math.cos(a)*s, vy: Math.sin(a)*s, life: 1, c: "#21e6ff" }); }
+}
+function segShards(x,y){
+  for (let i=0;i<5;i++){ const a = rnd()*Math.PI*2, s = 1.5+rnd()*4; fx.shards.push({ x, y, vx: Math.cos(a)*s, vy: Math.sin(a)*s, life: 1, c: "#ff5a5a" }); }
+}
+function rarityColor(r){ return r==="rare" ? "#b98bff" : r==="uncommon" ? "#21e6ff" : "#4a6a5a"; }
+
+function draw(){
+  ctx.clearRect(0,0,W,H);
+  const sx = (rnd()*2-1)*fx.shake, sy = (rnd()*2-1)*fx.shake;
+  fx.shake *= 0.85; if (fx.shake < 0.3) fx.shake = 0;
+  ctx.save(); ctx.translate(sx, sy);
+
+  // heat meter (top)
+  const heatFrac = node ? clamp(heat / K.heatCeil, 0, 1) : 0;
+  ctx.fillStyle = "#141a12"; ctx.fillRect(40, 18, W-80, 10);
+  const hc = heatFrac < .5 ? "#9ff7c4" : heatFrac < .8 ? "#ffb020" : "#ff2a2a";
+  ctx.fillStyle = hc; ctx.shadowColor = hc; ctx.shadowBlur = 10; ctx.fillRect(40, 18, (W-80)*heatFrac, 10); ctx.shadowBlur = 0;
+  ctx.fillStyle = "#4a6a5a"; ctx.font = "10px monospace"; ctx.textAlign = "left"; ctx.fillText("HEAT", 40, 14);
+
+  if (node){
+    // node = Star Castle-style segmented shield rings, eroded outer→inward
+    const cx = NODE_X, cy = H/2, step = Math.PI*2/SEG, radii = RADII_BY_COUNT[node.nRings];
+    const aliveCount = Math.ceil(clamp(node.coh/node.cohMax,0,1) * node.totalSegs);
+    // draw living segments — rings peel outer→inner, but WHICH segment dies within a ring is
+    // shuffled (ring.order) so the gaps look chaotic, not a clock-hand sweep.
+    for (let j=0;j<node.nRings;j++){
+      const ring = node.rings[j], r = radii[j], base = (node.nRings-1-j)*SEG;
+      ring.rot += ring.dir * ring.speed;
+      ctx.strokeStyle = "#ff2a2a"; ctx.shadowColor = "#ff2a2a"; ctx.shadowBlur = 8; ctx.lineWidth = 2.5;
+      for (let k=0;k<SEG;k++){
+        const dead = base + ring.order[k] >= aliveCount;
+        if (dead){
+          if (!ring.dead[k]){ ring.dead[k] = true; const a = (k+0.5)*step + ring.rot; segShards(cx + r*Math.cos(a), cy + r*Math.sin(a)); }
+          continue;
+        }
+        ring.dead[k] = false; // lets segments regrow cleanly if the reboot rule is added later
+        const a0 = ring.rot + k*step, a1 = ring.rot + (k+0.9)*step; // 0.9 → faceted gap between segments
+        ctx.beginPath(); ctx.moveTo(cx + r*Math.cos(a0), cy + r*Math.sin(a0)); ctx.lineTo(cx + r*Math.cos(a1), cy + r*Math.sin(a1)); ctx.stroke();
+      }
+    }
+    ctx.shadowBlur = 0;
+    // core (turns cyan + blooms when the last ring falls)
+    const cracked = aliveCount <= 0;
+    ctx.strokeStyle = cracked ? "#21e6ff" : "#ff5a5a"; ctx.shadowColor = ctx.strokeStyle; ctx.shadowBlur = fx.flash>0?30:10; ctx.lineWidth = 2;
+    polygon(cx, cy, CORE_R, 6); ctx.stroke(); ctx.shadowBlur = 0;
+    ctx.fillStyle = cracked ? "#7fefff" : "#ff8a8a"; ctx.textAlign = "center"; ctx.font = "12px monospace";
+    ctx.fillText(node.grade, cx, cy+4);
+    ctx.fillStyle = "#ff8a8a"; ctx.font = "10px monospace";
+    ctx.fillText("COHERENCE " + Math.round(node.coh) + "/" + node.cohMax, cx, cy + radii[0] + 22);
+
+    // orbiting exploit emitters (player = clockwise), counter-rotating vs. the CCW shield
+    emitAngle += 0.0042; // orbit speed (slowed 30% from 0.006)
+    const oR = radii[0] + 34, impactR = outerIntactRadius(node, aliveCount, radii);
+    for (let i=0;i<EMIT;i++){
+      const a = emitAngle + i*(Math.PI*2/EMIT), ex = cx + oR*Math.cos(a), ey = cy + oR*Math.sin(a);
+      const inx = Math.cos(a+Math.PI), iny = Math.sin(a+Math.PI), px = -Math.sin(a), py = Math.cos(a);
+      const fl = fx.emitFlash[i] || 0, sz = 7;
+      ctx.strokeStyle = fl>0 ? "#e8ffff" : "#21e6ff"; ctx.shadowColor = "#21e6ff"; ctx.shadowBlur = fl>0?14:6; ctx.lineWidth = 2;
+      ctx.beginPath(); // chevron reticle pointing inward
+      ctx.moveTo(ex + px*sz, ey + py*sz); ctx.lineTo(ex + inx*sz*1.4, ey + iny*sz*1.4); ctx.lineTo(ex - px*sz, ey - py*sz); ctx.stroke();
+      if (fl>0){ ctx.globalAlpha = fl; ctx.beginPath(); ctx.moveTo(ex, ey); ctx.lineTo(cx + impactR*Math.cos(a), cy + impactR*Math.sin(a)); ctx.stroke(); ctx.globalAlpha = 1; fx.emitFlash[i] = Math.max(0, fl - 0.15); }
+    }
+    ctx.shadowBlur = 0;
+
+    // hoard as a *collection* — stroked tick-grid; base tint = rarity, green flash = fired, red→dark = burned
+    const u = usable().length, px0 = 26, py0 = 54, cw = 12, chh = (H - 100) / HROWS, gw = HCOLS*cw;
+    ctx.textAlign = "center"; ctx.fillStyle = "#7fefff"; ctx.font = "10px monospace";
+    ctx.fillText("HOARD " + u + "/" + hoard.length, px0 + gw/2 - cw/2, py0 - 12);
+    for (let i=0;i<hoardCells.length;i++){
+      const cell = hoardCells[i], x = px0 + (i%HCOLS)*cw, y = py0 + Math.floor(i/HCOLS)*chh, s = Math.min(cw,chh) - 4;
+      let color = cell.dark ? "#16241c" : cell.c, glow = 0, lw = 1.5;
+      if (cell.g > 0){ color = "#7dffb0"; glow = 8; lw = 2; cell.g--; }
+      if (cell.r > 0){ color = "#ff5a5a"; glow = 8; lw = 2; cell.r--; }
+      ctx.strokeStyle = color; ctx.shadowColor = color; ctx.shadowBlur = glow; ctx.lineWidth = lw;
+      ctx.strokeRect(x, y, s, s);
+    }
+    ctx.shadowBlur = 0;
+  }
+
+  // in-flight shots
+  for (const s of fx.shots){
+    s.t += 0.16; const x = s.x + (s.tx - s.x) * Math.min(1, s.t); const y = s.y + (s.ty - s.y) * Math.min(1, s.t);
+    ctx.fillStyle = s.burn ? "#ff2a2a" : rarityColor(s.rarity);
+    ctx.shadowColor = ctx.fillStyle; ctx.shadowBlur = 8; ctx.font = "10px monospace"; ctx.textAlign = "left";
+    ctx.fillText(s.id, x, y); ctx.shadowBlur = 0;
+    if (s.t >= 1 && !s.done){ s.done = true; fx.impacts.push({ x: s.tx, y: s.ty, r: 4, chip: s.chip, match: s.match, burn: s.burn, life: 1 }); }
+  }
+  fx.shots = fx.shots.filter(s => s.t < 1.4);
+
+  // impacts + floating chip numbers
+  for (const im of fx.impacts){
+    im.life -= 0.04; im.r += 2.5;
+    ctx.strokeStyle = im.match ? "#b98bff" : "#ffb020"; ctx.globalAlpha = Math.max(0, im.life);
+    ctx.shadowColor = ctx.strokeStyle; ctx.shadowBlur = 10; ctx.lineWidth = 2;
+    ctx.beginPath(); ctx.arc(im.x, im.y, im.r, 0, Math.PI*2); ctx.stroke(); ctx.shadowBlur = 0;
+    ctx.fillStyle = im.match ? "#d9c2ff" : "#ffd48a"; ctx.textAlign = "center"; ctx.font = "11px monospace";
+    ctx.fillText("-" + Math.round(im.chip), im.x, im.y - 20 - (1-im.life)*24);
+    ctx.globalAlpha = 1;
+  }
+  fx.impacts = fx.impacts.filter(im => im.life > 0);
+
+  // crack shards
+  for (const sh of fx.shards){ sh.x += sh.vx; sh.y += sh.vy; sh.vy += 0.15; sh.life -= 0.02;
+    ctx.strokeStyle = sh.c || "#21e6ff"; ctx.globalAlpha = Math.max(0, sh.life); ctx.beginPath();
+    ctx.moveTo(sh.x, sh.y); ctx.lineTo(sh.x - sh.vx*2, sh.y - sh.vy*2); ctx.stroke(); ctx.globalAlpha = 1; }
+  fx.shards = fx.shards.filter(sh => sh.life > 0);
+
+  if (fx.flash > 0){ ctx.fillStyle = `rgba(33,230,255,${fx.flash*0.25})`; ctx.fillRect(-40,-40,W+80,H+80); fx.flash *= 0.9; if (fx.flash<0.02) fx.flash=0; }
+  ctx.restore();
+  requestAnimationFrame(draw);
+}
+function polygon(cx, cy, r, n){ ctx.beginPath(); for (let i=0;i<n;i++){ const a = -Math.PI/2 + i*2*Math.PI/n; const x=cx+r*Math.cos(a), y=cy+r*Math.sin(a); i?ctx.lineTo(x,y):ctx.moveTo(x,y);} ctx.closePath(); }
+
+// ---------- dom ----------
+function render(){
+  const $ = id => document.getElementById(id);
+  $("r-grade").textContent = node ? node.grade : "—";
+  $("r-coh").textContent = node ? `${Math.round(node.coh)}/${node.cohMax}` : "—";
+  $("r-hoard").textContent = `${usable().length}/${hoard.length}`;
+  $("r-heat").textContent = `${Math.round(heat)}/${K.heatCeil}`;
+  $("r-shots").textContent = shots;
+  $("r-burned").textContent = burned;
+}
+function setOutcome(txt, cls){ const el = document.getElementById("outcome"); el.textContent = txt; el.className = "outcome" + (cls?" "+cls:""); }
+function log(html){ const el = document.getElementById("log"); el.insertAdjacentHTML("afterbegin", `<div>${html}</div>`); while (el.children.length > 200) el.lastChild.remove(); }
+function logShot(e, chip, match, burn){
+  const m = match ? '<span style="color:#b98bff">◆</span>' : '';
+  const b = burn ? ' <span class="burn">✕burned</span>' : '';
+  log(`<span class="hit">${e.id}</span> <span style="color:${rarityColor(e.rarity)}">${e.rarity[0]}</span>${m} −${Math.round(chip)}${b}`);
+}
+
+function buildSliders(){
+  const wrap = document.getElementById("sliders");
+  for (const [key,label,min,max,step] of SLIDER_DEFS){
+    const div = document.createElement("div"); div.className = "slider";
+    div.innerHTML = `<div class="lbl"><span>${label}</span><span class="num" id="num-${key}">${K[key]}</span></div>
+      <input type="range" id="sl-${key}" min="${min}" max="${max}" step="${step}" value="${K[key]}">`;
+    wrap.appendChild(div);
+    div.querySelector("input").addEventListener("input", (ev) => {
+      K[key] = parseFloat(ev.target.value); document.getElementById("num-"+key).textContent = K[key];
+      if (key === "heatCeil" || key === "cohScale") render();
+      if (key === "cadence" && running){ clearInterval(tickTimer); tickTimer = setInterval(fireShot, K.cadence); }
+    });
+  }
+}
+
+document.getElementById("btn-go").addEventListener("click", start);
+document.getElementById("btn-abort").addEventListener("click", () => { stop(); setOutcome("↩ aborted","bail"); });
+document.getElementById("btn-target").addEventListener("click", () => { stop(); reset(false); });
+document.getElementById("btn-refill").addEventListener("click", () => { stop(); reset(true); });
+
+buildSliders();
+reset(true);
+requestAnimationFrame(draw);
+</script>
+</body>
+</html>

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/lab-a-flamethrower/index.html
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/lab-a-flamethrower/index.html
@@ -85,6 +85,14 @@
       </select>
     </label>
     <label class="inline"><input type="checkbox" id="chk-gear" checked /> ranking engine (fire best-ranked first)</label>
+    <label class="inline">gear
+      <select id="sel-gear-preset">
+        <option>bare rig</option>
+        <option selected>balanced</option>
+        <option>ghost (stealth+recon)</option>
+        <option>smash rig</option>
+      </select>
+    </label>
   </div>
 
   <div id="log"></div>
@@ -123,6 +131,15 @@ const K = {
   showSplash: false, showDamage: false, // off by default; toggles in the tuning panel
 };
 const TOGGLES = [["showSplash","impact splashes"], ["showDamage","damage numbers"]];
+// Gear presets — a loadout is a PROFILE across the gear-side attributes (noise, cadence,
+// signature-evasion, recon/match bonus). This is the meticulous-ghost ↔ smash-and-grab dial.
+const GEAR_ATTRS = ["heatPerShot","cadence","discScale","typeBite"];
+const GEAR_PRESETS = {
+  "bare rig":              { heatPerShot: 1.4, cadence: 110, discScale: 1.2, typeBite: 0.4 },
+  "balanced":             { heatPerShot: 1.0, cadence: 90,  discScale: 1.0, typeBite: 1.5 },
+  "ghost (stealth+recon)": { heatPerShot: 0.5, cadence: 140, discScale: 0.5, typeBite: 2.6 },
+  "smash rig":            { heatPerShot: 1.8, cadence: 45,  discScale: 1.5, typeBite: 1.0 },
+};
 const SLIDER_DEFS = [
   ["cohScale","coherence ×",0.25,3,0.05],
   ["chipScale","exploit bite ×",0.25,3,0.05],
@@ -179,12 +196,12 @@ function pickExploitSlot(){
   for (const ring of exploitRings) for (let j=0;j<ring.slots.length;j++) if (!ring.slots[j].dark) lit.push({ ring, j });
   return lit.length ? lit[Math.floor(rnd()*lit.length)] : null;
 }
-// staged (lit) slots ≈ min(capacity, usable library) — the gear keeps the rings topped up from the
-// library; monotonic during a run (only empties as you burn down), refills on Refill Library.
+// staged (lit) slots track the FRACTION of the library remaining (usable / total), so the rings
+// visibly thin as you burn through it — the player-side "bar" racing the shields. Refill restocks.
 function reconcileStaging(){
   const flat = [];
   for (const ring of exploitRings) for (const c of ring.slots) flat.push(c);
-  const litTarget = Math.min(flat.length, usable());
+  const litTarget = Math.round(usable().length / Math.max(1, hoard.length) * flat.length);
   let lit = flat.filter(c => !c.dark).length;
   if (lit > litTarget){
     const pool = flat.filter(c => !c.dark);
@@ -477,13 +494,25 @@ function buildSliders(){
     div.querySelector("input").addEventListener("change", (ev) => { K[key] = ev.target.checked; });
   }
 }
+// A gear loadout snaps the gear-side attribute sliders to a profile (and syncs the slider UI).
+function applyGearPreset(name){
+  const p = GEAR_PRESETS[name]; if (!p) return;
+  for (const k of GEAR_ATTRS){
+    K[k] = p[k];
+    const sl = document.getElementById("sl-"+k), num = document.getElementById("num-"+k);
+    if (sl) sl.value = p[k]; if (num) num.textContent = p[k];
+  }
+  if (running){ clearInterval(tickTimer); tickTimer = setInterval(fireShot, K.cadence); } // cadence may have changed
+}
 
 document.getElementById("btn-go").addEventListener("click", start);
 document.getElementById("btn-abort").addEventListener("click", () => { stop(); setOutcome("↩ aborted","bail"); });
 document.getElementById("btn-target").addEventListener("click", () => { stop(); reset(false); });
 document.getElementById("btn-refill").addEventListener("click", () => { stop(); reset(true); });
+document.getElementById("sel-gear-preset").addEventListener("change", (e) => applyGearPreset(e.target.value));
 
 buildSliders();
+applyGearPreset(document.getElementById("sel-gear-preset").value);
 reset(true);
 requestAnimationFrame(draw);
 </script>

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/lab-b-flow-heist/index.html
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/lab-b-flow-heist/index.html
@@ -57,9 +57,13 @@
 <div class="right">
   <div class="panel">
     <h2>Brief</h2>
-    <div class="legend">Skim <b>$2000</b> from the money artery to your sink before the security
-    <b>monitor</b>'s audit hits <b>100</b> (trace). Flows are encrypted until you <b>SNIFF</b> them —
-    read the board, find what's what, and cut the report path or pace your skim.</div>
+    <div class="legend">Skim <b>$2000</b> to your sink before the <b>monitor</b>'s audit hits <b>100</b>.
+    The <b>IDS</b> reconciles billing's "sent" report against the vault's "received" report — skim and
+    they disagree, so it flags the monitor. Read the board (<b>SNIFF</b>), then beat the check any of
+    several ways:<br>
+    • <b>own the vault</b> or <b>own billing</b> → the owned end fakes a reconciling balance<br>
+    • <b>cut/reroute a balance report</b> (→ ids) → the IDS goes blind<br>
+    • <b>cut/reroute the flag</b> (ids → monitor) → the alarm isn't heard</div>
   </div>
   <div class="panel">
     <h2>Flow types</h2>
@@ -92,22 +96,26 @@
 // one hand-authored financial LAN. positions on a 640x470 board.
 const TARGET = 2000, AUDIT_THRESHOLD = 100;
 const NODES = {
-  sink:    { x:70,  y:235, label:"you",      kind:"sink",   owned:true },
-  gateway: { x:170, y:235, label:"gateway",  kind:"host",   owned:true },
-  router:  { x:330, y:235, label:"router",   kind:"router", owned:true },
-  billing: { x:250, y:90,  label:"billing",  kind:"host",   owned:false, moneySource:true },
-  vault:   { x:545, y:150, label:"$vault",   kind:"vault",  owned:false, trustGated:true },
-  authsrv: { x:340, y:400, label:"auth-srv", kind:"host",   owned:false },
-  monitor: { x:560, y:350, label:"monitor",  kind:"monitor",owned:false },
+  sink:    { x:60,  y:235, label:"you",      kind:"sink",   owned:true },
+  gateway: { x:150, y:235, label:"gateway",  kind:"host",   owned:true },
+  router:  { x:300, y:210, label:"router",   kind:"router", owned:true },
+  billing: { x:270, y:70,  label:"billing",  kind:"host",   owned:false, moneySource:true, trustGated:true },
+  vault:   { x:560, y:120, label:"$vault",   kind:"vault",  owned:false, trustGated:true, moneyConsumer:true },
+  authsrv: { x:250, y:410, label:"auth-srv", kind:"host",   owned:false },
+  ids:     { x:450, y:300, label:"ids",      kind:"ids",    owned:false },
+  monitor: { x:590, y:390, label:"monitor",  kind:"monitor",owned:false },
 };
 // edges carry typed flows. revealed=false → shown encrypted until SNIFFed.
 let EDGES = [];
 function freshEdges(){ return [
   { id:"e_bill",  from:"billing", to:"router",  type:"money", vol:3, revealed:false, tapped:false, cut:false, rerouted:false },
   { id:"e_art",   from:"router",  to:"vault",   type:"money", vol:3, revealed:false, tapped:false, cut:false, rerouted:false }, // the artery
-  { id:"e_cred",  from:"authsrv", to:"vault",   type:"cred",  vol:1, revealed:false, tapped:false, cut:false },
-  { id:"e_audit", from:"router",  to:"monitor", type:"audit", vol:2, revealed:false, tapped:false, cut:false }, // the report path
-  { id:"e_ctrl",  from:"gateway", to:"router",  type:"data",  vol:1, revealed:true,  tapped:false, cut:false },
+  { id:"e_cred_v",from:"authsrv", to:"vault",   type:"cred",  vol:1, revealed:false, tapped:false, cut:false, rerouted:false }, // token trusted by $vault
+  { id:"e_cred_b",from:"authsrv", to:"billing", type:"cred",  vol:1, revealed:false, tapped:false, cut:false, rerouted:false }, // token trusted by billing
+  { id:"e_rep_b", from:"billing", to:"ids",     type:"audit", vol:1, revealed:false, tapped:false, cut:false, rerouted:false }, // "balance SENT" report
+  { id:"e_rep_v", from:"vault",   to:"ids",     type:"audit", vol:1, revealed:false, tapped:false, cut:false, rerouted:false }, // "balance RECEIVED" report
+  { id:"e_flag",  from:"ids",     to:"monitor", type:"audit", vol:2, revealed:false, tapped:false, cut:false, rerouted:false }, // red flag raised on mismatch
+  { id:"e_ctrl",  from:"gateway", to:"router",  type:"data",  vol:1, revealed:true,  tapped:false, cut:false, rerouted:false },
 ]; }
 
 const TYPE_COLOR = { money:"#ffd24a", data:"#21e6ff", audit:"#ff2a2a", cred:"#ff00aa" };
@@ -177,8 +185,10 @@ function doVerb(verb){
   const acquire = (kind,label,glyph) => inventory.push({ kind, label, glyph, target:e.to });
   if (verb==="SNIFF"){ e.revealed=true; heat+=1; log(`SNIFF ${e.id}: <span class="hit">${e.type}</span> flow, vol ${e.vol} (${from}→${to})`); }
   else if (verb==="TAP"){ heat+=2;   // siphon a copy — the flow continues; you acquire what it carries
-    if (e.type==="money"){ e.tapped=true; for (const ae of EDGES.filter(x=>x.type==="audit"&&!x.cut&&!x.rerouted)) for(let i=0;i<7;i++) packets.push({e:ae,t:i*0.12});
-      log(`<span class="good">TAP ${e.id}</span> — skimming money to your sink; <span class="bad">telemetry now streaming to the monitor</span>`); }
+    if (e.type==="money"){ e.tapped=true;
+      const flag = flagRaised();
+      if (flag){ const fe=auditEdge("ids","monitor"); for(let i=0;i<7;i++) packets.push({e:fe,t:i*0.12}); }
+      log(`<span class="good">TAP ${e.id}</span> — skimming money to your sink${flag?`; <span class="bad">the books won't reconcile — the IDS flags the monitor</span>`:` (no flag: the books reconcile, or the IDS is blind/owned)`}`); }
     else if (e.type==="cred"){ if(!hasCred(e.to)){ acquire("cred",`cred token · trusted by ${to}`,"⬡"); log(`<span class="good">TAP ${e.id}</span> — captured a credential token → inventory`);} else log(`already hold ${to}'s token`); }
     else if (e.type==="data"){ acquire("data",`data payload · ${from}→${to}`,"▢"); log(`<span class="good">TAP ${e.id}</span> — siphoned a data payload → inventory`); }
     else if (e.type==="audit"){ acquire("intel",`audit sample · monitor watches vol ${e.vol}`,"△"); log(`TAP ${e.id} — sampled the telemetry (intel) → inventory`); }
@@ -214,9 +224,20 @@ function liveMoneyEdges(){
   }
   return live;
 }
-// audit is DORMANT until you tamper with a LIVE money flow — then telemetry streams to the monitor
-// along the (intact) audit path. Cut the money upstream and the tap goes inert (no skim, no audit).
-const isTampering = () => { const live = liveMoneyEdges(); return EDGES.some(e => e.type==="money" && !e.cut && live.has(e.id) && (e.tapped || (e.rerouted && !node(e.to).owned))); };
+// The IDS reconciles billing's "balance SENT" report against the vault's "balance RECEIVED" report.
+// A skim makes them disagree → the IDS raises a red flag to the monitor. It's defeated by, in order:
+//   • owning billing OR the vault  → the owned endpoint doctors its report so the books reconcile;
+//   • cutting/rerouting either balance report to the IDS → it goes blind (can't reconcile);
+//   • cutting/rerouting the IDS→monitor flag → the alarm is never heard.
+// (Future: a hardened IDS expecting watchdog/heartbeat packets would ALARM on a silent cut instead.)
+const auditEdge = (from,to) => EDGES.find(e => e.type==="audit" && e.from===from && e.to===to);
+const wireLive = (e) => e && !e.cut && !e.rerouted;
+const skimming = () => { const live = liveMoneyEdges(); return EDGES.some(e => e.type==="money" && !e.cut && live.has(e.id) && (e.tapped || e.rerouted)); };
+const flagRaised = () => {
+  if (!skimming()) return false;
+  if (NODES.billing.owned || NODES.vault.owned) return false;  // an owned endpoint fakes a reconciling balance
+  return wireLive(auditEdge("billing","ids")) && wireLive(auditEdge("vault","ids")) && wireLive(auditEdge("ids","monitor"));
+};
 setInterval(() => {
   if (phase!=="playing") return;
   ticks++;
@@ -226,8 +247,7 @@ setInterval(() => {
     if (e.tapped) skimmed += e.vol*8;
     if (e.rerouted) skimmed += e.vol*14;
   }
-  const auditLive = EDGES.some(e => e.type==="audit" && !e.cut && !e.rerouted); // silenced by CUT or REROUTE-away
-  if (isTampering() && auditLive){ for (const e of EDGES.filter(e=>e.type==="audit"&&!e.cut&&!e.rerouted)) audit += e.vol; }
+  if (flagRaised()){ audit += auditEdge("ids","monitor").vol; } // the mismatch flag is heard by the monitor
   if (skimmed >= TARGET) finish("win");
   else if (audit >= AUDIT_THRESHOLD) finish("lose");
   render();
@@ -244,11 +264,11 @@ function finish(kind){
 function draw(){
   ctx.clearRect(0,0,W,H);
   _liveMoney = liveMoneyEdges();
-  const tampering = isTampering();
+  const alarming = flagRaised();
   // edges + flowing packets
   for (const e of EDGES){
     const a=node(e.from), b=node(e.to);
-    const dormant = e.type==="audit" && !tampering && !e.cut;           // idle report path
+    const dormant = e.type==="audit" && e.to==="monitor" && !alarming && !e.cut; // the flag edge is idle until a mismatch
     const dry = e.type==="money" && !e.cut && !_liveMoney.has(e.id);    // no source feeding it
     const diverted = e.rerouted && e.type!=="money" && !e.cut;          // flow redirected away from here
     const idle = dormant || dry || diverted;
@@ -264,10 +284,11 @@ function draw(){
   drawPackets();
   // nodes
   for (const id in NODES){ const n=NODES[id];
-    const c = n.kind==="monitor"?"#ff5a5a":n.kind==="vault"?"#ffd24a":n.kind==="sink"?"#7dffb0":n.owned?"#21e6ff":"#4a6a5a";
+    const c = (n.kind==="monitor"||n.kind==="ids")?"#ff5a5a":n.kind==="vault"?"#ffd24a":n.kind==="sink"?"#7dffb0":n.owned?"#21e6ff":"#4a6a5a";
     ctx.strokeStyle=c; ctx.shadowColor=c; ctx.shadowBlur=8; ctx.lineWidth=2;
     if (sel&&sel.kind==="node"&&sel.id===id){ ctx.lineWidth=3; }
-    polygon(n.x,n.y,16, n.kind==="monitor"?3:n.kind==="vault"?4:6); ctx.stroke(); ctx.shadowBlur=0;
+    polygon(n.x,n.y,16, n.kind==="monitor"?3:n.kind==="ids"?5:n.kind==="vault"?4:6); ctx.stroke(); ctx.shadowBlur=0;
+    if (id==="ids" && alarming){ ctx.strokeStyle="#ff2a2a"; ctx.shadowColor="#ff2a2a"; ctx.shadowBlur=14; ctx.lineWidth=2; ctx.beginPath(); ctx.arc(n.x,n.y,24,0,Math.PI*2); ctx.stroke(); ctx.shadowBlur=0; ctx.fillStyle="#ff8a8a"; ctx.fillText("⚠ won't reconcile!", n.x, n.y-24); }
     ctx.fillStyle=c; ctx.font="10px monospace"; ctx.textAlign="center"; ctx.fillText(n.label, n.x, n.y+28);
   }
   requestAnimationFrame(draw);
@@ -277,7 +298,7 @@ function drawPackets(){
   for (const e of EDGES){
     if (e.cut) continue;
     if (e.rerouted && e.type!=="money") continue;            // diverted away — no packets to original dest
-    if (e.type==="audit" && !isTampering()) continue;        // dormant until you tamper
+    if (e.type==="audit" && e.to==="monitor" && !flagRaised()) continue; // the flag is dormant until a mismatch; balance reports (→ids) flow always
     if (e.type==="money" && !_liveMoney.has(e.id)) continue; // dry — no source feeding it
     if (Math.random() < e.vol*0.02){ packets.push({ e, t:0 }); }
   }

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/lab-b-flow-heist/index.html
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/lab-b-flow-heist/index.html
@@ -1,0 +1,340 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Lab B — Flow-heist (finesse feel)</title>
+<style>
+  :root {
+    --bg:#0a0a0f; --fg:#9ff7c4; --dim:#4a6a5a; --cyan:#21e6ff; --amber:#ffb020;
+    --red:#ff2a2a; --mag:#ff00aa; --violet:#b98bff; --gold:#ffd24a; --panel:#10141a;
+    --glow-sm:0 0 4px currentColor; --glow-md:0 0 8px currentColor;
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--fg); padding:14px;
+    font:13px/1.45 "SF Mono","JetBrains Mono",Menlo,Consolas,monospace;
+    display:grid; grid-template-columns:1fr 300px; gap:14px; align-items:start; min-height:100vh; }
+  h1 { font-size:15px; letter-spacing:2px; margin:0 0 2px; color:var(--cyan); text-shadow:var(--glow-md); text-transform:uppercase; }
+  .sub { color:var(--dim); margin:0 0 12px; font-size:11px; }
+  canvas { width:100%; max-width:624px; height:auto; display:block; margin:0 auto; border:1px solid #1c2630; background:#070a0e; border-radius:3px; }
+  .readout { display:flex; gap:16px; flex-wrap:wrap; margin:8px 0; font-size:12px; }
+  .readout b { color:var(--cyan); font-weight:normal; } .readout .v { color:var(--fg); text-shadow:var(--glow-sm); }
+  .outcome { font-size:14px; letter-spacing:1px; min-height:20px; margin:4px 0 8px; text-transform:uppercase; }
+  .outcome.win { color:var(--cyan); text-shadow:var(--glow-md); } .outcome.lose { color:var(--red); text-shadow:var(--glow-sm); }
+  .panel { background:var(--panel); border:1px solid #1c2630; border-radius:3px; padding:12px; margin-bottom:12px; }
+  .panel h2 { font-size:11px; letter-spacing:1.5px; color:var(--amber); margin:0 0 8px; text-transform:uppercase; }
+  button { background:#0e1620; color:var(--cyan); border:1px solid #24424e; padding:6px 11px; font:inherit; letter-spacing:1px; cursor:pointer; border-radius:3px; text-transform:uppercase; margin:2px; }
+  button:hover:not(:disabled){ border-color:var(--cyan); box-shadow:var(--glow-sm); }
+  button:disabled { opacity:.3; cursor:default; }
+  .sel { color:var(--dim); font-size:11px; margin-bottom:6px; }
+  .sel b { color:var(--fg); }
+  #log { height:150px; overflow:auto; background:#070a0e; border:1px solid #1c2630; border-radius:3px; padding:6px 8px; font-size:11px; color:var(--dim); }
+  #log .good { color:var(--cyan); } #log .bad { color:var(--red); } #log .hit { color:var(--fg); }
+  .legend { font-size:11px; color:var(--dim); line-height:1.7; }
+  .legend .k { display:inline-block; width:74px; color:var(--fg); }
+  .hint { color:var(--dim); font-size:11px; margin-top:6px; }
+</style>
+</head>
+<body>
+<div class="left">
+  <h1>Lab B — Flow-heist</h1>
+  <p class="sub">finesse feel · read the running machine, reroute value to you, keep the audit nominal · does the "aha" land?</p>
+  <canvas id="cv" width="640" height="470"></canvas>
+  <div class="outcome" id="outcome"></div>
+  <div class="readout">
+    <span><b>skimmed</b> <span class="v" id="r-skim">$0</span> / $<span id="r-target">2000</span></span>
+    <span><b>audit</b> <span class="v" id="r-audit">0</span> / <span id="r-athr">100</span></span>
+    <span><b>heat</b> <span class="v" id="r-heat">0</span></span>
+    <span><b>t</b> <span class="v" id="r-time">0.0s</span></span>
+  </div>
+  <div class="panel">
+    <div class="sel" id="sel-desc">Select a node or edge on the graph.</div>
+    <div id="verbs"></div>
+  </div>
+  <div id="log"></div>
+</div>
+
+<div class="right">
+  <div class="panel">
+    <h2>Brief</h2>
+    <div class="legend">Skim <b>$2000</b> from the money artery to your sink before the security
+    <b>monitor</b>'s audit hits <b>100</b> (trace). Flows are encrypted until you <b>SNIFF</b> them —
+    read the board, find what's what, and cut the report path or pace your skim.</div>
+  </div>
+  <div class="panel">
+    <h2>Flow types</h2>
+    <div class="legend">
+      <span class="k" style="color:var(--gold)">◆ money</span> value to a sink — skim it<br>
+      <span class="k" style="color:var(--cyan)">▢ data</span> generic payload<br>
+      <span class="k" style="color:var(--red)">△ audit</span> security telemetry → monitor<br>
+      <span class="k" style="color:var(--mag)">⬡ cred</span> auth token a node trusts<br>
+      <span class="k" style="color:var(--dim)">⌗ encrypted</span> unread — SNIFF to reveal
+    </div>
+  </div>
+  <div class="panel">
+    <h2>Verbs</h2>
+    <div class="legend">
+      Every revealed edge offers the <i>same</i> verbs — what they <i>do</i> depends on the flow.<br>
+      <b>SNIFF</b> read an unknown flow's type/volume (recon)<br>
+      <b>TAP</b> siphon a copy → money to your sink (loud); or a cred/data/audit token to inventory<br>
+      <b>REROUTE</b> redirect the destination → money/data to you; <i>audit away from the monitor (silences it)</i>; cred to you<br>
+      <b>CUT</b> sever any wire (loud) · <b>RESTORE</b> undo · <b>THROTTLE</b> halve volume<br>
+      <b>SPOOF</b> (on a trust-gated node) spend a captured token → own it (quiet)
+    </div>
+  </div>
+  <div class="panel"><h2>Acquired</h2><div id="inv" class="legend"></div></div>
+  <div class="panel"><button id="btn-reset">↺ Reset puzzle</button></div>
+</div>
+
+<script>
+"use strict";
+// ---------------- puzzle definition ----------------
+// one hand-authored financial LAN. positions on a 640x470 board.
+const TARGET = 2000, AUDIT_THRESHOLD = 100;
+const NODES = {
+  sink:    { x:70,  y:235, label:"you",      kind:"sink",   owned:true },
+  gateway: { x:170, y:235, label:"gateway",  kind:"host",   owned:true },
+  router:  { x:330, y:235, label:"router",   kind:"router", owned:true },
+  billing: { x:250, y:90,  label:"billing",  kind:"host",   owned:false, moneySource:true },
+  vault:   { x:545, y:150, label:"$vault",   kind:"vault",  owned:false, trustGated:true },
+  authsrv: { x:340, y:400, label:"auth-srv", kind:"host",   owned:false },
+  monitor: { x:560, y:350, label:"monitor",  kind:"monitor",owned:false },
+};
+// edges carry typed flows. revealed=false → shown encrypted until SNIFFed.
+let EDGES = [];
+function freshEdges(){ return [
+  { id:"e_bill",  from:"billing", to:"router",  type:"money", vol:3, revealed:false, tapped:false, cut:false, rerouted:false },
+  { id:"e_art",   from:"router",  to:"vault",   type:"money", vol:3, revealed:false, tapped:false, cut:false, rerouted:false }, // the artery
+  { id:"e_cred",  from:"authsrv", to:"vault",   type:"cred",  vol:1, revealed:false, tapped:false, cut:false },
+  { id:"e_audit", from:"router",  to:"monitor", type:"audit", vol:2, revealed:false, tapped:false, cut:false }, // the report path
+  { id:"e_ctrl",  from:"gateway", to:"router",  type:"data",  vol:1, revealed:true,  tapped:false, cut:false },
+]; }
+
+const TYPE_COLOR = { money:"#ffd24a", data:"#21e6ff", audit:"#ff2a2a", cred:"#ff00aa" };
+
+// ---------------- state ----------------
+let skimmed = 0, audit = 0, heat = 0, ticks = 0, phase = "playing", sel = null, packets = [];
+let inventory = []; // acquired qualities (StoryNexus-style) — e.g. captured credential tokens
+const hasCred = (id) => inventory.some(q => q.kind==="cred" && q.target===id);
+
+function reset(){
+  EDGES = freshEdges(); skimmed = 0; audit = 0; heat = 0; ticks = 0; phase = "playing"; sel = null; packets = [];
+  inventory = [];
+  for (const id in NODES) NODES[id].owned = ["sink","gateway","router"].includes(id); // restore ownership
+  setOutcome(""); renderVerbs(); renderInv(); render();
+  log("── new target: corporate billing LAN · skim the money artery, keep the audit nominal ──");
+}
+
+// ---------------- geometry / hit-testing ----------------
+const cv = document.getElementById("cv"), ctx = cv.getContext("2d"), W = cv.width, H = cv.height;
+const node = (id) => NODES[id];
+function edgeMid(e){ const a=node(e.from), b=node(e.to); return { x:(a.x+b.x)/2, y:(a.y+b.y)/2 }; }
+function distToSeg(px,py, ax,ay, bx,by){
+  const dx=bx-ax, dy=by-ay, l2=dx*dx+dy*dy; let t=l2?((px-ax)*dx+(py-ay)*dy)/l2:0; t=Math.max(0,Math.min(1,t));
+  const x=ax+t*dx, y=ay+t*dy; return Math.hypot(px-x,py-y);
+}
+cv.addEventListener("click", (ev) => {
+  const r = cv.getBoundingClientRect(), mx = (ev.clientX-r.left)*(W/r.width), my = (ev.clientY-r.top)*(H/r.height);
+  // nodes first
+  for (const id in NODES){ const n=NODES[id]; if (Math.hypot(mx-n.x,my-n.y) < 24){ sel={kind:"node",id}; renderVerbs(); return; } }
+  // then edges
+  let best=null, bd=14;
+  for (const e of EDGES){ const a=node(e.from), b=node(e.to), d=distToSeg(mx,my,a.x,a.y,b.x,b.y); if (d<bd){ bd=d; best=e; } }
+  sel = best ? { kind:"edge", id:best.id } : null;
+  renderVerbs();
+});
+
+// ---------------- verbs ----------------
+const selEdge = () => sel && sel.kind==="edge" ? EDGES.find(e=>e.id===sel.id) : null;
+const selNode = () => sel && sel.kind==="node" ? sel.id : null;
+const ownedAdjacent = (e) => node(e.from).owned || node(e.to).owned;
+
+// UNIFORM verbs on every edge — the presence of an action is never a hint. What TAP/REROUTE
+// *do* depends on the flow type (which you learn by SNIFFing), not whether the button appears.
+function edgeVerbs(e){
+  if (e.cut) return ["RESTORE"];
+  if (!e.revealed) return ["SNIFF","CUT"];
+  return ["TAP","REROUTE","THROTTLE","CUT"];
+}
+function nodeVerbs(id){
+  const n = node(id), v = [];
+  if (n.trustGated && !n.owned && hasCred(id)) v.push("SPOOF"); // spend a captured token → own it
+  return v;
+}
+function doVerb(verb){
+  if (phase!=="playing") return;
+  if (sel && sel.kind==="node"){
+    const id = selNode(), n = node(id);
+    if (verb==="SPOOF"){
+      const i = inventory.findIndex(q => q.kind==="cred" && q.target===id);
+      if (i>=0) inventory.splice(i,1);           // spend the token
+      n.owned = true; heat += 2; log(`<span class="good">SPOOF ${n.label}</span> — replayed the captured token; now trusted &amp; owned (quiet)`);
+    }
+    renderVerbs(); renderInv(); render(); return;
+  }
+  const e = selEdge(); if (!e) return;
+  const to = node(e.to).label, from = node(e.from).label;
+  const acquire = (kind,label,glyph) => inventory.push({ kind, label, glyph, target:e.to });
+  if (verb==="SNIFF"){ e.revealed=true; heat+=1; log(`SNIFF ${e.id}: <span class="hit">${e.type}</span> flow, vol ${e.vol} (${from}→${to})`); }
+  else if (verb==="TAP"){ heat+=2;   // siphon a copy — the flow continues; you acquire what it carries
+    if (e.type==="money"){ e.tapped=true; for (const ae of EDGES.filter(x=>x.type==="audit"&&!x.cut&&!x.rerouted)) for(let i=0;i<7;i++) packets.push({e:ae,t:i*0.12});
+      log(`<span class="good">TAP ${e.id}</span> — skimming money to your sink; <span class="bad">telemetry now streaming to the monitor</span>`); }
+    else if (e.type==="cred"){ if(!hasCred(e.to)){ acquire("cred",`cred token · trusted by ${to}`,"⬡"); log(`<span class="good">TAP ${e.id}</span> — captured a credential token → inventory`);} else log(`already hold ${to}'s token`); }
+    else if (e.type==="data"){ acquire("data",`data payload · ${from}→${to}`,"▢"); log(`<span class="good">TAP ${e.id}</span> — siphoned a data payload → inventory`); }
+    else if (e.type==="audit"){ acquire("intel",`audit sample · monitor watches vol ${e.vol}`,"△"); log(`TAP ${e.id} — sampled the telemetry (intel) → inventory`); }
+  }
+  else if (verb==="REROUTE"){ heat+=2;   // redirect the flow's destination
+    if (e.type==="money"){ e.rerouted=true; e.tapped=false; const legit=node(e.to).owned;
+      log(`<span class="good">REROUTE ${e.id}</span> → your sink${legit?` — you own ${to}: legit path, no audit`:` — <span class="bad">unauthorized redirect: audit climbs</span>`}`); }
+    else if (e.type==="audit"){ e.rerouted=true; log(`<span class="good">REROUTE ${e.id}</span> — telemetry diverted away from the monitor; no report arrives`); }
+    else if (e.type==="cred"){ if(!hasCred(e.to)) acquire("cred",`cred token · trusted by ${to}`,"⬡"); e.rerouted=true; log(`<span class="good">REROUTE ${e.id}</span> — credential feed diverted to you (${to} loses its token)`); }
+    else if (e.type==="data"){ acquire("data",`data payload · ${from}→${to}`,"▢"); e.rerouted=true; log(`<span class="good">REROUTE ${e.id}</span> — data diverted to your sink`); }
+  }
+  else if (verb==="CUT"){ e.cut=true; heat+=12;
+    const note = !e.revealed ? " — severed an unread wire" : e.type==="money" ? " — downstream money stops" : e.type==="cred" ? ` — ${to}'s trust feed is cut` : e.type==="audit" ? " — telemetry silenced" : " — link down";
+    log(`<span class="bad">CUT ${e.id}</span> — loud (+12 heat)${note}`); }
+  else if (verb==="RESTORE"){ e.cut=false; heat+=3; log(`<span class="hit">RESTORE ${e.id}</span> — reconnected the link (+3 heat)`); }
+  else if (verb==="THROTTLE"){ e.vol=Math.max(1,Math.round(e.vol/2)); heat+=2; log(`THROTTLE ${e.id} → vol ${e.vol}`); }
+  renderVerbs(); renderInv(); render();
+}
+
+// ---------------- sim ----------------
+// Money PROPAGATES from source nodes (billing) along intact money edges. An edge only carries
+// money if it's fed from a source — so cutting an upstream edge dries up everything downstream.
+let _liveMoney = new Set();
+function liveMoneyEdges(){
+  const live = new Set(), fed = new Set();
+  for (const id in NODES) if (NODES[id].moneySource) fed.add(id);
+  let changed = true;
+  while (changed){ changed = false;
+    for (const e of EDGES){
+      if (e.type!=="money" || e.cut || live.has(e.id)) continue;
+      if (fed.has(e.from)){ live.add(e.id); changed = true; if (!fed.has(e.to)) fed.add(e.to); }
+    }
+  }
+  return live;
+}
+// audit is DORMANT until you tamper with a LIVE money flow — then telemetry streams to the monitor
+// along the (intact) audit path. Cut the money upstream and the tap goes inert (no skim, no audit).
+const isTampering = () => { const live = liveMoneyEdges(); return EDGES.some(e => e.type==="money" && !e.cut && live.has(e.id) && (e.tapped || (e.rerouted && !node(e.to).owned))); };
+setInterval(() => {
+  if (phase!=="playing") return;
+  ticks++;
+  // TAP = loud partial skim (raises audit); REROUTE = quiet full skim. Only LIVE (source-fed) edges pay out.
+  const live = liveMoneyEdges();
+  for (const e of EDGES.filter(e => e.type==="money" && !e.cut && live.has(e.id))){
+    if (e.tapped) skimmed += e.vol*8;
+    if (e.rerouted) skimmed += e.vol*14;
+  }
+  const auditLive = EDGES.some(e => e.type==="audit" && !e.cut && !e.rerouted); // silenced by CUT or REROUTE-away
+  if (isTampering() && auditLive){ for (const e of EDGES.filter(e=>e.type==="audit"&&!e.cut&&!e.rerouted)) audit += e.vol; }
+  if (skimmed >= TARGET) finish("win");
+  else if (audit >= AUDIT_THRESHOLD) finish("lose");
+  render();
+}, 250);
+
+function finish(kind){
+  phase = kind;
+  if (kind==="win"){ setOutcome(`⌁ SCORE — skimmed $${skimmed} clean`, "win"); log(`<span class="good">WIN — $${skimmed} skimmed, audit ${audit}/${AUDIT_THRESHOLD}</span>`); }
+  else { setOutcome("✕ TRACED — audit reached the monitor", "lose"); log(`<span class="bad">LOSE — audit hit ${AUDIT_THRESHOLD} (skimmed $${skimmed})</span>`); }
+  renderVerbs();
+}
+
+// ---------------- render ----------------
+function draw(){
+  ctx.clearRect(0,0,W,H);
+  _liveMoney = liveMoneyEdges();
+  const tampering = isTampering();
+  // edges + flowing packets
+  for (const e of EDGES){
+    const a=node(e.from), b=node(e.to);
+    const dormant = e.type==="audit" && !tampering && !e.cut;           // idle report path
+    const dry = e.type==="money" && !e.cut && !_liveMoney.has(e.id);    // no source feeding it
+    const diverted = e.rerouted && e.type!=="money" && !e.cut;          // flow redirected away from here
+    const idle = dormant || dry || diverted;
+    const col = e.cut ? "#33202a" : idle ? "#2c2622" : e.revealed ? TYPE_COLOR[e.type] : "#3a4a44";
+    ctx.strokeStyle = col; ctx.lineWidth = e.cut?1:2; ctx.setLineDash(e.cut?[3,5]:(e.revealed && !idle?[]:[2,6]));
+    ctx.shadowColor = col; ctx.shadowBlur = (e.cut||idle)?0:6;
+    ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke(); ctx.setLineDash([]); ctx.shadowBlur=0;
+    // selection highlight
+    if (sel && sel.kind==="edge" && sel.id===e.id){ ctx.strokeStyle="#fff"; ctx.globalAlpha=.25; ctx.lineWidth=6; ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke(); ctx.globalAlpha=1; }
+    if (e.tapped || e.rerouted){ const m=edgeMid(e); ctx.fillStyle=e.rerouted?"#7dffb0":"#ffd24a"; ctx.font="9px monospace"; ctx.textAlign="center"; ctx.fillText(e.rerouted?"⇄ →you":"⇱ TAP", m.x, m.y-8); }
+  }
+  // packets
+  drawPackets();
+  // nodes
+  for (const id in NODES){ const n=NODES[id];
+    const c = n.kind==="monitor"?"#ff5a5a":n.kind==="vault"?"#ffd24a":n.kind==="sink"?"#7dffb0":n.owned?"#21e6ff":"#4a6a5a";
+    ctx.strokeStyle=c; ctx.shadowColor=c; ctx.shadowBlur=8; ctx.lineWidth=2;
+    if (sel&&sel.kind==="node"&&sel.id===id){ ctx.lineWidth=3; }
+    polygon(n.x,n.y,16, n.kind==="monitor"?3:n.kind==="vault"?4:6); ctx.stroke(); ctx.shadowBlur=0;
+    ctx.fillStyle=c; ctx.font="10px monospace"; ctx.textAlign="center"; ctx.fillText(n.label, n.x, n.y+28);
+  }
+  requestAnimationFrame(draw);
+}
+function drawPackets(){
+  // spawn per revealed, non-cut edge based on vol
+  for (const e of EDGES){
+    if (e.cut) continue;
+    if (e.rerouted && e.type!=="money") continue;            // diverted away — no packets to original dest
+    if (e.type==="audit" && !isTampering()) continue;        // dormant until you tamper
+    if (e.type==="money" && !_liveMoney.has(e.id)) continue; // dry — no source feeding it
+    if (Math.random() < e.vol*0.02){ packets.push({ e, t:0 }); }
+  }
+  for (const p of packets){
+    p.t += 0.012 * p.e.vol;
+    const a=node(p.e.from), b=node(p.e.to), x=a.x+(b.x-a.x)*p.t, y=a.y+(b.y-a.y)*p.t;
+    const col = p.e.revealed ? TYPE_COLOR[p.e.type] : "#5a6a64";
+    ctx.strokeStyle=col; ctx.fillStyle=col; ctx.shadowColor=col; ctx.shadowBlur=6; ctx.lineWidth=1.5;
+    if (!p.e.revealed) glyph("enc",x,y);
+    else glyph(p.e.type,x,y);
+    ctx.shadowBlur=0;
+  }
+  packets = packets.filter(p => p.t < 1);
+}
+function glyph(type,x,y){ const s=4;
+  ctx.beginPath();
+  if (type==="money"){ ctx.moveTo(x,y-s); ctx.lineTo(x+s,y); ctx.lineTo(x,y+s); ctx.lineTo(x-s,y); ctx.closePath(); ctx.stroke(); }
+  else if (type==="data"){ ctx.strokeRect(x-s,y-s,s*2,s*2); }
+  else if (type==="audit"){ ctx.moveTo(x,y-s); ctx.lineTo(x+s,y+s); ctx.lineTo(x-s,y+s); ctx.closePath(); ctx.stroke(); }
+  else if (type==="cred"){ for(let i=0;i<6;i++){ const a=Math.PI/3*i; const px=x+s*Math.cos(a),py=y+s*Math.sin(a); i?ctx.lineTo(px,py):ctx.moveTo(px,py);} ctx.closePath(); ctx.stroke(); }
+  else { ctx.moveTo(x-s,y-s); ctx.lineTo(x+s,y+s); ctx.moveTo(x+s,y-s); ctx.lineTo(x-s,y+s); ctx.stroke(); } // enc = ⌗-ish x
+}
+function polygon(cx,cy,r,n){ ctx.beginPath(); for(let i=0;i<n;i++){ const a=-Math.PI/2+i*2*Math.PI/n; const x=cx+r*Math.cos(a),y=cy+r*Math.sin(a); i?ctx.lineTo(x,y):ctx.moveTo(x,y);} ctx.closePath(); }
+
+// ---------------- dom ----------------
+function render(){
+  const $=id=>document.getElementById(id);
+  $("r-skim").textContent = "$"+skimmed; $("r-audit").textContent = Math.round(audit);
+  $("r-heat").textContent = Math.round(heat); $("r-time").textContent = (ticks*0.25).toFixed(1)+"s";
+}
+function renderVerbs(){
+  const desc=document.getElementById("sel-desc"), vwrap=document.getElementById("verbs"); vwrap.innerHTML="";
+  if (!sel){ desc.textContent="Select a node or edge on the graph."; return; }
+  let verbs;
+  if (sel.kind==="node"){
+    const n=node(sel.id);
+    desc.innerHTML=`<b>${n.label}</b> — ${n.kind}${n.trustGated?" · trust-gated":""}${n.owned?" · owned":""}`;
+    verbs = nodeVerbs(sel.id);
+  } else {
+    const e=selEdge();
+    desc.innerHTML=`edge <b>${node(e.from).label} → ${node(e.to).label}</b> — ${e.revealed?e.type+" · vol "+e.vol:"encrypted"}${e.cut?" · CUT":""}${e.tapped?" · TAPPED":""}${e.rerouted?" · REROUTED":""}`;
+    verbs = edgeVerbs(e);
+  }
+  if (!verbs.length){ vwrap.innerHTML=`<span class="sel">no actions here yet</span>`; return; }
+  for (const v of verbs){ const b=document.createElement("button"); b.textContent=v; b.disabled=phase!=="playing"; b.onclick=()=>doVerb(v); vwrap.appendChild(b); }
+}
+function renderInv(){
+  const el=document.getElementById("inv");
+  if (!inventory.length){ el.innerHTML=`<span style="color:var(--dim)">nothing yet — TAP a cred/data flow to acquire</span>`; return; }
+  el.innerHTML = inventory.map(q => `<div><span style="color:var(--mag)">${q.glyph||"◆"}</span> ${q.label}</div>`).join("");
+}
+function setOutcome(t,c){ const el=document.getElementById("outcome"); el.textContent=t; el.className="outcome"+(c?" "+c:""); }
+function log(html){ const el=document.getElementById("log"); el.insertAdjacentHTML("beforeend",`<div>${html}</div>`); while(el.children.length>200) el.firstChild.remove(); el.scrollTop=el.scrollHeight; }
+
+document.getElementById("btn-reset").addEventListener("click", reset);
+reset();
+requestAnimationFrame(draw);
+</script>
+</body>
+</html>

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/lab-b-flow-heist/index.html
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/lab-b-flow-heist/index.html
@@ -80,10 +80,11 @@
     <div class="legend">
       Every revealed edge offers the <i>same</i> verbs — what they <i>do</i> depends on the flow.<br>
       <b>SNIFF</b> read an unknown flow's type/volume (recon)<br>
-      <b>TAP</b> siphon a copy → money to your sink (loud); or a cred/data/audit token to inventory<br>
-      <b>REROUTE</b> redirect the destination → money/data to you; <i>audit away from the monitor (silences it)</i>; cred to you<br>
+      <b>TAP</b> <i>copy/split</i> a portion off — the original flow continues (money → a share to you; cred/data/audit → a copy to inventory). <b>UNTAP</b> to revert.<br>
+      <b>REROUTE</b> redirect the <i>whole</i> flow — original recipient gets nothing (money/data → you; audit → away from monitor = silence; cred → you, de-authorizes it). <b>UN-REROUTE</b> to revert.<br>
       <b>CUT</b> sever any wire (loud) · <b>RESTORE</b> undo · <b>THROTTLE</b> halve volume<br>
-      <b>SPOOF</b> (on a trust-gated node) spend a captured token → own it (quiet)
+      <b>SPOOF</b> (trust-gated node) spend a captured token → own it (quiet)<br>
+      <i>Skim must route home:</i> money reaches you only over a live path to your sink — cut your exfil (router→gateway) and you get nothing.
     </div>
   </div>
   <div class="panel"><h2>Acquired</h2><div id="inv" class="legend"></div></div>
@@ -115,7 +116,8 @@ function freshEdges(){ return [
   { id:"e_rep_b", from:"billing", to:"ids",     type:"audit", vol:1, revealed:false, tapped:false, cut:false, rerouted:false }, // "balance SENT" report
   { id:"e_rep_v", from:"vault",   to:"ids",     type:"audit", vol:1, revealed:false, tapped:false, cut:false, rerouted:false }, // "balance RECEIVED" report
   { id:"e_flag",  from:"ids",     to:"monitor", type:"audit", vol:2, revealed:false, tapped:false, cut:false, rerouted:false }, // red flag raised on mismatch
-  { id:"e_ctrl",  from:"gateway", to:"router",  type:"data",  vol:1, revealed:true,  tapped:false, cut:false, rerouted:false },
+  { id:"e_ex1",   from:"router",  to:"gateway", type:"data",  vol:1, revealed:true,  tapped:false, cut:false, rerouted:false, exfil:true }, // your exfil path: skim routes back to you
+  { id:"e_ex2",   from:"gateway", to:"sink",    type:"data",  vol:1, revealed:true,  tapped:false, cut:false, rerouted:false, exfil:true },
 ]; }
 
 const TYPE_COLOR = { money:"#ffd24a", data:"#21e6ff", audit:"#ff2a2a", cred:"#ff00aa" };
@@ -162,7 +164,8 @@ const ownedAdjacent = (e) => node(e.from).owned || node(e.to).owned;
 function edgeVerbs(e){
   if (e.cut) return ["RESTORE"];
   if (!e.revealed) return ["SNIFF","CUT"];
-  return ["TAP","REROUTE","THROTTLE","CUT"];
+  // TAP and REROUTE are mutually exclusive ongoing states, each revertible (notice an audit problem → undo)
+  return [ e.tapped?"UNTAP":"TAP", e.rerouted?"UN-REROUTE":"REROUTE", "THROTTLE", "CUT" ];
 }
 function nodeVerbs(id){
   const n = node(id), v = [];
@@ -184,24 +187,26 @@ function doVerb(verb){
   const to = node(e.to).label, from = node(e.from).label;
   const acquire = (kind,label,glyph) => inventory.push({ kind, label, glyph, target:e.to });
   if (verb==="SNIFF"){ e.revealed=true; heat+=1; log(`SNIFF ${e.id}: <span class="hit">${e.type}</span> flow, vol ${e.vol} (${from}→${to})`); }
-  else if (verb==="TAP"){ heat+=2;   // siphon a copy — the flow continues; you acquire what it carries
-    if (e.type==="money"){ e.tapped=true;
+  else if (verb==="TAP"){ heat+=2;   // COPY/SPLIT: siphon a portion off; the ORIGINAL flow continues
+    if (e.type==="money"){ e.tapped=true; e.rerouted=false; // TAP and REROUTE are mutually exclusive
       const flag = flagRaised();
       if (flag){ const fe=auditEdge("ids","monitor"); for(let i=0;i<7;i++) packets.push({e:fe,t:i*0.12}); }
-      log(`<span class="good">TAP ${e.id}</span> — skimming money to your sink${flag?`; <span class="bad">the books won't reconcile — the IDS flags the monitor</span>`:` (no flag: the books reconcile, or the IDS is blind/owned)`}`); }
-    else if (e.type==="cred"){ if(!hasCred(e.to)){ acquire("cred",`cred token · trusted by ${to}`,"⬡"); log(`<span class="good">TAP ${e.id}</span> — captured a credential token → inventory`);} else log(`already hold ${to}'s token`); }
-    else if (e.type==="data"){ acquire("data",`data payload · ${from}→${to}`,"▢"); log(`<span class="good">TAP ${e.id}</span> — siphoned a data payload → inventory`); }
-    else if (e.type==="audit"){ acquire("intel",`audit sample · monitor watches vol ${e.vol}`,"△"); log(`TAP ${e.id} — sampled the telemetry (intel) → inventory`); }
+      log(`<span class="good">TAP ${e.id}</span> — splitting a share of the money to you (flow continues; $vault comes up short)${flag?`; <span class="bad">books won't reconcile — IDS flags the monitor</span>`:``}`); }
+    else if (e.type==="cred"){ if(!hasCred(e.to)){ acquire("cred",`cred token · trusted by ${to}`,"⬡"); log(`<span class="good">TAP ${e.id}</span> — copied the credential token (flow continues; ${to} stays authorized) → inventory`);} else log(`already hold ${to}'s token`); }
+    else if (e.type==="data"){ acquire("data",`data payload · ${from}→${to}`,"▢"); log(`<span class="good">TAP ${e.id}</span> — copied a data payload → inventory`); }
+    else if (e.type==="audit"){ acquire("intel",`audit sample · monitor watches vol ${e.vol}`,"△"); log(`TAP ${e.id} — copied a telemetry sample (intel) → inventory`); }
   }
-  else if (verb==="REROUTE"){ heat+=2;   // redirect the flow's destination
-    if (e.type==="money"){ e.rerouted=true; e.tapped=false; const legit=node(e.to).owned;
-      log(`<span class="good">REROUTE ${e.id}</span> → your sink${legit?` — you own ${to}: legit path, no audit`:` — <span class="bad">unauthorized redirect: audit climbs</span>`}`); }
-    else if (e.type==="audit"){ e.rerouted=true; log(`<span class="good">REROUTE ${e.id}</span> — telemetry diverted away from the monitor; no report arrives`); }
-    else if (e.type==="cred"){ if(!hasCred(e.to)) acquire("cred",`cred token · trusted by ${to}`,"⬡"); e.rerouted=true; log(`<span class="good">REROUTE ${e.id}</span> — credential feed diverted to you (${to} loses its token)`); }
-    else if (e.type==="data"){ acquire("data",`data payload · ${from}→${to}`,"▢"); e.rerouted=true; log(`<span class="good">REROUTE ${e.id}</span> — data diverted to your sink`); }
+  else if (verb==="REROUTE"){ heat+=2;   // WHOLE FLOW: redirect the destination; the original recipient gets nothing
+    if (e.type==="money"){ e.rerouted=true; e.tapped=false;
+      log(`<span class="good">REROUTE ${e.id}</span> — the whole money flow now routes to you ($vault gets nothing)${NODES.vault.owned?` — you own $vault, books reconcile`:``}`); }
+    else if (e.type==="audit"){ e.rerouted=true; log(`<span class="good">REROUTE ${e.id}</span> — telemetry rerouted away from the monitor; the report never arrives`); }
+    else if (e.type==="cred"){ if(!hasCred(e.to)) acquire("cred",`cred token · trusted by ${to}`,"⬡"); e.rerouted=true; log(`<span class="good">REROUTE ${e.id}</span> — the whole credential feed routes to you (${to} loses its token → de-authorized)`); }
+    else if (e.type==="data"){ acquire("data",`data payload · ${from}→${to}`,"▢"); e.rerouted=true; log(`<span class="good">REROUTE ${e.id}</span> — the whole data flow routes to you`); }
   }
+  else if (verb==="UNTAP"){ e.tapped=false; log(`UNTAP ${e.id} — stopped splitting the flow`); }
+  else if (verb==="UN-REROUTE"){ e.rerouted=false; log(`UN-REROUTE ${e.id} — flow restored to ${to}`); }
   else if (verb==="CUT"){ e.cut=true; heat+=12;
-    const note = !e.revealed ? " — severed an unread wire" : e.type==="money" ? " — downstream money stops" : e.type==="cred" ? ` — ${to}'s trust feed is cut` : e.type==="audit" ? " — telemetry silenced" : " — link down";
+    const note = !e.revealed ? " — severed an unread wire" : e.type==="money" ? " — downstream money stops" : e.type==="cred" ? ` — ${to} loses authorization → its money flow dries` : e.type==="audit" ? (e.to==="monitor"?" — the flag can't reach the monitor":" — the IDS loses a balance report → goes blind") : " — link down";
     log(`<span class="bad">CUT ${e.id}</span> — loud (+12 heat)${note}`); }
   else if (verb==="RESTORE"){ e.cut=false; heat+=3; log(`<span class="hit">RESTORE ${e.id}</span> — reconnected the link (+3 heat)`); }
   else if (verb==="THROTTLE"){ e.vol=Math.max(1,Math.round(e.vol/2)); heat+=2; log(`THROTTLE ${e.id} → vol ${e.vol}`); }
@@ -209,16 +214,31 @@ function doVerb(verb){
 }
 
 // ---------------- sim ----------------
-// Money PROPAGATES from source nodes (billing) along intact money edges. An edge only carries
-// money if it's fed from a source — so cutting an upstream edge dries up everything downstream.
+// Money PROPAGATES from source nodes along intact money edges (cut upstream → downstream dries).
+// PLUS: a trust-gated node must be AUTHORIZED to take part — it needs a live incoming credential
+// (auth-srv's token) OR you must own it. Cut/reroute that cred and the node drops out of the money
+// flow (a source stops sending, a consumer stops accepting). So the cred is load-bearing, not just
+// a finesse handle: TAP it to copy (money keeps flowing); CUT/REROUTE it to de-authorize.
 let _liveMoney = new Set();
+const credLiveTo = (id) => EDGES.some(e => e.type==="cred" && e.to===id && !e.cut && !e.rerouted);
+const authorized = (id) => { const n = NODES[id]; return n.owned || !n.trustGated || credLiveTo(id); };
+// Skimmed money must physically get back to YOU (the sink) over a live path. Cut your exfil path
+// (e.g. router→gateway) and the money can't reach you, even if the tap is working.
+function reachSink(start){
+  const seen = new Set([start]), q = [start];
+  while (q.length){ const cur = q.shift(); if (cur==="sink") return true;
+    for (const e of EDGES){ if (e.cut) continue; const nx = e.from===cur ? e.to : e.to===cur ? e.from : null; if (nx && !seen.has(nx)){ seen.add(nx); q.push(nx); } } }
+  return false;
+}
+const interceptNode = (e) => node(e.from).owned ? e.from : node(e.to).owned ? e.to : e.from; // where you tap into the flow
 function liveMoneyEdges(){
   const live = new Set(), fed = new Set();
-  for (const id in NODES) if (NODES[id].moneySource) fed.add(id);
+  for (const id in NODES) if (NODES[id].moneySource && authorized(id)) fed.add(id); // source must be authorized to emit
   let changed = true;
   while (changed){ changed = false;
     for (const e of EDGES){
       if (e.type!=="money" || e.cut || live.has(e.id)) continue;
+      if (!authorized(e.to)) continue;                    // consumer must be authorized to accept
       if (fed.has(e.from)){ live.add(e.id); changed = true; if (!fed.has(e.to)) fed.add(e.to); }
     }
   }
@@ -243,9 +263,9 @@ setInterval(() => {
   ticks++;
   // TAP = loud partial skim (raises audit); REROUTE = quiet full skim. Only LIVE (source-fed) edges pay out.
   const live = liveMoneyEdges();
-  for (const e of EDGES.filter(e => e.type==="money" && !e.cut && live.has(e.id))){
-    if (e.tapped) skimmed += e.vol*8;
-    if (e.rerouted) skimmed += e.vol*14;
+  for (const e of EDGES.filter(e => e.type==="money" && !e.cut && live.has(e.id) && (e.tapped||e.rerouted))){
+    if (!reachSink(interceptNode(e))) continue;   // no live exfil path back to you → you receive nothing
+    skimmed += e.tapped ? e.vol*8 : e.vol*14;
   }
   if (flagRaised()){ audit += auditEdge("ids","monitor").vol; } // the mismatch flag is heard by the monitor
   if (skimmed >= TARGET) finish("win");
@@ -294,21 +314,23 @@ function draw(){
   requestAnimationFrame(draw);
 }
 function drawPackets(){
-  // spawn per revealed, non-cut edge based on vol
+  // is any skim actually reaching you right now? (drives money flowing home along the exfil path)
+  const exfilOn = EDGES.some(e => e.type==="money" && (e.tapped||e.rerouted) && !e.cut && _liveMoney.has(e.id) && reachSink(interceptNode(e)));
   for (const e of EDGES){
     if (e.cut) continue;
+    if (e.exfil){ if (exfilOn && Math.random()<0.14) packets.push({ e, t:0, ft:"money" }); continue; } // your take routing home
     if (e.rerouted && e.type!=="money") continue;            // diverted away — no packets to original dest
-    if (e.type==="audit" && e.to==="monitor" && !flagRaised()) continue; // the flag is dormant until a mismatch; balance reports (→ids) flow always
+    if (e.type==="audit" && e.to==="monitor" && !flagRaised()) continue; // flag dormant until mismatch; balance reports (→ids) flow always
     if (e.type==="money" && !_liveMoney.has(e.id)) continue; // dry — no source feeding it
     if (Math.random() < e.vol*0.02){ packets.push({ e, t:0 }); }
   }
   for (const p of packets){
-    p.t += 0.012 * p.e.vol;
+    p.t += 0.012 * (p.e.vol||1);
     const a=node(p.e.from), b=node(p.e.to), x=a.x+(b.x-a.x)*p.t, y=a.y+(b.y-a.y)*p.t;
-    const col = p.e.revealed ? TYPE_COLOR[p.e.type] : "#5a6a64";
+    const t = p.ft || (p.e.revealed ? p.e.type : "enc");
+    const col = TYPE_COLOR[t] || "#5a6a64";
     ctx.strokeStyle=col; ctx.fillStyle=col; ctx.shadowColor=col; ctx.shadowBlur=6; ctx.lineWidth=1.5;
-    if (!p.e.revealed) glyph("enc",x,y);
-    else glyph(p.e.type,x,y);
+    glyph(t,x,y);
     ctx.shadowBlur=0;
   }
   packets = packets.filter(p => p.t < 1);

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
@@ -153,6 +153,16 @@ in the toy; carry them forward.
   blunt CUT — but only from a node that can afford the compute.)
 - **Credentials-as-authorization + exfil-must-route-home + reconciliation detection** (all built in the
   lab) are keepers for the real model — they make the network behave like a system you reason about.
+- **Collapse access levels `locked → owned` (drop the interstitial `open`).** (Decision, 2026-07-07.)
+  The old 3-step climb (xploit→open, xploit→owned) existed because one exploit was a tiny dice-roll
+  needing repetition. Now the **smash coherence-minigame IS the whole "work your way in"** (erode →
+  fault → owned) and **finesse is one decisive spoof → owned**, so `open` is a grind step the new
+  mechanics already replaced. Model becomes **hidden → accessible → probed (recon) → owned**; *owning*
+  (by smash OR finesse) unlocks the node's elevated actions. Finesse = the alt road to owned: exploit a
+  soft node, SNIFF/capture its auth, SPOOF a hard node's access instead of brute-forcing.
+  *Ripples to reconcile in E1:* "open" currently gates **dump** (loot reveal) and "owned" gates
+  **fetch/mine** → re-map (dump likely → probed, fetch/mine → owned); touches the **bot**, **set-pieces**,
+  and **MANUAL.md** (consult before changing).
 
 ### Design principles validated / decisions (from live poking with Les)
 - **Causal flow propagation.** Money propagates from a source (billing); cutting an upstream edge
@@ -187,3 +197,44 @@ in the toy; carry them forward.
   `watchdog` flag; deferred. Turns "blind the IDS" into a real cost.
 - Cross-lab: actually letting a smash **autopwn the IDS/monitor** here is the E-thread integration
   (needs Lab A's library+gear), not lab scope — but it's the convergence the labs proved out.
+
+## Retrospective
+
+**Recap.** Built two disposable-but-committed feel prototypes to de-risk the exploit-economy fun
+before the E1 build: **Lab A** (autopwn/smash — coherence-erosion barrage as a centered Star Castle
+"instrument") and **Lab B** (flow-heist/finesse — read a running financial LAN and reroute value
+while beating a reconciliation IDS). Both live under the session dir; draft PR #309. Seven commits.
+
+**Scope drift (the useful kind).** The spec framed the labs narrowly — "answer *is it fun*." They
+did (smash and finesse both landed), but they turned into a **live design forge** that reshaped the
+E-thread design far more than "feel validation": reconciliation-style detection, credentials-as-
+authorization, exfil-must-route-home, flows-transit-infrastructure (foothold = MITM vantage),
+node-capability tiers, and the `locked→owned` access collapse all fell out of *poking the toy*. The
+labs did double duty — feel + design discovery — and the second turned out higher-value than the first.
+
+**Surprises.** Poking a *disposable model* was a startlingly strong coherence engine: Les's "wait,
+why is the router snitching when I own it?" / "why isn't the money routing to me?" / "what do the
+auth packets even do?" each exposed a real design gap a spec would never have caught. The toy's
+*inconsistencies under play* were the signal. Also: Lab A's visual iteration organically converged on
+a form (radial stroked instrument) that fixed an actual aesthetic-rule violation (the first draining
+*bars* broke the game's no-fills vector rule).
+
+**Workflow friction.** (1) Two open PRs on separate branches — #308 (design doc) and #309 (labs) —
+created a doc-coordination seam: the access-level decision + structural findings logically belong in
+`flow-subversion.md` (on #308) but were captured in the labs' `notes.md` (on #309). E1 should base
+off / merge #308 first so the design of record is current. (2) The feel loop was many small
+edit->reopen cycles; effective but manual (no live-reload).
+
+**Misses.** Never did a long "20th-time" endurance sit on Lab A (fun-over-repetition still an
+inference, not observed). All balance is by-eye — no census/quantified pass (fine for a lab, but E1
+needs it). Didn't yet consult `MANUAL.md` for the access-level ripples (dump/fetch gating) — flagged
+for E1.
+
+**Memory candidates.** (a) Update `exploit-economy-gear-vs-ammo` with the lab-validated mechanics +
+the access-level collapse + structural findings (E1 will read it). (b) `interactive-lab-for-visual-
+tuning` extends beyond *visual* feel to *systems/fiction coherence* discovery — poking a toy model
+surfaces design gaps; worth generalizing that memory.
+
+**Skill candidate.** "Build a disposable toy of the *system* (not just the visuals) and poke it with
+the designer to discover coherence gaps" is a repeatable technique — a sibling to the visual-lab
+pattern. Candidate note, not a full skill yet.

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
@@ -99,23 +99,46 @@ system* fun?
 ### What it does
 - **Typed flows animate on edges** (money ◆ / data ▢ / audit △ / cred ⬡), **encrypted (grey ⌗)**
   until SNIFFed. You own gateway+router; the rest is the puzzle.
-- **Two routes to the money, discovered by reading:**
-  - **Loud:** TAP the artery (audit lights up + streams to monitor) → CUT or REROUTE the audit path
-    to silence it → skim out.
-  - **Finesse:** the `$vault` is **trust-gated** (can't tap it directly) → TAP its **credential**
-    flow to capture a token (a **quality** in the Acquired inventory) → **SPOOF** the vault to own
-    it → **REROUTE** the artery to your sink: full-volume, **no audit** (you're a trusted endpoint).
-- **StoryNexus-style quality inventory** (Acquired panel): captured creds / data payloads / audit
-  samples; SPOOF *spends* a cred quality.
+- **The detection machine is a reconciliation IDS** (the honest, packet-level model we landed on):
+  **billing** reports "balance SENT" to the IDS, **$vault** reports "balance RECEIVED"; the IDS
+  reconciles them. A skim makes them disagree → the IDS raises a **red flag → monitor** → audit
+  climbs. No hand-wavy "IDS watches a wire" — it reasons over the *report packets*.
+- **Many ways to beat the check** (this is the point — a subvertible machine, not one scripted solve):
+  - **own $vault** or **own billing** (capture its cred → SPOOF) → the owned end fakes a reconciling
+    balance;
+  - **cut / reroute a balance report** (→ ids) → the IDS goes blind and can't reconcile;
+  - **cut / reroute the flag** (ids → monitor) → the alarm is never heard;
+  - plus the money route itself: TAP (loud partial) vs. own-vault + REROUTE (quiet full).
+- **Causal money propagation:** cutting an upstream money edge dries everything downstream (taps go
+  inert). **StoryNexus-style quality inventory** (Acquired panel): captured creds / data / intel;
+  SPOOF spends a cred quality.
+
+### ★ Convergence — the keystone finding (why the two labs are one system)
+The IDS/monitor are **just nodes**. Everything in Lab B is the **finesse** way to defeat the
+reconciliation check (subvert its *flows*). But a **smash** player (Lab A) with a fat module library
++ noise-mitigation gear could **autopwn the IDS or monitor directly** → own it → it stops flagging →
+the whole knot is cut in one loud stroke. **Same obstacle, two weapons, choice driven by loadout** —
+the minigun-vs-sniper duality made concrete at the security layer:
+- hardened security → smashing it is expensive *and loud* (you generate exactly the noise it watches
+  for) → finesse (quiet flow-subversion) is the cheaper route → the puzzle *is* the game;
+- bring the firepower → skip the puzzle, autopwn the auditor, walk out (smash-and-grab).
+
+So Lab A + Lab B are **two halves of one system that meet at every security node**, and the meta-game
+is "read the network, read my loadout, pick my weapon." That's the whole Flow-Subversion pillar
+validated in miniature. (Wiring actual smash into Lab B = the E-thread integration, beyond lab scope.)
 
 ### Design principles validated / decisions (from live poking with Les)
 - **Causal flow propagation.** Money propagates from a source (billing); cutting an upstream edge
   dries up everything downstream (artery dims, packets stop, taps go inert — no skim, no audit).
   The graph behaves like a *running system you reason about*, not isolated edges. This is the
   pillar's thesis showing through, and it made the sandbox feel real.
-- **Consequence before solution.** Audit is **dormant until you tamper**, then lights up and
-  streams to the monitor (with an instant surge on TAP) — the visible cause→effect that reads as
-  "my skim is being reported, silence it."
+- **Consequence before solution.** The IDS flag (ids→monitor) is **dormant until the books won't
+  reconcile**, then lights up + the IDS flashes "⚠ won't reconcile" (with an instant surge on TAP) —
+  visible cause→effect. Balance reports (→ids) always flow; only the *flag* is dormant.
+- **Detection must be a mechanism, not a wire-watcher.** First cut had an IDS "watching a
+  connection," which Les rightly flagged as incoherent (and: *you owned the router that was
+  snitching*). The reconciliation model (sent-vs-received report packets) is honest and, better,
+  *generative* — it spawns the whole menu of defeats above from one rule.
 - **Uniform verbs (Les's principle): the presence of an action must never be a hint.** Every
   revealed edge offers the *same* TAP/REROUTE/THROTTLE/CUT; what they *do* depends on the flow type
   (learned by SNIFFing), not on which buttons appear. TAP siphons a type-appropriate acquisition
@@ -132,4 +155,8 @@ system* fun?
   tune into a sharper tradeoff later.
 - Only one topology so far — the spec wants **2-3 variants** to test whether the same verbs produce
   genuinely *different* reads (the emergent-puzzle promise) vs. one repeated recipe.
-- Richer consequences deferred (e.g. a trust-starved vault alarming/locking down).
+- **Watchdog IDS (Les):** a hardened IDS could expect heartbeat/watchdog packets, so a *silent cut*
+  of a report edge would itself alarm (detection-by-absence) — cutting stops being free. Per-LAN
+  `watchdog` flag; deferred. Turns "blind the IDS" into a real cost.
+- Cross-lab: actually letting a smash **autopwn the IDS/monitor** here is the E-thread integration
+  (needs Lab A's library+gear), not lab scope — but it's the convergence the labs proved out.

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
@@ -1,0 +1,3 @@
+# Notes — Exploit combat feel labs
+
+_Running notes + findings. Feed conclusions back to #307 and the design doc._

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
@@ -89,6 +89,47 @@ into E2.
 - Disclosure by grade: `[0.90,0.72,0.52,0.34,0.18,0.07,0.02]` × discScale.
 - Heat: 1/shot, ceiling 40 (the abort wager). Cadence 90ms. Staging: 2 rings, ~70 slots.
 
-## Lab B — Flow-heist (finesse feel) — not started
+## Lab B — Flow-heist (finesse feel) — checkpointed 2026-07-07 (still poking)
 
-See spec.md. Next up after Lab A feel is settled.
+Self-contained prototype at `lab-b-flow-heist/index.html`. A small hand-authored financial LAN:
+skim $2000 from a money artery to your sink before the monitor's audit hits trace. Click a node or
+edge → applicable verbs. Probing the higher-stakes question: is *reading + rerouting a running
+system* fun?
+
+### What it does
+- **Typed flows animate on edges** (money ◆ / data ▢ / audit △ / cred ⬡), **encrypted (grey ⌗)**
+  until SNIFFed. You own gateway+router; the rest is the puzzle.
+- **Two routes to the money, discovered by reading:**
+  - **Loud:** TAP the artery (audit lights up + streams to monitor) → CUT or REROUTE the audit path
+    to silence it → skim out.
+  - **Finesse:** the `$vault` is **trust-gated** (can't tap it directly) → TAP its **credential**
+    flow to capture a token (a **quality** in the Acquired inventory) → **SPOOF** the vault to own
+    it → **REROUTE** the artery to your sink: full-volume, **no audit** (you're a trusted endpoint).
+- **StoryNexus-style quality inventory** (Acquired panel): captured creds / data payloads / audit
+  samples; SPOOF *spends* a cred quality.
+
+### Design principles validated / decisions (from live poking with Les)
+- **Causal flow propagation.** Money propagates from a source (billing); cutting an upstream edge
+  dries up everything downstream (artery dims, packets stop, taps go inert — no skim, no audit).
+  The graph behaves like a *running system you reason about*, not isolated edges. This is the
+  pillar's thesis showing through, and it made the sandbox feel real.
+- **Consequence before solution.** Audit is **dormant until you tamper**, then lights up and
+  streams to the monitor (with an instant surge on TAP) — the visible cause→effect that reads as
+  "my skim is being reported, silence it."
+- **Uniform verbs (Les's principle): the presence of an action must never be a hint.** Every
+  revealed edge offers the *same* TAP/REROUTE/THROTTLE/CUT; what they *do* depends on the flow type
+  (learned by SNIFFing), not on which buttons appear. TAP siphons a type-appropriate acquisition
+  (money→skim, cred→token, data→payload, audit→intel); REROUTE redirects the destination
+  (money→you, audit→away-from-monitor=silence, cred→you, data→you). CUT/RESTORE/THROTTLE anywhere.
+- **SNIFF = recon, TAP = acquire, SPOOF = spend** — separated after the first cut conflated
+  reveal+capture. Acquisitions show in the inventory so you can *see* you're holding something.
+- **Poking is legible.** Non-solution actions (e.g. cutting the cred feed) give clear, type-specific
+  consequences so experimentation teaches the wiring.
+
+### Still open / to feel more
+- Does the **"aha" of reading + rerouting** actually land, or is it fiddly? (Needs more sitting.)
+- Balance: finesse is currently both quieter *and* faster — made strong so the route is discoverable;
+  tune into a sharper tradeoff later.
+- Only one topology so far — the spec wants **2-3 variants** to test whether the same verbs produce
+  genuinely *different* reads (the emergent-puzzle promise) vs. one repeated recipe.
+- Richer consequences deferred (e.g. a trust-starved vault alarming/locking down).

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
@@ -127,6 +127,33 @@ So Lab A + Lab B are **two halves of one system that meet at every security node
 is "read the network, read my loadout, pick my weapon." That's the whole Flow-Subversion pillar
 validated in miniature. (Wiring actual smash into Lab B = the E-thread integration, beyond lab scope.)
 
+### Structural findings for the real (E-thread) build — surfaced by poking Lab B
+
+These are the coherence truths the lab's simplifications kept bumping into. They're **design gold for
+the real implementation**, which already has the multi-hop flow substrate (#256) — don't rebuild them
+in the toy; carry them forward.
+
+- **Flows transit infrastructure — they are paths, not point-to-point wires.** Telemetry, credentials,
+  money all ride *through* routing nodes. The lab flattened flows to direct edges; every "should this
+  go through the router?" question is that flattening showing. The real substrate is already node-to-
+  node, so this is *confirmation of the substrate model*, not new work.
+- **Your foothold is a man-in-the-middle vantage.** You can SNIFF/CAPTURE/tamper with a flow *because
+  it transits a node you control* — not by magically reaching a distant wire. So **access footprint =
+  leverage**: the puzzle becomes "which flows cross nodes I own, and how do I get a vantage on the one
+  I want?" (dovetails with flows-as-scouting).
+- **Node capability tiers gate WHICH manipulations you can run there (2nd axis beyond crack-difficulty).**
+  Owning a node grants the flow-ops its hardware supports:
+  - low-grade **router** → coarse ops: SNIFF / CAPTURE, CUT / RESTORE (sever a link) — no compute for
+    sophisticated work;
+  - advanced **switch / firewall** (stronger compute) → fine ops: **packet-type filtering** (pass
+    money, drop audit), rate-shaping, selective REROUTE, etc.
+  → node *type/grade* now means "**what can I do from here**," not just "how hard to crack." Specific
+  infrastructure becomes worth owning *for its capabilities*, and a hardened high-capability switch is
+  a juicy, dangerous target. (E.g., filtering out audit packets by type is a surgical alternative to a
+  blunt CUT — but only from a node that can afford the compute.)
+- **Credentials-as-authorization + exfil-must-route-home + reconciliation detection** (all built in the
+  lab) are keepers for the real model — they make the network behave like a system you reason about.
+
 ### Design principles validated / decisions (from live poking with Les)
 - **Causal flow propagation.** Money propagates from a source (billing); cutting an upstream edge
   dries up everything downstream (artery dims, packets stop, taps go inert — no skim, no audit).

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
@@ -1,3 +1,70 @@
 # Notes — Exploit combat feel labs
 
 _Running notes + findings. Feed conclusions back to #307 and the design doc._
+
+## Lab A — Autopwn Barrage (smash feel) — checkpointed 2026-07-07
+
+Self-contained prototype at `lab-a-flamethrower/index.html` (vanilla JS + canvas, no deps;
+open via `file://`). Mechanic is untouched from the #307 design; the lab is about *feel*.
+
+### What it became — one centered radial "instrument"
+
+From the center out:
+- **Core** (target, grade letter).
+- **Shield rings = coherence** (Star Castle style). **Grade drives the ring count** (S=3 … E/F=1);
+  faceted rotating dodecagons (CCW = adversarial). Segments erode **outer→inner** for a
+  crescendo, but **which** segment dies within a ring is shuffled so gaps look chaotic, not a
+  clock-hand sweep. A segment popping throws red shards; last ring falls → core blooms cyan.
+- **STAGING rings** = 2 bounded rotating rings (CW = player), counter-rotating vs. the shield.
+  They **fire glyph+hex projectiles inward**, stopping at the outermost *intact* shield ring
+  (impact point marches inward as rings fall). No separate emitters.
+- **Noise bezel** = outer faceted tick-ring filling green→amber→red toward the ceiling.
+- Exact numbers live in the DOM readout row; the ring is impressionistic.
+
+### Key concepts / fiction (validated as feeling right in the lab)
+
+- **Metasploit re-skin (arcadey autopwn).** Library of modules; **reliability ranks**
+  (normal/good/excellent) = rarity; **service classes** (smb/http/ssh/rdp/kernel) = type tags,
+  each with a stroked glyph; firing = an autopwn barrage; success = **SESSION OPENED**; noise =
+  **IDS detection**; disclosure = signature **flagged**. Coherence stays our own fiction term.
+- **Coherence erosion (not HP).** Each node has a coherence reserve (grade-scaled). Each shot
+  chips it by `base(rarity×grade) + type-match bite (+jitter)`; node **faults** at zero. Fiction:
+  non-Von-Neumann, AI-analog systems degrade under fuzzing rather than flip binary.
+- **Attrition = probabilistic burn.** Grade-scaled disclosure roll per shot flags (kills) the
+  module. Two-bars-racing feel: shields eroding vs. library burning down — *"will my ammo outlast
+  its composure?"*
+- **Staging area (Les's reframe).** The rings are NOT the whole library — they're the working set
+  the **gear enqueues from the library** and feeds into the barrage. Occupancy = `min(capacity,
+  usable library)`, so a big library stages full rings, a small one stages sparse, and it visibly
+  **empties as you run dry** (gives back the "see my library size" read for free). Library size
+  stays numeric.
+- **Smash = a co-equal weapon** (minigun vs. finesse's sniper rifle), not a fallback.
+
+### Feel decisions locked this session
+- Vector-first: shields/staging/noise are all stroked faceted geometry (no fills, no arcs) — fixes
+  the earlier draining-bars which violated the game's own vector rule.
+- **No damage numbers, no impact splashes** by default (arcadey-wrong; splash was a literal arc).
+  Both behind tuning toggles.
+- Modules are **hex IDs** (anonymous ammo), tinted by rarity, with a per-service glyph.
+- Emitter → staging-ring firing; **pseudo-random** firing slot; slower rotation; zap beams dropped
+  (hex+glyph projectile is enough); hex rotates along its trajectory.
+- Log is terminal-style (newest at bottom, scrolls up).
+- Size tuned by eye to a compact centered instrument (~40% down, then +15% back).
+
+### Still open / to feel more
+- Does the burst stay fun the 20th time? (needs a longer sit — the mechanic supports it; the
+  *moment-to-moment* feedback is the make-or-break, per the E1 note in #307.)
+- Reboot/self-stabilize (optional): a not-cracked node regrows coherence over time → commit-to-the-
+  burst pacing. Not built.
+- Balance numbers here are placeholders (tuned by eye for feel, not census).
+
+### Values that felt reasonable (starting points, NOT final balance)
+- Coherence by grade: `[2000,1200,700,400,220,140,90]` (S..F) × cohScale.
+- Chip = `CHIP_FACTOR[grade] × RARITY_PUNCH[rarity] × chipScale`, ×(1+typeBite) on service match,
+  ± jitter. `CHIP_FACTOR=[6,10,16,26,40,60,90]`, `RARITY_PUNCH={common:1,uncommon:2.2,rare:5}`.
+- Disclosure by grade: `[0.90,0.72,0.52,0.34,0.18,0.07,0.02]` × discScale.
+- Heat: 1/shot, ceiling 40 (the abort wager). Cadence 90ms. Staging: 2 rings, ~70 slots.
+
+## Lab B — Flow-heist (finesse feel) — not started
+
+See spec.md. Next up after Lab A feel is settled.

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/notes.md
@@ -34,10 +34,11 @@ From the center out:
   module. Two-bars-racing feel: shields eroding vs. library burning down — *"will my ammo outlast
   its composure?"*
 - **Staging area (Les's reframe).** The rings are NOT the whole library — they're the working set
-  the **gear enqueues from the library** and feeds into the barrage. Occupancy = `min(capacity,
-  usable library)`, so a big library stages full rings, a small one stages sparse, and it visibly
-  **empties as you run dry** (gives back the "see my library size" read for free). Library size
-  stays numeric.
+  the **gear enqueues from the library** and feeds into the barrage. Occupancy tracks the **fraction
+  of the library remaining** (`usable / total`), so the staging rings visibly **thin as you burn
+  through the library** — the player-side "bar" racing the shields — and refill on Refill Library.
+  Library size stays exact in the numeric readout. (Earlier `min(capacity, usable)` model showed no
+  depletion until the last ~70 modules — regression; fixed.)
 - **Smash = a co-equal weapon** (minigun vs. finesse's sniper rifle), not a fallback.
 
 ### Feel decisions locked this session
@@ -50,6 +51,29 @@ From the center out:
   (hex+glyph projectile is enough); hex rotates along its trajectory.
 - Log is terminal-style (newest at bottom, scrolls up).
 - Size tuned by eye to a compact centered instrument (~40% down, then +15% back).
+
+### Gear attributes — the tuning knobs ARE the gear (E2 insight, 2026-07-07)
+
+Les's observation: the lab's tuning sliders aren't just balance knobs — several are literally the
+**Layer-1 gear's fingerprint**. Sorting the axes:
+
+- **Gear attributes** (equippable; a loadout is a *profile* across these):
+  - **noise / attempt** (`heatPerShot`) — quiet rig vs. loud.
+  - **cadence** (attempts/sec) — rig speed (*Netrunner* Deck Speed).
+  - **flag chance** (`discScale`) — signature-evasion / obfuscation gear.
+  - **service-match bonus** (`typeBite`) — recon/analysis quality (how much your targeting knows).
+  - **ranking engine** (fire best-ranked first) — Analyzation gear ordering the barrage.
+  - *(later)* **staging capacity** — cyberdeck RAM.
+- **Target properties** (the host's, scaled by grade — NOT gear): coherence, base chip-vs-grade,
+  baseline disclosure. The lab's `*Scale` sliders are really the gear-side multipliers on these.
+- **Run parameter** (player sets per-run): the **noise/heat ceiling** (the abort wager).
+- **Flavor:** jitter.
+
+Demonstrated in the lab with a **gear-preset selector** (bare rig / balanced / ghost (stealth+recon)
+/ smash rig) that snaps those sliders to archetypes. Running the same S node under *ghost* vs.
+*smash rig* feels like a genuinely different playstyle — concrete validation that the gear economy
+(#307 E2) will produce real meticulous-ghost ↔ smash-and-grab choices. Feed this attribute schema
+into E2.
 
 ### Still open / to feel more
 - Does the burst stay fun the 20th time? (needs a longer sit — the mechanic supports it; the

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/plan.md
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/plan.md
@@ -1,0 +1,3 @@
+# Plan — Exploit combat feel labs
+
+_To be written in the `plan` phase._

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/research.md
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/research.md
@@ -1,0 +1,23 @@
+# Research — Exploit combat feel labs
+
+_Codebase / prior-art notes gathered during the session._
+
+## Prior art: the `hackcombat` sketch
+
+lmorchard/sketches-v01, `src/sketches/hackcombat/` — the disposable-exploit-pool
+prototype this direction descends from.
+
+- `combat.js` — data model. `ExploitSet` (pool of ~100), `Exploit` (rarity + hex-ish
+  name + optional disclosure), `VulnerabilitySet` (a node: grade → `exploitChances` per
+  rarity + `disclosureChance` + `patchLag`). `EXPLOIT_RARITIES` = common 11/15, uncommon
+  3/15, rare 1/15. `VULNERABILITY_GRADES` S..F with per-grade rarity chances +
+  disclosure chance.
+- `index.js` — `launchExploits()`: shuffle the whole collection, iterate, roll
+  `disclosureChance` (burn), check `isVulnerableTo` (match → break/loot). Buy packs of 5.
+  Cost = attrition, weighted by grade. **No heat, no coherence** — those are what the lab
+  adds.
+
+Starting point for Lab A's exploit/rarity generator; the coherence + heat + two-bars +
+per-shot pacing are net-new.
+
+## (to fill in as needed)

--- a/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/spec.md
+++ b/docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/spec.md
@@ -1,0 +1,109 @@
+# Spec — Exploit combat feel labs (Lab A + Lab B)
+
+**Session:** 2026-07-06-2219-exploit-combat-labs
+**Branch:** `worktree-exploit-combat-labs`
+**Design context:** `docs/design/flow-subversion.md` → "Exploit economy: gear vs. ammo"
+(committed on branch `worktree-exploit-economy-design`, draft PR #308). Epic-child issue
+#307, epic #279.
+
+## Why this session exists
+
+The exploit-economy rework (#307) is a **big** change to core combat, and its payoff is
+**feel-dependent** — a spec can't tell us whether the loop is *fun*. Per the dev-session
+"feel-driven features want a prototype" guidance and Les's interactive-lab preference,
+we de-risk the two combat fantasies in **disposable-but-kept miniature labs** before
+committing to the full E1 build. The labs are **kept as committed doc artifacts** in
+this session directory (not gitignored `tmp/`), so the exploration survives.
+
+Two weapons, two fun-types, two labs:
+
+| Weapon | Fun type | Pillar thread | Lab |
+|---|---|---|---|
+| **Smash** (minigun) | kinetic — commit under pressure | anti-tedium / texture | **Lab A** (this session, first) |
+| **Finesse** (sniper) | cerebral — read & reroute | reconfiguration (structural cure) | **Lab B** (next) |
+
+**Labs answer "is the loop fun," not "ship these numbers."** No final balance, art, or
+game integration comes out of them.
+
+---
+
+## Lab A — Flamethrower (smash feel) — FIRST
+
+**The one question it must answer:** is the burst fun the *20th* time, not just the 1st?
+Does two-bars-racing produce a real "commit or bail" crescendo, and do soft vs. hard
+nodes *feel* meaningfully different?
+
+**Minimal ingredients:**
+- One target node: grade, a **coherence** reserve (scaled by grade), a vuln profile
+  (2–3 types).
+- A generated hoard: ~100–300 hex-ID exploits (rarity, type tags, multi-type rares).
+  Reuse the `hackcombat` sketch's exploit/rarity/disclosure generator as a starting
+  point (lmorchard/sketches-v01 `src/sketches/hackcombat/combat.js`).
+- The auto-burn loop **with visible per-shot beats** (~60–120 ms/shot so you *watch* the
+  barrage): each shot fires → chips coherence (`base(rarity×grade) + typeMatchBite +
+  jitter`) → rolls grade-scaled disclosure → maybe burns that exploit out of the hoard.
+- **Two depleting bars** (node coherence ↓, hoard size ↓) + a **heat meter** climbing.
+- Controls: set **heat ceiling** (the wager), GO, ABORT. Loop stops on
+  **cracked / heat-ceiling / hoard-dry**. Outcome feedback: cracked (payoff) vs. bailed
+  vs. dry.
+- A **gear toggle**: best-type-match-first vs. blind-random ordering — to *feel* what
+  gear would buy.
+
+**Knobs (live sliders):** coherence-by-grade, chip table (rarity × grade),
+typeMatchBite magnitude, disclosure-rate-by-grade, heat-per-shot, shot cadence, hoard
+size/composition, per-shot jitter.
+
+**Feedback is the thing under test** — the per-shot beats need juice (strong visual pops
+at minimum; a tick/drone is a stretch goal). A lab that resolves instantly can't answer
+its own question.
+
+**Out of scope:** the graph, finesse, store, saves, real game integration, final art.
+
+**Success test:** after ~10 min of play, do we feel the "will my ammo outlast its wall?"
+tension and want to go again? Does soft-vs-hard differ? Does the heat-ceiling wager
+create real decisions? Is watching the barrage satisfying or tedious?
+
+---
+
+## Lab B — Flow-heist (finesse feel) — NEXT (separate phase)
+
+**The one question:** is *reading a flow graph and rerouting it* fun — the "aha, I see
+the machine" click? Is there real depth (multiple routes, tradeoffs, alarm-management),
+or does it collapse to a fixed recipe?
+
+**Minimal ingredients:**
+- **2–3 tiny hand-authored flow graphs** (5–7 nodes): a money flow → sink, a credential
+  flow, one trust-gated node, one **audit flow → monitor**.
+- Flow rendering (lean on the Session 0/1 substrate): shape/direction/volume; encrypted
+  flows dashed until SNIFFed.
+- A **fixed finesse toolkit**: SNIFF (reveal / capture credential), SPOOF/REPLAY (own a
+  trust-gated node), TAP/REROUTE (divert money to your sink), CUT/JAM (kill/mask the
+  audit). Per-verb heat cost so "quietest solution" is felt.
+- An **objective** (skim $X / own the core) + a **notice condition** (audit reaches the
+  monitor → trace).
+
+**What the 2–3 variants test:** whether the *same verbs* produce *different reads* on
+different topologies. Same-recipe-everywhere is a finding (weak emergent promise);
+each-demands-a-fresh-read means the reconfiguration thread has legs.
+
+**Out of scope:** smash, gear, store, **procgen**, full ICE, final art, engine
+integration beyond what the flow substrate gives cheaply. Hand-author; fixed toolkit.
+
+**Success test:** does reading+rerouting click? More than one solution / a real tradeoff?
+Does keeping the alarm nominal make it *subversion* rather than *unlock*? Do the variants
+feel genuinely different with the same verbs?
+
+**Honest asymmetry:** Lab B tests the pillar's actual thesis (reconfiguration = the
+structural cure) — higher value, higher scope-creep risk. Discipline: keep it a puzzle
+sandbox, not "start building the reconfiguration system."
+
+---
+
+## Artifacts & housekeeping
+
+- Labs live under this session dir (e.g. `lab-a-flamethrower/`, `lab-b-flow-heist/`) as
+  **committed** self-contained HTML/JS — kept as documentation, not throwaway.
+- What the labs do **not** decide: final balance numbers, production art, game
+  integration. Those belong to the E1/E3 build sessions.
+- Findings (what felt good, what didn't, chosen ballpark values) get written into
+  `notes.md` and fed back to #307 / the design doc.


### PR DESCRIPTION
Disposable-but-committed **feel prototypes** to de-risk the exploit-economy fun before the big E1
build. Docs-only (self-contained HTML/JS under the session dir; no game code, no deps). Design
context: #307 / epic #279 / design PR #308.

Session: `docs/dev-sessions/2026-07-06-2219-exploit-combat-labs/` (spec + notes + labs).

## Lab A — Autopwn Barrage (smash feel) — checkpointed

A single centered radial "instrument" for the smash/coherence combat, iterated live with Les:

- **Star Castle shield rings = coherence** (grade → ring count; faceted rotating dodecagons; erode
  outer→inner in shuffled order; core blooms on crack).
- **Counter-rotating STAGING rings** (player CW) fire glyph+hex projectiles inward to the outermost
  intact shield ring; occupancy tracks the library fraction remaining (thins as you burn down).
- **Noise bezel** outer tick-ring fills to the abort ceiling.
- **Metasploit re-skin:** autopwn / modules / reliability ranks / service-class glyphs (smb/http/
  ssh/rdp/kernel) / SESSION OPENED / IDS noise / signature flagged.
- **Gear-preset selector** (bare / balanced / ghost / smash) — demonstrates that the tuning knobs
  (noise, cadence, flag-chance, service-match bonus) are the Layer-1 gear fingerprint.
- All stroked-vector (no fills/arcs); damage numbers + impact splashes off by default (toggles).

Design gains fed back to #307: the **coherence-erosion + probabilistic-burn** feel, the
**staging-area** concept (gear enqueues from library), and the **gear-attribute schema** (E2).
Full rationale in `notes.md`.

## Lab B — flow-heist (finesse feel)

Next up — the higher-stakes prototype (is reading + rerouting flows fun?).

**Draft / WIP:** prototypes for design validation, not shipping code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)